### PR TITLE
test(btp-utils): adapt missed test

### DIFF
--- a/packages/btp-utils/test/destination.test.ts
+++ b/packages/btp-utils/test/destination.test.ts
@@ -3,6 +3,7 @@ import {
     isAbapSystem,
     isAbapEnvironmentOnBtp,
     WebIDEUsage,
+    WebIDEAdditionalData,
     isGenericODataDestination,
     isPartialUrlDestination,
     isFullUrlDestination
@@ -87,7 +88,7 @@ describe('destination', () => {
                 isFullUrlDestination({
                     ...destination,
                     WebIDEUsage: WebIDEUsage.ODATA_GENERIC,
-                    WebIDEAdditionalData: 'full_url'
+                    WebIDEAdditionalData: WebIDEAdditionalData.FULL_URL
                 })
             ).toBe(true);
         });


### PR DESCRIPTION
Follow up of https://github.com/SAP/open-ux-tools/pull/609.
- Adapted missed test to use the `WebIDEAdditionalData` enum.