### PR TITLE
update(freestyle): update eslint.rc to ignore dist folder after deployment

### DIFF
--- a/packages/ui5-application-writer/templates/optional/eslint/.eslintrc
+++ b/packages/ui5-application-writer/templates/optional/eslint/.eslintrc
@@ -7,6 +7,7 @@
   ],
   "ignorePatterns": [
     "webapp/localservice/**",
-    "webapp/test/**"
+    "webapp/test/**",
+    "dist/**"
   ]
 }


### PR DESCRIPTION
## Issue Description

Issue #213 

relevant to issue in App Gen where eslint doesn't cover deployed app dist folder and throws errors. This has since been rectified for Fiori-elements but is still presenting issues for fiori freestyle, as shown:

![ff_issue](https://user-images.githubusercontent.com/95859201/145396632-c6cfdf13-7a20-41d5-9890-ec248541c871.png)


## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change.
- [x] The code conforms to the general [development principles](https://github.wdf.sap.corp/ux-engineering/tools-suite/tree/master/docs/dev-guide).
- [x] This branch is appropriately named for the associated issue.
