### PR TITLE
FIX: `store` module does not read the `api-hub` key from the secure storage

### DIFF
--- a/packages/store/src/data-provider/api-hub.ts
+++ b/packages/store/src/data-provider/api-hub.ts
@@ -11,7 +11,7 @@ export const ApiHubSettingsProvider: DataProviderConstructor<ApiHubSettings, Api
     implements DataProvider<ApiHubSettings, ApiHubSettingsKey>
 {
     private readonly dataAccessor: DataAccess<ApiHubSettings>;
-    private readonly entityName = Entities.BackendSystem;
+    private readonly entityName = Entities.ApiHub;
     private readonly logger: Logger;
 
     constructor(logger: Logger, options: ServiceOptions = {}) {

--- a/packages/store/src/data-provider/constants.ts
+++ b/packages/store/src/data-provider/constants.ts
@@ -1,5 +1,6 @@
 export enum Entities {
     BackendSystem = 'system',
     SystemMigrationStatus = 'systemMigrationStatus',
-    TelemetrySetting = 'telemetrySetting'
+    TelemetrySetting = 'telemetrySetting',
+    ApiHub = 'apiHub'
 }

--- a/packages/store/test/manual/system.ts
+++ b/packages/store/test/manual/system.ts
@@ -1,4 +1,12 @@
-import { getService, BackendSystem, BackendSystemKey, ServiceOptions } from '../../src';
+import {
+    getService,
+    BackendSystem,
+    BackendSystemKey,
+    ServiceOptions,
+    ApiHubSettingsKey,
+    ApiHubSettings,
+    ApiHubSettingsService
+} from '../../src';
 import os from 'os';
 import path from 'path';
 import { ConsoleTransport, ToolsLogger } from '@sap-ux/logger';
@@ -14,6 +22,11 @@ async function main(action: string, basedir?: string): Promise<void> {
         logger: new ToolsLogger({ transports: [new ConsoleTransport()] }),
         entityName: 'system',
         options: opt
+    });
+
+    const apiService = await getService<ApiHubSettings, ApiHubSettingsKey>({
+        logger: new ToolsLogger({ transports: [new ConsoleTransport()] }),
+        entityName: 'api-hub'
     });
 
     const sys1 = new BackendSystem({
@@ -49,6 +62,7 @@ async function main(action: string, basedir?: string): Promise<void> {
         console.dir(await systemService.delete(sys3));
     } else if (action === 'a') {
         console.dir(await systemService.getAll());
+        console.log(await apiService.getAll());
     }
 
     console.dir(action);


### PR DESCRIPTION
- [x] fix a wrong entity name mapping when trying to read the api-hub key from the secure storage
- [x] update for the manual test script to also play with api-hub key