### PR TITLE
fix(odata-service): Moves ui5-mock.yaml to odata service, allow no service yams

### DIFF
--- a/packages/fiori-freestyle/src/index.ts
+++ b/packages/fiori-freestyle/src/index.ts
@@ -4,13 +4,7 @@ import { render } from 'ejs';
 
 import { generate as generateUi5Project } from '@sap/ux-ui5-application-template';
 import { generate as addOdataService } from '@sap/ux-odata-service-template';
-import {
-    FreestyleApp,
-    WorklistSettings,
-    ListDetailSettings,
-    Template,
-    Package
-} from '@sap/open-ux-tools-types';
+import { FreestyleApp, WorklistSettings, ListDetailSettings, Template, Package } from '@sap/open-ux-tools-types';
 import { TemplateType } from '@sap/open-ux-tools-types'; // This is an enum dont import as type, we lose runtime values
 import { UI5Config } from '@sap/ux-ui5-config';
 import { getPackageTasks } from '@sap/open-ux-tools-common';
@@ -73,11 +67,7 @@ async function generate<T>(basePath: string, data: FreestyleApp<T>, fs?: Editor)
 
     // Add service to the project if provided
     if (ffApp.service) {
-        await addOdataService(basePath, ffApp.service, fs);
-    }
-    // Dont generate an invalid ui5-mock.yaml
-    if (!ffApp.service?.metadata) {
-        fs.delete(join(basePath, 'ui5-mock.yaml'));
+        await addOdataService(basePath, Object.assign(ffApp.service, { appid: ffApp.app.id }), fs);
     }
 
     // ui5-local.yaml

--- a/packages/fiori-freestyle/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle/test/__snapshots__/basic.test.ts.snap
@@ -85,10 +85,6 @@ server:
 ",
     "state": "modified",
   },
-  "ui5-mock.yaml": Object {
-    "contents": null,
-    "state": "deleted",
-  },
   "ui5.yaml": Object {
     "contents": "specVersion: \\"2.5\\"
 metadata:

--- a/packages/odata-service/src/index.ts
+++ b/packages/odata-service/src/index.ts
@@ -43,10 +43,6 @@ async function generate(basePath: string, data: OdataService, fs?: Editor): Prom
     validateBasePath(basePath, fs);
     enhanceData(data);
 
-    // add new and overwrite files from templates
-    //const tmpPath = join(__dirname, 'templates', 'add');
-    //fs.copyTpl(join(tmpPath, '**/*.*'), basePath, data);
-
     // merge content into existing files
     const templateRoot = join(__dirname, '..', 'templates');
     const extRoot = join(templateRoot, 'extend');
@@ -79,12 +75,15 @@ async function generate(basePath: string, data: OdataService, fs?: Editor): Prom
         proxyLocalMiddleware.comments
     );
     await addMiddlewareConfig(fs, basePath, 'ui5-local.yaml', appReloadMiddleware);
-    const mwMock = getMockServerMiddlewareConfig(data);
 
