### PR TITLE
Small fixes required for `easy-ui5` integration of new TS features

### DIFF
--- a/.changeset/giant-mirrors-jump.md
+++ b/.changeset/giant-mirrors-jump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix for generating a Component.ts using enableFpm

--- a/packages/fe-fpm-writer/templates/app/Component.js
+++ b/packages/fe-fpm-writer/templates/app/Component.js
@@ -9,14 +9,5 @@ sap.ui.define(
             metadata: {
                 manifest: "json"
             }
-            
-            /**
-             * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
-             * @public
-             * @override
-             */
-            //init: function() {
-            //    AppComponent.prototype.init.apply(this, arguments);
-            //}
         });
 });

--- a/packages/fe-fpm-writer/templates/app/Component.ts
+++ b/packages/fe-fpm-writer/templates/app/Component.ts
@@ -1,7 +1,7 @@
 import AppComponent from 'sap/fe/core/AppComponent';
 
 /**
- * @namespace <%- app.id %>
+ * @namespace <%- id %>
  */
 export default class Component extends AppComponent {
 

--- a/packages/fe-fpm-writer/templates/app/Component.ts
+++ b/packages/fe-fpm-writer/templates/app/Component.ts
@@ -8,13 +8,4 @@ export default class Component extends AppComponent {
 	public static metadata = {
 		manifest: "json"
 	};
-
-    /**
-     * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
-     * @public
-     * @override
-     */
-	//public init() : void {
-    //    super.init();
-	//}
 }

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -417,15 +417,6 @@ export default class Component extends AppComponent {
 	public static metadata = {
 		manifest: \\"json\\"
 	};
-
-    /**
-     * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
-     * @public
-     * @override
-     */
-	//public init() : void {
-    //    super.init();
-	//}
 }
 ",
     "state": "modified",

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -406,6 +406,30 @@ Object {
 ",
     "state": "modified",
   },
+  "ts/webapp/Component.ts": Object {
+    "contents": "import AppComponent from 'sap/fe/core/AppComponent';
+
+/**
+ * @namespace v4travel
+ */
+export default class Component extends AppComponent {
+
+	public static metadata = {
+		manifest: \\"json\\"
+	};
+
+    /**
+     * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
+     * @public
+     * @override
+     */
+	//public init() : void {
+    //    super.init();
+	//}
+}
+",
+    "state": "modified",
+  },
   "ts/webapp/ext/anotherCustomAction/AnotherCustomAction.ts": Object {
     "contents": "import MessageToast from 'sap/m/MessageToast';
 

--- a/packages/fe-fpm-writer/test/integration/index.test.ts
+++ b/packages/fe-fpm-writer/test/integration/index.test.ts
@@ -39,6 +39,7 @@ describe('use FPM with existing apps', () => {
         const tsConfig = {
             path: join(testOutput, 'ts'),
             settings: {
+                replaceAppComponent: true,
                 typescript: true
             }
         };
@@ -232,7 +233,9 @@ describe('use FPM with existing apps', () => {
         });
 
         afterAll(() => {
-            expect((fs as any).dump(testOutput, '**/test-output/*/webapp/{manifest.json,ext/**/*}')).toMatchSnapshot();
+            expect(
+                (fs as any).dump(testOutput, '**/test-output/*/webapp/{manifest.json,Component.ts,ext/**/*}')
+            ).toMatchSnapshot();
         });
     });
 });

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/webapp/Component.ts
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/webapp/Component.ts
@@ -1,4 +1,4 @@
-import AppComponent from "sap/fe/core/AppComponent";
+import AppComponent from "sap/ui/core/UIComponent";
 
 /**
  * @namespace v4travel

--- a/packages/fiori-freestyle-writer/src/index.ts
+++ b/packages/fiori-freestyle-writer/src/index.ts
@@ -29,7 +29,7 @@ async function generate<T>(basePath: string, data: FreestyleApp<T>, fs?: Editor)
     // add new and overwrite files from templates e.g.
     const tmplPath = join(__dirname, '..', 'templates');
     // Common files
-    const ignore = ffApp.appOptions?.typescript ? '**/*.js' : '**/*.ts';
+    const ignore = [ffApp.appOptions?.typescript ? '**/*.js' : '**/*.ts'];
     fs.copyTpl(join(tmplPath, 'common', 'add'), basePath, { ...ffApp, escapeFLPText }, undefined, {
         globOptions: { ignore }
     });


### PR DESCRIPTION
Feature: #621 
Required for: https://github.com/ui5-community/generator-ui5-project/pull/58

* Fixed incorrect id in `Component.ts` template when calling `enableFpm`
* Enhanced tests to cover this case
* Changed input for file ignore pattern to array to be compatible with older version of `ejs` (could happen if integrated in an older version of `yeoman`)