### PR TITLE
Fix lint warnings in @sap-ux/yaml

### DIFF
--- a/.changeset/serious-frogs-yell.md
+++ b/.changeset/serious-frogs-yell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/yaml': patch
+---
+
+Fix lint warnings

--- a/packages/yaml/.eslintignore
+++ b/packages/yaml/.eslintignore
@@ -1,3 +1,2 @@
-test
 dist
 templates

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -12,7 +12,7 @@
     "version": "0.12.2",
     "main": "dist/index.js",
     "scripts": {
-        "build": "pnpm clean && tsc",
+        "build": "pnpm clean && tsc -p tsconfig-build.json",
         "clean": "rimraf dist test/test-output coverage",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",

--- a/packages/yaml/test/yaml-document.test.ts
+++ b/packages/yaml/test/yaml-document.test.ts
@@ -234,7 +234,7 @@ key1: 42
 seq1:
   - name: name1
     config:
-      prop1: a      
+      prop1: a
   - name: name2
 `;
             const doc = await YamlDocument.newInstance(serializedYaml);
@@ -248,6 +248,22 @@ seq1:
   - name: name2
 `;
             expect(doc.toString()).toEqual(expectedValue);
+        });
+
+        it('will throw an error if matching node is not found', async () => {
+            const serializedYaml = `key1: 42
+seq1:
+  - name: name2
+`;
+            const doc = await YamlDocument.newInstance(serializedYaml);
+            expect(() => {
+                doc.updateAt({
+                    path: 'seq1',
+                    matcher: { key: 'name', value: 'name1' },
+                    value: { config: { prop2: 'b' } }
+                });
+            }).toThrowError();
+            expect(doc.toString()).toEqual(serializedYaml);
         });
     });
 
@@ -609,7 +625,7 @@ l1: # level 1
     l3: # level 3
       l4: # level 4
         seq1: []
-        
+
 #End comment
 `;
             const doc = await YamlDocument.newInstance(serializedYaml);
@@ -646,7 +662,7 @@ l1: # level 1
       l4: # level 4
         seq1:
           - 13
-        
+
 #End comment
 `;
             const doc = await YamlDocument.newInstance(serializedYaml);
@@ -681,7 +697,7 @@ l1: # level 1
     l3: # level 3
       l4: # level 4
         seq1: []
-        
+
 #End comment
 `;
             const doc = await YamlDocument.newInstance(serializedYaml);
@@ -718,7 +734,7 @@ l1: # level 1
       l4: # level 4
         seq1:
           - item: 13
-        
+
 #End comment
 `;
             const doc = await YamlDocument.newInstance(serializedYaml);
@@ -837,7 +853,7 @@ seq1:
     it('adds comments to object properties, existing seq', async () => {
         const serializedYaml = `seq1:
   - a: 13
-  - a: 
+  - a:
       b:
         c: 42
         d:

--- a/packages/yaml/tsconfig-build.json
+++ b/packages/yaml/tsconfig-build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["test/**/*.ts"]
+}

--- a/packages/yaml/tsconfig.json
+++ b/packages/yaml/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src/**/*.ts"],
+    "include": ["src/**/*.ts", "test/**/*.ts"],
     "compilerOptions": {
         "declaration": true,
         "outDir": "dist",


### PR DESCRIPTION
This PR carves out a slice of https://github.com/SAP/open-ux-tools/pull/689 and takes care of the `@sap-ux/yaml` module.

It contains the following changes:
* fixes all the linter warnings
* includes linting for tests
* splits the `tsconfig` into one for CI/CD and one for local dev (source and tests)

Pending linter warnings:
```
packages/yaml/test/yaml-document.test.ts:
   34:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  115:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  121:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  259:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  291:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  298:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  383:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  400:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  406:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  601:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
  614:20  warning  Too many nested callbacks (4). Maximum allowed is 3  max-nested-callbacks
```

These should be fixed when #689 is merged in.