### PR TITLE
feat: Controller Extension support in fe-fpm-writer

### DIFF
--- a/.changeset/late-planets-cheer.md
+++ b/.changeset/late-planets-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': minor
+---
+
+Controller Extension support

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -77,11 +77,20 @@ function handleExistingManifestExtension(
 /**
  * Method enhances the provided controller extension configuration with default and additional data.
  *
- * @param {InternalControllerExtension} config - a controller extension configuration object
+ * @param {ControllerExtension} data - a controller extension configuration object
  * @param {string} manifestPath - path to the project's manifest.json
  * @param {Manifest} manifest - the application manifest
+ * @returns enhanced configuration
  */
-function enhanceConfig(config: InternalControllerExtension, manifestPath: string, manifest: Manifest): void {
+function enhanceConfig(
+    data: ControllerExtension,
+    manifestPath: string,
+    manifest: Manifest
+): InternalControllerExtension {
+    // clone input
+    const config: ControllerExtension & Partial<InternalControllerExtension> = {
+        ...data
+    };
     // Apply default data
     setCommonDefaults(config, manifestPath, manifest);
     // Create `controllerName` with full path/namespace
@@ -105,6 +114,8 @@ function enhanceConfig(config: InternalControllerExtension, manifestPath: string
             config.controllerName
         );
     }
+
+    return config as InternalControllerExtension;
 }
 
 /**
@@ -130,7 +141,11 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            delete extension[deleteProperty];
+            if (deleteProperty === 'controllerName') {
+                delete extension['controllerName'];
+            } else if (deleteProperty === 'controllerNames') {
+                delete extension['controllerNames'];
+            }
         }
         return value;
     };
@@ -161,11 +176,7 @@ export function generateControllerExtension(
     const root = join(__dirname, '../../templates');
 
     // merge with defaults
-    const internalConfig = {
-        ...controllerConfig,
-        deleteProperty: undefined
-    } as InternalControllerExtension;
-    enhanceConfig(internalConfig, manifestPath, manifest);
+    const internalConfig = enhanceConfig(controllerConfig, manifestPath, manifest);
 
     // enhance manifest with view definition
     const filledTemplate = render(fs.read(join(root, 'controller-extension', `manifest.json`)), internalConfig, {});

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -134,6 +134,7 @@ function getManifestReplacer(
         // No request to delete any property
         return undefined;
     }
+    const propertyName = deleteProperty === 'controllerNames' ? 'controllerNames' : 'controllerName';
     return (key: string, value: Manifest) => {
         // Handle only root - more stable solution instead of checking 'key'
         if (key === '' && isRoot) {
@@ -141,9 +142,7 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            if (extension.hasOwnProperty(deleteProperty)) {
-                delete extension[deleteProperty];
-            }
+            delete extension[propertyName];
         }
         return value;
     };

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -134,7 +134,6 @@ function getManifestReplacer(
         // No request to delete any property
         return undefined;
     }
-    const propertyName = deleteProperty === 'controllerNames' ? 'controllerNames' : 'controllerName';
     return (key: string, value: Manifest) => {
         // Handle only root - more stable solution instead of checking 'key'
         if (key === '' && isRoot) {
@@ -142,7 +141,7 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            delete extension[propertyName];
+            delete extension[deleteProperty === 'controllerNames' ? 'controllerNames' : 'controllerName'];
         }
         return value;
     };

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -77,20 +77,11 @@ function handleExistingManifestExtension(
 /**
  * Method enhances the provided controller extension configuration with default and additional data.
  *
- * @param {ControllerExtension} data - a controller extension configuration object
+ * @param {InternalControllerExtension} config - a controller extension configuration object
  * @param {string} manifestPath - path to the project's manifest.json
  * @param {Manifest} manifest - the application manifest
- * @returns enhanced configuration
  */
-function enhanceConfig(
-    data: ControllerExtension,
-    manifestPath: string,
-    manifest: Manifest
-): InternalControllerExtension {
-    // clone input
-    const config: ControllerExtension & Partial<InternalControllerExtension> = {
-        ...data
-    };
+function enhanceConfig(config: InternalControllerExtension, manifestPath: string, manifest: Manifest): void {
     // Apply default data
     setCommonDefaults(config, manifestPath, manifest);
     // Create `controllerName` with full path/namespace
@@ -114,8 +105,6 @@ function enhanceConfig(
             config.controllerName
         );
     }
-
-    return config as InternalControllerExtension;
 }
 
 /**
@@ -141,7 +130,7 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            delete extension[deleteProperty === 'controllerNames' ? 'controllerNames' : 'controllerName'];
+            delete extension[deleteProperty];
         }
         return value;
     };
@@ -172,7 +161,11 @@ export function generateControllerExtension(
     const root = join(__dirname, '../../templates');
 
     // merge with defaults
-    const internalConfig = enhanceConfig(controllerConfig, manifestPath, manifest);
+    const internalConfig = {
+        ...controllerConfig,
+        deleteProperty: undefined
+    } as InternalControllerExtension;
+    enhanceConfig(internalConfig, manifestPath, manifest);
 
     // enhance manifest with view definition
     const filledTemplate = render(fs.read(join(root, 'controller-extension', `manifest.json`)), internalConfig, {});

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -141,7 +141,7 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            if (['controllerName', 'controllerNames'].includes(deleteProperty)) {
+            if (extension.hasOwnProperty(deleteProperty)) {
                 delete extension[deleteProperty];
             }
         }

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -172,16 +172,16 @@ export function generateControllerExtension(
     const root = join(__dirname, '../../templates');
 
     // merge with defaults
-    const completeController = enhanceConfig(controllerConfig, manifestPath, manifest);
+    const internalConfig = enhanceConfig(controllerConfig, manifestPath, manifest);
 
     // enhance manifest with view definition
-    const filledTemplate = render(fs.read(join(root, 'controller-extension', `manifest.json`)), completeController, {});
-    fs.extendJSON(manifestPath, JSON.parse(filledTemplate), getManifestReplacer(completeController));
+    const filledTemplate = render(fs.read(join(root, 'controller-extension', `manifest.json`)), internalConfig, {});
+    fs.extendJSON(manifestPath, JSON.parse(filledTemplate), getManifestReplacer(internalConfig));
 
     // add controller js file
-    const viewPath = join(completeController.path, `${completeController.name}.controller.js`);
+    const viewPath = join(internalConfig.path, `${internalConfig.name}.controller.js`);
     if (!fs.exists(viewPath)) {
-        fs.copyTpl(join(root, 'controller-extension/Controller.js'), viewPath, completeController);
+        fs.copyTpl(join(root, 'controller-extension/Controller.js'), viewPath, internalConfig);
     }
 
     return fs;

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -40,7 +40,7 @@ function appendUniqueEntryToArray<T>(values: T[], value: T): T[] {
  *
  * @param {Manifest} manifest - manifest
  * @param {string} extensionId - extension id
- * @returns Existing controller extension
+ * @returns {ManifestControllerExtension | undefined} Existing controller extension
  */
 function getExistingControllerExtension(
     manifest: Manifest,
@@ -52,6 +52,7 @@ function getExistingControllerExtension(
     if (extensions?.hasOwnProperty(extensionId)) {
         return extensions[extensionId];
     }
+    return undefined;
 }
 
 /**

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -1,0 +1,188 @@
+import { create as createStorage } from 'mem-fs';
+import { create } from 'mem-fs-editor';
+import type { Editor } from 'mem-fs-editor';
+import { join } from 'path';
+import { render } from 'ejs';
+import type { ControllerExtension, InternalControllerExtension, ManifestControllerExtension } from './types';
+import { ControllerExtensionPageType } from './types';
+import { validateBasePath } from '../common/validate';
+import type { Manifest } from '../common/types';
+import { setCommonDefaults } from '../common/defaults';
+
+export const UI5_CONTROLLER_EXTENSION_LIST_REPORT = 'sap.fe.templates.ListReport.ListReportController';
+export const UI5_CONTROLLER_EXTENSION_OBJECT_PAGE = 'sap.fe.templates.ObjectPage.ObjectPageController';
+const UI5_CONTROLLER_EXTENSIONS = 'sap.ui.controllerExtensions';
+export const EXTENSION_PAGE_TYPE_MAP = new Map<ControllerExtensionPageType, string>([
+    [ControllerExtensionPageType.ListReport, UI5_CONTROLLER_EXTENSION_LIST_REPORT],
+    [ControllerExtensionPageType.ObjectPage, UI5_CONTROLLER_EXTENSION_OBJECT_PAGE]
+]);
+
+interface ManifestControllerExtensions {
+    [key: string]: ManifestControllerExtension;
+}
+
+/**
+ * A function appends passed array of values with new value if value does not exist in array.
+ *
+ * @param values - array of values
+ * @param value - value to append
+ * @returns Array of values
+ */
+function appendUniqueEntryToArray<T>(values: T[], value: T): T[] {
+    if (!values.includes(value)) {
+        values.push(value);
+    }
+    return values;
+}
+
+/**
+ * Method enhances the provided controller extension by handling existing controller extension entry from manifest.
+ * Logic applies following:
+ * 1. Handles public property "overwrite" - if we should append or overwrite existing controller names.
+ * 2. Detects transition from "controllerName" to "controllerNames" when new controller is appended to exiusting entry with property "controllerNames".
+ * 3. Adds new controller entry to "controllerNames" array.
+ *
+ * @param {ManifestControllerExtension} manifestExtension - controller extension from manifest
+ * @param {InternalControllerExtension} config - internal controller extension configuration
+ * @param {string} controllerName - full name of new controller to add or replace/overwrite
+ */
+function handleExistingManifestExtension(
+    manifestExtension: ManifestControllerExtension,
+    config: InternalControllerExtension,
+    controllerName: string
+): void {
+    if (config.overwrite) {
+        if (manifestExtension.controllerNames) {
+            // Delete "controllerNames" from manifest because it will be overwritten by single controllerName
+            config.deleteProperty = 'controllerNames';
+        }
+        // Do not need append new controller with existing - exit further handling
+        return;
+    }
+    // Append new controller extension with existing controllers
+    if (manifestExtension.controllerName && manifestExtension.controllerName !== config.controllerName) {
+        // Manifest has single controller - transfer it into array
+        config.controllerNames = manifestExtension.controllerNames ? [...manifestExtension.controllerNames] : [];
+        // Check before append
+        appendUniqueEntryToArray(config.controllerNames, manifestExtension.controllerName);
+        appendUniqueEntryToArray(config.controllerNames, controllerName);
+        // Delete "controllerName" from manifest
+        config.deleteProperty = 'controllerName';
+    } else if (manifestExtension.controllerNames && !manifestExtension.controllerNames.includes(controllerName)) {
+        // Manifest has array of controllers - append new entry
+        config.controllerNames = appendUniqueEntryToArray([...manifestExtension.controllerNames], controllerName);
+    }
+}
+
+/**
+ * Method enhances the provided controller extension configuration with default and additional data.
+ *
+ * @param {ControllerExtension} data - a controller extension configuration object
+ * @param {string} manifestPath - path to the project's manifest.json
+ * @param {Manifest} manifest - the application manifest
+ * @returns enhanced configuration
+ */
+function enhanceConfig(
+    data: ControllerExtension,
+    manifestPath: string,
+    manifest: Manifest
+): InternalControllerExtension {
+    // clone input
+    const config: ControllerExtension & Partial<InternalControllerExtension> = {
+        ...data
+    };
+    // Apply default data
+    setCommonDefaults(config, manifestPath, manifest);
+    // Create `controllerName` with full path/namespace
+    config.controllerName = `${config.ns}.${config.name}`;
+    // Resolve controller extension id/key
+    let extensionId = EXTENSION_PAGE_TYPE_MAP.get(config.pageType) || UI5_CONTROLLER_EXTENSION_LIST_REPORT;
+    if (config.pageId) {
+        // Prepend project id
+        extensionId = `${extensionId}#${manifest['sap.app'].id}::${config.pageId}`;
+    }
+    config.extensionId = extensionId;
+    // Get existing controller extension entry from manifest
+    const manifestExtension = (
+        manifest['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
+    )?.[extensionId];
+    // If controller extension already exists in manifest - append new controller
+    if (manifestExtension) {
+        handleExistingManifestExtension(
+            manifestExtension,
+            config as InternalControllerExtension,
+            config.controllerName
+        );
+    }
+
+    return config as InternalControllerExtension;
+}
+
+/**
+ * A function that transforms JSON object during JSON.stringify call.
+ * Method is used to remove 'controllerName' or 'controllerNames' properties from manifest in case when we have transition from 'controllerName' to 'controllerNames'.
+ *
+ * @param {InternalControllerExtension} config - a controller extension configuration object
+ * @returns Json replacer method
+ */
+function getManifestReplacer(
+    config: InternalControllerExtension
+): ((key: string, value: Manifest) => unknown) | undefined {
+    let isRoot = true;
+    const { deleteProperty } = config;
+    if (!deleteProperty) {
+        // No request to delete any property
+        return undefined;
+    }
+    return (key: string, value: Manifest) => {
+        // Handle only root - more stable solution instead of checking 'key'
+        if (key === '' && isRoot) {
+            isRoot = false;
+            const extension = (
+                value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
+            )?.[config.extensionId];
+            delete extension[deleteProperty];
+        }
+        return value;
+    };
+}
+
+/**
+ * Add a controller extension to an existing UI5 application.
+ *
+ * @param {string} basePath - the base path
+ * @param {ControllerExtension} controllerConfig - the controller extension configuration
+ * @param {Editor} [fs] - the memfs editor instance
+ * @returns {Editor} the updated memfs editor instance
+ */
+export function generateControllerExtension(
+    basePath: string,
+    controllerConfig: ControllerExtension,
+    fs?: Editor
+): Editor {
+    // Validate the base and view paths
+    if (!fs) {
+        fs = create(createStorage());
+    }
+    validateBasePath(basePath, fs);
+
+    const manifestPath = join(basePath, 'webapp/manifest.json');
+    const manifest = fs.readJSON(manifestPath) as Manifest;
+
+    const root = join(__dirname, '../../templates');
+
+    // merge with defaults
+    const completeController = enhanceConfig(controllerConfig, manifestPath, manifest);
+
+    // enhance manifest with view definition
+    const filledTemplate = render(fs.read(join(root, 'controller-extension', `manifest.json`)), completeController, {});
+    fs.extendJSON(manifestPath, JSON.parse(filledTemplate), getManifestReplacer(completeController));
+
+    // add controller js file
+    const viewPath = join(completeController.path, `${completeController.name}.controller.js`);
+    if (!fs.exists(viewPath)) {
+        fs.copyTpl(join(root, 'controller-extension/Controller.js'), viewPath, completeController);
+    }
+
+    return fs;
+}

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -141,7 +141,9 @@ function getManifestReplacer(
             const extension = (
                 value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
             )?.[config.extensionId];
-            delete extension[deleteProperty];
+            if (['controllerName', 'controllerNames'].includes(deleteProperty)) {
+                delete extension[deleteProperty];
+            }
         }
         return value;
     };

--- a/packages/fe-fpm-writer/src/controller-extension/index.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/index.ts
@@ -138,13 +138,16 @@ function getManifestReplacer(
         // Handle only root - more stable solution instead of checking 'key'
         if (key === '' && isRoot) {
             isRoot = false;
-            const extension = (
-                value['sap.ui5']?.extends?.extensions?.[UI5_CONTROLLER_EXTENSIONS] as ManifestControllerExtensions
-            )?.[config.extensionId];
-            if (deleteProperty === 'controllerName') {
-                delete extension['controllerName'];
-            } else if (deleteProperty === 'controllerNames') {
-                delete extension['controllerNames'];
+            const extensions = value['sap.ui5']?.extends?.extensions?.[
+                UI5_CONTROLLER_EXTENSIONS
+            ] as ManifestControllerExtensions;
+            if (extensions.hasOwnProperty(config.extensionId)) {
+                const extension = extensions[config.extensionId];
+                if (deleteProperty === 'controllerName') {
+                    delete extension['controllerName'];
+                } else if (deleteProperty === 'controllerNames') {
+                    delete extension['controllerNames'];
+                }
             }
         }
         return value;

--- a/packages/fe-fpm-writer/src/controller-extension/types.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/types.ts
@@ -26,6 +26,10 @@ export interface ControllerExtension extends CustomElement {
      * Controls if controller(s) for existing controller extension should be appended or replaced with new controller.
      */
     overwrite?: boolean;
+    /**
+     * Typescript generation is not supported for control extensions.
+     */
+    typescript?: false;
 }
 
 /**
@@ -54,4 +58,8 @@ export interface InternalControllerExtension
      * Delete property from existing control extension object in manifest.
      */
     deleteProperty?: keyof ManifestControllerExtension;
+    /**
+     * Typescript generation is not supported for control extensions.
+     */
+    typescript?: false;
 }

--- a/packages/fe-fpm-writer/src/controller-extension/types.ts
+++ b/packages/fe-fpm-writer/src/controller-extension/types.ts
@@ -1,0 +1,57 @@
+import type { CustomElement, InternalCustomElement } from '../common/types';
+
+/**
+ * Controller extension's associated page type.
+ *
+ * @enum {string}
+ */
+export enum ControllerExtensionPageType {
+    ObjectPage = 'ObjectPage',
+    ListReport = 'ListReport'
+}
+
+/**
+ * Represents a controller extension configuration.
+ */
+export interface ControllerExtension extends CustomElement {
+    /**
+     * The page type for which controller extension should be triggered.
+     */
+    pageType: ControllerExtensionPageType;
+    /**
+     * The unique page id for which controller extension should be triggered.
+     */
+    pageId?: string;
+    /**
+     * Controls if controller(s) for existing controller extension should be appended or replaced with new controller.
+     */
+    overwrite?: boolean;
+}
+
+/**
+ * Represents a controller extension configuration in manifest.
+ */
+export interface ManifestControllerExtension {
+    /**
+     * Specifies single controller for controller extension.
+     */
+    controllerName?: string;
+    /**
+     * Specifies multiple controllers for controller extension.
+     */
+    controllerNames?: string[];
+}
+
+export interface InternalControllerExtension
+    extends ControllerExtension,
+        ManifestControllerExtension,
+        InternalCustomElement {
+    /**
+     * Derived full extension key/id in manifest "sap.ui.controllerExtensions" object.
+     */
+    extensionId: string;
+    /**
+     * Delete property from existing control extension object in manifest.
+     */
+    deleteProperty?: keyof ManifestControllerExtension;
+}

--- a/packages/fe-fpm-writer/src/index.ts
+++ b/packages/fe-fpm-writer/src/index.ts
@@ -19,3 +19,6 @@ export { validateBasePath, validateVersion } from './common/validate';
 
 export { BuildingBlockType, FilterBar, Chart, Field, FieldFormatOptions } from './building-block/types';
 export { generateBuildingBlock } from './building-block';
+
+export { ControllerExtension } from './controller-extension/types';
+export { generateControllerExtension } from './controller-extension';

--- a/packages/fe-fpm-writer/src/index.ts
+++ b/packages/fe-fpm-writer/src/index.ts
@@ -20,5 +20,5 @@ export { validateBasePath, validateVersion } from './common/validate';
 export { BuildingBlockType, FilterBar, Chart, Field, FieldFormatOptions } from './building-block/types';
 export { generateBuildingBlock } from './building-block';
 
-export { ControllerExtension } from './controller-extension/types';
+export { ControllerExtension, ControllerExtensionPageType } from './controller-extension/types';
 export { generateControllerExtension } from './controller-extension';

--- a/packages/fe-fpm-writer/templates/controller-extension/Controller.js
+++ b/packages/fe-fpm-writer/templates/controller-extension/Controller.js
@@ -1,0 +1,33 @@
+sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('<%- ns %>.<%- name %>', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+
+				// ... custom code here
+			},
+			viewState: {
+				applyInitialStateOnly: function () {
+					// ... custom code here
+				}
+			}
+		},
+		// you can add own formatter or helper
+		formatMyField: function () {
+			// ... custom code here
+		},
+		accept: function () {
+			// ... custom code here
+		},
+		// !!! bundling formatters or event handlers into an object does not work
+		formatter: {
+			formatMyField: function () {
+				// this method is not accessible
+			}
+		}
+	});
+});

