### PR TITLE
fix: avoid double delimiters

### DIFF
--- a/.changeset/eleven-ads-joke.md
+++ b/.changeset/eleven-ads-joke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-freestyle-writer': patch
+---
+
+Fix for double delim '??' in url in package.json scripts when sap-client param is present

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -38,9 +38,9 @@ export function getPackageJsonTasks({
     let searchParam = new URLSearchParams(searchParamList).toString();
     searchParam = searchParam ? `?${searchParam}` : '';
     // Build fragment identifier part of url
-    const harshFragment = flpAppId ? `#${flpAppId}` : '';
+    const hashFragment = flpAppId ? `#${flpAppId}` : '';
     // Full parameter section composed by search param and fragment identifier
-    const params = `${searchParam}${harshFragment}`;
+    const params = `${searchParam}${hashFragment}`;
 
     const startCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -28,10 +28,19 @@ export function getPackageJsonTasks({
     startFile?: string;
     localStartFile?: string;
 }): { start: string; 'start-local': string; 'start-noflp': string; 'start-mock'?: string } {
-    const sapClientParam = sapClient ? `?sap-client=${sapClient}` : '';
-    let urlParam = [sapClientParam, 'sap-ui-xx-viewCache=false'].filter((param) => !!param).join('&');
-    urlParam = urlParam ? `?${urlParam}` : '';
-    const params = `${urlParam}${flpAppId ? `#${flpAppId}` : ''}`;
+    // Build search param part of preview launch url
+    const searchParamList = [];
+    searchParamList.push(['sap-ui-xx-viewCache', 'false']);
+    if (sapClient) {
+        searchParamList.push([`sap-client`, `${sapClient}`]);
+    }
+    let searchParam = new URLSearchParams(searchParamList).toString();
+    searchParam = searchParam ? `?${searchParam}` : '';
+    // Build fragment identifier part of url
+    const harshFragment = flpAppId ? `#${flpAppId}` : '';
+    // Full parameter section composed by search param and fragment identifier
+    const params = `${searchParam}${harshFragment}`;
+
     const startCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
         : `fiori run --open '${startFile || 'test/flpSandbox.html'}${params}'`;
@@ -40,7 +49,7 @@ export function getPackageJsonTasks({
     }${params}'`;
     const startNoFlpCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
-        : `fiori run --open '${'index.html'}${urlParam}'`;
+        : `fiori run --open '${'index.html'}${searchParam}'`;
 
     const mockTask = `fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html${params}'`;
     return Object.assign(

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -30,10 +30,11 @@ export function getPackageJsonTasks({
 }): { start: string; 'start-local': string; 'start-noflp': string; 'start-mock'?: string } {
     // Build search param part of preview launch url
     const searchParamList = [];
-    searchParamList.push(['sap-ui-xx-viewCache', 'false']);
     if (sapClient) {
         searchParamList.push([`sap-client`, `${sapClient}`]);
     }
+    searchParamList.push(['sap-ui-xx-viewCache', 'false']);
+
     let searchParam = new URLSearchParams(searchParamList).toString();
     searchParam = searchParam ? `?${searchParam}` : '';
     // Build fragment identifier part of url

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -6710,13 +6710,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\",
+    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false&sap-client=012'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\"
+    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-client=012&sap-ui-xx-viewCache=false'\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -6710,13 +6710,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html??sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html??sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
+    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html??sap-client=012&sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html??sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\"
+    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false&sap-client=012'\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=012#wrk1-tile'\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/packageConfig.test.ts
+++ b/packages/fiori-freestyle-writer/test/packageConfig.test.ts
@@ -12,10 +12,10 @@ describe('Test common utils', () => {
                 })
             ).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open 'test/flpSandbox.html??sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html??sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html??sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-noflp": "fiori run --open 'index.html??sap-client=100&sap-ui-xx-viewCache=false'",
+                  "start": "fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
+                  "start-noflp": "fiori run --open 'index.html?sap-ui-xx-viewCache=false&sap-client=100'",
                 }
             `);
         });

--- a/packages/fiori-freestyle-writer/test/packageConfig.test.ts
+++ b/packages/fiori-freestyle-writer/test/packageConfig.test.ts
@@ -12,10 +12,10 @@ describe('Test common utils', () => {
                 })
             ).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false&sap-client=100#testApp-tile'",
-                  "start-noflp": "fiori run --open 'index.html?sap-ui-xx-viewCache=false&sap-client=100'",
+                  "start": "fiori run --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
+                  "start-noflp": "fiori run --open 'index.html?sap-client=100&sap-ui-xx-viewCache=false'",
                 }
             `);
         });


### PR DESCRIPTION
Fix for : #288

- Forgot to remove ? when building the sap-client parameter. This ? is duplicate when adding ? to the full query param. 
- Use node built-in URLSearchParams instead of using join('&') to build the full query param.
