### PR TITLE
chore: update version pipeline to use github PAT

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,6 +56,7 @@ jobs:
               uses: actions/checkout@v2
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.ACCESS_PAT }}
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.0.1
               with:
@@ -130,3 +131,5 @@ jobs:
               uses: changesets/action@b98cec97583b917ff1dc6179dd4d230d3e439894
               with:
                   publish: pnpm ci:publish
+              env:
+                  GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}


### PR DESCRIPTION
* Update `version` pipeline to use GitHub personal access token to ensure the pipeline is able to commit and push the changeset version commit.