### PR TITLE
fix(axios-ext): make response property on error object optional  

### DIFF
--- a/.changeset/tiny-horses-act.md
+++ b/.changeset/tiny-horses-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': minor
+---
+
+minor bug fix

--- a/packages/axios-extension/src/auth/connection.ts
+++ b/packages/axios-extension/src/auth/connection.ts
@@ -163,7 +163,7 @@ export function attachConnectionHandler(provider: ServiceProvider) {
         },
         (error: AxiosError) => {
             // remember xsrf token if provided even on error
-            if (error.response.headers?.[CSRF.ResponseHeaderName]) {
+            if (error.response?.headers?.[CSRF.ResponseHeaderName]) {
                 provider.defaults.headers.common[CSRF.RequestHeaderName] =
                     error.response.headers[CSRF.ResponseHeaderName];
             }

--- a/packages/axios-extension/test/auth/connection.test.ts
+++ b/packages/axios-extension/test/auth/connection.test.ts
@@ -67,6 +67,17 @@ describe('connection', () => {
             });
         });
 
+        it('response: do not cause problem for errors without response property', () => {
+            const response = {} as AxiosResponse;
+            const error = { message: '~test' } as AxiosError;
+            respHandlers.forEach((handler) => {
+                expect(handler.fulfilled(response)).toBe(response);
+                if (handler.rejected) {
+                    expect(() => handler.rejected(error)).toThrow(error.message);
+                }
+            });
+        });
+
         it('response: do not cause problem for normal responses', () => {
             const response = {} as AxiosResponse;
             const error = { response, message: '~test' } as AxiosError;


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/851

Reponse property is not always present on error object and throws an unwanted error - making it optional