### PR TITLE
chore(env-check): update bas-sdk dependency

### DIFF
--- a/.changeset/rare-lies-talk.md
+++ b/.changeset/rare-lies-talk.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/environment-check': patch
+---
+
+Update @sap/bas-sdk dependency

--- a/packages/environment-check/package.json
+++ b/packages/environment-check/package.json
@@ -21,7 +21,7 @@
         "unlink": "pnpm unlink --global"
     },
     "dependencies": {
-        "@sap/bas-sdk": "2.1.1",
+        "@sap/bas-sdk": "2.1.2",
         "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/logger": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
       '@sap-ux/btp-utils': workspace:*
       '@sap-ux/logger': workspace:*
       '@sap-ux/ui5-config': workspace:*
-      '@sap/bas-sdk': 2.1.1
+      '@sap/bas-sdk': 2.1.2
       '@types/archiver': 5.1.1
       '@types/vscode': 1.39.0
       archiver: 5.3.0
@@ -196,7 +196,7 @@ importers:
       '@sap-ux/btp-utils': link:../btp-utils
       '@sap-ux/logger': link:../logger
       '@sap-ux/ui5-config': link:../ui5-config
-      '@sap/bas-sdk': 2.1.1
+      '@sap/bas-sdk': 2.1.2
       '@types/archiver': 5.1.1
       archiver: 5.3.0
       axios: 0.24.0
@@ -3443,10 +3443,11 @@ packages:
       webpack: 5.74.0
     dev: true
 
-  /@sap/bas-sdk/2.1.1:
-    resolution: {integrity: sha512-6EpF/6jY+IeDGSR/DpiIOtmld2JfAX+ybuZFMfr8ZdIK9+sxYn1TtiDxidQrs6+Wltqtd33cOnmhWy8mrQ1abg==}
+  /@sap/bas-sdk/2.1.2:
+    resolution: {integrity: sha512-c1WcA4u59eM3f5z0QjFAN8KJPaGuYfdUFIyqF2LXgpDySnxHsexa3+JU+5z4HSmQ1YlJkpdAxkRRTtyTgXgpDA==}
     dependencies:
       axios: 0.21.4
+      cross-spawn: 7.0.3
       lodash: 4.17.21
       minimatch: 3.0.4
       url-join: 4.0.1
@@ -4792,7 +4793,6 @@ packages:
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
-    dev: true
 
   /@types/qs/6.9.1:
     resolution: {integrity: sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==}
@@ -4810,7 +4810,6 @@ packages:
     resolution: {integrity: sha512-idCEjROZ2cqh29+trmTmZhsBAUNQuYrF92JHKzZ5+aiFM1mlSk3bb23CK7HhYuOY75Apgap5y2jTyHzaM2AJGA==}
     dependencies:
       '@types/react': 16.14.0
-    dev: true
 
   /@types/react-virtualized/9.21.11:
     resolution: {integrity: sha512-ngNe2AY/2CHuZQstOS0Jo5jnSjeyKTdSgqrXCQEltRMXLp9rwPUpJdgkoWzES6wn427Z8zo8dkBN8Sx7hlRmig==}
@@ -4824,7 +4823,6 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       csstype: 3.1.1
-    dev: true
 
   /@types/sanitize-html/2.3.2:
     resolution: {integrity: sha512-DnmoXsiqG2/RoSf6/lD3Hrs+TCM8ILtzNuuSjmOtRaP/ud9Sy3M3ctwD+SB50EIDs5GzVFF1dJk2Fq/ID/PNCQ==}
@@ -7099,7 +7097,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /concat-stream/1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -12551,8 +12549,8 @@ packages:
   /nimnjs/1.3.2:
     resolution: {integrity: sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==}
     dependencies:
-      nimn_schema_builder: 1.1.0
       nimn-date-parser: 1.0.0
+      nimn_schema_builder: 1.1.0
     dev: false
 
   /no-case/3.0.4:
@@ -13924,7 +13922,6 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
-    dev: true
 
   /react-element-to-jsx-string/14.3.4_wcqkhtmu7mswc6yz4uyexck3ty:
     resolution: {integrity: sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==}
@@ -14000,7 +13997,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    dev: true
 
   /read-pkg-up/1.0.1:
     resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
@@ -14559,7 +14555,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /schema-utils/1.0.0:
     resolution: {integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==}
@@ -15934,6 +15929,7 @@ packages:
   /unified/9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5


### PR DESCRIPTION
This is a follow up on the issue mentioned here: https://github.com/SAP/open-ux-tools/pull/725#pullrequestreview-1136572849

## Issue
To reproduce the issue:
```
$ npm i @sap-ux/envcheck
$ node node_modules/.bin/envcheck
```

This results in issue:
```
Error: Cannot find module 'cross-spawn'
Require stack:
- node_modules/@sap/bas-sdk/dist/src/utils/core-utils.js
- node_modules/@sap/bas-sdk/dist/src/apis/is-app-studio.js
- node_modules/@sap/bas-sdk/dist/src/index.js
- node_modules/@sap-ux/environment-check/dist/checks/destination.js
- node_modules/@sap-ux/environment-check/dist/checks/environment.js
- node_modules/@sap-ux/environment-check/dist/cli/index.js
- node_modules/@sap-ux/environment-check/bin/envcheck
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/private/tmp/ec/node_modules/@sap/bas-sdk/dist/src/utils/core-utils.js:4:23)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19) {
  code: 'MODULE_NOT_FOUND',
```

Also reported here: https://github.wdf.sap.corp/devx-wing/bas-sdk/issues/95 and fixed with https://github.wdf.sap.corp/devx-wing/bas-sdk/pull/98. 

## Solution
The new version which contains the fix is now available: `@sap/bas-sdk@2.1.2`.
With this PR we consume the newer version.
