### PR TITLE
fix(backend-proxy-middleware): make onProxyReq handler more robust

### DIFF
--- a/.changeset/metal-ladybugs-promise.md
+++ b/.changeset/metal-ladybugs-promise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/backend-proxy-middleware': patch
+---
+
+Makes the proxy request handler more robust

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -38,7 +38,7 @@ export const ProxyEventHandlers = {
      * @param _options (not used)
      */
     onProxyReq(proxyReq: ClientRequest, _req?: IncomingMessage, _res?: ServerResponse, _options?: ServerOptions) {
-        if (proxyReq.path.indexOf('Fiorilaunchpad.html') !== -1 && !proxyReq.headersSent) {
+        if (proxyReq.path && proxyReq.path.indexOf('Fiorilaunchpad.html') !== -1 && !proxyReq.headersSent) {
             proxyReq.setHeader('accept-encoding', 'br');
         }
     },

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -38,7 +38,7 @@ export const ProxyEventHandlers = {
      * @param _options (not used)
      */
     onProxyReq(proxyReq: ClientRequest, _req?: IncomingMessage, _res?: ServerResponse, _options?: ServerOptions) {
-        if (proxyReq.path && proxyReq.path.indexOf('Fiorilaunchpad.html') !== -1 && !proxyReq.headersSent) {
+        if (proxyReq.path?.includes('Fiorilaunchpad.html') && !proxyReq.headersSent) {
             proxyReq.setHeader('accept-encoding', 'br');
         }
     },

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -105,22 +105,22 @@ describe('proxy', () => {
         const { onProxyReq, onProxyRes } = ProxyEventHandlers;
 
         test('onProxyReq', () => {
-            const mockSetHeader = jest.fn();
+            const mockSetHeader = jest.fn() as unknown;
 
-            onProxyReq({ setHeader: mockSetHeader as unknown } as ClientRequest);
+            onProxyReq({ setHeader: mockSetHeader } as ClientRequest);
             expect(mockSetHeader).not.toBeCalled();
 
-            onProxyReq({ path: 'hello/world', setHeader: mockSetHeader as unknown } as ClientRequest);
+            onProxyReq({ path: 'hello/world', setHeader: mockSetHeader } as ClientRequest);
             expect(mockSetHeader).not.toBeCalled();
 
             onProxyReq({
                 path: 'hello/Fiorilaunchpad.html',
                 headersSent: true,
-                setHeader: mockSetHeader as unknown
+                setHeader: mockSetHeader
             } as ClientRequest);
             expect(mockSetHeader).not.toBeCalled();
 
-            onProxyReq({ path: 'hello/Fiorilaunchpad.html', setHeader: mockSetHeader as unknown } as ClientRequest);
+            onProxyReq({ path: 'hello/Fiorilaunchpad.html', setHeader: mockSetHeader } as ClientRequest);
             expect(mockSetHeader).toBeCalled();
         });
 

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -107,6 +107,9 @@ describe('proxy', () => {
         test('onProxyReq', () => {
             const mockSetHeader = jest.fn();
 
+            onProxyReq({ setHeader: mockSetHeader as unknown } as ClientRequest);
+            expect(mockSetHeader).not.toBeCalled();
+
             onProxyReq({ path: 'hello/world', setHeader: mockSetHeader as unknown } as ClientRequest);
             expect(mockSetHeader).not.toBeCalled();
 


### PR DESCRIPTION
In some rare cases it could happen that the `proxyReq` in https://github.com/SAP/open-ux-tools/blob/main/packages/backend-proxy-middleware/src/base/proxy.ts#L41 is missing the `path` property. If this the case then the proxy request will throw an exception. This PR introduces a check for the `path` property to make the `onProxyReq` handler more robust.