### PR TITLE
fix(ui-components): apply lost background to splitter

### DIFF
--- a/.changeset/twelve-poets-shave.md
+++ b/.changeset/twelve-poets-shave.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+fix: transparent splitter issue, apply lost background color variable for splitter component

--- a/packages/ui-components/src/components/UISection/UISplitter.scss
+++ b/packages/ui-components/src/components/UISection/UISplitter.scss
@@ -16,7 +16,7 @@ $splitter-hover-contrast-border: 1px dashed var(--vscode-contrastActiveBorder);
 $splitter-focus-border: 1px solid var(--vscode-focusBorder);
 
 .splitter {
-    background-color: var(--vscode-debugToolBar-background);
+    background-color: var(--vscode-panelSection-border);
     position: absolute;
     outline: none;
 

--- a/packages/ui-components/src/components/UISection/UISplitter.scss
+++ b/packages/ui-components/src/components/UISection/UISplitter.scss
@@ -16,7 +16,7 @@ $splitter-hover-contrast-border: 1px dashed var(--vscode-contrastActiveBorder);
 $splitter-focus-border: 1px solid var(--vscode-focusBorder);
 
 .splitter {
-    background-color: var(--vscode-splitter-background);
+    background-color: var(--vscode-debugToolBar-background);
     position: absolute;
     outline: none;
 


### PR DESCRIPTION
vscode color regression after - https://github.com/SAP/open-ux-tools/pull/759
after we removed `vscuie` variables - splitter lost its background because `vscuie` variable name was not matching vscode variable:
![image](https://user-images.githubusercontent.com/90789422/201026022-ea9b0406-ea87-4da3-8734-7e89f19f02e3.png)

Adapted code to use previous variable `--vscode-debugToolBar-background`