### PR TITLE
fix(fe-fpm-writer): 'enableFPM' method throws 'Invalid Version' exception if unknown UI5 version stored in '["sap.ui5"]["dependencies"]["minUI5Version"]'

### DIFF
--- a/.changeset/little-foxes-mate.md
+++ b/.changeset/little-foxes-mate.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix: 'enableFPM' method throws 'Invalid Version' exception if unknown UI5 version stored in '["sap.ui5"]["dependencies"]["minUI5Version"]'. Like version '${sap.ui5.dist.version}'

--- a/packages/fe-fpm-writer/src/app/index.ts
+++ b/packages/fe-fpm-writer/src/app/index.ts
@@ -2,7 +2,7 @@ import { create as createStorage } from 'mem-fs';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
 import { join } from 'path';
-import { lt } from 'semver';
+import { lt, valid } from 'semver';
 import type { Manifest } from '@sap-ux/ui5-config';
 import { FCL_ROUTER } from '../common/defaults';
 import { getTemplatePath } from '../templates';
@@ -61,10 +61,8 @@ export function enableFPM(basePath: string, config: FPMConfig = {}, fs?: Editor)
     }
 
     // if a minUI5Version is set and it is smaller than the minimum required, increase it
-    if (
-        manifest['sap.ui5']?.dependencies.minUI5Version &&
-        lt(manifest['sap.ui5']?.dependencies.minUI5Version, MIN_VERSION)
-    ) {
+    const minUI5Version = manifest['sap.ui5']?.dependencies?.minUI5Version;
+    if (minUI5Version && valid(minUI5Version) && lt(minUI5Version, MIN_VERSION)) {
         fs.extendJSON(manifestPath, {
             'sap.ui5': {
                 dependencies: {

--- a/packages/fe-fpm-writer/test/unit/app.test.ts
+++ b/packages/fe-fpm-writer/test/unit/app.test.ts
@@ -81,16 +81,6 @@ describe('CustomApp', () => {
             expect(fs.read(join(target, 'webapp/Component.js'))).not.toBe(component);
         });
 
-        test('Missing dependencies', async () => {
-            const target = join(testDir, 'missing-dependencies');
-            const tempManifest = getTestManifest();
-            tempManifest['sap.ui5'] = {} as any;
-            fs.writeJSON(join(target, 'webapp/manifest.json'), tempManifest);
-            await enableFPM(target, {}, fs);
-            const manifest = fs.readJSON(join(target, 'webapp/manifest.json')) as Manifest;
-            expect(manifest['sap.ui5']?.dependencies?.minUI5Version).toBe(undefined);
-        });
-
         test('Invalid/unknown version', async () => {
             const unknownVersion = '${sap.ui5.dist.version}';
             const target = join(testDir, 'unknown-version');
@@ -99,5 +89,21 @@ describe('CustomApp', () => {
             const manifest = fs.readJSON(join(target, 'webapp/manifest.json')) as Manifest;
             expect(manifest['sap.ui5']?.dependencies?.minUI5Version).toBe(unknownVersion);
         });
+
+        const optionalPropertyCases = [
+            { name: '"sap.ui5" is undefined', value: undefined },
+            { name: '"sap.ui5/dependencies" is undefined', value: {} }
+        ];
+        for (const optionalPropertyCase of optionalPropertyCases) {
+            test(optionalPropertyCase.name, async () => {
+                const target = join(testDir, 'safe-check');
+                const tempManifest = getTestManifest();
+                tempManifest['sap.ui5'] = optionalPropertyCase.value as any;
+                fs.writeJSON(join(target, 'webapp/manifest.json'), tempManifest);
+                await enableFPM(target, {}, fs);
+                const manifest = fs.readJSON(join(target, 'webapp/manifest.json')) as Manifest;
+                expect(manifest['sap.ui5']?.dependencies?.minUI5Version).toBe(undefined);
+            });
+        }
     });
 });

--- a/packages/fe-fpm-writer/test/unit/app.test.ts
+++ b/packages/fe-fpm-writer/test/unit/app.test.ts
@@ -81,6 +81,16 @@ describe('CustomApp', () => {
             expect(fs.read(join(target, 'webapp/Component.js'))).not.toBe(component);
         });
 
+        test('Missing dependencies', async () => {
+            const target = join(testDir, 'missing-dependencies');
+            const tempManifest = getTestManifest();
+            tempManifest['sap.ui5'] = {} as any;
+            fs.writeJSON(join(target, 'webapp/manifest.json'), tempManifest);
+            await enableFPM(target, {}, fs);
+            const manifest = fs.readJSON(join(target, 'webapp/manifest.json')) as Manifest;
+            expect(manifest['sap.ui5']?.dependencies?.minUI5Version).toBe(undefined);
+        });
+
         test('Invalid/unknown version', async () => {
             const unknownVersion = '${sap.ui5.dist.version}';
             const target = join(testDir, 'unknown-version');

--- a/packages/fe-fpm-writer/test/unit/app.test.ts
+++ b/packages/fe-fpm-writer/test/unit/app.test.ts
@@ -80,5 +80,14 @@ describe('CustomApp', () => {
             await enableFPM(target, { replaceAppComponent: true }, fs);
             expect(fs.read(join(target, 'webapp/Component.js'))).not.toBe(component);
         });
+
+        test('Invalid/unknown version', async () => {
+            const unknownVersion = '${sap.ui5.dist.version}';
+            const target = join(testDir, 'unknown-version');
+            fs.writeJSON(join(target, 'webapp/manifest.json'), getTestManifest({ minVersion: unknownVersion }));
+            await enableFPM(target, {}, fs);
+            const manifest = fs.readJSON(join(target, 'webapp/manifest.json')) as Manifest;
+            expect(manifest['sap.ui5']?.dependencies?.minUI5Version).toBe(unknownVersion);
+        });
     });
 });


### PR DESCRIPTION
If we call `enableFPM`, when we have following entry in `manifest.json`:
![image](https://user-images.githubusercontent.com/90789422/191321078-eb84dcf4-7b8e-4abd-bb68-12a0280efa27.png)

we get exception `TypeError: Invalid Version: ${sap.ui5.dist.version}` in `..\node_modules\semver\classes\semver.js`.

Changes:
1. Applying additional check if version is valid by calling `semver.valid`;
2. Additional minor check if 'dependencies' property is defined;