+    // ui5-mock.yaml
     if (data.metadata) {
-        // ui5-mock.yaml
+        fs.copyTpl(join(templateRoot, 'add', 'ui5-mock.yaml'), join(basePath, 'ui5-mock.yaml'), data);
         await addMiddlewareConfig(fs, basePath, 'ui5-mock.yaml', proxyMiddleware.config, proxyMiddleware.comments);
+
+        const mwMock = getMockServerMiddlewareConfig(data);
         await addMiddlewareConfig(fs, basePath, 'ui5-mock.yaml', mwMock);
+
         await addMiddlewareConfig(fs, basePath, 'ui5-mock.yaml', appReloadMiddleware);
         // create local copy of metadata and annotations
         fs.write(join(basePath, 'webapp', 'localService', 'metadata.xml'), prettifyXml(data.metadata, { indent: 4 }));

--- a/packages/odata-service/templates/add/ui5-mock.yaml
+++ b/packages/odata-service/templates/add/ui5-mock.yaml
@@ -1,4 +1,4 @@
 specVersion: "2.5"
 metadata:
-  name: <%- app.id %>
+  name: <%- appid %>
 type: application

--- a/packages/odata-service/test/__snapshots__/index.test.ts.snap
+++ b/packages/odata-service/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Fiori freestyle templates generates all expected files correctly 1`] = `
+exports[`ODataService templates generates all expected files correctly 1`] = `
 Object {
   "package.json": Object {
     "contents": "{
@@ -37,8 +37,10 @@ server:
     "state": "modified",
   },
   "ui5-mock.yaml": Object {
-    "contents": "#empty file
-
+    "contents": "specVersion: \\"2.5\\"
+metadata:
+  name: testappid
+type: application
 server:
   customMiddleware:
     - name: fiori-tools-proxy

--- a/packages/odata-service/test/index.test.ts
+++ b/packages/odata-service/test/index.test.ts
@@ -5,7 +5,7 @@ import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
 import { removeSync } from 'fs-extra';
 
-describe('Fiori freestyle templates', () => {
+describe('ODataService templates', () => {
     const debug = !!process.env['UX_DEBUG'];
 
     const outputDir = join(__dirname, 'test-output');
@@ -34,7 +34,8 @@ describe('Fiori freestyle templates', () => {
                 annotations: {
                     technicalName: 'SEPM_XYZ',
                     xml: '<HELLO><ANNOTATION></ANNOTATION></WORLD></HELLO>'
-                }
+                },
+                appid: 'testappid'
             } as OdataService,
             fs
         );

--- a/packages/odata-service/test/unit/index.test.ts
+++ b/packages/odata-service/test/unit/index.test.ts
@@ -7,7 +7,8 @@ const testDir = 'virtual-temp';
 const commonConfig = {
     url: 'http://localhost',
     path: '/sap/odata/testme',
-    metadata: '<HELLO WORLD />'
+    metadata: '<HELLO WORLD />',
+    appid: 'testappid'
 };
 
 describe('Test generate method with invalid location', () => {

--- a/packages/types/src/odataService.ts
+++ b/packages/types/src/odataService.ts
@@ -18,4 +18,5 @@ export interface OdataService {
 		technicalName: string;
 		xml: string;
 	};
+	appid?: string; // Required for writing ui5-mock.yaml
 }

--- a/packages/ui5-application/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-application/test/__snapshots__/index.test.ts.snap
@@ -52,14 +52,6 @@ type: application
 ",
     "state": "modified",
   },
-  "ui5-mock.yaml": Object {
-    "contents": "specVersion: \\"2.5\\"
-metadata:
-  name: testAppId
-type: application
-",
-    "state": "modified",
-  },
   "ui5.yaml": Object {
     "contents": "specVersion: \\"2.5\\"
 metadata:

--- a/packages/ui5-application/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application/test/__snapshots__/options.test.ts.snap
@@ -91,14 +91,6 @@ type: application
 ",
     "state": "modified",
   },
-  "ui5-mock.yaml": Object {
-    "contents": "specVersion: \\"2.5\\"
-metadata:
-  name: testAppId
-type: application
-",
-    "state": "modified",
-  },
   "ui5.yaml": Object {
     "contents": "specVersion: \\"2.5\\"
 metadata:

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -22,28 +22,30 @@ export const getAppReloadMiddlewareConfig = (): MiddlewareConfig[] => {
 export const getFioriToolsProxyMiddlewareConfig = (
     data: OdataService,
     useUi5Cdn = true,
-		ui5CdnUrl = 'https://ui5.sap.com',
-		ui5Version = ''
+    ui5CdnUrl = 'https://ui5.sap.com',
+    ui5Version = ''
 ): { config: MiddlewareConfig[]; comments: NodeComment<MiddlewareConfig>[] } => {
-    const destination = data.destination?.name || undefined;
-    const destinationInstance = data.destination?.instance || undefined;
-
-    const pathSegments = data.path.split('/').filter((s: string) => s !== '');
     const fioriToolsProxy: MiddlewareConfig = {
         name: 'fiori-tools-proxy',
         afterMiddleware: 'compression',
         configuration: {
-            ignoreCertError: false,
-            backend: [
-                {
-                    path: `/${pathSegments[0]}`,
-                    url: data.url ?? DEFAULT_HOST,
-                    destination,
-                    destinationInstance
-                }
-            ]
+            ignoreCertError: false
         }
     };
+
+    if (data.url || data.path || data.destination?.name || data.destination?.instance) {
+        const destination = data.destination?.name || undefined;
+        const destinationInstance = data.destination?.instance || undefined;
+        const pathSegments = data.path.split('/').filter((s: string) => s !== '');
+        fioriToolsProxy.configuration.backend = [
+            {
+                path: `/${pathSegments[0]}`,
+                url: data.url ?? DEFAULT_HOST,
+                destination,
+                destinationInstance
+            }
+        ];
+    }
     if (useUi5Cdn === true) {
         fioriToolsProxy.configuration['ui5'] = {
             path: ['/resources', '/test-resources'],

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -40,6 +40,7 @@ describe('Fiori config utils', () => {
             ]
         `);
     });
+
     test('getFioriToolsProxyMiddlewareConfig', async () => {
         expect(getFioriToolsProxyMiddlewareConfig(serviceData)).toMatchInlineSnapshot(`
             Object {
@@ -81,6 +82,7 @@ describe('Fiori config utils', () => {
             }
         `);
     });
+
     test('getAppReloadMiddlewareConfig', async () => {
         expect(getAppReloadMiddlewareConfig()).toMatchInlineSnapshot(`
             Array [
@@ -116,8 +118,6 @@ describe('Fiori config utils', () => {
         `);
     });
 
-
-
     test('UI5Config addUI5Framework', async () => {
         const ui5Config = await UI5Config.newInstance('');
         ui5Config.addUI5Framework('1.64.0s', ['sap.m'], 'sap_belize');
@@ -129,6 +129,48 @@ describe('Fiori config utils', () => {
                 - name: sap.m
                 - name: themelib_sap_belize
             "
+        `);
+    });
+
+    /**
+     * Consumers may require scaffolded apps that do not yet have a service defined.
+     * This test ensures a valid middleware definition is generated without a full service defintion.
+     */
+    test('getFioriToolsProxyMiddlewareConfig no datasource provided', async () => {
+        const serviceData = {
+            name: 'maintestService',
+            version: OdataVersion.v2
+        } as OdataService;
+        expect(getFioriToolsProxyMiddlewareConfig(serviceData)).toMatchInlineSnapshot(`
+            Object {
+              "comments": Array [
+                Object {
+                  "comment": " If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted",
+                  "path": "configuration.ignoreCertError",
+                },
+                Object {
+                  "comment": " The UI5 version, for instance, 1.78.1. null means latest version",
+                  "path": "configuration.ui5.version",
+                },
+              ],
+              "config": Array [
+                Object {
+                  "afterMiddleware": "compression",
+                  "configuration": Object {
+                    "ignoreCertError": false,
+                    "ui5": Object {
+                      "path": Array [
+                        "/resources",
+                        "/test-resources",
+                      ],
+                      "url": "https://ui5.sap.com",
+                      "version": "",
+                    },
+                  },
+                  "name": "fiori-tools-proxy",
+                },
+              ],
+            }
         `);
     });
 });


### PR DESCRIPTION
Addresses:  https://github.com/SAP/open-ux-tools/issues/80
Also moves ui5-mock.yaml as requested by @tobiasqueck 