### PR TITLE
fix(fe-fpm-writer): namespace resolution handle backslashes

### DIFF
--- a/.changeset/metal-ads-tell.md
+++ b/.changeset/metal-ads-tell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': minor
+---
+
+custom extension - consider backslashes when "folder" converted into namespace for "template"

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -22,7 +22,7 @@ export function setCommonDefaults<T extends CustomElement & Partial<InternalCust
     config.folder = config.folder || `ext/${firstChar.toLocaleLowerCase() + config.name.substring(1)}`;
 
     // calculate namespace and path for generated artifacts
-    config.ns = `${manifest['sap.app'].id}.${config.folder.replace(/\/|\\/g, '.')}`;
+    config.ns = `${manifest['sap.app'].id}.${config.folder.replace(/[\/\\]/g, '.')}`;
     config.path = join(dirname(manifestPath), config.folder);
 
     return config as InternalCustomElement & T;

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -22,7 +22,7 @@ export function setCommonDefaults<T extends CustomElement & Partial<InternalCust
     config.folder = config.folder || `ext/${firstChar.toLocaleLowerCase() + config.name.substring(1)}`;
 
     // calculate namespace and path for generated artifacts
-    config.ns = `${manifest['sap.app'].id}.${config.folder.replace(/\//g, '.')}`;
+    config.ns = `${manifest['sap.app'].id}.${config.folder.replace(/\/|\\/g, '.')}`;
     config.path = join(dirname(manifestPath), config.folder);
 
     return config as InternalCustomElement & T;

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -170,5 +170,29 @@ describe('CustomSection', () => {
                 expect(fs.read(expectedFragmentPath.replace('.fragment.xml', '.js'))).toMatchSnapshot();
             });
         }
+
+        const folderVariants = ['extensions/custom', 'extensions\\custom'];
+        for (const folderVariant of folderVariants) {
+            test(`Existing folder variations - ${folderVariant}`, () => {
+                const testCustomSection: CustomSection = {
+                    target: 'dummy',
+                    name: 'DummySection',
+                    folder: folderVariant,
+                    title: 'Dummy Section',
+                    position: {
+                        placement: Placement.Before,
+                        anchor: 'NewDummyFacet'
+                    }
+                };
+                generateCustomSection(testDir, { ...testCustomSection }, fs);
+                const updatedManifest: any = fs.readJSON(join(testDir, 'webapp/manifest.json'));
+
+                const section =
+                    updatedManifest['sap.ui5']['routing']['targets'][testCustomSection.target]['options']['settings'][
+                        'content'
+                    ]['body']['sections'][testCustomSection.name];
+                expect(section.template).toEqual('sapux.fe.fpm.writer.test.extensions.custom.DummySection');
+            });
+        }
     });
 });

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -174,16 +174,8 @@ describe('CustomSection', () => {
         const folderVariants = ['extensions/custom', 'extensions\\custom'];
         for (const folderVariant of folderVariants) {
             test(`Existing folder variations - ${folderVariant}`, () => {
-                const testCustomSection: CustomSection = {
-                    target: 'dummy',
-                    name: 'DummySection',
-                    folder: folderVariant,
-                    title: 'Dummy Section',
-                    position: {
-                        placement: Placement.Before,
-                        anchor: 'NewDummyFacet'
-                    }
-                };
+                const testCustomSection = JSON.parse(JSON.stringify(customSection));
+                testCustomSection.folder = folderVariant;
                 generateCustomSection(testDir, { ...testCustomSection }, fs);
                 const updatedManifest: any = fs.readJSON(join(testDir, 'webapp/manifest.json'));
 
@@ -191,7 +183,9 @@ describe('CustomSection', () => {
                     updatedManifest['sap.ui5']['routing']['targets'][testCustomSection.target]['options']['settings'][
                         'content'
                     ]['body']['sections'][testCustomSection.name];
-                expect(section.template).toEqual('sapux.fe.fpm.writer.test.extensions.custom.DummySection');
+                expect(section.template).toEqual(
+                    `sapux.fe.fpm.writer.test.extensions.custom.${testCustomSection.name}`
+                );
             });
         }
     });


### PR DESCRIPTION
While working on integration of custom sections(custom sections was 3rd point from https://github.com/SAP/open-ux-tools/issues/73)

Issue relates to custom extension like Custom Section, Custom Column.
Issue happens if we pass `folder` property with backslashes `ext\\fragment`, then it would resolved as:
```
"fragmentName": "project4.ext\fragment.Sefse",
```

Issue does not happen if we pass folder as `ext/fragment`.

In result extending regex for replace from `/\//g` to `/\/|\\/g`