### PR TITLE
feat: enhancements as result of easy-ui5 integration

### DIFF
--- a/packages/fiori-freestyle/src/index.ts
+++ b/packages/fiori-freestyle/src/index.ts
@@ -106,7 +106,7 @@ function copyTemplates(tmplPath: string, basePath: string, ffApp: FreestyleApp<u
         return path
             .replace(new RegExp(replaceVer), '') // remove version template path
             .replace(/\$ViewName/, ffApp.ui5?.initialViewName || "View1") // dynamically set inital view file name
-            .replace(/\$ControllerName/, ffApp.ui5?.initialControllerName || "View1") // dynamically set inital controller file name
+            .replace(/\$ControllerName/, ffApp.ui5?.initialControllerName || "View1"); // dynamically set inital controller file name
     };
     // Ignore other odata version specific template folders
     const ignoreFolderPattern = Object.values(OdataVersion).filter((ver) => ver !== ffApp.service?.version);

--- a/packages/fiori-freestyle/src/index.ts
+++ b/packages/fiori-freestyle/src/index.ts
@@ -102,7 +102,12 @@ async function generate<T>(basePath: string, data: FreestyleApp<T>, fs?: Editor)
 function copyTemplates(tmplPath: string, basePath: string, ffApp: FreestyleApp<unknown>, fs: Editor) {
     // Remove odata versions specific path while copying template files
     const replaceVer = `\\${sep}v${Object.values(OdataVersion).join(`|\\${sep}v`)}`;
-    const removeVersionTmplPath = (path: string): string => path.replace(new RegExp(replaceVer), '');
+    const destPathManipulations = (path: string): string => {
+        return path
+            .replace(new RegExp(replaceVer), '') // remove version template path
+            .replace(/\$ViewName/, ffApp.ui5?.initialViewName || "View1") // dynamically set inital view file name
+            .replace(/\$ControllerName/, ffApp.ui5?.initialControllerName || "View1") // dynamically set inital view file name
+    };
     // Ignore other odata version specific template folders
     const ignoreFolderPattern = Object.values(OdataVersion).filter((ver) => ver !== ffApp.service?.version);
     // By template type
@@ -113,7 +118,7 @@ function copyTemplates(tmplPath: string, basePath: string, ffApp: FreestyleApp<u
         {},
         {
             globOptions: { ignore: ignoreFolderPattern.map((folder) => `**/v${folder}/**`) },
-            processDestinationPath: removeVersionTmplPath
+            processDestinationPath: destPathManipulations
         }
     );
 }

--- a/packages/fiori-freestyle/src/index.ts
+++ b/packages/fiori-freestyle/src/index.ts
@@ -106,7 +106,7 @@ function copyTemplates(tmplPath: string, basePath: string, ffApp: FreestyleApp<u
         return path
             .replace(new RegExp(replaceVer), '') // remove version template path
             .replace(/\$ViewName/, ffApp.ui5?.initialViewName || "View1") // dynamically set inital view file name
-            .replace(/\$ControllerName/, ffApp.ui5?.initialControllerName || "View1") // dynamically set inital view file name
+            .replace(/\$ControllerName/, ffApp.ui5?.initialControllerName || "View1") // dynamically set inital controller file name
     };
     // Ignore other odata version specific template folders
     const ignoreFolderPattern = Object.values(OdataVersion).filter((ver) => ver !== ffApp.service?.version);

