### PR TITLE
fix(fe-fpm-writer): building block generator does not add macros ns

### DIFF
--- a/.changeset/nine-seas-serve.md
+++ b/.changeset/nine-seas-serve.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix issue with fe-fpm-writer module's building block generator to add macros namespace if it is not found in the xml view.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,48 +13,21 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "lib/yaml: Debug Current Jest File",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
+            "name": "examples/odata-cli: Run Example",
+            "runtimeExecutable": "pnpm",
+            "runtimeArgs": ["start", "--", "${input:axiosODataExample}"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "cwd": "${workspaceFolder}/packages/yaml"
+            "cwd": "${workspaceFolder}/examples/odata-cli"
         },
         {
             "type": "node",
             "request": "launch",
-            "name": "templates/fiori-freestyle: Debug Current Jest File",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "cwd": "${workspaceFolder}/packages/fiori-freestyle-writer"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "templates/odata-service: Debug Current Jest File",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "windows": {
-                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
-            },
-            "cwd": "${workspaceFolder}/packages/odata-service-writer"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "fev4-fpm: Debug Current Jest File",
+            "name": "fe-fpm-writer: Debug Current Jest File",
             "program": "${workspaceFolder}/node_modules/jest/bin/jest",
             "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
             "windows": {
                 "program": "${workspaceFolder}/node_modules/jest/bin/jest"
             },
@@ -63,13 +36,35 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "examples: OData CLI",
-            "runtimeExecutable": "pnpm",
-            "runtimeArgs": ["start", "--", "${input:axiosODataExample}"],
+            "name": "fiori-freestyle-writer: Debug Current Jest File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "cwd": "${workspaceFolder}/examples/odata-cli"
+            "cwd": "${workspaceFolder}/packages/fiori-freestyle-writer"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "odata-service-writer: Debug Current Jest File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            },
+            "cwd": "${workspaceFolder}/packages/odata-service-writer"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "yaml: Debug Current Jest File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "cwd": "${workspaceFolder}/packages/yaml"
         }
     ]
 }

--- a/packages/fe-fpm-writer/src/building-block/index.ts
+++ b/packages/fe-fpm-writer/src/building-block/index.ts
@@ -80,6 +80,7 @@ function getOrAddMacrosNamespace(ui5XmlDocument: Document): string {
     const macrosNamespaceEntry = Object.entries(namespaceMap).find(([_, value]) => value === 'sap.fe.macros');
     if (!macrosNamespaceEntry) {
         (ui5XmlDocument.firstChild as any)._nsMap['macros'] = 'sap.fe.macros';
+        ui5XmlDocument.documentElement.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:macros', 'sap.fe.macros');
     }
     return macrosNamespaceEntry ? macrosNamespaceEntry[0] : 'macros';
 }

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Building Blocks Generate with just ID generate chart building block: generate-chart-with-id 1`] = `
+exports[`Building Blocks Generate with just ID and xml view without macros namespace generate chart building block: generate-chart-with-id-no-macros-ns 1`] = `
 Object {
-  "generate-chart-with-id/webapp/ext/main/Main.view.xml": Object {
+  "generate-chart-with-id-no-macros-ns/webapp/ext/main/Main.view.xml": Object {
     "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
     <Page title=\\"Main\\">
         <content>
@@ -12,16 +12,16 @@ Object {
 </mvc:View>",
     "state": "modified",
   },
-  "generate-chart-with-id/webapp/manifest.json": Object {
+  "generate-chart-with-id-no-macros-ns/webapp/manifest.json": Object {
     "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
     "state": "modified",
   },
 }
 `;
 
