### PR TITLE
fix(backend-proxy-middleware): Move handling of bsp to generateProxyMiddlewareOptions

### DIFF
--- a/.changeset/cuddly-kiwis-vanish.md
+++ b/.changeset/cuddly-kiwis-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/backend-proxy-middleware': patch
+---
+
+Moves bsp logic to function generateProxyMiddlewareOptions

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -22,6 +22,7 @@ import type { ApiHubSettings, ApiHubSettingsKey, ApiHubSettingsService, BackendS
 import { AuthenticationType, BackendSystemKey, getService } from '@sap-ux/store';
 import { getCorporateProxyServer, isHostExcludedFromProxy } from './config';
 import type { Url } from 'url';
+import { addOptionsForEmbeddedBSP } from '../ext/bsp';
 
 /**
  * Collection of custom event handler for the proxy.
@@ -316,6 +317,10 @@ export async function generateProxyMiddlewareOptions(
     }
 
     proxyOptions.pathRewrite = PathRewriters.getPathRewrite(backend, logger);
+
+    if (backend.bsp) {
+        addOptionsForEmbeddedBSP(backend.bsp, proxyOptions, logger);
+    }
 
     if (backend.apiHub) {
         const apiHubKey = await getApiHubKey(logger);

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -13,7 +13,8 @@ import {
     getCredentialsForDestinationService,
     listDestinations,
     isFullUrlDestination,
-    BAS_DEST_INSTANCE_CRED_HEADER
+    BAS_DEST_INSTANCE_CRED_HEADER,
+    ServiceInfo
 } from '@sap-ux/btp-utils';
 import type { BackendConfig, DestinationBackendConfig, LocalBackendConfig } from './types';
 import translations from './i18n.json';
@@ -240,7 +241,7 @@ export async function enhanceConfigForSystem(
         if (system.serviceKeys) {
             const provider = createForAbapOnCloud({
                 environment: AbapCloudEnvironment.Standalone,
-                service: JSON.parse(system.serviceKeys as string),
+                service: system.serviceKeys as ServiceInfo,
                 refreshToken: system.refreshToken,
                 refreshTokenChangedCb: tokenChangedCallback
             });

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -319,7 +319,7 @@ export async function generateProxyMiddlewareOptions(
     proxyOptions.pathRewrite = PathRewriters.getPathRewrite(backend, logger);
 
     if (backend.bsp) {
-        addOptionsForEmbeddedBSP(backend.bsp, proxyOptions, logger);
+        await addOptionsForEmbeddedBSP(backend.bsp, proxyOptions, logger);
     }
 
     if (backend.apiHub) {

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -13,9 +13,9 @@ import {
     getCredentialsForDestinationService,
     listDestinations,
     isFullUrlDestination,
-    BAS_DEST_INSTANCE_CRED_HEADER,
-    ServiceInfo
+    BAS_DEST_INSTANCE_CRED_HEADER
 } from '@sap-ux/btp-utils';
+import type { ServiceInfo } from '@sap-ux/btp-utils';
 import type { BackendConfig, DestinationBackendConfig, LocalBackendConfig } from './types';
 import translations from './i18n.json';
 

--- a/packages/backend-proxy-middleware/src/middleware.ts
+++ b/packages/backend-proxy-middleware/src/middleware.ts
@@ -5,7 +5,6 @@ import { Router as createRouter } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import type { MiddlewareParameters, BackendMiddlewareConfig } from './base/types';
 import { generateProxyMiddlewareOptions, initI18n } from './base/proxy';
-import { addOptionsForEmbeddedBSP } from './ext/bsp';
 
 /**
  * Hides the proxy credentials for displaying the proxy configuration in the console.
@@ -46,9 +45,6 @@ module.exports = async ({ options }: MiddlewareParameters<BackendMiddlewareConfi
 
     try {
         const proxyOptions = await generateProxyMiddlewareOptions(options.configuration.backend, configOptions, logger);
-        if (backend.bsp) {
-            addOptionsForEmbeddedBSP(backend.bsp, proxyOptions, logger);
-        }
         router.use(backend.path, createProxyMiddleware(proxyOptions));
         logger.info(
             `Starting backend-proxy-middleware using following configuration:\nbackend: ${JSON.stringify({

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -263,7 +263,7 @@ describe('proxy', () => {
             const proxyOptions: OptionsWithHeaders = { headers: {} };
             const cloudSystem = {
                 ...system,
-                serviceKeys: '{"keys": "~keys"}',
+                serviceKeys: { keys: '~keys' },
                 refreshToken: '~token'
             };
             const callback = jest.fn();
@@ -271,7 +271,7 @@ describe('proxy', () => {
             expect(proxyOptions.headers.cookie).toBe('~cookies');
             expect(mockCreateForAbapOnCloud).toBeCalledWith({
                 environment: AbapCloudEnvironment.Standalone,
-                service: JSON.parse(cloudSystem.serviceKeys),
+                service: cloudSystem.serviceKeys,
                 refreshToken: cloudSystem.refreshToken,
                 refreshTokenChangedCb: callback
             });

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -389,6 +389,7 @@ describe('proxy', () => {
             expect(options.pathRewrite).toBeDefined();
             expect(options.router).toBeDefined();
             expect(options.auth).toBeDefined();
+            expect(options.auth).toBe(`${answers.username}:${answers.password}`);
         });
     });
 

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -38,6 +38,11 @@ const mockListDestinations = listDestinations as jest.Mock;
 const mockGetCredentialsForDestinationService = getCredentialsForDestinationService as jest.Mock;
 const mockIsAppStudio = isAppStudio as jest.Mock;
 
+const mockPrompt = jest.fn();
+jest.mock('prompts', () => {
+    return () => mockPrompt();
+});
+
 describe('proxy', () => {
     type OptionsWithHeaders = Options & { headers: object };
     const logger = new ToolsLogger({
@@ -366,6 +371,24 @@ describe('proxy', () => {
             expect(options.ws).toBeUndefined();
             expect(options.xfwd).toBeUndefined();
             expect(options.secure).toBeUndefined();
+        });
+
+        test('generate proxy middleware options for FLP Embedded flow', async () => {
+            const backend: LocalBackendConfig = {
+                url: 'http://backend.example',
+                path: '/my/path',
+                bsp: 'my_bsp'
+            };
+            const answers = {
+                username: '~user',
+                password: '~password'
+            };
+            mockIsAppStudio.mockReturnValue(false);
+            mockPrompt.mockResolvedValue({ ...answers, authNeeded: true });
+            const options = await generateProxyMiddlewareOptions(backend);
+            expect(options.pathRewrite).toBeDefined();
+            expect(options.router).toBeDefined();
+            expect(options.auth).toBeDefined();
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/SAP/open-ux-tools/issues/541