### PR TITLE
chore(open-ux-tools) ignore source map files when publishing to npm

### DIFF
--- a/.changeset/tricky-mice-whisper.md
+++ b/.changeset/tricky-mice-whisper.md
@@ -1,0 +1,19 @@
+---
+'@sap-ux/odata-cli': patch
+'@sap-ux/generator-simple-fe': patch
+'@sap-ux/axios-extension': patch
+'@sap-ux/backend-proxy-middleware': patch
+'@sap-ux/btp-utils': patch
+'@sap-ux/fe-fpm-writer': patch
+'@sap-ux/fiori-elements-writer': patch
+'@sap-ux/fiori-freestyle-writer': patch
+'@sap-ux/logger': patch
+'@sap-ux/odata-service-writer': patch
+'@sap-ux/store': patch
+'@sap-ux/ui5-application-writer': patch
+'@sap-ux/ui5-config': patch
+'@sap-ux/ui5-proxy-middleware': patch
+'@sap-ux/yaml': patch
+---
+
+chore(open-ux-tools) ignore source map files when publishing to npm

--- a/packages/axios-extension/package.json
+++ b/packages/axios-extension/package.json
@@ -43,7 +43,9 @@
     },
     "files": [
         "dist",
-        "LICENSE"
+        "LICENSE",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/backend-proxy-middleware/package.json
+++ b/packages/backend-proxy-middleware/package.json
@@ -25,7 +25,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "ui5.yaml"
+        "ui5.yaml",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/axios-extension": "workspace:*",

--- a/packages/btp-utils/package.json
+++ b/packages/btp-utils/package.json
@@ -34,7 +34,9 @@
     },
     "files": [
         "dist",
-        "LICENSE"
+        "LICENSE",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/fe-fpm-writer/package.json
+++ b/packages/fe-fpm-writer/package.json
@@ -24,7 +24,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "templates"
+        "templates",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@xmldom/xmldom": "0.8.2",

--- a/packages/fiori-elements-writer/package.json
+++ b/packages/fiori-elements-writer/package.json
@@ -26,7 +26,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "templates"
+        "templates",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/odata-service-writer": "workspace:*",

--- a/packages/fiori-freestyle-writer/package.json
+++ b/packages/fiori-freestyle-writer/package.json
@@ -26,7 +26,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "templates"
+        "templates",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/odata-service-writer": "workspace:*",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -39,7 +39,9 @@
     },
     "files": [
         "dist",
-        "LICENSE"
+        "LICENSE",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/odata-service-writer/package.json
+++ b/packages/odata-service-writer/package.json
@@ -28,7 +28,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "templates"
+        "templates",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/ui5-config": "workspace:*",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -49,7 +49,9 @@
     },
     "files": [
         "dist",
-        "LICENSE"
+        "LICENSE",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "engines": {
         "pnpm": ">=6.0.2",

--- a/packages/ui5-application-writer/package.json
+++ b/packages/ui5-application-writer/package.json
@@ -27,7 +27,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "templates"
+        "templates",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/ui5-config": "workspace:*",

--- a/packages/ui5-config/package.json
+++ b/packages/ui5-config/package.json
@@ -26,7 +26,9 @@
     },
     "files": [
         "LICENSE",
-        "dist"
+        "dist",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/yaml": "workspace:*"

--- a/packages/ui5-proxy-middleware/package.json
+++ b/packages/ui5-proxy-middleware/package.json
@@ -25,7 +25,9 @@
     "files": [
         "LICENSE",
         "dist",
-        "ui5.yaml"
+        "ui5.yaml",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "@sap-ux/logger": "workspace:*",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -24,7 +24,9 @@
     },
     "files": [
         "LICENSE",
-        "dist"
+        "dist",
+        "!dist/*.map",
+        "!dist/**/*.map"
     ],
     "dependencies": {
         "i18next": "20.3.2",


### PR DESCRIPTION
Source map files are not needed in the tgz published to npm. Removing reduces the install size.
