### PR TITLE
fix(fiori-freestyle-writer): use double quotes for start commands

### DIFF
--- a/.changeset/angry-vans-train.md
+++ b/.changeset/angry-vans-train.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-freestyle-writer': patch
+---
+
+use double quotes for files in start commands

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -44,15 +44,15 @@ export function getPackageJsonTasks({
 
     const startCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
-        : `fiori run --open '${startFile || 'test/flpSandbox.html'}${params}'`;
-    const startLocalCommand = `fiori run --config ./ui5-local.yaml --open '${
+        : `fiori run --open \\"${startFile || 'test/flpSandbox.html'}${params}\\"`;
+    const startLocalCommand = `fiori run --config ./ui5-local.yaml --open \\"${
         localStartFile || 'test/flpSandbox.html'
-    }${params}'`;
+    }${params}\\"`;
     const startNoFlpCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
-        : `fiori run --open '${'index.html'}${searchParam}'`;
+        : `fiori run --open \\"${'index.html'}${searchParam}\\"`;
 
-    const mockTask = `fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html${params}'`;
+    const mockTask = `fiori run --config ./ui5-mock.yaml --open \\"test/flpSandbox.html${params}\\"`;
     return Object.assign(
         {
             start: startCommand,

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -44,15 +44,15 @@ export function getPackageJsonTasks({
 
     const startCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
-        : `fiori run --open \\"${startFile || 'test/flpSandbox.html'}${params}\\"`;
-    const startLocalCommand = `fiori run --config ./ui5-local.yaml --open \\"${
+        : `fiori run --open "${startFile || 'test/flpSandbox.html'}${params}"`;
+    const startLocalCommand = `fiori run --config ./ui5-local.yaml --open "${
         localStartFile || 'test/flpSandbox.html'
-    }${params}\\"`;
+    }${params}"`;
     const startNoFlpCommand = localOnly
         ? `echo \\"${t('info.mockOnlyWarning')}\\"`
-        : `fiori run --open \\"${'index.html'}${searchParam}\\"`;
+        : `fiori run --open "${'index.html'}${searchParam}"`;
 
-    const mockTask = `fiori run --config ./ui5-mock.yaml --open \\"test/flpSandbox.html${params}\\"`;
+    const mockTask = `fiori run --config ./ui5-mock.yaml --open "test/flpSandbox.html${params}"`;
     return Object.assign(
         {
             start: startCommand,

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -33,12 +33,12 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -681,12 +681,12 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -33,12 +33,12 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -681,12 +681,12 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#nods1-tile\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
@@ -34,13 +34,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -1288,13 +1288,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -3890,13 +3890,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
@@ -34,13 +34,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -1288,13 +1288,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -3890,13 +3890,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -34,13 +34,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -34,13 +34,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#testme-app\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -35,12 +35,12 @@ archive.zip
   },
   \\"scripts\\": {
     \\"start\\": \\"echo \\\\\\\\\\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile'\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
     \\"start-noflp\\": \\"echo \\\\\\\\\\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile'\\"
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -6710,13 +6710,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-client=012&sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-client=012&sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -9995,13 +9995,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile'\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile'\\",
+    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open 'index.html?sap-ui-xx-viewCache=false'\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile'\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -35,12 +35,12 @@ archive.zip
   },
   \\"scripts\\": {
     \\"start\\": \\"echo \\\\\\\\\\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
     \\"start-noflp\\": \\"echo \\\\\\\\\\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -6710,13 +6710,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-client=012&sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-client=012&sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-client=012&sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [
@@ -9995,13 +9995,13 @@ archive.zip
     \\"@sap/ux-ui5-fe-mockserver-middleware\\": \\"1\\"
   },
   \\"scripts\\": {
-    \\"start\\": \\"fiori run --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
-    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\",
+    \\"start\\": \\"fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\",
+    \\"start-local\\": \\"fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\",
     \\"build\\": \\"ui5 build --config=ui5.yaml --clean-dest --dest dist\\",
     \\"deploy\\": \\"fiori verify\\",
     \\"deploy-config\\": \\"fiori add deploy-config\\",
-    \\"start-noflp\\": \\"fiori run --open \\\\\\\\\\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\\\\\\\\\"\\",
-    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\\\\\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\\\\\\\\\"\\"
+    \\"start-noflp\\": \\"fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"\\",
+    \\"start-mock\\": \\"fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false#wrk1-tile\\\\\\"\\"
   },
   \\"ui5\\": {
     \\"dependencies\\": [

--- a/packages/fiori-freestyle-writer/test/packageConfig.test.ts
+++ b/packages/fiori-freestyle-writer/test/packageConfig.test.ts
@@ -12,10 +12,10 @@ describe('Test common utils', () => {
                 })
             ).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile'",
-                  "start-noflp": "fiori run --open 'index.html?sap-client=100&sap-ui-xx-viewCache=false'",
+                  "start": "fiori run --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
+                  "start-noflp": "fiori run --open \\\\\\"index.html?sap-client=100&sap-ui-xx-viewCache=false\\\\\\"",
                 }
             `);
         });
@@ -23,10 +23,10 @@ describe('Test common utils', () => {
         test('addMock: true, sap-client not specified', () => {
             expect(getPackageJsonTasks({ localOnly: false, addMock: true })).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false'",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false'",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open 'test/flpSandbox.html?sap-ui-xx-viewCache=false'",
-                  "start-noflp": "fiori run --open 'index.html?sap-ui-xx-viewCache=false'",
+                  "start": "fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
+                  "start-noflp": "fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"",
                 }
             `);
         });