--- a/packages/fe-fpm-writer/templates/controller-extension/Controller.js
+++ b/packages/fe-fpm-writer/templates/controller-extension/Controller.js
@@ -4,29 +4,14 @@ sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExten
 	return ControllerExtension.extend('<%- ns %>.<%- name %>', {
 		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
 		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf <%- ns %>.<%- name %>
+             */
 			onInit: function () {
 				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
 				var oModel = this.base.getExtensionAPI().getModel();
-
-				// ... custom code here
-			},
-			viewState: {
-				applyInitialStateOnly: function () {
-					// ... custom code here
-				}
-			}
-		},
-		// you can add own formatter or helper
-		formatMyField: function () {
-			// ... custom code here
-		},
-		accept: function () {
-			// ... custom code here
-		},
-		// !!! bundling formatters or event handlers into an object does not work
-		formatter: {
-			formatMyField: function () {
-				// this method is not accessible
 			}
 		}
 	});

--- a/packages/fe-fpm-writer/templates/controller-extension/manifest.json
+++ b/packages/fe-fpm-writer/templates/controller-extension/manifest.json
@@ -1,0 +1,14 @@
+{
+    "sap.ui5": {
+        "extends": {
+            "extensions": {
+                "sap.ui.controllerExtensions": {
+                    "<%- extensionId -%>": {<%if (typeof controllerNames !== 'undefined') {%>
+                        "controllerNames": <%- JSON.stringify(controllerNames) %><% } else {%>
+                        "controllerName": "<%- controllerName %>"<% } %>
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`use FPM with existing apps extend UI5 application with FPM generateCustomSection in ObjectPage 1`] = `
+exports[`use FPM with existing apps extend UI5 application with FPM generateControllerExtension in ObjectPage 1`] = `
 Object {
   "lrop/webapp/ext/anotherCustomAction/AnotherCustomAction.js": Object {
     "contents": "sap.ui.define([
@@ -16,6 +16,28 @@ Object {
             window.location.href += '/_Booking';
         }
     };
+});
+",
+    "state": "modified",
+  },
+  "lrop/webapp/ext/myControllerExtension/MyControllerExtension.controller.js": Object {
+    "contents": "sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('v4travel.ext.myControllerExtension.MyControllerExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf v4travel.ext.myControllerExtension.MyControllerExtension
+             */
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+			}
+		}
+	});
 });
 ",
     "state": "modified",
