### PR TITLE
fix(fe-fpm-writer): Add sap.se.macros namespace to custom section's Fragment.xml when ui5 version >= 1.90

### DIFF
--- a/.changeset/many-onions-hammer.md
+++ b/.changeset/many-onions-hammer.md
@@ -2,4 +2,4 @@
 '@sap-ux/fe-fpm-writer': patch
 ---
 
-Add sap.se.macros namespace to custom section's Fragment.xml where ui5 version >- 1.90
+Add 'sap.se.macros' namespace to custom section's 'Fragment.xml' when ui5 version >= 1.90

--- a/.changeset/many-onions-hammer.md
+++ b/.changeset/many-onions-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Add sap.se.macros namespace to custom section's Fragment.xml where ui5 version >- 1.90

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -1,7 +1,7 @@
 import { create as createStorage } from 'mem-fs';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
-import type { CustomSection, InternalCustomSection } from './types';
+import type { CustomSection, InternalCustomSection, CustomSectionDependencies } from './types';
 import { join } from 'path';
 import { render } from 'ejs';
 import { validateVersion, validateBasePath } from '../common/validate';
@@ -24,6 +24,17 @@ export function getManifestRoot(ui5Version?: string): string {
     } else {
         return getTemplatePath('/section/1.85');
     }
+}
+
+/**
+ * Get additional dependencies for fragment of section based on passed version.
+ *
+ * @param ui5Version required UI5 version.
+ * @returns Additional dependencies for fragment
+ */
+function getAdditionalDependencies(ui5Version?: string): CustomSectionDependencies | undefined {
+    const minVersion = coerce(ui5Version);
+    return !minVersion || minVersion.minor >= 90 ? { 'xmlns:macros': 'sap.fe.macros' } : undefined;
 }
 
 /**
@@ -51,6 +62,8 @@ function enhanceConfig(
 
     // generate section content
     config.content = config.control || getDefaultFragmentContent(config.name, config.eventHandler);
+    // Additional dependencies to include
+    config.dependencies = getAdditionalDependencies(config.minUI5Version);
 
     return config as InternalCustomSection;
 }

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -27,10 +27,10 @@ export function getManifestRoot(ui5Version?: string): string {
 }
 
 /**
- * Get additional dependencies for fragment of section based on passed version.
+ * Get additional dependencies for fragment.xml template based on passed ui5 version.
  *
  * @param ui5Version required UI5 version.
- * @returns Additional dependencies for fragment
+ * @returns Additional dependencies for fragment.xml
  */
 function getAdditionalDependencies(ui5Version?: string): CustomSectionDependencies | undefined {
     const minVersion = coerce(ui5Version);

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -62,7 +62,7 @@ function enhanceConfig(
 
     // generate section content
     config.content = config.control || getDefaultFragmentContent(config.name, config.eventHandler);
-    // Additional dependencies to include
+    // Additional dependencies to include into 'Fragment.xml'
     config.dependencies = getAdditionalDependencies(config.minUI5Version);
 
     return config as InternalCustomSection;

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -22,6 +22,11 @@ export interface CustomSection extends CustomElement, EventHandler {
     control?: string;
 }
 
+export interface CustomSectionDependencies {
+    [key: string]: string;
+}
+
 export interface InternalCustomSection extends CustomSection, InternalCustomElement {
     content: string;
+    dependencies?: CustomSectionDependencies;
 }

--- a/packages/fe-fpm-writer/templates/common/Fragment.xml
+++ b/packages/fe-fpm-writer/templates/common/Fragment.xml
@@ -1,3 +1,3 @@
-<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m">
+<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m"<%- typeof dependencies !== 'undefined' ? Object.entries(dependencies).map((dependency) => ` ${dependency[0]}="${dependency[1]}"`).join('') : '' %>>
 	<%- content %>
 </core:FragmentDefinition>

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -116,7 +116,7 @@ Object {
     "state": "modified",
   },
   "lrop/webapp/ext/myCustomSection/MyCustomSection.fragment.xml": Object {
-    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'v4travel/ext/myCustomSection/MyCustomSection'}\\" text=\\"MyCustomSection\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>",
     "state": "modified",
@@ -571,7 +571,7 @@ export default class MyCustomPage extends Controller {
     "state": "modified",
   },
   "ts/webapp/ext/myCustomSection/MyCustomSection.fragment.xml": Object {
-    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'v4travel/ext/myCustomSection/MyCustomSection'}\\" text=\\"MyCustomSection\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>",
     "state": "modified",

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom file and function names 1`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/dummyAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 </core:FragmentDefinition>"
 `;
@@ -22,7 +22,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 `;
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom function name 1`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 </core:FragmentDefinition>"
 `;
@@ -43,7 +43,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 `;
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is empty "object" - create new file with default function name 1`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;
@@ -64,7 +64,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 `;
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with position {"line":8,"character":9} 1`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 </core:FragmentDefinition>"
 `;
@@ -88,7 +88,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 `;
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with position absolute 1`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 </core:FragmentDefinition>"
 `;
@@ -251,6 +251,98 @@ exports[`CustomSection generateCustomSection Versions 1.86, with handler, all pr
 "
 `;
 
+exports[`CustomSection generateCustomSection Versions 1.89, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "title": "Custom Title",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.89, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.89, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function(oEvent) {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.90, with handler, all properties 1`] = `
+Object {
+  "body": Object {
+    "sections": Object {
+      "ExistingCustomSection": Object {
+        "position": Object {
+          "anchor": "IncidentOverviewFacet",
+          "placement": "Before",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.Custom1",
+        "title": "Custom Title",
+      },
+      "NewCustomSection": Object {
+        "position": Object {
+          "anchor": "DummyFacet",
+          "placement": "After",
+        },
+        "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+        "title": "New Custom Section",
+      },
+    },
+  },
+}
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.90, with handler, all properties 2`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+</core:FragmentDefinition>"
+`;
+
+exports[`CustomSection generateCustomSection Versions 1.90, with handler, all properties 3`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function(oEvent) {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
 exports[`CustomSection generateCustomSection Versions 1.98, with handler, all properties 1`] = `
 Object {
   "body": Object {
@@ -277,7 +369,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection Versions 1.98, with handler, all properties 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;
@@ -323,7 +415,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection custom control 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<CustomXML text=\\"\\" />
 </core:FragmentDefinition>"
 `;
@@ -379,7 +471,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection different data and not existing target 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Text text=\\"DummySection\\" />
 </core:FragmentDefinition>"
 `;
@@ -410,7 +502,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection no handler, all properties 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Text text=\\"NewCustomSection\\" />
 </core:FragmentDefinition>"
 `;
@@ -441,7 +533,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection no handler, no fs, all properties 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Text text=\\"NewCustomSection\\" />
 </core:FragmentDefinition>"
 `;
@@ -497,7 +589,7 @@ Object {
 `;
 
 exports[`CustomSection generateCustomSection with handler, all properties 2`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -153,7 +153,7 @@ describe('CustomSection', () => {
             expect(fs.read(fragmentPath)).toMatchSnapshot();
         });
 
-        const testVersions = ['1.85', '1.84', '1.86', '1.98'];
+        const testVersions = ['1.85', '1.84', '1.86', '1.89', '1.90', '1.98'];
         for (const minUI5Version of testVersions) {
             test(`Versions ${minUI5Version}, with handler, all properties`, () => {
                 const testCustomSection: CustomSection = {


### PR DESCRIPTION
Add `sap.se.macros` namespace to custom section's `Fragment.xml` when ui5 version >= 1.90
I am not fully sure about `1.90`, but it is listed here as `Available since` - https://sapui5.hana.ondemand.com/sdk/#/api/sap.fe.macros.FormElement