### PR TITLE
chore(ui-components): align linting and fix issues

### DIFF
--- a/.changeset/beige-pans-sit.md
+++ b/.changeset/beige-pans-sit.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Fixing eslint issues

--- a/.eslintrc
+++ b/.eslintrc
@@ -255,7 +255,8 @@
         "prettier/prettier": [
             "error",
             {
-                "endOfLine": "auto"
+                "endOfLine": "auto",
+                "quoteProps": "preserve"
             }
         ]
     },

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -16,7 +16,7 @@ module.exports = {
     jsxSingleQuote: false,
     printWidth: 120,
     proseWrap: 'preserve',
-    quoteProps: 'as-needed',
+    quoteProps: 'preserve',
     semi: true,
     singleQuote: true,
     tabWidth: 4,

--- a/packages/ui-components/.eslintrc
+++ b/packages/ui-components/.eslintrc
@@ -9,15 +9,13 @@
             "parser": "@typescript-eslint/parser",
             "files": ["./test/**/*.tsx"],
             "rules": {
-                "no-loop-func": "off",
-                "space-before-function-paren": "off"
+                "no-loop-func": "off"
             }
         },
         {
             "parser": "@typescript-eslint/parser",
             "files": ["./src/**/*.tsx"],
             "rules": {
-                "space-before-function-paren": "off",
                 "@typescript-eslint/no-unused-vars": [
                     "error",
                     { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_", "ignoreRestSiblings": true }
@@ -26,18 +24,10 @@
         }
     ],
     "rules": {
-        "@typescript-eslint/no-use-before-define": [
-            "error",
-            {
-                "functions": false,
-                "typedefs": false,
-                "classes": false
-            }
-        ],
+        "react/no-unknown-property": ["error", { "ignore": ["onFocusCapture"] }],
         "jsdoc/require-param-description": "off",
         "jsdoc/require-returns-description": "off",
-        "jsdoc/no-undefined-types": "off",
-        "jsdoc/newline-after-description": "off"
+        "jsdoc/no-undefined-types": "off"
     },
     "settings": {
         "react": {

--- a/packages/ui-components/src/components/Icons.tsx
+++ b/packages/ui-components/src/components/Icons.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { registerIcons, initializeIcons } from '@fluentui/react';
 
 const COLORS = {
-    // eslint-disable-next-line quote-props
-    default: 'var(--vscode-icon-foreground, var(--vscode-foreground))',
+    'default': 'var(--vscode-icon-foreground, var(--vscode-foreground))',
     success: 'var(--vscode-charts-green, #84C881)',
     warning: 'var(--vscode-notificationsWarningIcon-foreground)',
     error: 'var( --vscode-notificationsErrorIcon-foreground)',
@@ -114,7 +113,7 @@ export enum UiIcons {
     NoResults = 'NoResults'
 }
 
-export const initIcons = function (): void {
+export function initIcons(): void {
     registerIcons({
         icons: {
             [UiIcons.Chevron]: (
@@ -1272,7 +1271,7 @@ export const initIcons = function (): void {
     });
 
     initializeIcons(undefined, { disableWarnings: true });
-};
+}
 
 export { registerIcons as UIregisterIcons };
 export { initializeIcons as UIinitializeIcons };

--- a/packages/ui-components/src/components/UIBreadcrumb/UIBreadcrumb.tsx
+++ b/packages/ui-components/src/components/UIBreadcrumb/UIBreadcrumb.tsx
@@ -14,6 +14,7 @@ import { Breadcrumb } from '@fluentui/react';
 export class UIBreadcrumb extends React.Component<IBreadcrumbProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IBreadcrumbProps} props
      */
     public constructor(props: IBreadcrumbProps) {

--- a/packages/ui-components/src/components/UIButton/UIActionButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIActionButton.tsx
@@ -15,6 +15,7 @@ import { UIContextualMenu } from '../UIContextualMenu';
 export class UIActionButton extends React.Component<IButtonProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IButtonProps} props
      */
     public constructor(props: IButtonProps) {

--- a/packages/ui-components/src/components/UIButton/UIDefaultButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIDefaultButton.tsx
@@ -14,6 +14,7 @@ import { UIContextualMenu } from '../UIContextualMenu';
 export class UIDefaultButton extends React.Component<IButtonProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IButtonProps} props
      */
     public constructor(props: IButtonProps) {

--- a/packages/ui-components/src/components/UIButton/UIIconButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIIconButton.tsx
@@ -24,6 +24,7 @@ export interface ButtonProps extends IBaseButtonProps {
 export class UIIconButton extends React.Component<ButtonProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {ButtonProps} props
      */
     public constructor(props: ButtonProps) {

--- a/packages/ui-components/src/components/UIButton/UISplitButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UISplitButton.tsx
@@ -32,6 +32,7 @@ export class UISplitButton extends React.Component<UISplitButtonProps, UISplitBu
     id = this.props.id ? this.props.id : getUIId('ui-split-button-');
     /**
      * Initializes component properties.
+     *
      * @param {UISplitButtonProps} props
      */
     public constructor(props: UISplitButtonProps) {

--- a/packages/ui-components/src/components/UIButton/UISplitButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UISplitButton.tsx
@@ -5,7 +5,7 @@ import { UIContextualMenu } from '../UIContextualMenu';
 import { UiIcons } from '../Icons';
 import type { UIContextualMenuProps, UIContextualMenuItem } from '../UIContextualMenu';
 
-import { UIGetId } from '../../utilities';
+import { getUIId } from '../../utilities';
 
 export interface UISplitButtonProps {
     button: UIContextualMenuItem;
@@ -29,7 +29,7 @@ export interface UISplitButtonState {
  * @extends {React.Component<UISplitButtonProps, UISplitButtonState>}
  */
 export class UISplitButton extends React.Component<UISplitButtonProps, UISplitButtonState> {
-    id = this.props.id ? this.props.id : UIGetId('ui-split-button-');
+    id = this.props.id ? this.props.id : getUIId('ui-split-button-');
     /**
      * Initializes component properties.
      * @param {UISplitButtonProps} props

--- a/packages/ui-components/src/components/UICallout/UICallout.tsx
+++ b/packages/ui-components/src/components/UICallout/UICallout.tsx
@@ -88,6 +88,7 @@ export const getCalloutStyle = (props: UICalloutProps): ICalloutContentStyles =>
 export class UICallout extends React.Component<UICalloutProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {UICalloutProps} props
      */
     public constructor(props: UICalloutProps) {

--- a/packages/ui-components/src/components/UICheckbox/UICheckbox.tsx
+++ b/packages/ui-components/src/components/UICheckbox/UICheckbox.tsx
@@ -28,6 +28,7 @@ export class UICheckbox extends React.Component<UICheckboxProps, {}> {
 
     /**
      * Initializes component properties.
+     *
      * @param {UICheckboxProps} props
      */
     public constructor(props: UICheckboxProps) {

--- a/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
+++ b/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
@@ -57,6 +57,7 @@ const UI_CHOICE_GROUP_STYLES = {
 export class UIChoiceGroup extends React.Component<ChoiceGroupProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {ChoiceGroupProps} props
      */
     public constructor(props: ChoiceGroupProps) {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -79,6 +79,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
 
     /**
      * Initializes component properties.
+     *
      * @param {UIComboBoxProps} props
      */
     public constructor(props: UIComboBoxProps) {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -257,7 +257,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
     private getCurrentSelectedIndex = (): number | undefined => {
         const baseCombobox = this.comboBox.current;
         if (!baseCombobox) {
-            return;
+            return undefined;
         }
         if (baseCombobox.state.currentPendingValueValidIndex !== -1) {
             return baseCombobox.state.currentPendingValueValidIndex;
@@ -424,7 +424,9 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
     }
 
     public handleChange: IComboBoxProps['onChange'] = (event, option): void => {
-        option && this.props.onHandleChange && this.props.onHandleChange(option.key);
+        if (option && this.props.onHandleChange) {
+            this.props.onHandleChange(option.key);
+        }
     };
 
     private onRenderListLoading = (): JSX.Element | null => {

--- a/packages/ui-components/src/components/UIDatePicker/UIDatePicker.tsx
+++ b/packages/ui-components/src/components/UIDatePicker/UIDatePicker.tsx
@@ -33,6 +33,7 @@ export class UIDatePicker extends React.Component<UIDatePickerProps> {
 
     /**
      * Initializes component properties.
+     *
      * @param {UIDatePickerProps} props
      */
     public constructor(props: UIDatePickerProps) {

--- a/packages/ui-components/src/components/UIDialog/UIDialog.tsx
+++ b/packages/ui-components/src/components/UIDialog/UIDialog.tsx
@@ -67,6 +67,7 @@ export enum UIDialogScrollArea {
 export class UIDialog extends React.Component<DialogProps, DialogState> {
     /**
      * Initializes component properties.
+     *
      * @param {DialogProps} props
      */
     public constructor(props: DialogProps) {
@@ -82,6 +83,7 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
 
     /**
      * Called when component is rerendered.
+     *
      * @param {Readonly<DialogProps>} prevProps
      */
     componentDidUpdate(prevProps: Readonly<DialogProps>): void {

--- a/packages/ui-components/src/components/UIDialog/UIDialog.tsx
+++ b/packages/ui-components/src/components/UIDialog/UIDialog.tsx
@@ -139,6 +139,7 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
      * @returns {JSX.Element | null} Footer element to render.
      */
     getFooter(): JSX.Element | undefined {
+        let element;
         const { acceptButtonText, cancelButtonText, onAccept, onCancel, acceptButtonId, cancelButtonId, footer } =
             this.props;
         const dialogFooterProps: IDialogFooterProps = {
@@ -159,9 +160,9 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
         };
 
         if (footer) {
-            return <DialogFooter {...dialogFooterProps}>{footer}</DialogFooter>;
+            element = <DialogFooter {...dialogFooterProps}>{footer}</DialogFooter>;
         } else if (onAccept || onCancel) {
-            return (
+            element = (
                 <DialogFooter {...dialogFooterProps}>
                     {onAccept ? (
                         <UIDefaultButton onClick={onAccept} primary style={{ height: '26px' }} id={acceptButtonId}>
@@ -180,6 +181,7 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
                 </DialogFooter>
             );
         }
+        return element;
     }
 
     /**

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -42,6 +42,7 @@ const ERROR_BORDER_COLOR = 'var(--vscode-inputValidation-errorBorder)';
 export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState> {
     /**
      * Initializes component properties.
+     *
      * @param {UIDropdownProps} props
      */
     public constructor(props: UIDropdownProps) {

--- a/packages/ui-components/src/components/UIFlexibleTable/RowData.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/RowData.tsx
@@ -82,6 +82,7 @@ function getRowDataCells<T>(props: RowDataCellsProps<T>): Array<React.ReactNode>
 
 /**
  * RowDataCells component.
+ *
  * @param {RowDataCellsProps<T>} props
  * @returns {React.ReactElement}
  */

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableActionButton.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableActionButton.tsx
@@ -16,6 +16,7 @@ export interface UIFlexibleTableActionProps {
 
 /**
  * UIFlexibleTableActionButton component.
+ *
  * @exports
  * @param {UIFlexibleTableActionProps} props
  * @returns { React.ReactElement}

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRow.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRow.tsx
@@ -71,7 +71,6 @@ function getActionsContainer(
  *
  * @param {UIFlexibleTableProps<T>} props
  * @param {number} paddingRight
- *
  * @returns {React.ReactNode}
  */
 export function renderTitleRow<T>(props: UIFlexibleTableProps<T>, paddingRight: number): React.ReactNode {
@@ -178,7 +177,6 @@ export function renderTitleRow<T>(props: UIFlexibleTableProps<T>, paddingRight: 
  *
  * @exports
  * @param {UIFlexibleTableRowProps} props
- *
  * @returns {JSX.Element}
  */
 export function UIFlexibleTableRow<T>(props: UIFlexibleTableRowProps<T>) {

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRowNoData.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRowNoData.tsx
@@ -9,6 +9,12 @@ export interface UIFlexibleTableRowNoDataProps {
     reverseBackground?: boolean;
 }
 
+/**
+ * Visualize a table row without data.
+ *
+ * @param props {UIFlexibleTableRowNoDataProps}
+ * @returns {React.Component}
+ */
 export function UIFlexibleTableRowNoData(props: UIFlexibleTableRowNoDataProps) {
     const { align = UIFlexibleTableNoDataAlignment.Center, noRowBackground, reverseBackground } = props;
     const rowClassName = composeClassNames('flexible-table-content-table-row-no-data', [

--- a/packages/ui-components/src/components/UIFlexibleTable/utils.ts
+++ b/packages/ui-components/src/components/UIFlexibleTable/utils.ts
@@ -4,7 +4,6 @@
  * @param {string} tableId
  * @param {number | undefined} rowNumber
  * @param {string} actionName
- *
  * @returns {string}
  */
 export function getRowActionButtonId(tableId: string, rowNumber: number | undefined, actionName: string): string {
@@ -16,7 +15,6 @@ export function getRowActionButtonId(tableId: string, rowNumber: number | undefi
  *
  * @param {string} tableId
  * @param {string} actionName
- *
  * @returns {string}
  */
 export function getTableActionButtonId(tableId: string, actionName: string): string {
@@ -28,7 +26,6 @@ export function getTableActionButtonId(tableId: string, actionName: string): str
  *
  * @param {string} initialClass
  * @param {string | string[]} additionalClassNames
- *
  * @returns {string}
  */
 export function composeClassNames(

--- a/packages/ui-components/src/components/UIFocusZone/UIFocusTrapZone.tsx
+++ b/packages/ui-components/src/components/UIFocusZone/UIFocusTrapZone.tsx
@@ -14,6 +14,7 @@ import { FocusTrapZone } from '@fluentui/react';
 export class UIFocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IFocusTrapZoneProps} props
      */
     public constructor(props: IFocusTrapZoneProps) {

--- a/packages/ui-components/src/components/UIFocusZone/UIFocusZone.tsx
+++ b/packages/ui-components/src/components/UIFocusZone/UIFocusZone.tsx
@@ -19,6 +19,7 @@ export {
 export class UIFocusZone extends React.Component<IFocusZoneProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IFocusZoneProps} props
      */
     public constructor(props: IFocusZoneProps) {

--- a/packages/ui-components/src/components/UIIcon/UIIcon.tsx
+++ b/packages/ui-components/src/components/UIIcon/UIIcon.tsx
@@ -14,6 +14,7 @@ import './UIIcon.scss';
 export class UIIcon extends React.Component<IIconProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IIconProps} props
      */
     public constructor(props: IIconProps) {

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -21,6 +21,7 @@ export type UITextInputProps = ITextFieldProps & UIMessagesExtendedProps;
 export class UITextInput extends React.Component<UITextInputProps> {
     /**
      * Initializes component properties.
+     *
      * @param {UITextInputProps} props
      */
     public constructor(props: UITextInputProps) {

--- a/packages/ui-components/src/components/UILabel/UILabel.tsx
+++ b/packages/ui-components/src/components/UILabel/UILabel.tsx
@@ -24,6 +24,7 @@ export const labelGlobalStyle = {
 export class UILabel extends React.Component<UILabelProps> {
     /**
      * Initializes component properties.
+     *
      * @param {UILabelProps} props
      */
     public constructor(props: UILabelProps) {

--- a/packages/ui-components/src/components/UILink/UILink.tsx
+++ b/packages/ui-components/src/components/UILink/UILink.tsx
@@ -14,6 +14,7 @@ import { Link } from '@fluentui/react';
 export class UILink extends React.Component<ILinkProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {ILinkProps} props
      */
     public constructor(props: ILinkProps) {

--- a/packages/ui-components/src/components/UIList/UIList.tsx
+++ b/packages/ui-components/src/components/UIList/UIList.tsx
@@ -31,6 +31,7 @@ export interface ListProps {
 export class UIList extends React.Component<ListProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {ListProps} props
      */
     public constructor(props: ListProps) {

--- a/packages/ui-components/src/components/UILoader/UILoader.tsx
+++ b/packages/ui-components/src/components/UILoader/UILoader.tsx
@@ -20,6 +20,7 @@ export interface UILoaderProps extends ISpinnerProps {
 export class UILoader extends React.Component<UILoaderProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {UILoaderProps} props
      */
     public constructor(props: UILoaderProps) {

--- a/packages/ui-components/src/components/UIMessageBar/UIMessageBar.tsx
+++ b/packages/ui-components/src/components/UIMessageBar/UIMessageBar.tsx
@@ -17,6 +17,7 @@ export { MessageBarType as UIMessageBarType };
 export class UIMessageBar extends React.Component<IMessageBarProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IMessageBarProps} props
      */
     public constructor(props: IMessageBarProps) {

--- a/packages/ui-components/src/components/UIModal/UIModal.tsx
+++ b/packages/ui-components/src/components/UIModal/UIModal.tsx
@@ -13,6 +13,7 @@ import { Modal } from '@fluentui/react';
 export class UIModal extends React.Component<IModalProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IModalProps} props
      */
     public constructor(props: IModalProps) {

--- a/packages/ui-components/src/components/UIOverlay/UIOverlay.tsx
+++ b/packages/ui-components/src/components/UIOverlay/UIOverlay.tsx
@@ -13,6 +13,7 @@ import { Overlay } from '@fluentui/react';
 export class UIOverlay extends React.Component<IOverlayProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {IOverlayProps} props
      */
     public constructor(props: IOverlayProps) {

--- a/packages/ui-components/src/components/UISearchBox/UISearchBox.tsx
+++ b/packages/ui-components/src/components/UISearchBox/UISearchBox.tsx
@@ -18,6 +18,7 @@ const searchIcon = { iconName: UiIcons.Search };
 export class UISearchBox extends React.Component<ISearchBoxProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {ISearchBoxProps} props
      */
     public constructor(props: ISearchBoxProps) {

--- a/packages/ui-components/src/components/UISection/UISection.tsx
+++ b/packages/ui-components/src/components/UISection/UISection.tsx
@@ -31,7 +31,7 @@ export interface UISectionProps {
  * @class {UISection}
  * @extends {React.Component<UISectionProps>}
  */
-export class UISection extends React.Component<UISectionProps> {
+export class UISection extends React.Component<UISectionProps & Readonly<{ children?: React.ReactNode }>> {
     private onScroll(): void {
         if (this.props.onScroll) {
             this.props.onScroll();
@@ -63,10 +63,7 @@ export class UISection extends React.Component<UISectionProps> {
                     </div>
                 )}
                 <div className="section__body" onScroll={this.onScroll.bind(this)}>
-                    {
-                        // eslint-disable-next-line  react/prop-types
-                        this.props.children
-                    }
+                    {this.props.children}
                 </div>
             </div>
         );

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -625,7 +625,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
             ? this.getVisibleSectionStyle(index)
             : this.getHiddenSectionStyle(index);
         if (!sectionStyle) {
-            return;
+            return undefined;
         }
         const splitterType = this.props.splitterType || UISplitterType.Resize;
         const splitterLayoutType = this.props.splitterLayoutType || UISplitterLayoutType.Standard;

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -60,6 +60,7 @@ interface SizeCalculationInfo {
 
 /**
  * UISections component.
+ *
  * @exports
  * @class {UISections}
  * @extends {React.Component<UISectionsProps, UISectionsState>}
@@ -165,7 +166,6 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
      *
      * @param {UISectionProps} nextProps
      * @param {UISectionsState} prevState
-     *
      * @returns {UISectionsState | null}
      */
     static getDerivedStateFromProps(nextProps: UISectionsProps, prevState: UISectionsState): UISectionsState | null {
@@ -475,7 +475,6 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
      *
      * @param {number} childrenCount
      * @param {string} value
-     *
      * @returns {string}
      */
     private getPositionStyleValue(childrenCount: number, value: string): string {

--- a/packages/ui-components/src/components/UITable/UITable-helper.tsx
+++ b/packages/ui-components/src/components/UITable/UITable-helper.tsx
@@ -11,7 +11,6 @@ import type { UIColumn, EditedCell, UITableProps, UITableState } from '.';
  * @param {T[]} items
  * @param {string }columnKey
  * @param {boolean} isSortedDescending
- *
  * @returns {T[]}
  */
 export function _copyAndSort<T>(items: T[], columnKey: string, isSortedDescending?: boolean): T[] {
@@ -25,7 +24,6 @@ export function _copyAndSort<T>(items: T[], columnKey: string, isSortedDescendin
  * @param {EditedCell | undefined} editedCell
  * @param {UITableProps} props
  * @param {string} direction
- *
  * @returns {Promise<void>}
  */
 export function focusEditedCell(
@@ -85,7 +83,6 @@ export function focusEditedCell(
  * @param {string} columnKey
  * @param {UIColumn} columns
  * @param {boolean} addOneToColIndex
- *
  * @returns {NodeListOf<Element>}
  */
 export function getCellFromCoords(rowIdx: number, columnKey: string, columns: UIColumn[], addOneToColIndex = false) {
@@ -176,7 +173,6 @@ export async function waitFor(selector: string) {
  *
  * @param {any} columns
  * @param {boolean} showRowNumbers
- *
  * @returns {any}
  */
 export function addRowNumbers(columns: any, showRowNumbers = false): any {
@@ -193,7 +189,6 @@ export function addRowNumbers(columns: any, showRowNumbers = false): any {
     return columns;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const _onHeaderRender: IRenderFunction<IDetailsHeaderProps> = (props, defaultRender?) => {
     if (!props || !defaultRender) {
         return null;
@@ -201,7 +196,6 @@ export const _onHeaderRender: IRenderFunction<IDetailsHeaderProps> = (props, def
 
     const customProps: IDetailsHeaderProps = {
         ...props,
-        // eslint-disable-next-line react/display-name
         onRenderColumnHeaderTooltip: (item?, tooltipDefaultRender?) => {
             if (item?.column) {
                 const column: UIColumn = item.column;
@@ -220,7 +214,6 @@ export const _onHeaderRender: IRenderFunction<IDetailsHeaderProps> = (props, def
             }
 
             const isCheckTooltip = item?.hostClassName === 'ms-DetailsHeader-checkTooltip';
-            // eslint-disable-next-line react/prop-types
             if (props.selection && isCheckTooltip && tooltipDefaultRender) {
                 return tooltipDefaultRender(item);
             }

--- a/packages/ui-components/src/components/UITable/UITable-helper.tsx
+++ b/packages/ui-components/src/components/UITable/UITable-helper.tsx
@@ -158,12 +158,14 @@ export async function waitFor(selector: string) {
     const el = document.querySelector(selector);
     return new Promise((resolve) => {
         if (el) {
-            return resolve(el);
+            resolve(el);
+            return;
         }
         setTimeout(async () => {
             const el2 = await waitFor(selector);
             if (el2) {
-                return resolve(el2);
+                resolve(el2);
+                return;
             }
         }, 100);
     });
@@ -265,12 +267,12 @@ export function getStylesForSelectedCell(state: UITableState): Partial<IDetailsL
     return styles;
 }
 
-export function showFocus() {
+export function showFocus(): void {
     document.body.classList.remove('ms-Fabric--isFocusHidden');
     document.body.classList.add('ms-Fabric--isFocusVisible');
 }
 
-export function hideFocus() {
+export function hideFocus(): void {
     document.body.classList.add('ms-Fabric--isFocusHidden');
     document.body.classList.remove('ms-Fabric--isFocusVisible');
 }

--- a/packages/ui-components/src/components/UITable/UITable.tsx
+++ b/packages/ui-components/src/components/UITable/UITable.tsx
@@ -500,7 +500,8 @@ export class UITable extends React.Component<UITableProps, UITableState> {
         if (e.key === 'Escape') {
             this.cancelEdit();
             focusEditedCell(this.state.editedCell, this.props);
-            return showFocus();
+            showFocus();
+            return;
         }
 
         if (this.state.editedCell?.errorMessage) {
@@ -551,7 +552,8 @@ export class UITable extends React.Component<UITableProps, UITableState> {
             focusEditedCell(this.state.editedCell, this.props, direction)
                 .then(() => {
                     if (!direction) {
-                        return showFocus();
+                        showFocus();
+                        return;
                     }
                     hideFocus();
                     const { rowIndex, item, column } = this.activeElement;
@@ -820,7 +822,7 @@ export class UITable extends React.Component<UITableProps, UITableState> {
     private _renderTextInput(item: UIDocument, rowIndex: number, column: UIColumn | undefined): any {
         const compRef = this._getInputRef(rowIndex, column) as React.RefObject<ITextField>;
         const newValue = this.state.editedCell?.newValue;
-
+        let element;
         let value;
         if (column?.fieldName) {
             value = item[column?.fieldName];
@@ -829,7 +831,7 @@ export class UITable extends React.Component<UITableProps, UITableState> {
             value = newValue;
         }
         if (!item.hideCells) {
-            return (
+            element = (
                 <UITextInput
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
@@ -844,6 +846,7 @@ export class UITable extends React.Component<UITableProps, UITableState> {
                 />
             );
         }
+        return element;
     }
 
     /**

--- a/packages/ui-components/src/components/UITable/UITable.tsx
+++ b/packages/ui-components/src/components/UITable/UITable.tsx
@@ -222,7 +222,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      *
      * @param props
      * @param defaultRender
-     *
      * @returns {null | JSX.Element}
      */
     private _onRenderField(
@@ -315,7 +314,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      * @param {UIDocument} item
      * @param {number} index
      * @param {UIColumn} column
-     *
      * @returns {React.ReactNode}
      */
     private _onRenderItemColumn(item: UIDocument, index?: number, column?: UIColumn): React.ReactNode {
@@ -591,14 +589,10 @@ export class UITable extends React.Component<UITableProps, UITableState> {
         requestAnimationFrame(() => {
             // check the checkbox & focus the clicked cell
             if (el) {
-                // the eslint comments below are necessary.
-                // If removed - eslint will show another error, that click/focus don't exist...
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 const fz = el.closest('.ms-FocusZone') as HTMLElement;
                 if (fz && fz.click) {
                     fz.click();
                 }
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 const cell = el.closest('.ms-DetailsRow-cell') as HTMLElement;
                 if (cell && cell.focus) {
                     cell.focus();
@@ -617,6 +611,7 @@ export class UITable extends React.Component<UITableProps, UITableState> {
 
     /**
      * Validates cell.
+     *
      * @param value
      */
     private validateCell(value: string): void {
@@ -669,11 +664,12 @@ export class UITable extends React.Component<UITableProps, UITableState> {
         column: UIColumn | undefined
     ): void => {
         const newValue = selectedOption.key;
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (typeof this.props.onSave === 'function' && Number.isInteger(rowIndex) && column) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
+        if (
+            typeof this.props.onSave === 'function' &&
+            typeof rowIndex === 'number' &&
+            Number.isInteger(rowIndex) &&
+            column
+        ) {
             const currentValue = this.props.items[rowIndex][column.key];
             const editedCell = { rowIndex, item, column, errorMessage: undefined } as EditedCell;
             if (currentValue !== newValue) {
@@ -699,9 +695,9 @@ export class UITable extends React.Component<UITableProps, UITableState> {
         rowIndex: number | undefined,
         column: UIColumn | undefined
     ): React.RefObject<ITextField | IDropdown | UIComboBox> | undefined {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return this?.inputRefs?.[rowIndex]?.[column.key];
+        return typeof rowIndex === 'number' && typeof column?.key === 'string'
+            ? this?.inputRefs?.[rowIndex]?.[column.key]
+            : undefined;
     }
 
     /**
@@ -720,9 +716,11 @@ export class UITable extends React.Component<UITableProps, UITableState> {
                 placeholder="Select an option"
                 componentRef={compRef}
                 options={column?.data.dropdownOptions}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                defaultSelectedKey={item[column?.key] || column?.data.defaultSelectedKey}
+                defaultSelectedKey={
+                    typeof column?.key === 'string' && item[column?.key]
+                        ? item[column?.key]
+                        : column?.data.defaultSelectedKey
+                }
                 onChange={(ev, text) => this.onDropdownCellValueChange(text, item, rowIndex, column)}
                 onKeyDown={this.onKeyDown}
             />
@@ -735,7 +733,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      * @param item
      * @param rowIndex
      * @param column
-     *
      * @returns {any}
      */
     private _renderBooleanSelect(item: UIDocument, rowIndex?: number, column?: UIColumn): any {
@@ -780,7 +777,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      * @param rowIndex
      * @param column
      * @param dateOnly
-     *
      * @returns {any}
      */
     private _renderDatePicker(item: UIDocument, rowIndex?: number, column?: UIColumn, dateOnly = true): any {
@@ -816,7 +812,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      * @param item
      * @param rowIndex
      * @param column
-     *
      * @returns {any}
      */
     private _renderTextInput(item: UIDocument, rowIndex: number, column: UIColumn | undefined): any {
@@ -833,8 +828,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
         if (!item.hideCells) {
             element = (
                 <UITextInput
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
                     defaultValue={value}
                     componentRef={compRef}
                     errorMessage={this.state.editedCell?.errorMessage}

--- a/packages/ui-components/src/components/UITabs/UITabs.tsx
+++ b/packages/ui-components/src/components/UITabs/UITabs.tsx
@@ -19,6 +19,7 @@ export interface UITabsProps extends IPivotProps {
 export class UITabs extends React.Component<UITabsProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {UITabsProps} props
      */
     public constructor(props: UITabsProps) {

--- a/packages/ui-components/src/components/UIToggle/UIToggle.tsx
+++ b/packages/ui-components/src/components/UIToggle/UIToggle.tsx
@@ -94,6 +94,7 @@ const COLORS = {
 export class UIToggle extends React.Component<UIToggleProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {UIToggleProps} props
      */
     public constructor(props: UIToggleProps) {

--- a/packages/ui-components/src/components/UIToggleGroup/UIToggleGroup.tsx
+++ b/packages/ui-components/src/components/UIToggleGroup/UIToggleGroup.tsx
@@ -26,6 +26,7 @@ export class UIToggleGroup extends React.Component<UIToggleGroupProps, UIToggleG
 
     /**
      * Initializes component properties.
+     *
      * @param {UIToggleGroupProps} props
      */
     public constructor(props: UIToggleGroupProps) {

--- a/packages/ui-components/src/components/UIToggleGroup/UIToggleGroup.tsx
+++ b/packages/ui-components/src/components/UIToggleGroup/UIToggleGroup.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { UIToggleGroupOption } from './UIToggleGroupOption';
 import { UILabel } from '../UILabel';
 import { UIFocusZone, UIFocusZoneDirection } from '../UIFocusZone';
-import { UIGetId } from '../../utilities';
+import { getUIId } from '../../utilities';
 
 import type { UIToggleGroupProps, ToggleGroupOption } from './UIToggleGroup.types';
 import type { UIToggleGroupOptionProps } from './UIToggleGroupOption/UIToggleGroupOption.types';
@@ -22,7 +22,7 @@ interface UIToggleGroupState {
  * @extends {React.Component<UIToggleGroupProps, UIToggleGroupState>}
  */
 export class UIToggleGroup extends React.Component<UIToggleGroupProps, UIToggleGroupState> {
-    labelId = this.props.labelId ? this.props.labelId : UIGetId('ui-toggle-group-option-');
+    labelId = this.props.labelId ? this.props.labelId : getUIId('ui-toggle-group-option-');
 
     /**
      * Initializes component properties.

--- a/packages/ui-components/src/components/UIToggleGroup/UIToggleGroupOption/UIToggleGroupOption.tsx
+++ b/packages/ui-components/src/components/UIToggleGroup/UIToggleGroupOption/UIToggleGroupOption.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { UIIcon } from '../../UIIcon';
-import { UIGetId } from '../../../utilities';
+import { getUIId } from '../../../utilities';
 
 import type { UIToggleGroupOptionProps } from './UIToggleGroupOption.types';
 
@@ -44,7 +44,7 @@ export class UIToggleGroupOption extends React.Component<UIToggleGroupOptionProp
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
-        const labelId = this.props.labelId ? this.props.labelId : UIGetId('ui-toggle-group-option-');
+        const labelId = this.props.labelId ? this.props.labelId : getUIId('ui-toggle-group-option-');
 
         return (
             <button

--- a/packages/ui-components/src/components/UIToolbar/UIToolbarDivider.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbarDivider.tsx
@@ -10,6 +10,7 @@ export interface UIToolbarDividerProps {
 
 /**
  * UIToolbarDivider component.
+ *
  * @exports
  * @class UIToolbarDivider
  + @extends {React.Component<UIToolbarDividerProps, {}>}
@@ -17,6 +18,7 @@ export interface UIToolbarDividerProps {
 export class UIToolbarDivider extends React.Component<UIToolbarDividerProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param props
      */
     constructor(props: UIToolbarDividerProps) {

--- a/packages/ui-components/src/components/UITooltip/UITooltip.tsx
+++ b/packages/ui-components/src/components/UITooltip/UITooltip.tsx
@@ -31,6 +31,7 @@ export interface UITooltipProps extends ITooltipHostProps {
 export class UITooltip extends React.Component<UITooltipProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {UITooltipProps} props
      */
     public constructor(props: UITooltipProps) {
@@ -91,7 +92,6 @@ export class UITooltip extends React.Component<UITooltipProps, {}> {
             tooltipHost
         ) : (
             <div
-                // eslint-disable-next-line react/no-unknown-property
                 onFocusCapture={(event) => {
                     if (event.target.parentElement && event.target.parentElement.classList.contains('ms-TooltipHost')) {
                         // Stop propagation to avoid display of tooltip on focus

--- a/packages/ui-components/src/components/UITooltip/UITooltipUtils.tsx
+++ b/packages/ui-components/src/components/UITooltip/UITooltipUtils.tsx
@@ -6,6 +6,7 @@ import { CALLOUT_STYLES } from '../UICallout';
 
 /**
  * UITooltipUtil class for rendering content
+ *
  * @class UITooltipUtils
  */
 export class UITooltipUtils {
@@ -27,7 +28,6 @@ export class UITooltipUtils {
 
     public static renderContent = (content: string | React.ReactElement | null): ITooltipProps => {
         return {
-            // eslint-disable-next-line react/display-name
             onRenderContent: () => <span>{content ?? ''}</span>,
             styles: UITooltipUtils.getStyles()
         } as ITooltipProps;
@@ -37,7 +37,6 @@ export class UITooltipUtils {
         const sanitized = sanitizeHtml(content);
 
         return {
-            // eslint-disable-next-line react/display-name
             onRenderContent: () => <span dangerouslySetInnerHTML={{ __html: sanitized }} />,
             styles: UITooltipUtils.getStyles()
         } as ITooltipProps;

--- a/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
+++ b/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
@@ -84,11 +84,11 @@ const KEYBOARD_KEYS = {
 
 /**
  * UITreeDropdown component.
+ *
  * @exports
  * @class UIVerticalDivider
  * @extends {React.Component<UITreeDropdownProps, UITreeDropdownState>}
  */
-
 export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeDropdownState> {
     private readonly UITreeDropdownRef = React.createRef<{ props: UITreeDropdownProps }>();
     private readonly UITreeDropdownFocusZoneRef = React.createRef<FocusZone>();
@@ -108,6 +108,7 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
     private originalValue?: string;
     /**
      * Initializes component properties.
+     *
      * @param {UITreeDropdownProps} props
      */
     public constructor(props: UITreeDropdownProps) {
@@ -282,6 +283,9 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
                 }
                 this.handleSelection(this.state.value ? this.state.value : '');
                 break;
+            default: {
+                // do nothing
+            }
         }
         this.lastKeyDown = event.key;
     };

--- a/packages/ui-components/src/components/UIVirtualList/UIAutoSizer.tsx
+++ b/packages/ui-components/src/components/UIVirtualList/UIAutoSizer.tsx
@@ -13,6 +13,7 @@ import { AutoSizer } from 'react-virtualized';
 export class UIAutoSizer extends React.Component<AutoSizerProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {AutoSizerProps} props
      */
     public constructor(props: AutoSizerProps) {

--- a/packages/ui-components/src/components/UIVirtualList/UICellMeasurer.tsx
+++ b/packages/ui-components/src/components/UIVirtualList/UICellMeasurer.tsx
@@ -13,6 +13,7 @@ export { Index, OnScrollParams } from 'react-virtualized';
 export class UICellMeasurer extends React.Component<CellMeasurerProps, {}> {
     /**
      * Initializes component properties.
+     *
      * @param {CellMeasurerProps} props
      */
     public constructor(props: CellMeasurerProps) {

--- a/packages/ui-components/src/components/UIVirtualList/UIVirtualList.tsx
+++ b/packages/ui-components/src/components/UIVirtualList/UIVirtualList.tsx
@@ -23,6 +23,7 @@ export class UIVirtualList extends React.Component<ListProps, {}> {
     private listRef = React.createRef<List>();
     /**
      * Initializes component properties.
+     *
      * @param {CellMeasurerProps} props
      */
     public constructor(props: ListProps) {

--- a/packages/ui-components/src/helper/ValidationMessage/utils.ts
+++ b/packages/ui-components/src/helper/ValidationMessage/utils.ts
@@ -136,9 +136,7 @@ const getMessageType = (props?: UIComponentMessagesProps): ErrorMessageType => {
  * @returns {string | undefined} Message string.
  */
 const getErrorMessage = (props?: UIComponentMessagesProps): string | undefined => {
-    if (props) {
-        return props.errorMessage || props.warningMessage || props.infoMessage;
-    }
+    return props?.errorMessage || props?.warningMessage || props?.infoMessage;
 };
 
 /**

--- a/packages/ui-components/src/utilities/DeepMerge.ts
+++ b/packages/ui-components/src/utilities/DeepMerge.ts
@@ -4,6 +4,7 @@ import React from 'react';
  * Performs deep merge on two objects.
  * Parameters are not mutated.
  * Arrays are copied as references and are not merged.
+ *
  * @param a
  * @param b
  * @returns  Record<string, unknown>
@@ -28,6 +29,7 @@ export function deepMerge(a: any, b: any): Record<string, unknown> {
 
 /**
  * Method checks item is object.
+ *
  * @param item
  * @returns boolean
  */

--- a/packages/ui-components/src/utilities/Id.ts
+++ b/packages/ui-components/src/utilities/Id.ts
@@ -1,3 +1,3 @@
 import { getId } from '@fluentui/react';
 
-export { getId as UIGetId };
+export { getId as getUIId };

--- a/packages/ui-components/stories/UIIcon.story.tsx
+++ b/packages/ui-components/stories/UIIcon.story.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import React from 'react';
 import type { IColumn } from '@fluentui/react';
 import { DetailsList, SelectionMode } from '@fluentui/react';

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -125,11 +125,13 @@ describe('<UIDropdown />', () => {
     describe('Test "useDropdownAsMenuMinWidth" property', () => {
         const getCalloutStyles = (width: number): Partial<ICalloutContentStyles> | undefined => {
             const calloutProps = wrapper.find(Dropdown).prop('calloutProps');
+            let calloutStyles;
             if (calloutProps.styles) {
-                return (calloutProps.styles as IStyleFunction<{}, {}>)({
+                calloutStyles = (calloutProps.styles as IStyleFunction<{}, {}>)({
                     calloutWidth: width
                 });
             }
+            return calloutStyles;
         };
 
         it('Default', () => {

--- a/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
+++ b/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
@@ -214,9 +214,7 @@ describe('<UIFlexibleTable />', () => {
         it('Render custom row content', () => {
             wrapper.setProps({
                 onRenderRowDataContent: (params) => {
-                    if (params.rowIndex === 1) {
-                        return <div id="custom-row">This is too complex row</div>;
-                    }
+                    return params.rowIndex === 1 ? <div id="custom-row">This is too complex row</div> : undefined;
                 }
             });
 

--- a/packages/ui-components/test/unit/components/UISections.test.tsx
+++ b/packages/ui-components/test/unit/components/UISections.test.tsx
@@ -224,10 +224,10 @@ describe('<Sections />', () => {
 
     it('Test window resize', () => {
         const mockWidth = (windowWidth: number) => {
-            jest.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function () {
+            jest.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => {
                 return windowWidth;
             });
-            jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+            jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
                 return {
                     top: 0,
                     height: 1000,

--- a/packages/ui-components/test/unit/components/UISplitButton.test.tsx
+++ b/packages/ui-components/test/unit/components/UISplitButton.test.tsx
@@ -19,15 +19,14 @@ describe('<UISplitButton />', () => {
     const getContextMenuProps = (id: string): UIContextualMenuProps => {
         return wrapper.find(`UIDefaultButton#${id}`).prop<UIContextualMenuProps>('menuProps');
     };
-    // eslint-disable-next-line jsdoc/require-returns
-    function mockEvent(targetValue: string): React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> {
+    const mockEvent = (targetValue: string): React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement> => {
         const target: EventTarget = {
             value: targetValue
         } as HTMLInputElement;
         return {
             target
         } as React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
-    }
+    };
 
     beforeEach(() => {
         splitButtonProps = Object.freeze({

--- a/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
@@ -378,15 +378,16 @@ describe('<UITreeDropdown />', () => {
 
     describe('Circular navigation should be disabled', () => {
         const clossestMock = (at: number) => {
-            return (selector: string) => {
+            return (selector: string): HTMLElement | undefined => {
                 if (selector === 'ul') {
-                    return wrapper.find('ul.ms-ContextualMenu-list').getDOMNode();
+                    return wrapper.find('ul.ms-ContextualMenu-list').getDOMNode() as HTMLElement;
                 } else if (selector === 'li') {
-                    return wrapper.find('li.ms-ContextualMenu-item').at(at).getDOMNode();
+                    return wrapper.find('li.ms-ContextualMenu-item').at(at).getDOMNode() as HTMLElement;
                 } else if (selector.indexOf('ui-tree-callout') !== -1) {
                     // Just dummy element is enough
                     return document.createElement('div');
                 }
+                return undefined;
             };
         };
         it('Ordinary scenario', async () => {


### PR DESCRIPTION
This pull requests aligns eslint configuration and fixes eslint reported issues for module `@sap-ux/ui-components`.

What I did in this pull request:

- 🍒-picked @Jimmy-Joseph19 's commit https://github.com/SAP/open-ux-tools/pull/689/commits/86189e40e6686aab9a595830d100ba1d9ccdc7b2 which contains lint fixes for module `@sap-ux/ui-components`.
- ~~Resolved conflicting eslint rule `quoteProps` https://github.com/SAP/open-ux-tools/commit/4fd115cd26cfb2e60f1aa639e233e11026af18e8, for further details see: https://github.com/SAP/open-ux-tools/pull/689#issuecomment-1255628784 and https://github.com/SAP/open-ux-tools/pull/689#issuecomment-1256112736~~ **->** was fixed in PR https://github.com/SAP/open-ux-tools/pull/701
- adjusted local settings in `packages/ui-components/.eslintrc`. Basically, I've removed rules to fall back to the root eslint settings and had to add one rule: `"react/no-unknown-property": ["error", { "ignore": ["onFocusCapture"] }]`. Problem here is, that react 16 supports property `onFocusCapture`, but `eslint-plugin-react@7.31.6` doesn't like it, so I've added it to ignore list: https://github.com/SAP/open-ux-tools/commit/72e8466c280aa3c1be0a862e56cdba54756e40b1
- deleted all occurrences of comment `eslint-disable` and fixed the eslint issues in sources: https://github.com/SAP/open-ux-tools/commit/0fa1d3be72b2a50d9376ce613b70ac7e85d421a9 and in tests: https://github.com/SAP/open-ux-tools/commit/673285013359d2b9f77d6c2b932daaa0b225536c. I've started with `pnpm lint:fix:all` which updated many JSDoc comments automatically and continued with manual fixes.

There are three issues left:
```
open-ux-tools/packages/ui-components/test/unit/components/UICombobox.test.tsx
  214:57  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  277:57  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks

open-ux-tools/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
  706:30  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks

✖ 3 problems (0 errors, 3 warnings)
```

This will vanish once we've updated the ruleset for linting of tests. See discussion here: https://github.com/SAP/open-ux-tools/pull/689#discussion_r978089651

