### PR TITLE
fix: include property for id

### DIFF
--- a/.changeset/little-foxes-clap.md
+++ b/.changeset/little-foxes-clap.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': minor
+---
+
+new property "id" for custom sections

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -2,6 +2,11 @@ import { CustomElement, InternalCustomElement, Position } from '../common/types'
 
 export interface CustomSection extends CustomElement {
     /**
+     * Unique section identifier
+     */
+    id: string;
+
+    /**
      * Name of the routing target
      */
     target: string;

--- a/packages/fe-fpm-writer/templates/section/1.85/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.85/manifest.json
@@ -8,7 +8,7 @@
                             "content": {
                                 "body": {
                                     "sections": {
-                                        "<%- name %>": {
+                                        "<%- id %>": {
                                             "name": "<%- ns %>.<%- name %>",
                                             "type": "XMLFragment",
                                             "position": {

--- a/packages/fe-fpm-writer/templates/section/1.86/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.86/manifest.json
@@ -8,7 +8,7 @@
                             "content": {
                                 "body": {
                                     "sections": {
-                                        "<%- name %>": {
+                                        "<%- id %>": {
                                             "template": "<%- ns %>.<%- name %>",
                                             "position": {
                                                 <% if (position.placement) { %> 

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -451,7 +451,7 @@ Object {
                 },
                 \\"body\\": {
                   \\"sections\\": {
-                    \\"MyCustomSection\\": {
+                    \\"sectionId\\": {
                       \\"template\\": \\"v4travel.ext.myCustomSection.MyCustomSection\\",
                       \\"position\\": {
                         \\"placement\\": \\"After\\",

--- a/packages/fe-fpm-writer/test/integration/index.test.ts
+++ b/packages/fe-fpm-writer/test/integration/index.test.ts
@@ -104,6 +104,7 @@ describe('use FPM with existing apps', () => {
             generateCustomSection(
                 targetPath,
                 {
+                    id: 'sectionId',
                     name: 'MyCustomSection',
                     target: 'TravelObjectPage',
                     title: 'My Custom Section',

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -12,7 +12,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -58,7 +58,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
@@ -105,7 +105,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
         "position": Object {
           "anchor": "DummyFacet",
@@ -152,7 +152,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -198,7 +198,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -244,7 +244,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -271,7 +271,7 @@ Object {
         "content": Object {
           "body": Object {
             "sections": Object {
-              "DummySection": Object {
+              "sectionId": Object {
                 "position": Object {
                   "anchor": "NewDummyFacet",
                   "placement": "Before",
@@ -331,7 +331,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -362,7 +362,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -393,7 +393,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",
@@ -418,7 +418,7 @@ Object {
         "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
         "title": "Custom Title",
       },
-      "NewCustomSection": Object {
+      "sectionId": Object {
         "position": Object {
           "anchor": "DummyFacet",
           "placement": "After",

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -34,6 +34,7 @@ describe('CustomSection', () => {
     describe('generateCustomSection', () => {
         let fs: Editor;
         const customSection: CustomSection = {
+            id: 'sectionId',
             target: 'sample',
             name: 'NewCustomSection',
             folder: 'extensions/custom',
@@ -128,6 +129,7 @@ describe('CustomSection', () => {
 
         test('different data and not existing target', () => {
             const testCustomSection: CustomSection = {
+                id: 'sectionId',
                 target: 'dummy',
                 name: 'DummySection',
                 folder: 'extensions/custom',


### PR DESCRIPTION
Part of 3rd point from https://github.com/SAP/open-ux-tools/issues/73

Root implementation was 
https://github.com/SAP/open-ux-tools/pull/212
https://github.com/SAP/open-ux-tools/pull/238

While I started to use custom sections - I noticed that `name` and `id`(object key) was not separated.
In result introducing new property `id` for custom section extension.