### PR TITLE
feat(fiori-freestyle): make relative UI5 resource paths compatible with OPA pipeline

### DIFF
--- a/packages/fiori-freestyle-writer/templates/common/add/webapp/test/flpSandbox.html
+++ b/packages/fiori-freestyle-writer/templates/common/add/webapp/test/flpSandbox.html
@@ -54,10 +54,10 @@
 		};
 	</script>
 
-	<script src="/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
+	<script src="../test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id="sap-ui-bootstrap"
-		src="/resources/sap-ui-core.js"
+		src="../resources/sap-ui-core.js"
 		data-sap-ui-libs="<%- ui5.ui5Libs %>"
 		data-sap-ui-async="true"
 		data-sap-ui-preload="async"

--- a/packages/fiori-freestyle-writer/templates/common/add/webapp/utils/locate-reuse-libs.js
+++ b/packages/fiori-freestyle-writer/templates/common/add/webapp/utils/locate-reuse-libs.js
@@ -1,100 +1,114 @@
 /*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = "";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            "sap.apf",
-            "sap.base",
-            "sap.chart",
-            "sap.collaboration",
-            "sap.f",
-            "sap.fe",
-            "sap.fileviewer",
-            "sap.gantt",
-            "sap.landvisz",
-            "sap.m",
-            "sap.ndc",
-            "sap.ovp",
-            "sap.rules",
-            "sap.suite",
-            "sap.tnt",
-            "sap.ui",
-            "sap.uiext",
-            "sap.ushell",
-            "sap.uxap",
-            "sap.viz",
-            "sap.webanalytics",
-            "sap.zen"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest["sap.ui5"] &&
-                            manifest["sap.ui5"].dependencies &&
-                            manifest["sap.ui5"].dependencies.libs
-                        ) {
-                            Object.keys(manifest["sap.ui5"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + "."); })) {
-                                    if (result.length > 0) {
-                                        result = result + "," + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error("Could not fetch manifest at '" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = "/sap/bc/ui2/app_index/ui5_app_info?id=" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get("sap-client");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + "&sap-client=" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === "UI5LIB") {
-                                        jQuery.sap.log.info(
-                                            "Registering Library " +
-                                            dependency.componentId +
-                                            " from server " +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = "";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      "sap.apf",
+      "sap.base",
+      "sap.chart",
+      "sap.collaboration",
+      "sap.f",
+      "sap.fe",
+      "sap.fileviewer",
+      "sap.gantt",
+      "sap.landvisz",
+      "sap.m",
+      "sap.ndc",
+      "sap.ovp",
+      "sap.rules",
+      "sap.suite",
+      "sap.tnt",
+      "sap.ui",
+      "sap.uiext",
+      "sap.ushell",
+      "sap.uxap",
+      "sap.viz",
+      "sap.webanalytics",
+      "sap.zen"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + "."); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + "," + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest["sap.ui5"] &&
+              manifest["sap.ui5"].dependencies
+            ) {
+              if (manifest["sap.ui5"].dependencies.libs){
+                result = getKeys(manifest["sap.ui5"].dependencies.libs, result)
+              }
+              if (manifest["sap.ui5"].dependencies.components){
+                result = getKeys(manifest["sap.ui5"].dependencies.components, result)
+              }
             }
+            if (
+              manifest["sap.ui5"] &&
+              manifest["sap.ui5"].componentUsages
+            ) {
+              result = getKeys(manifest["sap.ui5"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error("Could not fetch manifest at '" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = "/sap/bc/ui2/app_index/ui5_app_info?id=" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get("sap-client");
+        if (sapClient && sapClient.length === 3) {
+          url = url + "&sap-client=" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === "UI5LIB") {
+                    jQuery.sap.log.info(
+                      "Registering Library " +
+                      dependency.componentId +
+                      " from server " +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -104,53 +118,53 @@ var manifestUri = currentScript.getAttribute("data-sap-ui-manifest-uri");
 var componentName = currentScript.getAttribute("data-sap-ui-componentName");
 var useMockserver = currentScript.getAttribute("data-sap-ui-use-mockserver");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require("jquery.sap.resources");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: "i18n/i18n.properties",
-                locale: sLocale
-            });
-            document.title = oBundle.getText("appTitle");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === "true") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\./g, "/") + "/localService/mockserver"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt("content");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require(["sap/ui/core/ComponentSupport"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require("jquery.sap.resources");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: "i18n/i18n.properties",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText("appTitle");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt("content");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require("jquery.sap.resources");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: "i18n/i18n.properties",
+        locale: sLocale
+      });
+      document.title = oBundle.getText("appTitle");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === "true") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\./g, "/") + "/localService/mockserver"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt("content");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require(["sap/ui/core/ComponentSupport"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require("jquery.sap.resources");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: "i18n/i18n.properties",
+            locale: sLocale
+          });
+          document.title = oBundle.getText("appTitle");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt("content");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -418,10 +418,10 @@ title=App Title",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.f,sap.m,sap.suite.ui.generic.template,sap.ui.comp,sap.ui.core,sap.ui.generic.app,sap.ui.table,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -447,101 +447,115 @@ title=App Title",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -551,54 +565,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
@@ -2079,10 +2079,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.m,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -2108,101 +2108,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -2212,54 +2226,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",
@@ -4174,10 +4188,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.m,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -4203,101 +4217,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -4307,54 +4335,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -1999,10 +1999,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.m,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -2028,101 +2028,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -2132,54 +2146,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -6276,10 +6276,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.f,sap.m,sap.suite.ui.generic.template,sap.ui.comp,sap.ui.core,sap.ui.generic.app,sap.ui.table,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -6305,101 +6305,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -6409,54 +6423,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",
@@ -9504,10 +9518,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.f,sap.m,sap.suite.ui.generic.template,sap.ui.comp,sap.ui.core,sap.ui.generic.app,sap.ui.table,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -9533,101 +9547,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -9637,54 +9665,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",
@@ -12340,10 +12368,10 @@ errorText=Sorry, a technical error occurred! Please try again later.",
 		};
 	</script>
 
-	<script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+	<script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
 	<!-- Bootstrap the UI5 core library -->
 	<script id=\\"sap-ui-bootstrap\\"
-		src=\\"/resources/sap-ui-core.js\\"
+		src=\\"../resources/sap-ui-core.js\\"
 		data-sap-ui-libs=\\"sap.f,sap.m,sap.suite.ui.generic.template,sap.ui.comp,sap.ui.core,sap.ui.generic.app,sap.ui.table,sap.ushell\\"
 		data-sap-ui-async=\\"true\\"
 		data-sap-ui-preload=\\"async\\"
@@ -12369,101 +12397,115 @@ errorText=Sorry, a technical error occurred! Please try again later.",
   "webapp/utils/locate-reuse-libs.js": Object {
     "contents": "/*eslint-disable semi, no-console*/
 (function (sap) {
-    var fioriToolsGetManifestLibs = function (manifestPath) {
-        var url = manifestPath;
-        var result = \\"\\";
-        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
-        var ui5Libs = [
-            \\"sap.apf\\",
-            \\"sap.base\\",
-            \\"sap.chart\\",
-            \\"sap.collaboration\\",
-            \\"sap.f\\",
-            \\"sap.fe\\",
-            \\"sap.fileviewer\\",
-            \\"sap.gantt\\",
-            \\"sap.landvisz\\",
-            \\"sap.m\\",
-            \\"sap.ndc\\",
-            \\"sap.ovp\\",
-            \\"sap.rules\\",
-            \\"sap.suite\\",
-            \\"sap.tnt\\",
-            \\"sap.ui\\",
-            \\"sap.uiext\\",
-            \\"sap.ushell\\",
-            \\"sap.uxap\\",
-            \\"sap.viz\\",
-            \\"sap.webanalytics\\",
-            \\"sap.zen\\"
-        ];
-        return new Promise(function (resolve, reject) {
-            $.ajax(url)
-                .done(function (manifest) {
-                    if (manifest) {
-                        if (
-                            manifest[\\"sap.ui5\\"] &&
-                            manifest[\\"sap.ui5\\"].dependencies &&
-                            manifest[\\"sap.ui5\\"].dependencies.libs
-                        ) {
-                            Object.keys(manifest[\\"sap.ui5\\"].dependencies.libs).forEach(function (manifestLibKey) {
-                                // ignore libs that start with SAPUI5 delivered namespaces
-                                if (!ui5Libs.some(function (substring) { return manifestLibKey === substring || manifestLibKey.startsWith(substring + \\".\\"); })) {
-                                    if (result.length > 0) {
-                                        result = result + \\",\\" + manifestLibKey;
-                                    } else {
-                                        result = manifestLibKey;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                    resolve(result);
-                })
-                .fail(function (error) {
-                    reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
-                });
-        });
-    };
-    /**
-     * Registers the module paths for dependencies of the given component.
-     * @param {string} manifestPath The the path to the app manifest path
-     * for which the dependencies should be registered.
-     * @returns {Promise} A promise which is resolved when the ajax request for
-     * the app-index was successful and the module paths were registered.
-     */
-    sap.registerComponentDependencyPaths = function (manifestPath) {
-        /*eslint-disable semi, consistent-return*/
-        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
-            if (libs && libs.length > 0) {
-                var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
-                var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
-                if (sapClient && sapClient.length === 3) {
-                    url = url + \\"&sap-client=\\" + sapClient;
-                }
-                return $.ajax(url).done(function (data) {
-                    if (data) {
-                        Object.keys(data).forEach(function (moduleDefinitionKey) {
-                            var moduleDefinition = data[moduleDefinitionKey];
-                            if (moduleDefinition && moduleDefinition.dependencies) {
-                                moduleDefinition.dependencies.forEach(function (dependency) {
-                                    if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
-                                        jQuery.sap.log.info(
-                                            \\"Registering Library \\" +
-                                            dependency.componentId +
-                                            \\" from server \\" +
-                                            dependency.url
-                                        );
-                                        jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+  var fioriToolsGetManifestLibs = function (manifestPath) {
+    var url = manifestPath;
+    var result = \\"\\";
+    // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+    var ui5Libs = [
+      \\"sap.apf\\",
+      \\"sap.base\\",
+      \\"sap.chart\\",
+      \\"sap.collaboration\\",
+      \\"sap.f\\",
+      \\"sap.fe\\",
+      \\"sap.fileviewer\\",
+      \\"sap.gantt\\",
+      \\"sap.landvisz\\",
+      \\"sap.m\\",
+      \\"sap.ndc\\",
+      \\"sap.ovp\\",
+      \\"sap.rules\\",
+      \\"sap.suite\\",
+      \\"sap.tnt\\",
+      \\"sap.ui\\",
+      \\"sap.uiext\\",
+      \\"sap.ushell\\",
+      \\"sap.uxap\\",
+      \\"sap.viz\\",
+      \\"sap.webanalytics\\",
+      \\"sap.zen\\"
+    ];
+    function getKeys(libOrComp,libOrCompKeysString) {
+      Object.keys(libOrComp).forEach(function (libOrCompKey) {
+        // ignore libs or Components that start with SAPUI5 delivered namespaces
+        if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + \\".\\"); })) {
+          if (libOrCompKeysString.length > 0) {
+            libOrCompKeysString = libOrCompKeysString + \\",\\" + libOrCompKey;
+          } else {
+            libOrCompKeysString = libOrCompKey;
+          }
+        }
+      });
+      return libOrCompKeysString;
+    }
+    return new Promise(function (resolve, reject) {
+      $.ajax(url)
+        .done(function (manifest) {
+          if (manifest) {
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].dependencies
+            ) {
+              if (manifest[\\"sap.ui5\\"].dependencies.libs){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.libs, result)
+              }
+              if (manifest[\\"sap.ui5\\"].dependencies.components){
+                result = getKeys(manifest[\\"sap.ui5\\"].dependencies.components, result)
+              }
             }
+            if (
+              manifest[\\"sap.ui5\\"] &&
+              manifest[\\"sap.ui5\\"].componentUsages
+            ) {
+              result = getKeys(manifest[\\"sap.ui5\\"].componentUsages, result)
+            }
+          }
+          resolve(result);
+        })
+        .fail(function (error) {
+          reject(new Error(\\"Could not fetch manifest at '\\" + manifestPath));
         });
-    };
+    });
+  };
+  /**
+   * Registers the module paths for dependencies of the given component.
+   * @param {string} manifestPath The the path to the app manifest path
+   * for which the dependencies should be registered.
+   * @returns {Promise} A promise which is resolved when the ajax request for
+   * the app-index was successful and the module paths were registered.
+   */
+  sap.registerComponentDependencyPaths = function (manifestPath) {
+    /*eslint-disable semi, consistent-return*/
+    return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+      if (libs && libs.length > 0) {
+        var url = \\"/sap/bc/ui2/app_index/ui5_app_info?id=\\" + libs;
+        var sapClient = jQuery.sap.getUriParameters().get(\\"sap-client\\");
+        if (sapClient && sapClient.length === 3) {
+          url = url + \\"&sap-client=\\" + sapClient;
+        }
+        return $.ajax(url).done(function (data) {
+          if (data) {
+            Object.keys(data).forEach(function (moduleDefinitionKey) {
+              var moduleDefinition = data[moduleDefinitionKey];
+              if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                  if (dependency.url && dependency.url.length > 0 && dependency.type === \\"UI5LIB\\") {
+                    jQuery.sap.log.info(
+                      \\"Registering Library \\" +
+                      dependency.componentId +
+                      \\" from server \\" +
+                      dependency.url
+                    );
+                    jQuery.sap.registerModulePath(dependency.componentId, dependency.url);
+                  }
+                });
+              }
+            });
+          }
+        });
+      }
+    });
+  };
 })(sap);
 
 /*eslint-disable sap-browser-api-warning, sap-no-dom-access*/
@@ -12473,54 +12515,54 @@ var manifestUri = currentScript.getAttribute(\\"data-sap-ui-manifest-uri\\");
 var componentName = currentScript.getAttribute(\\"data-sap-ui-componentName\\");
 var useMockserver = currentScript.getAttribute(\\"data-sap-ui-use-mockserver\\");
 sap.registerComponentDependencyPaths(manifestUri)
-    .catch(function (error) {
-        jQuery.sap.log.error(error);
-    })
-    .finally(function () {
+  .catch(function (error) {
+    jQuery.sap.log.error(error);
+  })
+  .finally(function () {
 
-        // setting the app title with internationalization 
-        sap.ui.getCore().attachInit(function () {
-            jQuery.sap.require(\\"jquery.sap.resources\\");
-            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-            var oBundle = jQuery.sap.resources({
-                url: \\"i18n/i18n.properties\\",
-                locale: sLocale
-            });
-            document.title = oBundle.getText(\\"appTitle\\");
-        });
-
-        if (componentName && componentName.length > 0) {
-            if (useMockserver && useMockserver === \\"true\\") {
-                sap.ui.getCore().attachInit(function () {
-                    sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
-                        // set up test service for local testing
-                        server.init();
-                        // initialize the ushell sandbox component
-                        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-                    });
-                });
-            } else {
-                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
-                sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
-
-                // setting the app title with the i18n text 
-                sap.ui.getCore().attachInit(function () {
-                    jQuery.sap.require(\\"jquery.sap.resources\\");
-                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
-                    var oBundle = jQuery.sap.resources({
-                        url: \\"i18n/i18n.properties\\",
-                        locale: sLocale
-                    });
-                    document.title = oBundle.getText(\\"appTitle\\");
-                });
-            }
-        } else {
-            sap.ui.getCore().attachInit(function () {
-                // initialize the ushell sandbox component
-                sap.ushell.Container.createRenderer().placeAt(\\"content\\");
-            });
-        }
+    // setting the app title with internationalization
+    sap.ui.getCore().attachInit(function () {
+      jQuery.sap.require(\\"jquery.sap.resources\\");
+      var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+      var oBundle = jQuery.sap.resources({
+        url: \\"i18n/i18n.properties\\",
+        locale: sLocale
+      });
+      document.title = oBundle.getText(\\"appTitle\\");
     });
+
+    if (componentName && componentName.length > 0) {
+      if (useMockserver && useMockserver === \\"true\\") {
+        sap.ui.getCore().attachInit(function () {
+          sap.ui.require([componentName.replace(/\\\\./g, \\"/\\") + \\"/localService/mockserver\\"], function (server) {
+            // set up test service for local testing
+            server.init();
+            // initialize the ushell sandbox component
+            sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+          });
+        });
+      } else {
+        // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+        sap.ui.require([\\"sap/ui/core/ComponentSupport\\"]);
+
+        // setting the app title with the i18n text
+        sap.ui.getCore().attachInit(function () {
+          jQuery.sap.require(\\"jquery.sap.resources\\");
+          var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+          var oBundle = jQuery.sap.resources({
+            url: \\"i18n/i18n.properties\\",
+            locale: sLocale
+          });
+          document.title = oBundle.getText(\\"appTitle\\");
+        });
+      }
+    } else {
+      sap.ui.getCore().attachInit(function () {
+        // initialize the ushell sandbox component
+        sap.ushell.Container.createRenderer().placeAt(\\"content\\");
+      });
+    }
+  });
 
 sap.registerComponentDependencyPaths(manifestUri);
 ",


### PR DESCRIPTION
This PR:
* makes UI5 resource paths compatible with OPA pipeline
* updates locate-reuse-lib.js to load components and componentUsages from Frontend server