--- a/packages/fiori-freestyle/templates/basic/add/webapp/Component.js
+++ b/packages/fiori-freestyle/templates/basic/add/webapp/Component.js
@@ -1,7 +1,7 @@
 sap.ui.define([
 		"<%=app.baseComponent%>",
 		"sap/ui/Device",
-		"<%=app.id.replace('.', '/')%>/model/models"
+		"<%=app.id.replace(/\./g, '/')%>/model/models"
 	],
     function (UIComponent, Device, models) {
         "use strict";

--- a/packages/fiori-freestyle/templates/basic/add/webapp/controller/$ControllerName.controller.js
+++ b/packages/fiori-freestyle/templates/basic/add/webapp/controller/$ControllerName.controller.js
@@ -7,7 +7,7 @@ sap.ui.define([
 	function (Controller) {
 		"use strict";
 
-		return Controller.extend("<%=app.id%>.controller.View1", {
+		return Controller.extend("<%=app.id%>.controller.<%= ui5.initialControllerName ? ui5.initialControllerName : 'View1' %>", {
 			onInit: function () {
 
 			}

--- a/packages/fiori-freestyle/templates/basic/add/webapp/view/$ViewName.view.xml
+++ b/packages/fiori-freestyle/templates/basic/add/webapp/view/$ViewName.view.xml
@@ -1,5 +1,5 @@
 <mvc:View
-    controllerName="<%=app.id%>.controller.View1"
+    controllerName="<%=app.id%>.controller.<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>"
     xmlns:mvc="sap.ui.core.mvc"
     displayBlock="true"
     xmlns="sap.m"

--- a/packages/fiori-freestyle/templates/basic/extend/webapp/manifest.json
+++ b/packages/fiori-freestyle/templates/basic/extend/webapp/manifest.json
@@ -33,7 +33,7 @@
                 }
             ],
             "targets": {
-                "TargetView1": {
+                "Target<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>": {
                     "viewType": "XML",
                     "transition": "slide",
                     "clearControlAggregation": false,

--- a/packages/fiori-freestyle/templates/basic/extend/webapp/manifest.json
+++ b/packages/fiori-freestyle/templates/basic/extend/webapp/manifest.json
@@ -1,10 +1,10 @@
 {
     "sap.ui5": {
         "rootView": {
-            "viewName": "<%=app.id%>.view.View1",
+            "viewName": "<%=app.id%>.view.<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>",
             "type": "XML",
             "async": true,
-            "id": "View1"
+            "id": "<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>"
         },
         "resources": {
             "css": [
@@ -25,10 +25,10 @@
             },
             "routes": [
                 {
-                    "name": "RouteView1",
-                    "pattern": "RouteView1",
+                    "name": "Route<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>",
+                    "pattern": "Route<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>",
                     "target": [
-                        "TargetView1"
+                        "Target<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>"
                     ]
                 }
             ],
@@ -37,8 +37,8 @@
                     "viewType": "XML",
                     "transition": "slide",
                     "clearControlAggregation": false,
-                    "viewId": "View1",
-                    "viewName": "View1"
+                    "viewId": "<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>",
+                    "viewName": "<%= ui5.initialViewName ? ui5.initialViewName : 'View1' %>"
                 }
             }
         }

--- a/packages/fiori-freestyle/test/index.test.ts
+++ b/packages/fiori-freestyle/test/index.test.ts
@@ -90,4 +90,30 @@ describe(`Fiori freestyle templates: ${TEST_NAME}`, () => {
             fs.commit(resolve);
         });
     });
+
+    test("initial view- and controller-name can be adjusted by configuration", async () => {
+        const testPath = join(curTestOutPath, "initViewAndController")
+        const viewPrefix = "MainView"
+        const contollerPrefix = "MainView" // well...
+        const FreestyleApp: FreestyleApp<any> = {
+            app: {
+                id: "someId",
+            },
+            ui5: {
+                initialViewName: viewPrefix,
+                initialControllerName: contollerPrefix
+            },
+            package: {
+                name: "someId",
+            },
+            template: {
+                type: TemplateType.Basic,
+                settings: {}
+            }
+        }
+
+        const fs = await generate(testPath, FreestyleApp)
+        expect(fs.exists(join(testPath, "webapp", "view", `${viewPrefix}.view.xml`))).toBeTruthy()
+        expect(fs.exists(join(testPath, "webapp", "controller", `${contollerPrefix}.controller.js`))).toBeTruthy()
+    })
 });

--- a/packages/fiori-freestyle/test/index.test.ts
+++ b/packages/fiori-freestyle/test/index.test.ts
@@ -1,6 +1,6 @@
 import { FreestyleApp, generate } from '../src';
 import { join } from 'path';
-import { TemplateType, OdataService, OdataVersion } from '@sap/open-ux-tools-types';
+import { TemplateType, OdataService, BootstrapSrc } from '@sap/open-ux-tools-types';
 import { rmdirSync } from 'fs';
 import { sample } from './sample/metadata';
 import { testOutputDir, debug, northwind } from './common';
@@ -91,8 +91,7 @@ describe(`Fiori freestyle templates: ${TEST_NAME}`, () => {
         });
     });
 
-    test("initial view- and controller-name can be adjusted by configuration", async () => {
-        const testPath = join(curTestOutPath, "initViewAndController")
+    describe("set view-and controller-name at scaffolding time", () => {
         const viewPrefix = "MainView"
         const contollerPrefix = "MainView" // well...
         const FreestyleApp: FreestyleApp<any> = {
@@ -112,8 +111,58 @@ describe(`Fiori freestyle templates: ${TEST_NAME}`, () => {
             }
         }
 
-        const fs = await generate(testPath, FreestyleApp)
-        expect(fs.exists(join(testPath, "webapp", "view", `${viewPrefix}.view.xml`))).toBeTruthy()
-        expect(fs.exists(join(testPath, "webapp", "controller", `${contollerPrefix}.controller.js`))).toBeTruthy()
+        test("initial view- and controller-name can be adjusted by configuration", async () => {
+            const testPath = join(curTestOutPath, "initViewAndController")
+            const fs = await generate(testPath, FreestyleApp)
+            expect(fs.exists(join(testPath, "webapp", "view", `${viewPrefix}.view.xml`))).toBeTruthy()
+            expect(fs.exists(join(testPath, "webapp", "controller", `${contollerPrefix}.controller.js`))).toBeTruthy()
+        })
+
+        test("manifest.json adheres to view-/controller-name set at scaffolding time", async () => {
+            const testPath = join(curTestOutPath, "mainfestJson")
+            const fs = await generate(testPath, FreestyleApp)
+            const manifest = { json: fs.readJSON(join(testPath, "webapp", "manifest.json")) as any }
+            expect(
+                [
+                    manifest.json["sap.ui5"].rootView.viewName,
+                    manifest.json["sap.ui5"].rootView.id,
+                    manifest.json["sap.ui5"].routing.routes[0].name,
+                    manifest.json["sap.ui5"].routing.routes[0].pattern,
+                    manifest.json["sap.ui5"].routing.routes[0].target[0],
+                    manifest.json["sap.ui5"].routing.targets[`Target${viewPrefix}`].viewId,
+                    manifest.json["sap.ui5"].routing.targets[`Target${viewPrefix}`].viewName,
+                ].every(entry => entry.includes(viewPrefix))
+            ).toBeTruthy()
+        })
     })
+
+
+    describe("index.html UI5 bootstrap location can be set dynamically", () => {
+        const FreestyleApp: FreestyleApp<any> = {
+            app: {
+                id: "someId",
+            },
+            package: {
+                name: "someId",
+            },
+            template: {
+                type: TemplateType.Basic,
+                settings: {}
+            }
+        }
+
+        const testData = [
+            [BootstrapSrc.CdnOpenUI5, { ...FreestyleApp, ui5: { bootstrapSrc: BootstrapSrc.CdnOpenUI5 } } as FreestyleApp<any>, "https://openui5.hana.ondemand.com/resources/sap-ui-core.js"],
+            [BootstrapSrc.CdnSAPUI5, { ...FreestyleApp, ui5: { bootstrapSrc: BootstrapSrc.CdnSAPUI5 } } as FreestyleApp<any>, "https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"],
+            [BootstrapSrc.Local, { ...FreestyleApp, ui5: { bootstrapSrc: BootstrapSrc.Local } } as FreestyleApp<any>, "resources/sap-ui-core.js"],
+        ]
+
+        test.each(testData)("%s", async (_, appConfig, expectation) => {
+            const testPath = join(curTestOutPath, Date.now().toString())
+            const fs = await generate(testPath, appConfig as FreestyleApp<any>)
+            const index = { html: fs.read(join(testPath, "webapp", "index.html")) }
+            expect(index.html).toContain(expectation)
+        })
+    })
+
 });

--- a/packages/types/src/ui5App.ts
+++ b/packages/types/src/ui5App.ts
@@ -22,6 +22,11 @@ export interface App {
 	localStartFile?: string;
 }
 
+export enum BootstrapSrc {
+	CdnOpenUI5 = "Content delivery network (OpenUI5)",
+	CdnSAPUI5 = "Content delivery network (SAPUI5)",
+	Local = "Local Resources"
+}
 export interface UI5 {
 	minUI5Version?: string;
 	version?: string;
@@ -32,7 +37,7 @@ export interface UI5 {
 	ui5Theme?: string;
 	initialViewName?: string; // scaffolding-time: dynamic view name
 	initialControllerName?: string; // scaffolding-time: dynamic controller name
-	bootstrapSrc?: string; // scaffolding-time: where to consume the bootstrap resources from (cdn, local)
+	bootstrapSrc?: BootstrapSrc; // scaffolding-time: where to consume the bootstrap resources from (cdn, local)
 }
 
 // Additional configurable features

--- a/packages/types/src/ui5App.ts
+++ b/packages/types/src/ui5App.ts
@@ -30,6 +30,7 @@ export interface UI5 {
 	descriptorVersion?: string;
 	ui5Libs?: string | string[];
 	ui5Theme?: string;
+	bootstrapSrc?: string; // scaffolding-time: where to consume the bootstrap resources from (cdn, local)
 }
 
 // Additional configurable features

--- a/packages/types/src/ui5App.ts
+++ b/packages/types/src/ui5App.ts
@@ -30,6 +30,8 @@ export interface UI5 {
 	descriptorVersion?: string;
 	ui5Libs?: string | string[];
 	ui5Theme?: string;
+	initialViewName?: string; // scaffolding-time: dynamic view name
+	initialControllerName?: string; // scaffolding-time: dynamic controller name
 	bootstrapSrc?: string; // scaffolding-time: where to consume the bootstrap resources from (cdn, local)
 }
 

--- a/packages/ui5-application/templates/core/webapp/index.html
+++ b/packages/ui5-application/templates/core/webapp/index.html
@@ -12,7 +12,10 @@
     </style>
     <script
         id="sap-ui-bootstrap"
-        src="resources/sap-ui-core.js"
+        src="<%= ui5.bootstrapSrc === 'Content delivery network (OpenUI5)' ?
+            'https://openui5.hana.ondemand.com/resources/sap-ui-core.js' :
+                ui5.bootstrapSrc === 'Content delivery network (SAPUI5)' ?
+                    'https://sapui5.hana.ondemand.com/resources/sap-ui-core.js' : 'resources/sap-ui-core.js'  %>"
         data-sap-ui-theme="sap_fiori_3"
         data-sap-ui-resourceroots='{
             "<%=app.id%>": "./"


### PR DESCRIPTION
this PR is based on using `fiori-freestyle` for scaffolding a basic UI5 app in `easy-ui5`. 
(more precise, `fiori-freestyle`'s `generate()`-API is used  in the `generator-template-ui5-project` sub-generator to scaffold the UI5 app)

as a result, the following enhancements were introduced to `open-ux-tools`/`fiori-freestyle`:
- dynamically set initial view- and controller-name at scaffolding time: https://github.com/vobu/open-ux-tools-1/commit/bb8a2b508b58321e7cea51ec5f7993b6e4720f61
- same for manifest.json: https://github.com/vobu/open-ux-tools-1/commit/1aef09425831277760531d4a1d4dbac1a016f572
- provide CDN- and local resources for bootstrapping UI5 in `index.html`: https://github.com/vobu/open-ux-tools-1/commit/c451411f908539c5a46e6a8c14d13c7ec965249f

Also, a small regex fix is included: https://github.com/vobu/open-ux-tools-1/commit/86a9cb4c4974d3607af53aea2da6caf63d0ed3cc