-exports[`Building Blocks Generate with just ID generate field building block: generate-field-with-id 1`] = `
+exports[`Building Blocks Generate with just ID and xml view without macros namespace generate field building block: generate-field-with-id-no-macros-ns 1`] = `
 Object {
-  "generate-field-with-id/webapp/ext/main/Main.view.xml": Object {
+  "generate-field-with-id-no-macros-ns/webapp/ext/main/Main.view.xml": Object {
     "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
     <Page title=\\"Main\\">
         <content>
@@ -31,16 +31,16 @@ Object {
 </mvc:View>",
     "state": "modified",
   },
-  "generate-field-with-id/webapp/manifest.json": Object {
+  "generate-field-with-id-no-macros-ns/webapp/manifest.json": Object {
     "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
     "state": "modified",
   },
 }
 `;
 
-exports[`Building Blocks Generate with just ID generate filter-bar building block: generate-filter-bar-with-id 1`] = `
+exports[`Building Blocks Generate with just ID and xml view without macros namespace generate filter-bar building block: generate-filter-bar-with-id-no-macros-ns 1`] = `
 Object {
-  "generate-filter-bar-with-id/webapp/ext/main/Main.view.xml": Object {
+  "generate-filter-bar-with-id-no-macros-ns/webapp/ext/main/Main.view.xml": Object {
     "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
     <Page title=\\"Main\\">
         <content>
@@ -50,64 +50,7 @@ Object {
 </mvc:View>",
     "state": "modified",
   },
-  "generate-filter-bar-with-id/webapp/manifest.json": Object {
-    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
-    "state": "modified",
-  },
-}
-`;
-
-exports[`Building Blocks Generate with optional parameters generate chart building block: generate-chart-with-optional-params 1`] = `
-Object {
-  "generate-chart-with-optional-params/webapp/ext/main/Main.view.xml": Object {
-    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
-    <Page title=\\"Main\\">
-        <content>
-            <macros:Chart id=\\"testChart\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" filterBar=\\"testFilterBar\\" personalization=\\"testPersonalization\\" selectionMode=\\"MULTIPLE\\" selectionChange=\\"testOnSelectionChange\\"/>
-        </content>
-    </Page>
-</mvc:View>",
-    "state": "modified",
-  },
-  "generate-chart-with-optional-params/webapp/manifest.json": Object {
-    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
-    "state": "modified",
-  },
-}
-`;
-
-exports[`Building Blocks Generate with optional parameters generate field building block: generate-field-with-optional-params 1`] = `
-Object {
-  "generate-field-with-optional-params/webapp/ext/main/Main.view.xml": Object {
-    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
-    <Page title=\\"Main\\">
-        <content>
-            <macros:Field id=\\"testField\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" formatOptions=\\"{'displayMode':'Value'}\\" readOnly=\\"true\\" semanticObject=\\"testSemanticObject\\"/>
-        </content>
-    </Page>
-</mvc:View>",
-    "state": "modified",
-  },
-  "generate-field-with-optional-params/webapp/manifest.json": Object {
-    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
-    "state": "modified",
-  },
-}
-`;
-
-exports[`Building Blocks Generate with optional parameters generate filter-bar building block: generate-filter-bar-with-optional-params 1`] = `
-Object {
-  "generate-filter-bar-with-optional-params/webapp/ext/main/Main.view.xml": Object {
-    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
-    <Page title=\\"Main\\">
-        <content>
-            <macros:FilterBar id=\\"testFilterBar\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" search=\\"testOnSearch\\" filterChanged=\\"testOnFilterChanged\\"/>
-        </content>
-    </Page>
-</mvc:View>",
-    "state": "modified",
-  },
-  "generate-filter-bar-with-optional-params/webapp/manifest.json": Object {
+  "generate-filter-bar-with-id-no-macros-ns/webapp/manifest.json": Object {
     "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
     "state": "modified",
   },

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
@@ -56,3 +56,117 @@ Object {
   },
 }
 `;
+
+exports[`Building Blocks Generate with just ID generate chart building block: generate-chart-with-id 1`] = `
+Object {
+  "generate-chart-with-id/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:Chart id=\\"testChart\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-chart-with-id/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;
+
+exports[`Building Blocks Generate with just ID generate field building block: generate-field-with-id 1`] = `
+Object {
+  "generate-field-with-id/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:Field id=\\"testField\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-field-with-id/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;
+
+exports[`Building Blocks Generate with just ID generate filter-bar building block: generate-filter-bar-with-id 1`] = `
+Object {
+  "generate-filter-bar-with-id/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:FilterBar id=\\"testFilterBar\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-filter-bar-with-id/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;
+
+exports[`Building Blocks Generate with optional parameters generate chart building block: generate-chart-with-optional-params 1`] = `
+Object {
+  "generate-chart-with-optional-params/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:Chart id=\\"testChart\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" filterBar=\\"testFilterBar\\" personalization=\\"testPersonalization\\" selectionMode=\\"MULTIPLE\\" selectionChange=\\"testOnSelectionChange\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-chart-with-optional-params/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;
+
+exports[`Building Blocks Generate with optional parameters generate field building block: generate-field-with-optional-params 1`] = `
+Object {
+  "generate-field-with-optional-params/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:Field id=\\"testField\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" formatOptions=\\"{'displayMode':'Value'}\\" readOnly=\\"true\\" semanticObject=\\"testSemanticObject\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-field-with-optional-params/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;
+
+exports[`Building Blocks Generate with optional parameters generate filter-bar building block: generate-filter-bar-with-optional-params 1`] = `
+Object {
+  "generate-filter-bar-with-optional-params/webapp/ext/main/Main.view.xml": Object {
+    "contents": "<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:FilterBar id=\\"testFilterBar\\" metaPath=\\"testMetaPath\\" contextPath=\\"testContextPath\\" search=\\"testOnSearch\\" filterChanged=\\"testOnFilterChanged\\"/>
+        </content>
+    </Page>
+</mvc:View>",
+    "state": "modified",
+  },
+  "generate-filter-bar-with-optional-params/webapp/manifest.json": Object {
+    "contents": "{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}},\\"default\\":{\\"sap.app\\":{\\"id\\":\\"my.test.App\\"},\\"sap.ui5\\":{\\"dependencies\\":{\\"libs\\":{\\"sap.fe.templates\\":{}}}}}}",
+    "state": "modified",
+  },
+}
+`;

--- a/packages/fe-fpm-writer/test/unit/building-block.test.ts
+++ b/packages/fe-fpm-writer/test/unit/building-block.test.ts
@@ -168,7 +168,7 @@ describe('Building Blocks', () => {
         ).toThrowError(/Unable to parse xml view file/);
     });
 
-    describe.only('Generate with just ID and xml view without macros namespace', () => {
+    describe('Generate with just ID and xml view without macros namespace', () => {
         const testInput = [
             {
                 buildingBlockData: {

--- a/packages/fe-fpm-writer/test/unit/building-block.test.ts
+++ b/packages/fe-fpm-writer/test/unit/building-block.test.ts
@@ -168,6 +168,60 @@ describe('Building Blocks', () => {
         ).toThrowError(/Unable to parse xml view file/);
     });
 
+    describe.only('Generate with just ID and xml view without macros namespace', () => {
+        const testInput = [
+            {
+                buildingBlockData: {
+                    id: 'testFilterBar',
+                    buildingBlockType: BuildingBlockType.FilterBar
+                } as FilterBar
+            },
+            {
+                buildingBlockData: {
+                    id: 'testChart',
+                    buildingBlockType: BuildingBlockType.Chart
+                } as Chart
+            },
+            {
+                buildingBlockData: {
+                    id: 'testField',
+                    buildingBlockType: BuildingBlockType.Field
+                } as Field
+            }
+        ];
+
+        test.each(testInput)('generate $buildingBlockData.buildingBlockType building block', async (testData) => {
+            const basePath = join(
+                testAppPath,
+                `generate-${testData.buildingBlockData.buildingBlockType}-with-id-no-macros-ns`
+            );
+            const xmlViewContentWithoutMacrosNs = (
+                await fsPromises.readFile(
+                    join('test/unit/sample/building-block/webapp-without-macros-ns-xml-view/ext/main/Main.view.xml'),
+                    'utf-8'
+                )
+            ).toLocaleString();
+            const aggregationPath = `/mvc:View/*[local-name()='Page']/*[local-name()='content']`;
+            fs.write(join(basePath, manifestFilePath), JSON.stringify(testManifestContent));
+            fs.write(join(basePath, xmlViewFilePath), xmlViewContentWithoutMacrosNs);
+
+            // Test generator with valid manifest.json, view.xml files and build block data with just id
+            generateBuildingBlock(
+                basePath,
+                {
+                    viewOrFragmentPath: xmlViewFilePath,
+                    aggregationPath,
+                    buildingBlockData: testData.buildingBlockData
+                },
+                fs
+            );
+            expect((fs as any).dump(testAppPath)).toMatchSnapshot(
+                `generate-${testData.buildingBlockData.buildingBlockType}-with-id-no-macros-ns`
+            );
+            await writeFilesForDebugging(fs);
+        });
+    });
+
     describe('Generate with just ID', () => {
         const testInput = [
             {

--- a/packages/fe-fpm-writer/test/unit/sample/building-block/webapp-without-macros-ns-xml-view/ext/main/Main.view.xml
+++ b/packages/fe-fpm-writer/test/unit/sample/building-block/webapp-without-macros-ns-xml-view/ext/main/Main.view.xml
@@ -1,0 +1,6 @@
+<mvc:View xmlns:core="sap.ui.core" xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m"
+    xmlns:html="http://www.w3.org/1999/xhtml" controllerName="com.test.myApp.ext.main.Main">
+    <Page title="Main">
+        <content />
+    </Page>
+</mvc:View>

--- a/packages/fe-fpm-writer/test/unit/sample/building-block/webapp-without-macros-ns-xml-view/manifest.json
+++ b/packages/fe-fpm-writer/test/unit/sample/building-block/webapp-without-macros-ns-xml-view/manifest.json
@@ -1,0 +1,12 @@
+{
+    "sap.app": {
+        "id": "my.test.App"
+    },
+    "sap.ui5": {
+        "dependencies": {
+            "libs": {
+                "sap.fe.templates": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue 
The building block generator in the `fe-fpm-writer` module does not add the `macros` namespace to the xml view or fragment file if the namespace doesn't already exist.

## Description
* Update building block generator to add the `xmlns:macros='sap.fe.macros'` namespace if the xml view or fragment file doesn't already contain it.
* Cleanup `.vscode/launch.json` to use the correct module names as prefixes and sort the configurations alphabetically.