### PR TITLE
fix(f-e-w/f-f-w): Fix unstable tests relying on dynamic version

### DIFF
--- a/.changeset/dry-waves-develop.md
+++ b/.changeset/dry-waves-develop.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fiori-elements-writer': patch
+'@sap-ux/fiori-freestyle-writer': patch
+---
+
+Fix for #487: `sourceTemplate.toolsId` not written

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -16954,8 +16954,8 @@ appDescription=A Fiori application.",
     \\"description\\": \\"{{appDescription}}\\",
     \\"resources\\": \\"resources.json\\",
     \\"sourceTemplate\\": {
-      \\"id\\": \\"@sap-ux/fiori-elements-writer:lrop\\",
-      \\"version\\": \\"0.3.2\\",
+      \\"id\\": \\"mocked-package-name:lrop\\",
+      \\"version\\": \\"9.9.9-mocked\\",
       \\"toolsId\\": \\"toolsId:1234abcd\\"
     },
     \\"dataSources\\": {

--- a/packages/fiori-elements-writer/test/lrop.test.ts
+++ b/packages/fiori-elements-writer/test/lrop.test.ts
@@ -13,6 +13,15 @@ import {
 
 const TEST_NAME = 'lropTemplates';
 
+jest.mock('read-pkg-up', () => ({
+    sync: jest.fn().mockReturnValue({
+        packageJson: {
+            name: 'mocked-package-name',
+            version: '9.9.9-mocked'
+        }
+    })
+}));
+
 describe(`Fiori Elements template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
 

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -1622,8 +1622,8 @@ title=App Title",
     \\"description\\": \\"{{appDescription}}\\",
     \\"resources\\": \\"resources.json\\",
     \\"sourceTemplate\\": {
-      \\"id\\": \\"@sap-ux/fiori-freestyle-writer:basic\\",
-      \\"version\\": \\"0.11.11\\",
+      \\"id\\": \\"mocked-package-name:basic\\",
+      \\"version\\": \\"9.9.9-mocked\\",
       \\"toolsId\\": \\"testToolsId:abcd1234\\"
     },
     \\"dataSources\\": {

--- a/packages/fiori-freestyle-writer/test/basic.test.ts
+++ b/packages/fiori-freestyle-writer/test/basic.test.ts
@@ -7,6 +7,15 @@ import { BasicAppSettings } from '../src/types';
 
 const TEST_NAME = 'basicTemplate';
 
+jest.mock('read-pkg-up', () => ({
+    sync: jest.fn().mockReturnValue({
+        packageJson: {
+            name: 'mocked-package-name',
+            version: '9.9.9-mocked'
+        }
+    })
+}));
+
 describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
 

--- a/packages/fiori-freestyle-writer/test/common.ts
+++ b/packages/fiori-freestyle-writer/test/common.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { readFileSync } from 'fs';
 import { sample } from './sample/metadata';
 import { create as createStore } from 'mem-fs';
-import { create, Editor } from 'mem-fs-editor';
+import { create } from 'mem-fs-editor';
 
 export const testOutputDir = join(__dirname, '/test-output');
 


### PR DESCRIPTION
Recently added snapshots reference a dynamic value (the version of the `@sap-ux/fiori-elements-writer` and `@sap-ux/fiori-freestyle-writer`). This is blocking publish and would continue to break with each version. 

This PR mocks the dynamic values while maintaining the test coverage.