@@ -384,6 +406,9 @@ Object {
         \\"sap.ui.controllerExtensions\\": {
           \\"sap.fe.templates.ListReport.ListReportController\\": {
             \\"controllerName\\": \\"v4travel.ext.newCustomView.NewCustomView\\"
+          },
+          \\"sap.fe.templates.ObjectPage.ObjectPageController\\": {
+            \\"controllerName\\": \\"v4travel.ext.myControllerExtension.MyControllerExtension\\"
           }
         }
       }
@@ -434,6 +459,28 @@ export function onPress() {
 export function onAppended() {
             window.location.href += '/_Booking';
         }",
+    "state": "modified",
+  },
+  "ts/webapp/ext/myControllerExtension/MyControllerExtension.controller.js": Object {
+    "contents": "sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('v4travel.ext.myControllerExtension.MyControllerExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf v4travel.ext.myControllerExtension.MyControllerExtension
+             */
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+			}
+		}
+	});
+});
+",
     "state": "modified",
   },
   "ts/webapp/ext/myCustomAction/MyCustomAction.ts": Object {
@@ -768,6 +815,9 @@ export function onPress() {
         \\"sap.ui.controllerExtensions\\": {
           \\"sap.fe.templates.ListReport.ListReportController\\": {
             \\"controllerName\\": \\"v4travel.ext.newCustomView.NewCustomView\\"
+          },
+          \\"sap.fe.templates.ObjectPage.ObjectPageController\\": {
+            \\"controllerName\\": \\"v4travel.ext.myControllerExtension.MyControllerExtension\\"
           }
         }
       }

--- a/packages/fe-fpm-writer/test/integration/index.test.ts
+++ b/packages/fe-fpm-writer/test/integration/index.test.ts
@@ -8,7 +8,9 @@ import {
     TargetControl,
     generateCustomSection,
     generateCustomView,
-    enableFPM
+    enableFPM,
+    generateControllerExtension,
+    ControllerExtensionPageType
 } from '../../src';
 import { Placement } from '../../src/common/types';
 import { generateListReport, generateObjectPage } from '../../src/page';
@@ -227,6 +229,20 @@ describe('use FPM with existing apps', () => {
                     },
                     eventHandler: true,
                     ...config.settings
+                },
+                fs
+            );
+        });
+
+        test.each(configs)('generateControllerExtension in ObjectPage', (config) => {
+            generateControllerExtension(
+                config.path,
+                {
+                    name: 'MyControllerExtension',
+                    pageType: ControllerExtensionPageType.ObjectPage,
+                    ...config.settings,
+                    // Typescript version is not supported
+                    typescript: false
                 },
                 fs
             );

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
@@ -394,29 +394,14 @@ exports[`ControllerExtension generateControllerExtension New control extension -
 	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
 		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
 		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf my.test.App.ext.controller.NewExtension
+             */
 			onInit: function () {
 				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
 				var oModel = this.base.getExtensionAPI().getModel();
-
-				// ... custom code here
-			},
-			viewState: {
-				applyInitialStateOnly: function () {
-					// ... custom code here
-				}
-			}
-		},
-		// you can add own formatter or helper
-		formatMyField: function () {
-			// ... custom code here
-		},
-		accept: function () {
-			// ... custom code here
-		},
-		// !!! bundling formatters or event handlers into an object does not work
-		formatter: {
-			formatMyField: function () {
-				// this method is not accessible
 			}
 		}
 	});
@@ -465,29 +450,14 @@ exports[`ControllerExtension generateControllerExtension New control extension -
 	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
 		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
 		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf my.test.App.ext.controller.NewExtension
+             */
 			onInit: function () {
 				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
 				var oModel = this.base.getExtensionAPI().getModel();
-
-				// ... custom code here
-			},
-			viewState: {
-				applyInitialStateOnly: function () {
-					// ... custom code here
-				}
-			}
-		},
-		// you can add own formatter or helper
-		formatMyField: function () {
-			// ... custom code here
-		},
-		accept: function () {
-			// ... custom code here
-		},
-		// !!! bundling formatters or event handlers into an object does not work
-		formatter: {
-			formatMyField: function () {
-				// this method is not accessible
 			}
 		}
 	});
