### PR TITLE
Make backend-proxy-middleware more robust

### DIFF
--- a/.changeset/witty-islands-refuse.md
+++ b/.changeset/witty-islands-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/backend-proxy-middleware': patch
+---
+
+Make backend-proxy-middleware more robust

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -14,6 +14,9 @@ import { BackendConfig, DestinationBackendConfig, LocalBackendConfig } from '../
 import { AuthenticationType, BackendSystem } from '@sap-ux/store';
 import { getInstance } from '@sap-ux/store/dist/services/backend-system';
 
+jest.mock('@sap-ux/store/dist/services/api-hub', () => ({
+    getInstance: jest.fn().mockReturnValue({ read: () => {} })
+}));
 jest.mock('@sap-ux/store/dist/services/backend-system', () => ({
     getInstance: jest.fn().mockReturnValue({ read: () => {} })
 }));


### PR DESCRIPTION
* Make backend-proxy-middleware more robust by catching store errors and continuing the flow.
* improve unit tests by using a mocked store instead of the real one

The issue was found when running the `backend-proxy-middleware` unit tests on a machine that had matching but invalid entries in the secure store