### PR TITLE
chore: exclude pnpm lock from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ typings/
 **/test-output
 **/coverage
 **/__snapshots__
+pnpm-lock.yaml


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/716 exclude file [pnpm-lock.yaml](https://github.com/SAP/open-ux-tools/blob/main/pnpm-lock.yaml) from prettier formatting.

