### PR TITLE
fix(odata-service-writer): #580 prevents oDataService properties being used as ejs render options

### DIFF
--- a/.changeset/quiet-olives-scream.md
+++ b/.changeset/quiet-olives-scream.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Fix: Prevent ejs.render() using oDataService props as options

--- a/packages/fe-fpm-writer/src/action/index.ts
+++ b/packages/fe-fpm-writer/src/action/index.ts
@@ -93,7 +93,7 @@ export function generateCustomAction(basePath: string, actionConfig: CustomActio
 
     // enhance manifest with action definition and controller reference
     const actions = enhanceManifestAndGetActionsElementReference(manifest, config.target);
-    Object.assign(actions, JSON.parse(render(fs.read(join(root, `action/manifest.action.json`)), config)));
+    Object.assign(actions, JSON.parse(render(fs.read(join(root, `action/manifest.action.json`)), config, {})));
     fs.writeJSON(manifestPath, manifest);
 
     return fs;

--- a/packages/fe-fpm-writer/src/building-block/index.ts
+++ b/packages/fe-fpm-writer/src/building-block/index.ts
@@ -99,10 +99,14 @@ function getTemplateDocument<T extends BuildingBlock>(
 ): Document {
     const templateFolderName = buildingBlockData.buildingBlockType;
     const templateFilePath = join(__dirname, `../../templates/building-block/${templateFolderName}/View.xml`);
-    const templateContent = render(fs.read(templateFilePath), {
-        macrosNamespace: getOrAddMacrosNamespace(viewDocument),
-        data: buildingBlockData
-    }, {});
+    const templateContent = render(
+        fs.read(templateFilePath),
+        {
+            macrosNamespace: getOrAddMacrosNamespace(viewDocument),
+            data: buildingBlockData
+        },
+        {}
+    );
     const errorHandler = (level: string, message: string) => {
         throw new Error(`Unable to parse template file with building block data. Details: [${level}] - ${message}`);
     };

--- a/packages/fe-fpm-writer/src/building-block/index.ts
+++ b/packages/fe-fpm-writer/src/building-block/index.ts
@@ -102,7 +102,7 @@ function getTemplateDocument<T extends BuildingBlock>(
     const templateContent = render(fs.read(templateFilePath), {
         macrosNamespace: getOrAddMacrosNamespace(viewDocument),
         data: buildingBlockData
-    });
+    }, {});
     const errorHandler = (level: string, message: string) => {
         throw new Error(`Unable to parse template file with building block data. Details: [${level}] - ${message}`);
     };

--- a/packages/fe-fpm-writer/src/column/index.ts
+++ b/packages/fe-fpm-writer/src/column/index.ts
@@ -86,7 +86,7 @@ export function generateCustomColumn(basePath: string, customColumn: CustomTable
 
     // enhance manifest with column definition
     const manifestRoot = getManifestRoot(customColumn.ui5Version);
-    const filledTemplate = render(fs.read(join(manifestRoot, `manifest.json`)), completeColumn);
+    const filledTemplate = render(fs.read(join(manifestRoot, `manifest.json`)), completeColumn, {});
     fs.extendJSON(manifestPath, JSON.parse(filledTemplate));
 
     // add fragment

--- a/packages/fe-fpm-writer/src/page/custom.ts
+++ b/packages/fe-fpm-writer/src/page/custom.ts
@@ -75,7 +75,7 @@ export function generate(basePath: string, data: CustomPage, fs?: Editor): Edito
     // enhance manifest.json
     fs.extendJSON(
         manifestPath,
-        JSON.parse(render(fs.read(join(root, `manifest.json`)), config)),
+        JSON.parse(render(fs.read(join(root, `manifest.json`)), config, {})),
         getManifestJsonExtensionHelper(config)
     );
 

--- a/packages/fe-fpm-writer/src/page/list.ts
+++ b/packages/fe-fpm-writer/src/page/list.ts
@@ -58,7 +58,7 @@ export function generate(basePath: string, data: ListReport, fs?: Editor): Edito
     // enhance manifest.json
     fs.extendJSON(
         manifestPath,
-        JSON.parse(render(fs.read(join(__dirname, '../../templates/page/list/manifest.json')), config)),
+        JSON.parse(render(fs.read(join(__dirname, '../../templates/page/list/manifest.json')), config, {})),
         getManifestJsonExtensionHelper(config)
     );
 

--- a/packages/fe-fpm-writer/src/page/object.ts
+++ b/packages/fe-fpm-writer/src/page/object.ts
@@ -49,7 +49,7 @@ export function generate(basePath: string, data: ObjectPage, fs?: Editor): Edito
     // enhance manifest.json
     fs.extendJSON(
         manifestPath,
-        JSON.parse(render(fs.read(join(__dirname, '../../templates/page/object/manifest.json')), config)),
+        JSON.parse(render(fs.read(join(__dirname, '../../templates/page/object/manifest.json')), config, {})),
         getManifestJsonExtensionHelper(config)
     );
 

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -81,7 +81,7 @@ export function generateCustomSection(basePath: string, customSection: CustomSec
 
     // enhance manifest with section definition
     const manifestRoot = getManifestRoot(root, customSection.ui5Version);
-    const filledTemplate = render(fs.read(join(manifestRoot, `manifest.json`)), completeSection);
+    const filledTemplate = render(fs.read(join(manifestRoot, `manifest.json`)), completeSection, {});
     fs.extendJSON(manifestPath, JSON.parse(filledTemplate));
 
     // add fragment

--- a/packages/fe-fpm-writer/src/view/index.ts
+++ b/packages/fe-fpm-writer/src/view/index.ts
@@ -75,7 +75,7 @@ export function generateCustomView(basePath: string, customView: CustomView, fs?
     const completeView = enhanceConfig(fs, root, customView, manifestPath, manifest);
 
     // enhance manifest with view definition
-    const filledTemplate = render(fs.read(join(root, 'view', `manifest.json`)), completeView);
+    const filledTemplate = render(fs.read(join(root, 'view', `manifest.json`)), completeView, {});
     fs.extendJSON(manifestPath, JSON.parse(filledTemplate));
 
     // add fragment

--- a/packages/fiori-elements-writer/src/data/manifestSettings.ts
+++ b/packages/fiori-elements-writer/src/data/manifestSettings.ts
@@ -55,7 +55,7 @@ export function extendManifestJson<T>(
     extendTemplatePaths.forEach((extendTemplatePath) => {
         const manifestTemplatePath = join(extendTemplatePath, 'manifest.json');
         if (fs.exists(manifestTemplatePath)) {
-            fs.extendJSON(manifestPath, JSON.parse(render(fs.read(manifestTemplatePath), templateSettings)));
+            fs.extendJSON(manifestPath, JSON.parse(render(fs.read(manifestTemplatePath), templateSettings, {})));
         }
     });
 }

--- a/packages/fiori-elements-writer/src/index.ts
+++ b/packages/fiori-elements-writer/src/index.ts
@@ -61,7 +61,7 @@ async function generate<T>(basePath: string, data: FioriElementsApp<T>, fs?: Edi
     // Extend package.json
     fs.extendJSON(
         packagePath,
-        JSON.parse(render(fs.read(join(rootTemplatesPath, 'common', 'extend', 'package.json')), feApp))
+        JSON.parse(render(fs.read(join(rootTemplatesPath, 'common', 'extend', 'package.json')), feApp, {}))
     );
 
     const templateVersionPath = join(rootTemplatesPath, `v${feApp.service?.version}`);

--- a/packages/fiori-freestyle-writer/jest.config.js
+++ b/packages/fiori-freestyle-writer/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
             }
         ]
     ],
+    coverageReporters: ['text', ['lcov', { projectRoot: '../../' }]],
     modulePathIgnorePatterns: [
         '<rootDir>/dist',
         '<rootDir>/test/test-output',

--- a/packages/fiori-freestyle-writer/src/index.ts
+++ b/packages/fiori-freestyle-writer/src/index.ts
@@ -54,7 +54,10 @@ async function generate<T>(basePath: string, data: FreestyleApp<T>, fs?: Editor)
 
     // package.json
     const packagePath = join(basePath, 'package.json');
-    fs.extendJSON(packagePath, JSON.parse(render(fs.read(join(tmplPath, 'common', 'extend', 'package.json')), ffApp, {})));
+    fs.extendJSON(
+        packagePath,
+        JSON.parse(render(fs.read(join(tmplPath, 'common', 'extend', 'package.json')), ffApp, {}))
+    );
     const packageJson: Package = JSON.parse(fs.read(packagePath));
 
     packageJson.scripts = Object.assign(packageJson.scripts, {

--- a/packages/fiori-freestyle-writer/src/index.ts
+++ b/packages/fiori-freestyle-writer/src/index.ts
@@ -44,17 +44,17 @@ async function generate<T>(basePath: string, data: FreestyleApp<T>, fs?: Editor)
     // Add template specific manifest settings
     const manifestPath = join(basePath, 'webapp', 'manifest.json');
     const extRoot = join(__dirname, '..', 'templates', ffApp.template.type, 'extend', 'webapp');
-    fs.extendJSON(manifestPath, JSON.parse(render(fs.read(join(extRoot, 'manifest.json')), ffApp)));
+    fs.extendJSON(manifestPath, JSON.parse(render(fs.read(join(extRoot, 'manifest.json')), ffApp, {})));
 
     // i18n.properties
     fs.append(
         join(basePath, 'webapp', 'i18n', 'i18n.properties'),
-        render(fs.read(join(extRoot, 'i18n', 'i18n.properties')), ffApp)
+        render(fs.read(join(extRoot, 'i18n', 'i18n.properties')), ffApp, {})
     );
 
     // package.json
     const packagePath = join(basePath, 'package.json');
-    fs.extendJSON(packagePath, JSON.parse(render(fs.read(join(tmplPath, 'common', 'extend', 'package.json')), ffApp)));
+    fs.extendJSON(packagePath, JSON.parse(render(fs.read(join(tmplPath, 'common', 'extend', 'package.json')), ffApp, {})));
     const packageJson: Package = JSON.parse(fs.read(packagePath));
 
     packageJson.scripts = Object.assign(packageJson.scripts, {

--- a/packages/odata-service-writer/src/updates.ts
+++ b/packages/odata-service-writer/src/updates.ts
@@ -27,7 +27,10 @@ export function updateManifest(basePath: string, service: OdataService, fs: Edit
     }
 
     const manifestJsonExt = fs.read(join(templateRoot, 'extend', `manifest.json`));
-    fs.extendJSON(manifestPath, JSON.parse(render(manifestJsonExt, service)));
+
+    // If the service object includes ejs options, for example 'client' (see: https://ejs.co/#docs),
+    // resulting in unexpected behaviour and problems when webpacking. Passing an empty options object prevents this.
+    fs.extendJSON(manifestPath, JSON.parse(render(manifestJsonExt, service, {})));
 }
 
 /**

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -6,7 +6,7 @@ import { OdataService, OdataVersion } from '../../src';
 import * as ejs from 'ejs';
 
 jest.mock('ejs', () => ({
-    __esModule: true, // Allows mocking off ejs funcs
+    __esModule: true, // Allows mocking of ejs funcs
     ...(jest.requireActual('ejs') as {})
 }));
 

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -1,0 +1,42 @@
+import { updateManifest } from '../../src/updates';
+import { join } from 'path';
+import { create, Editor } from 'mem-fs-editor';
+import { create as createStorage } from 'mem-fs';
+import { OdataService, OdataVersion } from '../../src';
+import * as ejs from 'ejs';
+
+jest.mock('ejs', () => ({
+    __esModule: true, // Allows mocking off ejs funcs
+    ...(jest.requireActual('ejs') as {})
+}));
+
+describe('updates', () => {
+    let fs: Editor;
+    beforeEach(async () => {
+        fs = create(createStorage());
+    });
+
+    describe('updateManifest', () => {
+        test('Ensure OdataService properties are not interpretted as ejs render options', () => {
+            const testManifest = {
+                'sap.app': {
+                    id: 'test.update.manifest'
+                }
+            };
+
+            const service: OdataService = {
+                version: OdataVersion.v2,
+                client: '123',
+                model: 'amodel',
+                name: 'aname',
+                path: '/a/path'
+            };
+
+            fs.writeJSON('./webapp/manifest.json', testManifest);
+            const ejsMock = jest.spyOn(ejs, 'render');
+            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            // Passing empty options prevents ejs interpretting OdataService properties as ejs options
+            expect(ejsMock).toHaveBeenCalledWith(expect.anything(), service, {});
+        });
+    });
+});

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -70,7 +70,7 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
                             globOptions: { dot: true }
                         });
                     } else {
-                        const add = JSON.parse(render(fs?.read(optTmplFilePath), ui5App));
+                        const add = JSON.parse(render(fs?.read(optTmplFilePath), ui5App, {}));
                         const existingFile = JSON.parse(fs?.read(outPath));
                         const merged = mergeObjects([existingFile, add], { defaultArrayMergeOperation: 'concat' });
                         fs?.writeJSON(outPath, merged);


### PR DESCRIPTION

Fixes: https://github.com/SAP/open-ux-tools/issues/580

By passing an empty options object into `ejs.render()` we can avoid the `oDataService` properties being interpreted as options.  

Note: This is preferable than renaming properties on a case by case basis.