### PR TITLE
Feat/228/backend proxy

### DIFF
--- a/packages/backend-proxy-middleware/.eslintignore
+++ b/packages/backend-proxy-middleware/.eslintignore
@@ -1,0 +1,2 @@
+test
+dist

--- a/packages/backend-proxy-middleware/.eslintrc
+++ b/packages/backend-proxy-middleware/.eslintrc
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../.eslintrc"],
+    "parserOptions": { "project": "./tsconfig.json" }
+}

--- a/packages/backend-proxy-middleware/LICENSE
+++ b/packages/backend-proxy-middleware/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/backend-proxy-middleware/README.md
+++ b/packages/backend-proxy-middleware/README.md
@@ -1,0 +1,9 @@
+#  `@sap-ux/backend-proxy-middleware`
+
+TBD
+
+## Keywords
+Backend Proxy Middleware
+Fiori tools
+Fiori elements
+SAP UI5

--- a/packages/backend-proxy-middleware/jest.config.js
+++ b/packages/backend-proxy-middleware/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+    transform: {
+        '^.+\\.ts$': 'ts-jest'
+    },
+    collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
+    reporters: [
+        'default',
+        [
+            'jest-sonar',
+            {
+                reportedFilePath: 'relative',
+                relativeRootDir: '<rootDir>/../../../'
+            }
+        ]
+    ],
+    modulePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/test/test-output'],
+    verbose: true
+};

--- a/packages/backend-proxy-middleware/package.json
+++ b/packages/backend-proxy-middleware/package.json
@@ -1,0 +1,51 @@
+{
+    "name": "@sap-ux/backend-proxy-middleware",
+    "description": "SAP backend proxy middleware",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/SAP/open-ux-tools.git",
+        "directory": "packages/backend-proxy-middleware"
+    },
+    "bugs": {
+        "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Abackend-proxy-middleware"
+    },
+    "version": "1.0.7",
+    "license": "Apache-2.0",
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "pnpm clean && tsc",
+        "clean": "rimraf dist",
+        "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
+        "lint": "eslint . --ext .ts",
+        "lint:fix": "eslint . --ext .ts --fix",
+        "test": "jest --ci --forceExit --detectOpenHandles --colors",
+        "watch": "tsc --watch"
+    },
+    "files": [
+        "LICENSE",
+        "dist",
+        "ui5.yaml"
+    ],
+    "dependencies": {
+        "@sap-ux/logger": "workspace:*",
+        "@sap-ux/ui5-config": "workspace:*",
+        "express": "4.17.2",
+        "http-proxy-middleware": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "i18next": "20.3.2"
+    },
+    "devDependencies": {
+        "@types/express": "4.17.13",
+        "nock": "13.2.4",
+        "supertest": "6.2.2",
+        "@types/supertest": "2.0.12",
+        "yaml": "2.0.0-10"
+    },
+    "ui5": {
+        "dependencies": []
+    },
+    "engines": {
+        "pnpm": ">=6.26.1",
+        "node": ">=12.22.5 < 13.0.0 || >= 14.16.0 < 15.0.0 || >=16.1.0 < 17.0.0"
+    }
+}

--- a/packages/backend-proxy-middleware/src/index.ts
+++ b/packages/backend-proxy-middleware/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = 'world';

--- a/packages/backend-proxy-middleware/tsconfig.json
+++ b/packages/backend-proxy-middleware/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "include": ["src"],
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "dist",
+        "sourceMap": true,
+        "baseUrl": "./src",
+        "resolveJsonModule": true
+    },
+    "extends": "../../tsconfig.json"
+}