@@ -536,29 +506,14 @@ exports[`ControllerExtension generateControllerExtension New control extension -
 	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
 		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
 		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf my.test.App.ext.controller.NewExtension
+             */
 			onInit: function () {
 				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
 				var oModel = this.base.getExtensionAPI().getModel();
-
-				// ... custom code here
-			},
-			viewState: {
-				applyInitialStateOnly: function () {
-					// ... custom code here
-				}
-			}
-		},
-		// you can add own formatter or helper
-		formatMyField: function () {
-			// ... custom code here
-		},
-		accept: function () {
-			// ... custom code here
-		},
-		// !!! bundling formatters or event handlers into an object does not work
-		formatter: {
-			formatMyField: function () {
-				// this method is not accessible
 			}
 		}
 	});
@@ -607,29 +562,14 @@ exports[`ControllerExtension generateControllerExtension New control extension w
 	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
 		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
 		override: {
+			/**
+             * Called when a controller is instantiated and its View controls (if available) are already created.
+             * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+             * @memberOf my.test.App.ext.controller.NewExtension
+             */
 			onInit: function () {
 				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
 				var oModel = this.base.getExtensionAPI().getModel();
-
-				// ... custom code here
-			},
-			viewState: {
-				applyInitialStateOnly: function () {
-					// ... custom code here
-				}
-			}
-		},
-		// you can add own formatter or helper
-		formatMyField: function () {
-			// ... custom code here
-		},
-		accept: function () {
-			// ... custom code here
-		},
-		// !!! bundling formatters or event handlers into an object does not work
-		formatter: {
-			formatMyField: function () {
-				// this method is not accessible
 			}
 		}
 	});

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
@@ -1,0 +1,638 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerName" and "controllerNames" exists - append new value 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.LRExtension2",
+              "my.test.App.ext.controller.LRExtension",
+              "my.test.App.ext.controller.LRExtension3",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerName" and "controllerNames" exists - duplicate 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.LRExtension2",
+              "my.test.App.ext.controller.LRExtension",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerName" exists - append new value 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.LRExtension",
+              "my.test.App.ext.controller.Dummy",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerName" exists - duplication 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.LRExtension",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerName" exists - overwrite 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.Dummy",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerNames" exists - append new value 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.LRExtension",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+              "my.test.App.ext.controller.OPExtensionNew",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerNames" exists - duplication 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.LRExtension",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerName": "my.test.App.ext.controller.OPExtension2",
+            "controllerNames": Array [
+              "my.test.App.ext.controller.OPExtension",
+              "my.test.App.ext.controller.OPExtension2",
+            ],
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension Controller extension exists "controllerNames" exists - overwrite 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.LRExtension",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerName": "my.test.App.ext.controller.Dummy",
+          },
+          "sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage": Object {
+            "controllerName": "my.test.App.ext.controller.OPBookingExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - ListReport 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.NewExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - ListReport 2`] = `
+"sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+
+				// ... custom code here
+			},
+			viewState: {
+				applyInitialStateOnly: function () {
+					// ... custom code here
+				}
+			}
+		},
+		// you can add own formatter or helper
+		formatMyField: function () {
+			// ... custom code here
+		},
+		accept: function () {
+			// ... custom code here
+		},
+		// !!! bundling formatters or event handlers into an object does not work
+		formatter: {
+			formatMyField: function () {
+				// this method is not accessible
+			}
+		}
+	});
+});
+"
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - ObjectPage 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ObjectPage.ObjectPageController": Object {
+            "controllerName": "my.test.App.ext.controller.NewExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - ObjectPage 2`] = `
+"sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+
+				// ... custom code here
+			},
+			viewState: {
+				applyInitialStateOnly: function () {
+					// ... custom code here
+				}
+			}
+		},
+		// you can add own formatter or helper
+		formatMyField: function () {
+			// ... custom code here
+		},
+		accept: function () {
+			// ... custom code here
+		},
+		// !!! bundling formatters or event handlers into an object does not work
+		formatter: {
+			formatMyField: function () {
+				// this method is not accessible
+			}
+		}
+	});
+});
+"
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - undefined 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController": Object {
+            "controllerName": "my.test.App.ext.controller.NewExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension - undefined 2`] = `
+"sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+
+				// ... custom code here
+			},
+			viewState: {
+				applyInitialStateOnly: function () {
+					// ... custom code here
+				}
+			}
+		},
+		// you can add own formatter or helper
+		formatMyField: function () {
+			// ... custom code here
+		},
+		accept: function () {
+			// ... custom code here
+		},
+		// !!! bundling formatters or event handlers into an object does not work
+		formatter: {
+			formatMyField: function () {
+				// this method is not accessible
+			}
+		}
+	});
+});
+"
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension with page id 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.templates": Object {},
+      },
+    },
+    "extends": Object {
+      "extensions": Object {
+        "sap.ui.controllerExtensions": Object {
+          "sap.fe.templates.ListReport.ListReportController#my.test.App::TestListReport": Object {
+            "controllerName": "my.test.App.ext.controller.NewExtension",
+          },
+        },
+      },
+    },
+    "routing": Object {
+      "targets": Object {
+        "TestListReport": Object {
+          "name": "sap.fe.templates.ListReport",
+        },
+        "TestObjectPage": Object {
+          "name": "sap.fe.templates.ObjectPage",
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ControllerExtension generateControllerExtension New control extension with page id 2`] = `
+"sap.ui.define(['sap/ui/core/mvc/ControllerExtension'], function (ControllerExtension) {
+	'use strict';
+
+	return ControllerExtension.extend('my.test.App.ext.controller.NewExtension', {
+		// this section allows to extend lifecycle hooks or hooks provided by Fiori elements
+		override: {
+			onInit: function () {
+				// you can access the Fiori elements extensionAPI via this.base.getExtensionAPI
+				var oModel = this.base.getExtensionAPI().getModel();
+
+				// ... custom code here
+			},
+			viewState: {
+				applyInitialStateOnly: function () {
+					// ... custom code here
+				}
+			}
+		},
+		// you can add own formatter or helper
+		formatMyField: function () {
+			// ... custom code here
+		},
+		accept: function () {
+			// ... custom code here
+		},
+		// !!! bundling formatters or event handlers into an object does not work
+		formatter: {
+			formatMyField: function () {
+				// this method is not accessible
+			}
+		}
+	});
+});
+"
+`;

--- a/packages/fe-fpm-writer/test/unit/controller-extension.test.ts
+++ b/packages/fe-fpm-writer/test/unit/controller-extension.test.ts
@@ -1,0 +1,211 @@
+import { create, Editor } from 'mem-fs-editor';
+import { create as createStorage } from 'mem-fs';
+import { join } from 'path';
+import { generateControllerExtension } from '../../src';
+import { ControllerExtension, ControllerExtensionPageType } from '../../src/controller-extension/types';
+
+describe('ControllerExtension', () => {
+    describe('generateControllerExtension', () => {
+        const testDir = '' + Date.now();
+        let fs: Editor;
+        const controllerExtension: ControllerExtension = {
+            name: 'NewExtension',
+            folder: 'ext/controller',
+            pageType: ControllerExtensionPageType.ListReport
+        };
+        const getControllerPath = (controller: ControllerExtension): string => {
+            return join(testDir, 'webapp', controller.folder!, `${controller.name}.controller.js`);
+        };
+        const expectedControllerPath = getControllerPath(controllerExtension);
+
+        const getManifest = (extensions: unknown = undefined): string => {
+            const manifest = {
+                'sap.app': {
+                    id: 'my.test.App'
+                },
+                'sap.ui5': {
+                    dependencies: {
+                        libs: {
+                            'sap.fe.templates': {}
+                        }
+                    },
+                    routing: {
+                        targets: {
+                            TestListReport: { name: 'sap.fe.templates.ListReport' },
+                            TestObjectPage: { name: 'sap.fe.templates.ObjectPage' }
+                        }
+                    },
+                    extends: {
+                        extensions
+                    }
+                }
+            };
+            return JSON.stringify(manifest, null, 2);
+        };
+        const testAppManifest = getManifest();
+
+        beforeEach(() => {
+            fs = create(createStorage());
+            fs.delete(testDir);
+            fs.write(join(testDir, 'webapp/manifest.json'), testAppManifest);
+        });
+
+        const pageTypeTests = [
+            ControllerExtensionPageType.ListReport,
+            ControllerExtensionPageType.ObjectPage,
+            undefined
+        ];
+        for (const pageType of pageTypeTests) {
+            test(`New control extension - ${pageType}`, () => {
+                generateControllerExtension(
+                    testDir,
+                    {
+                        ...controllerExtension,
+                        pageType
+                    } as ControllerExtension,
+                    fs
+                );
+                expect(fs.readJSON(join(testDir, 'webapp/manifest.json'))).toMatchSnapshot();
+                expect(fs.exists(expectedControllerPath)).toBeTruthy();
+                expect(fs.read(expectedControllerPath)).toMatchSnapshot();
+            });
+        }
+
+        test('New control extension with page id', () => {
+            generateControllerExtension(
+                testDir,
+                {
+                    ...controllerExtension,
+                    pageId: 'TestListReport',
+                    pageType: ControllerExtensionPageType.ListReport
+                },
+                fs
+            );
+            expect(fs.readJSON(join(testDir, 'webapp/manifest.json'))).toMatchSnapshot();
+            expect(fs.read(expectedControllerPath)).toMatchSnapshot();
+        });
+
+        describe('Controller extension exists', () => {
+            const getExtensions = (): any => {
+                return {
+                    'sap.ui.controllerExtensions': {
+                        'sap.fe.templates.ListReport.ListReportController': {
+                            controllerName: 'my.test.App.ext.controller.LRExtension'
+                        },
+                        'sap.fe.templates.ObjectPage.ObjectPageController': {
+                            controllerNames: [
+                                'my.test.App.ext.controller.OPExtension',
+                                'my.test.App.ext.controller.OPExtension2'
+                            ]
+                        },
+                        'sap.fe.templates.ObjectPage.ObjectPageController#project4::BookingObjectPage': {
+                            controllerName: 'my.test.App.ext.controller.OPBookingExtension'
+                        }
+                    }
+                };
+            };
+
+            const testCases = [
+                // "controllerName" exists
+                {
+                    name: '"controllerName" exists - append new value',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'Dummy',
+                        pageType: ControllerExtensionPageType.ListReport
+                    }
+                },
+                {
+                    name: '"controllerName" exists - duplication',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'LRExtension',
+                        pageType: ControllerExtensionPageType.ListReport
+                    }
+                },
+                {
+                    name: '"controllerName" exists - overwrite',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'Dummy',
+                        pageType: ControllerExtensionPageType.ListReport,
+                        overwrite: true
+                    }
+                },
+                // "controllerNames" exists
+                {
+                    name: '"controllerNames" exists - append new value',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'OPExtensionNew',
+                        pageType: ControllerExtensionPageType.ObjectPage
+                    }
+                },
+                {
+                    name: '"controllerNames" exists - duplication',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'OPExtension2',
+                        pageType: ControllerExtensionPageType.ObjectPage
+                    }
+                },
+                {
+                    name: '"controllerNames" exists - overwrite',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'Dummy',
+                        pageType: ControllerExtensionPageType.ObjectPage,
+                        overwrite: true
+                    }
+                }
+            ];
+
+            for (const testCase of testCases) {
+                test(testCase.name, () => {
+                    const manifestWithExtensions = getManifest(getExtensions());
+                    fs = create(createStorage());
+                    fs.delete(testDir);
+                    fs.write(join(testDir, 'webapp/manifest.json'), manifestWithExtensions);
+                    generateControllerExtension(testDir, testCase.controllerConfig, fs);
+                    expect(fs.readJSON(join(testDir, 'webapp/manifest.json'))).toMatchSnapshot();
+                    expect(fs.exists(getControllerPath(testCase.controllerConfig))).toBeTruthy();
+                });
+            }
+
+            const mixStateTestCases = [
+                {
+                    name: '"controllerName" and "controllerNames" exists - append new value',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'LRExtension3',
+                        pageType: ControllerExtensionPageType.ListReport
+                    }
+                },
+                {
+                    name: '"controllerName" and "controllerNames" exists - duplicate',
+                    controllerConfig: {
+                        ...controllerExtension,
+                        name: 'LRExtension2',
+                        pageType: ControllerExtensionPageType.ListReport
+                    }
+                }
+            ];
+
+            for (const testCase of mixStateTestCases) {
+                test(testCase.name, () => {
+                    const extension = getExtensions();
+                    extension['sap.ui.controllerExtensions'][
+                        'sap.fe.templates.ListReport.ListReportController'
+                    ].controllerNames = ['my.test.App.ext.controller.LRExtension2'];
+                    const manifestWithExtensions = getManifest(extension);
+                    fs = create(createStorage());
+                    fs.delete(testDir);
+                    fs.write(join(testDir, 'webapp/manifest.json'), manifestWithExtensions);
+                    generateControllerExtension(testDir, testCase.controllerConfig, fs);
+                    expect(fs.readJSON(join(testDir, 'webapp/manifest.json'))).toMatchSnapshot();
+                    expect(fs.exists(getControllerPath(testCase.controllerConfig))).toBeTruthy();
+                });
+            }
+        });
+    });
+});


### PR DESCRIPTION
Support for controller extension creation using `fe-fpm-writer`.

Some special parts to mention:
1. In `manifest.json` - for controller extension we can have:
1.1. Single controller using property `controllerName` - string;
1.2. Multiple controllers using property `controllerNames` - string array;
In result we need handle cases when `controllerName` is defined in `manifest.json` and we try to add new `controllerName`, then we need apply transition from `controllerName` to `controllerNames`.
Also additional property `overwrite` is available in case user wants to replace existing with new.
2. There no support for `typescript` controller version, because did not find valid syntax for it. And there is also issue reported in https://github.com/SAP/ui5-typescript/issues/332