### PR TITLE
chore: ensure pretty-quick respects .prettierignore file

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx pretty-quick --staged
+npx pretty-quick --staged --ignore-path .prettierignore


### PR DESCRIPTION
This PR adds `--ignore-path .prettierignore` to the `pretty-quick` config so that `.prettierignore` settings are respected.