--- a/packages/backend-proxy-middleware/ui5.yaml
+++ b/packages/backend-proxy-middleware/ui5.yaml
@@ -1,0 +1,7 @@
+specVersion: '2.6'
+metadata:
+    name: backend-proxy-middleware
+kind: extension
+type: server-middleware
+middleware:
+    path: dist/middleware/index.js

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -17,7 +17,7 @@ interface Service<Entity, EntityKey> {
 }
 ```
 
-Currently, `'system'` is the only supported entity. Support for `'user'` and `'api-key'` may be added in the future.
+Currently, `'system'`, `'telemetry'` and `'api-hub'`  are the only supported entities. Support for `'user'` may be added in the future.
 Unsupported entity names will result in an error being thrown.
 
 # Recommended way to add support for a new entity

--- a/packages/store/src/data-provider/api-hub.ts
+++ b/packages/store/src/data-provider/api-hub.ts
@@ -1,0 +1,43 @@
+import type { Logger } from '@sap-ux/logger';
+import type { ServiceOptions } from '../types';
+import type { DataProvider, DataProviderConstructor } from '.';
+import type { DataAccess } from '../data-access';
+import { getHybridStore } from '../data-access/hybrid';
+import { Entities } from './constants';
+import { ApiHubSettings, ApiHubSettingsKey } from '../entities/api-hub';
+
+export const ApiHubSettingsProvider: DataProviderConstructor<ApiHubSettings, ApiHubSettingsKey> = class
+    implements DataProvider<ApiHubSettings, ApiHubSettingsKey>
+{
+    private readonly dataAccessor: DataAccess<ApiHubSettings>;
+    private readonly entityName = Entities.BackendSystem;
+    private readonly logger: Logger;
+
+    constructor(logger: Logger, options: ServiceOptions = {}) {
+        this.logger = logger;
+        this.dataAccessor = getHybridStore(this.logger, options);
+    }
+
+    public read(key: ApiHubSettingsKey): Promise<ApiHubSettings | undefined> {
+        return this.dataAccessor.read({ entityName: this.entityName, id: key.getId() });
+    }
+
+    public write(entity: ApiHubSettings): Promise<ApiHubSettings | undefined> {
+        return this.dataAccessor.write({
+            entityName: this.entityName,
+            id: ApiHubSettingsKey.SINGLETON,
+            entity
+        });
+    }
+
+    public delete(_entity: ApiHubSettings): Promise<boolean> {
+        return this.dataAccessor.del({
+            entityName: this.entityName,
+            id: ApiHubSettingsKey.SINGLETON
+        });
+    }
+
+    public getAll(): Promise<ApiHubSettings[] | []> {
+        return this.dataAccessor.getAll({ entityName: this.entityName });
+    }
+};

--- a/packages/store/src/entities/api-hub.ts
+++ b/packages/store/src/entities/api-hub.ts
@@ -1,0 +1,18 @@
+import type { EntityKey } from '.';
+import { sensitiveData } from '../decorators';
+
+export class ApiHubSettings {
+    @sensitiveData public readonly apiKey?: string;
+
+    constructor({ apiKey }: { apiKey: string }) {
+        this.apiKey = apiKey;
+    }
+}
+
+export class ApiHubSettingsKey implements EntityKey {
+    static SINGLETON: string = 'API_HUB_API_KEY';
+
+    public getId(): string {
+        return ApiHubSettingsKey.SINGLETON;
+    }
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -5,13 +5,17 @@ import { initI18n, text } from './i18n';
 import type { Service } from './services';
 import { getInstance as getSystemService } from './services/backend-system';
 import { getInstance as getTelemetrySettingService } from './services/telemetry-setting';
+import { getInstance as getApiHubSettingsService } from './services/api-hub';
 import { getDefaultLogger } from './defaults';
+
+export type EnityName = 'system' | 'telemetrySetting' | 'api-hub';
 
 const services: {
     [entityName: string]: (logger: Logger, options: ServiceOptions) => Service<unknown, unknown>;
 } = {
     system: getSystemService,
-    telemetrySetting: getTelemetrySettingService
+    telemetrySetting: getTelemetrySettingService,
+    'api-hub': getApiHubSettingsService
 };
 
 export async function getService<Entity, Key>({
@@ -20,7 +24,7 @@ export async function getService<Entity, Key>({
     options = {}
 }: {
     logger?: Logger;
-    entityName: string;
+    entityName: EnityName;
     options?: ServiceOptions;
 }): Promise<Service<Entity, Key>> {
     await initI18n();
@@ -36,6 +40,7 @@ export * from './services';
 export * from './secure-store';
 export * from './entities/backend-system';
 export * from './entities/telemetry-setting';
+export * from './entities/api-hub';
 
 // @todo: change notification needs to be more generic and not tied to filesystems
 // Support any filesystem watchers

--- a/packages/store/src/services/api-hub.ts
+++ b/packages/store/src/services/api-hub.ts
@@ -1,0 +1,38 @@
+import type { Logger } from '@sap-ux/logger';
+import type { Service } from '.';
+import type { DataProvider } from '../data-provider';
+import { ApiHubSettingsProvider } from '../data-provider/api-hub';
+import type { ApiHubSettings } from '../entities/api-hub';
+import { ApiHubSettingsKey } from '../entities/api-hub';
+
+export class ApiHubSettingsService implements Service<ApiHubSettings, ApiHubSettingsKey> {
+    private readonly dataProvider: DataProvider<ApiHubSettings, ApiHubSettingsKey>;
+    private readonly logger: Logger;
+    private readonly key: ApiHubSettingsKey = new ApiHubSettingsKey();
+
+    constructor(logger: Logger) {
+        this.logger = logger;
+        this.dataProvider = new ApiHubSettingsProvider(this.logger);
+    }
+
+    public async partialUpdate(): Promise<ApiHubSettings> {
+        throw new Error('NOT IMPLEMENTED');
+    }
+
+    public async read(): Promise<ApiHubSettings | undefined> {
+        return this.dataProvider.read(this.key);
+    }
+    public async write(entity: ApiHubSettings): Promise<ApiHubSettings | undefined> {
+        return this.dataProvider.write(entity);
+    }
+    public async delete(entity: ApiHubSettings): Promise<boolean> {
+        return this.dataProvider.delete(entity);
+    }
+    public async getAll(): Promise<ApiHubSettings[] | []> {
+        return this.dataProvider.getAll();
+    }
+}
+
+export function getInstance(logger: Logger): ApiHubSettingsService {
+    return new ApiHubSettingsService(logger);
+}


### PR DESCRIPTION
Evaluating what it takes to move the backend-proxy-middleware from the Fiori tools to the open source repo
* enhanced the store to handle api-hub-key
* removed internal odata-client and replace it with new OSS modules
* added todos to clarify open questions