### PR TITLE
chore: resolve conflicting eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -255,7 +255,8 @@
         "prettier/prettier": [
             "error",
             {
-                "endOfLine": "auto"
+                "endOfLine": "auto",
+                "quoteProps": "preserve"
             }
         ]
     },

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -16,7 +16,7 @@ module.exports = {
     jsxSingleQuote: false,
     printWidth: 120,
     proseWrap: 'preserve',
-    quoteProps: 'as-needed',
+    quoteProps: 'preserve',
     semi: true,
     singleQuote: true,
     tabWidth: 4,


### PR DESCRIPTION
While working on fixing eslint issues, I found a conflicting eslint rule.

Following example:

![image](https://user-images.githubusercontent.com/66327622/191862470-65361433-25cc-4158-9e9b-61719ee6d73c.png)


It tells me, that I should quote the property `default`, as it is a reserved word. The rule comes from `quote-props` -> `as-needed` ->  `keywords: true`

https://github.com/SAP/open-ux-tools/blob/83fea4a611e43a646cbd454f3382d15d491c2062/.eslintrc#L214-L221

If I change it to quoted, I get another error:

![image](https://user-images.githubusercontent.com/66327622/191863042-95c3cafa-527a-4afb-b64a-64a306e81f21.png)

that tells me to replace `'default'` with `default`. This is caused by rule `prettier/prettier`:

https://github.com/SAP/open-ux-tools/blob/83fea4a611e43a646cbd454f3382d15d491c2062/.eslintrc#L255-L260

What helps is adding `"quoteProps": "preserve"`. The value `as-needed` doesn't do the trick, I assume it does not consider keywords, like quote-props does, but only property names that need quoting like `'prop-needs-quoting'`.

In order to have also prettier formatting considering this, `.prettierrc.js` needs also adjustment. Otherwise, `lint -fix` still removes the quotes.


See also https://github.com/SAP/open-ux-tools/pull/689#issuecomment-1255628784 and https://github.com/SAP/open-ux-tools/pull/689#issuecomment-1256112736