@@ -40,12 +40,12 @@ describe('Test common utils', () => {
                     localStartFile: 'testLocalStart.html'
                 })
             ).toMatchInlineSnapshot(`
-                            Object {
-                              "start": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
-                              "start-local": "fiori run --config ./ui5-local.yaml --open 'testLocalStart.html?sap-ui-xx-viewCache=false#testApp-tile'",
-                              "start-noflp": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
-                            }
-                    `);
+                Object {
+                  "start": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"testLocalStart.html?sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
+                  "start-noflp": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
+                }
+            `);
         });
     });
 });

--- a/packages/fiori-freestyle-writer/test/packageConfig.test.ts
+++ b/packages/fiori-freestyle-writer/test/packageConfig.test.ts
@@ -12,10 +12,10 @@ describe('Test common utils', () => {
                 })
             ).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
-                  "start-noflp": "fiori run --open \\\\\\"index.html?sap-client=100&sap-ui-xx-viewCache=false\\\\\\"",
+                  "start": "fiori run --open \\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\"",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\"test/flpSandbox.html?sap-client=100&sap-ui-xx-viewCache=false#testApp-tile\\"",
+                  "start-noflp": "fiori run --open \\"index.html?sap-client=100&sap-ui-xx-viewCache=false\\"",
                 }
             `);
         });
@@ -23,10 +23,10 @@ describe('Test common utils', () => {
         test('addMock: true, sap-client not specified', () => {
             expect(getPackageJsonTasks({ localOnly: false, addMock: true })).toMatchInlineSnapshot(`
                 Object {
-                  "start": "fiori run --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
-                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\\\\\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\\\\\"",
-                  "start-noflp": "fiori run --open \\\\\\"index.html?sap-ui-xx-viewCache=false\\\\\\"",
+                  "start": "fiori run --open \\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\"",
+                  "start-mock": "fiori run --config ./ui5-mock.yaml --open \\"test/flpSandbox.html?sap-ui-xx-viewCache=false\\"",
+                  "start-noflp": "fiori run --open \\"index.html?sap-ui-xx-viewCache=false\\"",
                 }
             `);
         });
@@ -42,7 +42,7 @@ describe('Test common utils', () => {
             ).toMatchInlineSnapshot(`
                 Object {
                   "start": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
-                  "start-local": "fiori run --config ./ui5-local.yaml --open \\\\\\"testLocalStart.html?sap-ui-xx-viewCache=false#testApp-tile\\\\\\"",
+                  "start-local": "fiori run --config ./ui5-local.yaml --open \\"testLocalStart.html?sap-ui-xx-viewCache=false#testApp-tile\\"",
                   "start-noflp": "echo \\\\\\"This application was generated with a local metadata file and does not reference a live server. Please add the required server configuration or start this application with mock data using the target: npm run start-mock\\\\\\"",
                 }
             `);


### PR DESCRIPTION
#271 

Use double quotes for start commands in package.json, this will enable handling of params it in the start args with multiple params across platforms.