### PR TITLE
linting fixes for base writers

### DIFF
--- a/.changeset/smart-days-camp.md
+++ b/.changeset/smart-days-camp.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/odata-service-writer': patch
+'@sap-ux/ui5-application-writer': patch
+---
+
+Code quality improvements but no functionality change

--- a/packages/odata-service-writer/.eslintignore
+++ b/packages/odata-service-writer/.eslintignore
@@ -1,3 +1,4 @@
-test
+test/test-output
+test/test-input
 dist
 templates

--- a/packages/odata-service-writer/package.json
+++ b/packages/odata-service-writer/package.json
@@ -13,7 +13,7 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "scripts": {
-        "build": "pnpm clean && tsc",
+        "build": "pnpm clean && tsc -p tsconfig-build.json",
         "clean": "rimraf dist test/test-output coverage",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -105,10 +105,10 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
     // Add mockserver entries
     if (service.metadata) {
         // copy existing `ui5.yaml` as starting point for ui5-mock.yaml
-        if (ui5Config) {
+        if (paths.ui5Yaml && ui5Config) {
             const ui5MockConfig = await UI5Config.newInstance(ui5Config.toString());
             ui5MockConfig.addMockServerMiddleware(service.path);
-            fs.write(join(dirname(paths.ui5Yaml!), 'ui5-mock.yaml'), ui5MockConfig.toString());
+            fs.write(join(dirname(paths.ui5Yaml), 'ui5-mock.yaml'), ui5MockConfig.toString());
 
             // also add mockserver middleware to ui5-local.yaml
             if (ui5LocalConfig) {
@@ -138,8 +138,8 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
         updatePackageJson(paths.packageJson, fs, !!service.metadata);
     }
 
-    if (ui5LocalConfig) {
-        fs.write(ui5LocalConfigPath!, ui5LocalConfig.toString());
+    if (ui5LocalConfigPath && ui5LocalConfig) {
+        fs.write(ui5LocalConfigPath, ui5LocalConfig.toString());
     }
 
     if (service.annotations?.xml) {

--- a/packages/odata-service-writer/test/index.test.ts
+++ b/packages/odata-service-writer/test/index.test.ts
@@ -43,6 +43,7 @@ describe('ODataService templates', () => {
     });
 
     /**
+     * Helper function to create app directories for testing in mem-fs.
      *
      * @param name testDir name
      */

--- a/packages/odata-service-writer/test/index.test.ts
+++ b/packages/odata-service-writer/test/index.test.ts
@@ -1,7 +1,9 @@
-import { OdataService, OdataVersion } from '../src/types';
+import type { OdataService } from '../src/types';
+import { OdataVersion } from '../src/types';
 import { generate } from '../src';
 import { join } from 'path';
-import { create, Editor } from 'mem-fs-editor';
+import type { Editor } from 'mem-fs-editor';
+import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
 import { readFile, removeSync } from 'fs-extra';
 import { UI5Config } from '@sap-ux/ui5-config';
@@ -25,7 +27,6 @@ describe('ODataService templates', () => {
     beforeAll(() => {
         if (debug) {
             removeSync(outputDir);
-            console.log(outputDir);
         } else {
             fs.delete(outputDir);
         }
@@ -41,6 +42,10 @@ describe('ODataService templates', () => {
         fs = create(createStorage());
     });
 
+    /**
+     *
+     * @param name testDir name
+     */
     async function createTestDir(name: string): Promise<string> {
         const testDir = join(outputDir, name);
         const ui5Yaml = (await UI5Config.newInstance('')).addFioriToolsProxydMiddleware({ ui5: {} }).toString();

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -1,6 +1,8 @@
-import { generate, OdataService, OdataVersion, findProjectFiles } from '../../src';
+import type { OdataService } from '../../src';
+import { generate, OdataVersion } from '../../src';
 import { join } from 'path';
-import { create, Editor } from 'mem-fs-editor';
+import type { Editor } from 'mem-fs-editor';
+import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
 import { enhanceData } from '../../src/data';
 import cloneDeep from 'lodash/cloneDeep';

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -1,8 +1,10 @@
 import { updateManifest } from '../../src/updates';
 import { join } from 'path';
-import { create, Editor } from 'mem-fs-editor';
+import type { Editor } from 'mem-fs-editor';
+import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
-import { OdataService, OdataVersion } from '../../src';
+import type { OdataService } from '../../src';
+import { OdataVersion } from '../../src';
 import * as ejs from 'ejs';
 
 jest.mock('ejs', () => ({

--- a/packages/odata-service-writer/tsconfig-build.json
+++ b/packages/odata-service-writer/tsconfig-build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["test/**/*.ts"]
+}

--- a/packages/odata-service-writer/tsconfig.json
+++ b/packages/odata-service-writer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src"],
+    "include": ["src", "test"],
     "exclude": ["dist", "templates", "coverage"],
     "compilerOptions": {
         "declaration": true,

--- a/packages/ui5-application-writer/.eslintignore
+++ b/packages/ui5-application-writer/.eslintignore
@@ -1,3 +1,4 @@
-test
+test/test-output
+test/test-input
 dist
 templates

--- a/packages/ui5-application-writer/.eslintrc
+++ b/packages/ui5-application-writer/.eslintrc
@@ -1,4 +1,4 @@
 {
     "extends": ["../../.eslintrc"],
-    "parserOptions": {"project": "./tsconfig.json"}
+    "parserOptions": { "project": "./tsconfig.json" }
 }

--- a/packages/ui5-application-writer/package.json
+++ b/packages/ui5-application-writer/package.json
@@ -13,7 +13,7 @@
     "license": "Apache-2.0",
     "main": "dist/index.js",
     "scripts": {
-        "build": "pnpm clean && tsc",
+        "build": "pnpm clean && tsc -p tsconfig-build.json",
         "clean": "rimraf dist test/test-output coverage",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",

--- a/packages/ui5-application-writer/test/data.test.ts
+++ b/packages/ui5-application-writer/test/data.test.ts
@@ -236,7 +236,7 @@ describe('Setting defaults', () => {
                 id: 'test_appId',
                 description: 'Should be default package description'
             },
-            package: {
+            'package': {
                 name: 'test-package-name',
                 dependencies: {
                     depA: '1.2.3',

--- a/packages/ui5-application-writer/test/index.test.ts
+++ b/packages/ui5-application-writer/test/index.test.ts
@@ -2,7 +2,8 @@ import { join } from 'path';
 import { removeSync } from 'fs-extra';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
-import { generate, isTypescriptEnabled, enableTypescript, Ui5App } from '../src';
+import type { Ui5App } from '../src';
+import { generate, isTypescriptEnabled, enableTypescript } from '../src';
 
 describe('UI5 templates', () => {
     const fs = create(createStorage());
@@ -37,7 +38,7 @@ describe('UI5 templates', () => {
         ui5: {
             framework: 'OpenUI5'
         },
-        package: {
+        'package': {
             name: 'testPackageName'
         }
     } as Ui5App;

--- a/packages/ui5-application-writer/test/options.test.ts
+++ b/packages/ui5-application-writer/test/options.test.ts
@@ -5,7 +5,6 @@ import { removeSync } from 'fs-extra';
 describe('UI5 templates', () => {
     const debug = !!process.env['UX_DEBUG'];
     const outputDir = join(__dirname, '/test-output');
-    if (debug) console.log(outputDir);
 
     const baseAppConfig = {
         app: {
@@ -13,7 +12,7 @@ describe('UI5 templates', () => {
             title: 'Test App Title',
             description: 'Test App Description'
         },
-        package: {
+        'package': {
             name: 'testPackageName'
         }
     };

--- a/packages/ui5-application-writer/tsconfig-build.json
+++ b/packages/ui5-application-writer/tsconfig-build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["test/**/*.ts"]
+}

--- a/packages/ui5-application-writer/tsconfig.json
+++ b/packages/ui5-application-writer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src"],
+    "include": ["src", "test"],
     "compilerOptions": {
         "declaration": true,
         "outDir": "dist",


### PR DESCRIPTION
Carve out from #689 for `odata-service-writer` and `ui5-application-writer`
Main focus was on null-checks when using semver