### PR TITLE
fix(fev4-fpm): Custom Section. Two 'manifest.json' generations versions for different UI5 versions below and above 1.86

### DIFF
--- a/.changeset/fresh-ears-doubt.md
+++ b/.changeset/fresh-ears-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Custom Section. Fix to support old(<1.86) and new(>=1.86) manifest.json syntaxes

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -8,6 +8,21 @@ import { Manifest } from '../common/types';
 import { setCommonDefaults, getDefaultFragmentContent } from '../common/defaults';
 
 /**
+ * Get the template folder for the given UI5 version.
+ *
+ * @param ui5Version required UI5 version.
+ * @returns path to the template folder containing the manifest.json ejs template
+ */
+export function getManifestRoot(root: string, ui5Version?: number): string {
+    let subFolder = '1.86';
+    if (ui5Version !== undefined && ui5Version < 1.86) {
+        // Old
+        subFolder = '1.85';
+    }
+    return join(root, 'section', subFolder);
+}
+
+/**
  * Enhances the provided custom section configuration with additonal data.
  *
  * @param {CustomSection} data - a custom section configuration object
@@ -63,7 +78,8 @@ export function generateCustomSection(basePath: string, customSection: CustomSec
     }
 
     // enhance manifest with section definition
-    const filledTemplate = render(fs.read(join(root, `section/manifest.section.json`)), completeSection);
+    const manifestRoot = getManifestRoot(root, customSection.ui5Version);
+    const filledTemplate = render(fs.read(join(manifestRoot, `manifest.json`)), completeSection);
     fs.extendJSON(manifestPath, JSON.parse(filledTemplate));
 
     // add fragment

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -10,6 +10,7 @@ import { setCommonDefaults, getDefaultFragmentContent } from '../common/defaults
 /**
  * Get the template folder for the given UI5 version.
  *
+ * @param root root path to templates folder.
  * @param ui5Version required UI5 version.
  * @returns path to the template folder containing the manifest.json ejs template
  */

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -26,6 +26,12 @@ export interface CustomSection extends CustomElement {
      * Optional control XML that will be generated into the fragment of section. If the property isn't provided then a sample control will be generated.
      */
     control?: string;
+
+    /**
+     * Optional property to define the minimum UI5 version that the generated code must support.
+     * If undefined then the latest version of the template is used.
+     */
+     ui5Version?: number;
 }
 
 export interface InternalCustomSection extends CustomSection, InternalCustomElement {

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -26,12 +26,6 @@ export interface CustomSection extends CustomElement {
      * Optional control XML that will be generated into the fragment of section. If the property isn't provided then a sample control will be generated.
      */
     control?: string;
-
-    /**
-     * Optional property to define the minimum UI5 version that the generated code must support.
-     * If undefined then the latest version of the template is used.
-     */
-     ui5Version?: number;
 }
 
 export interface InternalCustomSection extends CustomSection, InternalCustomElement {

--- a/packages/fe-fpm-writer/templates/section/1.85/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.85/manifest.json
@@ -1,0 +1,33 @@
+{
+    "sap.ui5": {
+        "routing": {
+            "targets": {
+                "<%- target %>": {
+                    "options": {
+                        "settings": {
+                            "content": {
+                                "body": {
+                                    "sections": {
+                                        "<%- name %>": {
+                                            "name": "<%- ns %>.<%- name %>",
+                                            "type": "XMLFragment",
+                                            "position": {
+                                                <% if (position.placement) { %> 
+                                                    "placement": "<%- position.placement %>", 
+                                                <% } %>
+                                                <% if (position.anchor) { %> 
+                                                    "anchor": "<%- position.anchor %>" 
+                                                <% } %>
+                                            },
+                                            "title": "<%- title %>"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/fe-fpm-writer/templates/section/1.86/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.86/manifest.json
@@ -9,7 +9,7 @@
                                 "body": {
                                     "sections": {
                                         "<%- name %>": {
-                                            "name": "<%- ns %>.<%- name %>",
+                                            "template": "<%- ns %>.<%- name %>",
                                             "position": {
                                                 <% if (position.placement) { %> 
                                                     "placement": "<%- position.placement %>", 

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -452,7 +452,7 @@ Object {
                 \\"body\\": {
                   \\"sections\\": {
                     \\"MyCustomSection\\": {
-                      \\"name\\": \\"v4travel.ext.myCustomSection.MyCustomSection\\",
+                      \\"template\\": \\"v4travel.ext.myCustomSection.MyCustomSection\\",
                       \\"position\\": {
                         \\"placement\\": \\"After\\",
                         \\"anchor\\": \\"DummyFacet\\"

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -1,5 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "title": "Custom Title",
+        "type": "XMLFragment",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "title": "Custom Title",
+        "type": "XMLFragment",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.85, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "title": "Custom Title",
+        "type": "XMLFragment",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.85, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.85, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.86, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "title": "Custom Title",
+        "type": "XMLFragment",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.86, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.86, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
 exports[`CustomSection generateCustomSection generateCustomSection - different data and unexisting target 1`] = `
 Object {
   "dummy": Object {

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -9,11 +9,11 @@ Object {
           "body": Object {
             "sections": Object {
               "DummySection": Object {
-                "name": "sapux.fe.fpm.writer.test.extensions.custom.DummySection",
                 "position": Object {
                   "anchor": "NewDummyFacet",
                   "placement": "Before",
                 },
+                "template": "sapux.fe.fpm.writer.test.extensions.custom.DummySection",
                 "title": "Dummy Section",
               },
             },
@@ -71,11 +71,11 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
       },
     },
@@ -103,11 +103,11 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
       },
     },
@@ -135,11 +135,11 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
       },
     },
@@ -167,11 +167,11 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
       },
     },

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -5,13 +5,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {
@@ -47,18 +46,63 @@ exports[`CustomSection generateCustomSection Versions 1.9, with handler, all pro
 "
 `;
 
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 4`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "title": "Custom Title",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 5`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.9, with handler, all properties 6`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
 exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 1`] = `
 Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
@@ -100,13 +144,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
@@ -148,13 +191,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {
@@ -221,13 +263,12 @@ Object {
           "body": Object {
             "sections": Object {
               "ExistingCustomSection": Object {
-                "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
                 "position": Object {
                   "anchor": "IncidentOverviewFacet",
                   "placement": "Before",
                 },
+                "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
                 "title": "Custom Title",
-                "type": "XMLFragment",
               },
             },
           },
@@ -252,13 +293,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {
@@ -284,13 +324,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {
@@ -316,13 +355,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {
@@ -348,13 +386,12 @@ Object {
   "body": Object {
     "sections": Object {
       "ExistingCustomSection": Object {
-        "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "position": Object {
           "anchor": "IncidentOverviewFacet",
           "placement": "Before",
         },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
-        "type": "XMLFragment",
       },
       "NewCustomSection": Object {
         "position": Object {

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -61,12 +61,13 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
-        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
+        "type": "XMLFragment",
       },
     },
   },
@@ -108,12 +109,13 @@ Object {
         "type": "XMLFragment",
       },
       "NewCustomSection": Object {
+        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
         },
-        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "title": "New Custom Section",
+        "type": "XMLFragment",
       },
     },
   },

--- a/packages/fe-fpm-writer/test/unit/sample/section/webapp/manifest.json
+++ b/packages/fe-fpm-writer/test/unit/sample/section/webapp/manifest.json
@@ -66,12 +66,11 @@
                                 "body": {
                                     "sections": {
                                         "ExistingCustomSection": {
-                                            "name": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+                                            "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
                                             "position": {
                                                 "anchor": "IncidentOverviewFacet",
                                                 "placement": "Before"
                                             },
-                                            "type": "XMLFragment",
                                             "title": "Custom Title"
                                         }
                                     }

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -136,7 +136,7 @@ describe('CustomSection', () => {
             expect(fs.read(fragmentPath)).toMatchSnapshot();
         });
 
-        const testVersions = [1.9, 1.86, 1.85, 1.84];
+        const testVersions = [1.9, 1.85, 1.84,  1.86, 1.90];
         for (const ui5Version of testVersions) {
             test(`Versions ${ui5Version}, with handler, all properties`, () => {
                 const testCustomSection: CustomSection = {

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -137,12 +137,12 @@ describe('CustomSection', () => {
         });
 
         const testVersions = [1.9, 1.86, 1.85, 1.84];
-        for (const testVersion of testVersions) {
-            test(`Versions ${testVersion}, with handler, all properties`, () => {
+        for (const ui5Version of testVersions) {
+            test(`Versions ${ui5Version}, with handler, all properties`, () => {
                 const testCustomSection: CustomSection = {
                     ...customSection,
                     eventHandler: true,
-                    ui5Version: testVersion
+                    ui5Version
                 };
                 generateCustomSection(testDir, { ...testCustomSection }, fs);
                 const updatedManifest: any = fs.readJSON(join(testDir, 'webapp/manifest.json'));


### PR DESCRIPTION
Part of 3rd point from #73

Main PR was - https://github.com/SAP/open-ux-tools/pull/212

According to latest documentation `name` property in `manifest.json` is deprecated since 1.86 and new approach is:
```
"NewCustomSection": {
        "position": {
          "anchor": "DummyFacet",
          "placement": "After",
        },
        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
        "title": "New Custom Section",
      },
```

Old approach is(<1.86):
```
"NewCustomSection": {
        "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
        "position": {
          "anchor": "DummyFacet",
          "placement": "After",
        },
        "title": "New Custom Section",
        "type": "XMLFragment",
      },
```

In scope of PR - we support both variants by specifying target UI5 version.

API was not changed and still accepts property `name` - similar like it is for `columns`. In result property `name` is transferred to `template` or `name` depending on passed target UI5 version