### PR TITLE
feat(ui-components): Tinkering with disabled and readonly input fields

### DIFF
--- a/.changeset/twelve-ways-unite.md
+++ b/.changeset/twelve-ways-unite.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITextInput, UIComboBox, UIDropdown, UITreeDropdown. Support for "readonly" property

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -52,14 +52,11 @@
         &,
         &:hover {
             input {
-                &,
+                color: $dropdown-input-color;
                 &::placeholder {
-                    color: $dropdown-input-color;
+                    color: $dropdown-input-placeholder-color;
                 }
             }
-        }
-        input::placeholder {
-            opacity: 0.7;
         }
         // Overwrite default border
         &:after {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -15,20 +15,6 @@
 }
 
 .ts-ComboBox {
-    &--readonly {
-        .ms-ComboBox {
-            &.is-disabled {
-                @include input-readonly;
-            }
-        }
-    }
-    &--disabled {
-        .ms-ComboBox {
-            &.is-disabled {
-                @include input-disabled;
-            }
-        }
-    }
     .ms-ComboBox {
         background: $dropdown-input-background;
         height: $dropdown-input-height;
@@ -70,10 +56,31 @@
                 border-color: $dropdown-input-focus-border-color;
             }
         }
-        &:focus-within,
-        &.is-open {
-            &:after {
-                border-style: solid;
+    }
+    &--readonly {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-readonly;
+            }
+            &:focus-within,
+            &.is-open {
+                &:after {
+                    border-style: solid;
+                    border-color: $dropdown-input-focus-border-color !important;
+                }
+            }
+        }
+        // Empty and readonly field - disable hover efect
+        &.ts-ComboBox--empty {
+            .ms-ComboBox:hover:after {
+                border-color: $dropdown-input-border-color;
+            }
+        }
+    }
+    &--disabled {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-disabled;
             }
         }
     }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -15,6 +15,20 @@
 }
 
 .ts-ComboBox {
+    &--readonly {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-readonly;
+            }
+        }
+    }
+    &--disabled {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-disabled;
+            }
+        }
+    }
     .ms-ComboBox {
         background: $dropdown-input-background;
         height: $dropdown-input-height;
@@ -59,18 +73,10 @@
                 border-color: $dropdown-input-focus-border-color;
             }
         }
-    }
-    &--readonly {
-        .ms-ComboBox {
-            &.is-disabled {
-                @include input-readonly;
-            }
-        }
-    }
-    &--disabled {
-        .ms-ComboBox {
-            &.is-disabled {
-                @include input-disabled;
+        &:focus-within,
+        &.is-open {
+            &:after {
+                border-style: solid;
             }
         }
     }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -82,6 +82,11 @@
             &.is-disabled {
                 @include input-disabled;
             }
+            &:focus-within {
+                &:after {
+                    border-color: $dropdown-input-focus-border-color;
+                }
+            }
         }
     }
     &--error {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -59,8 +59,12 @@
                 border-color: $dropdown-input-focus-border-color;
             }
         }
-        &.is-disabled {
-            @include input-disabled;
+    }
+    &--disabled {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-disabled;
+            }
         }
     }
     &--error {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -62,13 +62,6 @@
             &.is-disabled {
                 @include input-readonly;
             }
-            &:focus-within,
-            &.is-open {
-                &:after {
-                    border-style: solid;
-                    border-color: $dropdown-input-focus-border-color !important;
-                }
-            }
         }
         // Empty and readonly field - disable hover efect
         &.ts-ComboBox--empty {
@@ -82,10 +75,14 @@
             &.is-disabled {
                 @include input-disabled;
             }
-            &:focus-within {
-                &:after {
-                    border-color: $dropdown-input-focus-border-color;
-                }
+        }
+    }
+    &--readonly,
+    &--disabled {
+        .ms-ComboBox:focus-within {
+            &:after {
+                border-style: solid;
+                border-color: $dropdown-input-focus-border-color !important;
             }
         }
     }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -60,6 +60,13 @@
             }
         }
     }
+    &--readonly {
+        .ms-ComboBox {
+            &.is-disabled {
+                @include input-readonly;
+            }
+        }
+    }
     &--disabled {
         .ms-ComboBox {
             &.is-disabled {

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -496,13 +496,37 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
      * @returns {string} Class names of root combobox element.
      */
     private getClassNames(messageInfo: InputValidationMessageInfo): string {
-        const { readOnly } = this.props;
+        const { readOnly, disabled } = this.props;
         const errorSuffix = messageInfo.message ? MESSAGE_TYPES_CLASSNAME_MAP.get(messageInfo.type) : undefined;
         let classNames = `ts-ComboBox${messageInfo.message ? ' ts-ComboBox--' + errorSuffix : ''}`;
-        if (readOnly) {
+        if (readOnly && !disabled) {
             classNames += ' ts-ComboBox--readonly';
         }
+        if (disabled) {
+            classNames += ' ts-ComboBox--disabled';
+        }
         return classNames;
+    }
+
+    /**
+     * Method returns properties for Autofill component(combobox's inner compnent for text input).
+     * Method handles 'highlight' and 'readOnly' properties.
+     *
+     * @returns {IAutofillProps} Properties for Autofill component.
+     */
+    private getAutofillProps(): IAutofillProps {
+        const { highlight, readOnly, disabled } = this.props;
+        const autofill: IAutofillProps = {};
+        // Handle search highligh
+        if (highlight) {
+            autofill.onKeyDownCapture = this.onKeyDown;
+        }
+        // Handle readOnly property
+        if (readOnly && !disabled) {
+            autofill.readOnly = readOnly;
+            autofill.tabIndex = 'tabIndex' in this.props ? this.props.tabIndex : undefined;
+        }
+        return autofill;
     }
 
     /**
@@ -510,12 +534,6 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
      */
     render(): JSX.Element {
         const messageInfo = getMessageInfo(this.props);
-        const autofill: IAutofillProps = {
-            readOnly: this.props.readOnly
-        };
-        if (this.props.highlight) {
-            autofill.onKeyDownCapture = this.onKeyDown;
-        }
         let disabled = this.props.isForceEnabled ? false : !this.props.options.length;
         if (this.props.readOnly) {
             disabled = true;
@@ -571,7 +589,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                         placeholder: this.getPlaceholder(),
                         onPendingValueChanged: this.onPendingValueChanged
                     })}
-                    autofill={autofill}
+                    autofill={this.getAutofillProps()}
                     {...(this.props.useComboBoxAsMenuMinWidth && {
                         // Use 'onMenuOpen', because there can be dynamic size of combobox
                         onMenuOpen: this.calculateMenuMinWidth.bind(this)

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -525,13 +525,18 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
         if (highlight) {
             autofill.onKeyDownCapture = this.onKeyDown;
         }
+        const tabIndex = 'tabIndex' in this.props ? this.props.tabIndex : undefined;
         // Handle readOnly property
         if (readOnly && !disabled) {
             autofill.readOnly = readOnly;
-            autofill.tabIndex = 'tabIndex' in this.props ? this.props.tabIndex : undefined;
+            autofill.tabIndex = tabIndex;
             // Adjust aria attributes for readonly
             autofill['aria-disabled'] = undefined;
             autofill['aria-readonly'] = true;
+        } else if (disabled) {
+            autofill.disabled = undefined;
+            autofill.readOnly = true;
+            autofill.tabIndex = tabIndex;
         }
         return autofill;
     }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -525,6 +525,9 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
         if (readOnly && !disabled) {
             autofill.readOnly = readOnly;
             autofill.tabIndex = 'tabIndex' in this.props ? this.props.tabIndex : undefined;
+            // Adjust aria attributes for readonly
+            autofill['aria-disabled'] = undefined;
+            autofill['aria-readonly'] = true;
         }
         return autofill;
     }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -16,6 +16,7 @@ import { UiIcons } from '../Icons';
 import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo, MESSAGE_TYPES_CLASSNAME_MAP } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
+import { isDropdownEmpty } from '../UIDropdown';
 
 export {
     IComboBoxOption as UIComboBoxOption,
@@ -504,6 +505,9 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
         }
         if (disabled) {
             classNames += ' ts-ComboBox--disabled';
+        }
+        if (isDropdownEmpty(this.props)) {
+            classNames += ' ts-ComboBox--empty';
         }
         return classNames;
     }

--- a/packages/ui-components/src/components/UIComboBox/_mixins.scss
+++ b/packages/ui-components/src/components/UIComboBox/_mixins.scss
@@ -17,8 +17,16 @@
 @mixin input-disabled() {
     opacity: $dropdown-input-disabled-opacity;
     background-color: $dropdown-input-disabled-background-color;
-    font-style: italic;
     &:after {
         border-color: $dropdown-input-border-color;
     }
 }
+
+@mixin input-readonly() {
+    background-color: $dropdown-input-readonly-background-color;
+    font-style: italic;
+    &:after {
+        border-style: dashed;
+    }
+}
+

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -56,8 +56,19 @@
                 border: $dropdown-input-border-width solid $dropdown-input-focus-border-color;
             }
         }
-        &.is-disabled {
-            @include input-disabled;
+    }
+    &--readonly {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-readonly;
+            }
+        }
+    }
+    &--disabled {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-disabled;
+            }
         }
     }
     &--error {

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -51,6 +51,9 @@
                 color: $dropdown-input-color;
             }
         }
+        .ms-Dropdown-titleIsPlaceHolder {
+            color: $dropdown-input-placeholder-color;
+        }
         &:after {
             pointer-events: none;
             content: '';

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -71,13 +71,6 @@
             &.is-disabled {
                 @include input-readonly;
             }
-            &.is-open,
-            &:focus {
-                &:after {
-                    border-style: solid;
-                    border-color: $dropdown-input-focus-border-color !important;
-                }
-            }
         }
         // Empty and readonly field - disable hover efect
         &.ts-SelectBox--empty {
@@ -90,6 +83,15 @@
         .ms-Dropdown {
             &.is-disabled {
                 @include input-disabled;
+            }
+        }
+    }
+    &--readonly,
+    &--disabled {
+        .ms-Dropdown:focus {
+            &:after {
+                border-style: solid;
+                border-color: $dropdown-input-focus-border-color !important;
             }
         }
     }

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -14,6 +14,20 @@
 }
 
 .ts-SelectBox {
+    &--readonly {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-readonly;
+            }
+        }
+    }
+    &--disabled {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-disabled;
+            }
+        }
+    }
     .ms-Dropdown {
         background: $dropdown-input-background;
         .ms-Dropdown-title {
@@ -53,21 +67,13 @@
         &:focus,
         &:hover {
             &:after {
-                border: $dropdown-input-border-width solid $dropdown-input-focus-border-color;
+                border-color: $dropdown-input-focus-border-color;
             }
         }
-    }
-    &--readonly {
-        .ms-Dropdown {
-            &.is-disabled {
-                @include input-readonly;
-            }
-        }
-    }
-    &--disabled {
-        .ms-Dropdown {
-            &.is-disabled {
-                @include input-disabled;
+        &:focus,
+        &.is-open {
+            &:after {
+                border-style: solid;
             }
         }
     }

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -14,20 +14,6 @@
 }
 
 .ts-SelectBox {
-    &--readonly {
-        .ms-Dropdown {
-            &.is-disabled {
-                @include input-readonly;
-            }
-        }
-    }
-    &--disabled {
-        .ms-Dropdown {
-            &.is-disabled {
-                @include input-disabled;
-            }
-        }
-    }
     .ms-Dropdown {
         background: $dropdown-input-background;
         .ms-Dropdown-title {
@@ -77,6 +63,33 @@
         &.is-open {
             &:after {
                 border-style: solid;
+            }
+        }
+    }
+    &--readonly {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-readonly;
+            }
+            &.is-open,
+            &:focus {
+                &:after {
+                    border-style: solid;
+                    border-color: $dropdown-input-focus-border-color !important;
+                }
+            }
+        }
+        // Empty and readonly field - disable hover efect
+        &.ts-SelectBox--empty {
+            .ms-Dropdown:hover:after {
+                border-color: $dropdown-input-border-color;
+            }
+        }
+    }
+    &--disabled {
+        .ms-Dropdown {
+            &.is-disabled {
+                @include input-disabled;
             }
         }
     }

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -31,6 +31,8 @@ export interface UIDropdownState {
     isOpen: boolean;
 }
 
+type AccessibilityProps = Partial<IDropdownProps & { ['data-is-focusable']?: boolean }>;
+
 const ERROR_BORDER_COLOR = 'var(--vscode-inputValidation-errorBorder)';
 
 /**
@@ -199,12 +201,13 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
     }
 
     /**
-     * @returns {JSX.Element}
+     * Method returns additional component properties for accessibility.
+     *
+     * @returns {AccessibilityProps} Additional properties.
      */
-    render(): JSX.Element {
+    private getAccessibilityProps(): AccessibilityProps {
         const { readOnly, disabled } = this.props;
-        const messageInfo = getMessageInfo(this.props);
-        const additionalProps: Partial<IDropdownProps & { ['data-is-focusable']?: boolean }> = {};
+        const additionalProps: AccessibilityProps = {};
         if (readOnly && !disabled) {
             // Make dropdown focusable
             additionalProps.tabIndex = 0;
@@ -212,7 +215,19 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
             // Adjust aria attributes for readonly
             additionalProps['aria-disabled'] = undefined;
             additionalProps['aria-readonly'] = true;
+        } else if (disabled) {
+            additionalProps.tabIndex = 0;
+            additionalProps['data-is-focusable'] = true;
         }
+        return additionalProps;
+    }
+
+    /**
+     * @returns {JSX.Element}
+     */
+    render(): JSX.Element {
+        const messageInfo = getMessageInfo(this.props);
+        const additionalProps = this.getAccessibilityProps();
         const dropdownStyles = (): Partial<IDropdownStyles> => ({
             ...{
                 label: {

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -11,6 +11,7 @@ import { UIIcon } from '../UIIcon';
 import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo, MESSAGE_TYPES_CLASSNAME_MAP } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
+import { isDropdownEmpty } from './utils';
 
 import './UIDropdown.scss';
 
@@ -189,6 +190,10 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
         // Custom external classes
         if (className) {
             classNames += ` ${className}`;
+        }
+        // Empty value
+        if (isDropdownEmpty(this.props)) {
+            classNames += ' ts-SelectBox--empty';
         }
         return classNames;
     }

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -22,6 +22,7 @@ export interface UIDropdownProps extends IDropdownProps, UIMessagesExtendedProps
     onHandleOpen?(): void;
     onHandleRenderTitle?(items: IDropdownOption[] | undefined): JSX.Element;
     useDropdownAsMenuMinWidth?: boolean;
+    readOnly?: boolean;
 }
 
 export interface UIDropdownState {

--- a/packages/ui-components/src/components/UIDropdown/index.tsx
+++ b/packages/ui-components/src/components/UIDropdown/index.tsx
@@ -1,1 +1,2 @@
 export * from './UIDropdown';
+export * from './utils';

--- a/packages/ui-components/src/components/UIDropdown/utils.ts
+++ b/packages/ui-components/src/components/UIDropdown/utils.ts
@@ -1,0 +1,18 @@
+import type { IDropdownProps, IComboBoxProps } from '@fluentui/react';
+
+/**
+ * Method checks if drodpown or combobox is empty or any value is selected.
+ *
+ * @param {Partial<IDropdownProps | IComboBoxProps>} props Dropdown or combobox props.
+ * @returns {boolean} Is dropdown or combobox empty.
+ */
+export function isDropdownEmpty(props: Partial<IDropdownProps | IComboBoxProps>): boolean {
+    const { selectedKey } = props;
+    if (Array.isArray(selectedKey)) {
+        return selectedKey.length === 0;
+    }
+    if ('text' in props && props.text) {
+        return false;
+    }
+    return !selectedKey;
+}

--- a/packages/ui-components/src/components/UIDropdown/utils.ts
+++ b/packages/ui-components/src/components/UIDropdown/utils.ts
@@ -11,7 +11,7 @@ export function isDropdownEmpty(props: Partial<IDropdownProps | IComboBoxProps>)
     if (Array.isArray(selectedKey)) {
         return selectedKey.length === 0;
     }
-    if ('text' in props && props.text) {
+    if (('text' in props && props.text) || ('selectedKeys' in props && props.selectedKeys?.length)) {
         return false;
     }
     return !selectedKey;

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -70,6 +70,154 @@ export class UITextInput extends React.Component<UITextInputProps> {
     }
 
     /**
+     * Method returns styles for text field.
+     *
+     * @param {ITextFieldStyleProps} props Component properties.
+     * @returns {Partial<ITextFieldStyles>} Styles to apply for text field.
+     */
+    private getStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
+        const messageInfo = getMessageInfo(this.props);
+        return {
+            ...{
+                root: {
+                    height: 'auto',
+                    fontFamily: 'var(--vscode-font-family)'
+                },
+                fieldGroup: [
+                    // Common styles
+                    {
+                        backgroundColor: COLOR_STYLES.regular.backgroundColor,
+                        borderWidth: 1,
+                        borderStyle: COLOR_STYLES.regular.borderStyle,
+                        borderColor: COLOR_STYLES.regular.borderColor,
+                        color: COLOR_STYLES.regular.color,
+                        borderRadius: 0,
+                        boxSizing: 'initial'
+                    },
+                    // Single line common styles
+                    !props.multiline && {
+                        height: 24,
+                        maxHeight: 24,
+                        minHeight: 24
+                    },
+                    // Hoverable input
+                    !props.disabled && {
+                        selectors: {
+                            '&:hover': {
+                                borderColor: COLOR_STYLES.hover.borderColor
+                            }
+                        }
+                    },
+                    // Disabled field
+                    props.disabled && {
+                        backgroundColor: COLOR_STYLES.disabled.backgroundColor,
+                        opacity: COLOR_STYLES.disabled.opacity,
+                        borderRadius: 0
+                    },
+                    // Read only container - disable hover style
+                    this.props.readOnly && {
+                        borderStyle: COLOR_STYLES.readOnly.borderStyle,
+                        // No hover efect on input without value
+                        selectors: !this.props.value
+                            ? {
+                                  '&:hover': {
+                                      borderColor: 'var(--vscode-editorWidget-border)'
+                                  }
+                              }
+                            : undefined
+                    },
+                    // Error message
+                    props.hasErrorMessage && {
+                        borderColor: messageInfo.style.borderColor
+                    },
+                    props.focused && {
+                        selectors: {
+                            ':after': {
+                                border: this.getFocusBorder(messageInfo)
+                            }
+                        }
+                    }
+                ],
+                field: [
+                    // Common styles
+                    {
+                        backgroundColor: COLOR_STYLES.regular.backgroundColor,
+                        color: COLOR_STYLES.regular.color,
+                        fontSize: '13px',
+                        fontWeight: 'normal',
+                        boxSizing: 'border-box',
+                        selectors: {
+                            '::placeholder': {
+                                fontSize: 13,
+                                fontFamily: 'var(--vscode-font-family)',
+                                color: 'var(--vscode-input-placeholderForeground)'
+                            }
+                        }
+                    },
+                    // Single line common styles
+                    !props.multiline && {
+                        lineHeight: 'normal'
+                    },
+                    // Multi line common styles
+                    props.multiline && {
+                        minHeight: '60px',
+                        height: 'auto',
+                        display: 'flex'
+                    },
+                    // Disabled input
+                    props.disabled && {
+                        backgroundColor: 'transparent'
+                    },
+                    // Readonly input
+                    this.props.readOnly && {
+                        fontStyle: 'italic',
+                        backgroundColor: COLOR_STYLES.readOnly.backgroundColor
+                    },
+                    // Input with icon
+                    props.hasIcon && {
+                        selectors: {
+                            '&:hover': {
+                                cursor: 'pointer'
+                            }
+                        }
+                    }
+                ],
+                suffix: {
+                    backgroundColor: 'var(--vscode-input-background)'
+                },
+                subComponentStyles: {
+                    label: {
+                        root: [
+                            {
+                                marginTop: 25,
+                                ...labelGlobalStyle
+                            },
+                            props.disabled && {
+                                opacity: COLOR_STYLES.disabled.opacity
+                            },
+                            props.required && {
+                                selectors: {
+                                    '::after': {
+                                        content: `' *'`,
+                                        color: 'var(--vscode-inputValidation-errorBorder)',
+                                        paddingRight: 12
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                errorMessage: [messageInfo.style],
+                icon: [
+                    {
+                        bottom: 2
+                    }
+                ]
+            }
+        };
+    };
+
+    /**
      * Method to render HTML input element.
      * Custom rendering is used to use "readonly" attribute instead of "disabled" to make disabled field focusable.
      *
@@ -95,147 +243,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
      */
     render(): JSX.Element {
         const messageInfo = getMessageInfo(this.props);
-        const textFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
-            return {
-                ...{
-                    root: {
-                        height: 'auto',
-                        fontFamily: 'var(--vscode-font-family)'
-                    },
-                    fieldGroup: [
-                        // Common styles
-                        {
-                            backgroundColor: COLOR_STYLES.regular.backgroundColor,
-                            borderWidth: 1,
-                            borderStyle: COLOR_STYLES.regular.borderStyle,
-                            borderColor: COLOR_STYLES.regular.borderColor,
-                            color: COLOR_STYLES.regular.color,
-                            borderRadius: 0,
-                            boxSizing: 'initial'
-                        },
-                        // Single line common styles
-                        !props.multiline && {
-                            height: 24,
-                            maxHeight: 24,
-                            minHeight: 24
-                        },
-                        // Hoverable input
-                        !props.disabled && {
-                            selectors: {
-                                '&:hover': {
-                                    borderColor: COLOR_STYLES.hover.borderColor
-                                }
-                            }
-                        },
-                        // Disabled field
-                        props.disabled && {
-                            backgroundColor: COLOR_STYLES.disabled.backgroundColor,
-                            opacity: COLOR_STYLES.disabled.opacity,
-                            borderRadius: 0
-                        },
-                        // Read only container - disable hover style
-                        this.props.readOnly && {
-                            borderStyle: COLOR_STYLES.readOnly.borderStyle,
-                            // No hover efect on input without value
-                            selectors: !this.props.value
-                                ? {
-                                      '&:hover': {
-                                          borderColor: 'var(--vscode-editorWidget-border)'
-                                      }
-                                  }
-                                : undefined
-                        },
-                        // Error message
-                        props.hasErrorMessage && {
-                            borderColor: messageInfo.style.borderColor
-                        },
-                        props.focused && {
-                            selectors: {
-                                ':after': {
-                                    border: this.getFocusBorder(messageInfo)
-                                }
-                            }
-                        }
-                    ],
-                    field: [
-                        // Common styles
-                        {
-                            backgroundColor: COLOR_STYLES.regular.backgroundColor,
-                            color: COLOR_STYLES.regular.color,
-                            fontSize: '13px',
-                            fontWeight: 'normal',
-                            boxSizing: 'border-box',
-                            selectors: {
-                                '::placeholder': {
-                                    fontSize: 13,
-                                    fontFamily: 'var(--vscode-font-family)',
-                                    color: 'var(--vscode-input-placeholderForeground)'
-                                }
-                            }
-                        },
-                        // Single line common styles
-                        !props.multiline && {
-                            lineHeight: 'normal'
-                        },
-                        // Multi line common styles
-                        props.multiline && {
-                            minHeight: '60px',
-                            height: 'auto',
-                            display: 'flex'
-                        },
-                        // Disabled input
-                        props.disabled && {
-                            backgroundColor: 'transparent'
-                        },
-                        // Readonly input
-                        this.props.readOnly && {
-                            fontStyle: 'italic',
-                            backgroundColor: COLOR_STYLES.readOnly.backgroundColor
-                        },
-                        // Input with icon
-                        props.hasIcon && {
-                            selectors: {
-                                '&:hover': {
-                                    cursor: 'pointer'
-                                }
-                            }
-                        }
-                    ],
-                    suffix: {
-                        backgroundColor: 'var(--vscode-input-background)'
-                    },
-                    subComponentStyles: {
-                        label: {
-                            root: [
-                                {
-                                    marginTop: 25,
-                                    ...labelGlobalStyle
-                                },
-                                props.disabled && {
-                                    opacity: COLOR_STYLES.disabled.opacity
-                                },
-                                props.required && {
-                                    selectors: {
-                                        '::after': {
-                                            content: `' *'`,
-                                            color: 'var(--vscode-inputValidation-errorBorder)',
-                                            paddingRight: 12
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    errorMessage: [messageInfo.style],
-                    icon: [
-                        {
-                            bottom: 2
-                        }
-                    ]
-                }
-            };
-        };
-
+        const textFieldStyles = this.getStyles;
         return (
             <TextField
                 onRenderInput={this.props.disabled ? this.onRenderDisabledInput : undefined}

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -33,6 +33,8 @@ const COLOR_STYLES = {
     }
 };
 
+type InputRenderProps = React.InputHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>;
+
 /**
  * UITextInput component
  * based on https://developer.microsoft.com/en-us/fluentui#/controls/web/textfield
@@ -49,6 +51,8 @@ export class UITextInput extends React.Component<UITextInputProps> {
      */
     public constructor(props: UITextInputProps) {
         super(props);
+
+        this.onRenderDisabledInput = this.onRenderDisabledInput.bind(this);
     }
 
     /**
@@ -64,6 +68,27 @@ export class UITextInput extends React.Component<UITextInputProps> {
         }
         return `1px ${COLOR_STYLES.regular.borderStyle} ${color}`;
     }
+
+    /**
+     * Method to render HTML input element.
+     * Custom rendering is used to use "readonly" attribute instead of "disabled" to make disabled field focusable.
+     *
+     * @param {InputRenderProps} [props] Input props.
+     * @param {(props?: InputRenderProps) => JSX.Element | null} [defaultRender] Default renderer.
+     * @returns {JSX.Element | null} Input element to render.
+     */
+    private onRenderDisabledInput = (
+        props?: InputRenderProps,
+        defaultRender?: (props?: InputRenderProps) => JSX.Element | null
+    ): JSX.Element | null => {
+        const inputProps = {
+            ...props,
+            disabled: undefined,
+            readOnly: true,
+            ['aria-disabled']: true
+        };
+        return defaultRender?.(inputProps) || null;
+    };
 
     /**
      * @returns {JSX.Element}
@@ -211,6 +236,13 @@ export class UITextInput extends React.Component<UITextInputProps> {
             };
         };
 
-        return <TextField {...this.props} errorMessage={messageInfo.message} styles={textFieldStyles} />;
+        return (
+            <TextField
+                onRenderInput={this.props.disabled ? this.onRenderDisabledInput : undefined}
+                {...this.props}
+                errorMessage={messageInfo.message}
+                styles={textFieldStyles}
+            />
+        );
     }
 }

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type { ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react';
 import { TextField } from '@fluentui/react';
-import type { UIMessagesExtendedProps } from '../../helper/ValidationMessage';
+import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
 
@@ -52,13 +52,17 @@ export class UITextInput extends React.Component<UITextInputProps> {
     }
 
     /**
-     * Method wraps passed css variable name into css variable syntax.
+     * Method returns value for CSS property "border" for focus state.
      *
-     * @param {string} name
-     * @returns {string} CSS variable.
+     * @param {InputValidationMessageInfo} messageInfo
+     * @returns {string} Value for CSS "border" property.
      */
-    private wrapCssVariable(name: string): string {
-        return `var(${name})`;
+    private getFocusBorder(messageInfo: InputValidationMessageInfo): string {
+        let color = COLOR_STYLES.focus.borderColor;
+        if (this.props.errorMessage && messageInfo.style.borderColor) {
+            color = `var(${messageInfo.style.borderColor})`;
+        }
+        return `1px ${COLOR_STYLES.regular.borderStyle} ${color}`;
     }
 
     /**
@@ -123,11 +127,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         props.focused && {
                             selectors: {
                                 ':after': {
-                                    border: `1px ${COLOR_STYLES.regular.borderStyle} ${
-                                        this.props.errorMessage && messageInfo.style.borderColor
-                                            ? this.wrapCssVariable(messageInfo.style.borderColor)
-                                            : COLOR_STYLES.focus.borderColor
-                                    }`
+                                    border: this.getFocusBorder(messageInfo)
                                 }
                             }
                         }

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -46,7 +46,6 @@ export class UITextInput extends React.Component<UITextInputProps> {
                             backgroundColor: 'var(--vscode-input-background)',
                             borderWidth: 1,
                             borderStyle: 'solid',
-                            //borderColor: 'blue',
                             borderColor: 'var(--vscode-editorWidget-border)',
                             borderRadius: 0,
                             boxSizing: 'initial'
@@ -61,24 +60,26 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         !props.disabled && {
                             selectors: {
                                 '&:hover': {
-                                    border: '1px solid var(--vscode-focusBorder)'
+                                    borderColor: 'var(--vscode-focusBorder)'
                                 }
                             }
                         },
                         // Disabled field
                         props.disabled &&
-                            !props.multiline && {
-                                color: 'var(--vscode-input-foreground)',
-                                opacity: 0.4,
-                                borderRadius: 0
-                            },
+                        !props.multiline && {
+                            color: 'var(--vscode-input-foreground)',
+                            opacity: 0.4,
+                            borderRadius: 0
+                        },
                         // Read only container - disable hover style
                         this.props.readOnly && {
-                            selectors: {
+                            borderStyle: 'dashed',
+                            // No hover efect on input without value
+                            selectors: !this.props.value ? {
                                 '&:hover': {
-                                    border: '1px solid var(--vscode-editorWidget-border)'
+                                    borderColor: 'var(--vscode-editorWidget-border)'
                                 }
-                            }
+                            } : undefined
                         },
                         // Error message
                         props.hasErrorMessage && {
@@ -87,12 +88,11 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         props.focused && {
                             selectors: {
                                 ':after': {
-                                    border: `1px solid var(${
-                                        this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
-                                    })`
+                                    border: `1px solid var(${this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
+                                        })`
                                 }
                             }
-                        }
+                        },
                     ],
                     field: [
                         // Common styles

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -47,6 +47,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                             borderWidth: 1,
                             borderStyle: 'solid',
                             borderColor: 'var(--vscode-editorWidget-border)',
+                            color: 'var(--vscode-input-foreground)',
                             borderRadius: 0,
                             boxSizing: 'initial'
                         },
@@ -65,9 +66,8 @@ export class UITextInput extends React.Component<UITextInputProps> {
                             }
                         },
                         // Disabled field
-                        props.disabled &&
-                        !props.multiline && {
-                            color: 'var(--vscode-input-foreground)',
+                        props.disabled && {
+                            backgroundColor: `var(--vscode-editor-inactiveSelectionBackground)`,
                             opacity: 0.4,
                             borderRadius: 0
                         },
@@ -75,11 +75,13 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         this.props.readOnly && {
                             borderStyle: 'dashed',
                             // No hover efect on input without value
-                            selectors: !this.props.value ? {
-                                '&:hover': {
-                                    borderColor: 'var(--vscode-editorWidget-border)'
-                                }
-                            } : undefined
+                            selectors: !this.props.value
+                                ? {
+                                      '&:hover': {
+                                          borderColor: 'var(--vscode-editorWidget-border)'
+                                      }
+                                  }
+                                : undefined
                         },
                         // Error message
                         props.hasErrorMessage && {
@@ -88,11 +90,12 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         props.focused && {
                             selectors: {
                                 ':after': {
-                                    border: `1px solid var(${this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
-                                        })`
+                                    border: `1px solid var(${
+                                        this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
+                                    })`
                                 }
                             }
-                        },
+                        }
                     ],
                     field: [
                         // Common styles

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -41,69 +41,64 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         fontFamily: 'var(--vscode-font-family)'
                     },
                     fieldGroup: [
-                        !props.disabled &&
-                            !props.multiline && {
-                                backgroundColor: 'var(--vscode-input-background)',
-                                border: '1px solid var(--vscode-editorWidget-border)',
-                                borderRadius: 0,
-                                height: 24,
-                                maxHeight: 24,
-                                minHeight: 24,
-                                boxSizing: 'initial',
-                                selectors: {
-                                    '&:hover': {
-                                        border: '1px solid var(--vscode-focusBorder)'
-                                    }
-                                }
-                            },
-                        props.multiline && {
+                        // Common styles
+                        {
                             backgroundColor: 'var(--vscode-input-background)',
-                            border: '1px solid var(--vscode-editorWidget-border)',
+                            borderWidth: 1,
+                            borderStyle: 'solid',
+                            //borderColor: 'blue',
+                            borderColor: 'var(--vscode-editorWidget-border)',
                             borderRadius: 0,
-                            boxSizing: 'initial',
+                            boxSizing: 'initial'
+                        },
+                        // Single line common styles
+                        !props.multiline && {
+                            height: 24,
+                            maxHeight: 24,
+                            minHeight: 24
+                        },
+                        // Hoverable input
+                        !props.disabled && {
                             selectors: {
                                 '&:hover': {
                                     border: '1px solid var(--vscode-focusBorder)'
                                 }
                             }
                         },
+                        // Disabled field
                         props.disabled &&
                             !props.multiline && {
                                 color: 'var(--vscode-input-foreground)',
                                 opacity: 0.4,
-                                backgroundColor: `var(--vscode-editor-inactiveSelectionBackground)`,
-                                borderColor: 'var(--vscode-editorWidget-border)',
-                                border: '1px solid var(--vscode-editorWidget-border)',
-                                borderRadius: 0,
-                                height: 24,
-                                maxHeight: 24,
-                                minHeight: 24,
-                                boxSizing: 'initial'
+                                borderRadius: 0
                             },
+                        // Read only container - disable hover style
+                        this.props.readOnly && {
+                            selectors: {
+                                '&:hover': {
+                                    border: '1px solid var(--vscode-editorWidget-border)'
+                                }
+                            }
+                        },
+                        // Error message
                         props.hasErrorMessage && {
                             borderColor: messageInfo.style.borderColor
                         },
-                        props.focused &&
-                            !props.disabled && {
-                                selectors: {
-                                    ':after': {
-                                        border: `1px solid var(${
-                                            this.props.errorMessage
-                                                ? messageInfo.style.borderColor
-                                                : '--vscode-focusBorder'
-                                        })`
-                                    }
+                        props.focused && {
+                            selectors: {
+                                ':after': {
+                                    border: `1px solid var(${
+                                        this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
+                                    })`
                                 }
                             }
+                        }
                     ],
                     field: [
-                        !props.multiline && {
+                        // Common styles
+                        {
                             backgroundColor: 'var(--vscode-input-background)',
                             color: 'var(--vscode-input-foreground)',
-                            lineHeight: 'normal',
-                            height: 24,
-                            maxHeight: 24,
-                            minHeight: 24,
                             fontSize: '13px',
                             fontWeight: 'normal',
                             boxSizing: 'border-box',
@@ -115,36 +110,32 @@ export class UITextInput extends React.Component<UITextInputProps> {
                                 }
                             }
                         },
+                        // Single line common styles
+                        !props.multiline && {
+                            lineHeight: 'normal'
+                        },
+                        // Multi line common styles
+                        props.multiline && {
+                            minHeight: '60px',
+                            height: 'auto',
+                            display: 'flex'
+                        },
+                        // Disabled input
+                        props.disabled && {
+                            backgroundColor: 'transparent'
+                        },
+                        // Readonly input
+                        this.props.readOnly && {
+                            fontStyle: 'italic',
+                            backgroundColor: 'var(--vscode-editor-background)'
+                        },
+                        // Input with icon
                         props.hasIcon && {
                             selectors: {
                                 '&:hover': {
                                     cursor: 'pointer'
                                 }
                             }
-                        },
-
-                        props.multiline && {
-                            backgroundColor: 'var(--vscode-input-background)',
-                            color: 'var(--vscode-input-foreground)',
-                            minHeight: '60px',
-                            height: 'auto',
-                            display: 'flex',
-                            fontSize: '13px',
-                            fontWeight: 'normal',
-                            boxSizing: 'border-box',
-                            selectors: {
-                                '::placeholder': {
-                                    fontSize: 13,
-                                    fontFamily: 'var(--vscode-font-family)',
-                                    color: 'var(--vscode-input-placeholderForeground)'
-                                }
-                            }
-                        },
-
-                        // props for input element inside field group
-                        props.disabled && {
-                            fontStyle: 'italic',
-                            backgroundColor: 'transparent'
                         }
                     ],
                     suffix: {

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -10,6 +10,29 @@ export { ITextField, ITextFieldProps } from '@fluentui/react';
 
 export type UITextInputProps = ITextFieldProps & UIMessagesExtendedProps;
 
+const COLOR_STYLES = {
+    regular: {
+        backgroundColor: 'var(--vscode-input-background)',
+        borderColor: 'var(--vscode-editorWidget-border)',
+        color: 'var(--vscode-input-foreground)',
+        borderStyle: 'solid'
+    },
+    disabled: {
+        backgroundColor: 'var(--vscode-editor-inactiveSelectionBackground)',
+        opacity: 0.5
+    },
+    readOnly: {
+        backgroundColor: 'var(--vscode-editor-background)',
+        borderStyle: 'dashed'
+    },
+    hover: {
+        borderColor: 'var(--vscode-focusBorder)'
+    },
+    focus: {
+        borderColor: 'var(--vscode-focusBorder)'
+    }
+};
+
 /**
  * UITextInput component
  * based on https://developer.microsoft.com/en-us/fluentui#/controls/web/textfield
@@ -29,6 +52,16 @@ export class UITextInput extends React.Component<UITextInputProps> {
     }
 
     /**
+     * Method wraps passed css variable name into css variable syntax.
+     *
+     * @param {string} name
+     * @returns {string} CSS variable.
+     */
+    private wrapCssVariable(name: string): string {
+        return `var(${name})`;
+    }
+
+    /**
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
@@ -43,11 +76,11 @@ export class UITextInput extends React.Component<UITextInputProps> {
                     fieldGroup: [
                         // Common styles
                         {
-                            backgroundColor: 'var(--vscode-input-background)',
+                            backgroundColor: COLOR_STYLES.regular.backgroundColor,
                             borderWidth: 1,
-                            borderStyle: 'solid',
-                            borderColor: 'var(--vscode-editorWidget-border)',
-                            color: 'var(--vscode-input-foreground)',
+                            borderStyle: COLOR_STYLES.regular.borderStyle,
+                            borderColor: COLOR_STYLES.regular.borderColor,
+                            color: COLOR_STYLES.regular.color,
                             borderRadius: 0,
                             boxSizing: 'initial'
                         },
@@ -61,19 +94,19 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         !props.disabled && {
                             selectors: {
                                 '&:hover': {
-                                    borderColor: 'var(--vscode-focusBorder)'
+                                    borderColor: COLOR_STYLES.hover.borderColor
                                 }
                             }
                         },
                         // Disabled field
                         props.disabled && {
-                            backgroundColor: `var(--vscode-editor-inactiveSelectionBackground)`,
-                            opacity: 0.4,
+                            backgroundColor: COLOR_STYLES.disabled.backgroundColor,
+                            opacity: COLOR_STYLES.disabled.opacity,
                             borderRadius: 0
                         },
                         // Read only container - disable hover style
                         this.props.readOnly && {
-                            borderStyle: 'dashed',
+                            borderStyle: COLOR_STYLES.readOnly.borderStyle,
                             // No hover efect on input without value
                             selectors: !this.props.value
                                 ? {
@@ -90,9 +123,11 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         props.focused && {
                             selectors: {
                                 ':after': {
-                                    border: `1px solid var(${
-                                        this.props.errorMessage ? messageInfo.style.borderColor : '--vscode-focusBorder'
-                                    })`
+                                    border: `1px ${COLOR_STYLES.regular.borderStyle} ${
+                                        this.props.errorMessage && messageInfo.style.borderColor
+                                            ? this.wrapCssVariable(messageInfo.style.borderColor)
+                                            : COLOR_STYLES.focus.borderColor
+                                    }`
                                 }
                             }
                         }
@@ -100,8 +135,8 @@ export class UITextInput extends React.Component<UITextInputProps> {
                     field: [
                         // Common styles
                         {
-                            backgroundColor: 'var(--vscode-input-background)',
-                            color: 'var(--vscode-input-foreground)',
+                            backgroundColor: COLOR_STYLES.regular.backgroundColor,
+                            color: COLOR_STYLES.regular.color,
                             fontSize: '13px',
                             fontWeight: 'normal',
                             boxSizing: 'border-box',
@@ -130,7 +165,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                         // Readonly input
                         this.props.readOnly && {
                             fontStyle: 'italic',
-                            backgroundColor: 'var(--vscode-editor-background)'
+                            backgroundColor: COLOR_STYLES.readOnly.backgroundColor
                         },
                         // Input with icon
                         props.hasIcon && {
@@ -152,7 +187,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                                     ...labelGlobalStyle
                                 },
                                 props.disabled && {
-                                    opacity: '0.4'
+                                    opacity: COLOR_STYLES.disabled.opacity
                                 },
                                 props.required && {
                                     selectors: {

--- a/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.scss
+++ b/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.scss
@@ -8,21 +8,16 @@
     }
     &-wrapper {
         position: relative;
-
-        &.disabled {
-            opacity: $dropdown-input-disabled-opacity;
-        }
-        .ms-TextField {
-            .ms-TextField-wrapper {
-                .ms-TextField-fieldGroup {
-                    opacity: initial;
-                    background: $dropdown-input-background;
-                }
-            }
-        }
         input {
             padding: 0 26px 0 8px;
             font-family: var(--vscode-font-family);
+        }
+        // Decrease z-index for open menu button when component is disabled
+        &.disabled > button {
+            z-index: -1;
+        }
+        &.readonly > button {
+            pointer-events: none;
         }
     }
     &-caret {

--- a/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
+++ b/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
@@ -46,6 +46,7 @@ export interface UITreeDropdownProps extends UIMessagesExtendedProps {
     maxWidth?: number;
     useTargetWidth?: string;
     errorMessage?: string;
+    readOnly?: boolean;
 }
 
 interface TreeItemInfo {
@@ -367,6 +368,9 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
      * @param {React.KeyboardEvent<HTMLInputElement>} event
      */
     toggleMenu = (status: boolean, event?: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (this.props.readOnly) {
+            return;
+        }
         this.setState({
             isHidden: status
         });
@@ -730,6 +734,7 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
                     <UITextInput
                         componentRef={this.inputRef}
                         disabled={this.state.isDisabled}
+                        readOnly={this.props.readOnly}
                         autoComplete="off"
                         value={this.state.value}
                         placeholder={this.props.placeholderText}

--- a/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
+++ b/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
@@ -705,6 +705,24 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
     };
 
     /**
+     * Method returns class names for wrapper element depending on props and component state.
+     *
+     * @returns {string} Class names of wrapper element.
+     */
+    private getClassNames(): string {
+        let classNames = `ui-treeDropdown-wrapper ui-treeDropdown-wrapper-menu${
+            this.state.isMenuOpen ? '-open' : '-close'
+        } ui-treeDropdown-wrapper-${this.state.uiidInput}`;
+        if (this.state.isDisabled) {
+            classNames += ' disabled';
+        }
+        if (this.props.readOnly) {
+            classNames += ' readonly';
+        }
+        return classNames;
+    }
+
+    /**
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
@@ -726,11 +744,7 @@ export class UITreeDropdown extends React.Component<UITreeDropdownProps, UITreeD
                         {this.props.label}
                     </label>
                 )}
-                <div
-                    className={`ui-treeDropdown-wrapper${this.state.isDisabled ? ' disabled' : ''}
-                        ui-treeDropdown-wrapper-menu${
-                            this.state.isMenuOpen ? '-open' : '-close'
-                        } ui-treeDropdown-wrapper-${this.state.uiidInput}`}>
+                <div className={this.getClassNames()}>
                     <UITextInput
                         componentRef={this.inputRef}
                         disabled={this.state.isDisabled}

--- a/packages/ui-components/src/styles/_variables.scss
+++ b/packages/ui-components/src/styles/_variables.scss
@@ -11,6 +11,7 @@ $button-font-size: $font-size-base;
 // colors
 $dropdown-input-height: $base-element-height;
 $dropdown-input-color: var(--vscode-foreground);
+$dropdown-input-placeholder-color: var(--vscode-input-placeholderForeground);
 $dropdown-input-background: var(--vscode-input-background);
 $dropdown-input-border-color: var(--vscode-editorWidget-border);
 $dropdown-input-focus-border-color: var(--vscode-focusBorder);

--- a/packages/ui-components/src/styles/_variables.scss
+++ b/packages/ui-components/src/styles/_variables.scss
@@ -20,5 +20,6 @@ $dropdown-input-expand-icon-size: 16px;
 $dropdown-input-text-padding: 0px $dropdown-input-height 0 8px;
 $dropdown-input-border-width: 1px;
 $dropdown-input-border: $dropdown-input-border-width solid $dropdown-input-border-color;
-$dropdown-input-disabled-opacity: 0.4;
+$dropdown-input-disabled-opacity: 0.5;
 $dropdown-input-disabled-background-color: var(--vscode-editor-inactiveSelectionBackground);
+$dropdown-input-readonly-background-color: var(--vscode-editor-background);

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@fluentui/react';
 import type { IComboBox, IComboBoxOption } from '@fluentui/react';
 
 import { UIComboBox } from '../src/components/UIComboBox';
+import { UICheckbox } from '../src/components/UICheckbox';
 import { data } from '../test/__mock__/select-data';
 
 import { initIcons } from '../src/components/Icons';
@@ -183,6 +184,7 @@ export const openMenuOnClick = (): JSX.Element => (
 );
 
 export const accessibilityStates = () => {
+    const [multiSelect, setMultiSelect] = React.useState(false);
     const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
@@ -190,6 +192,7 @@ export const accessibilityStates = () => {
         highlight: true,
         allowFreeform: true,
         useComboBoxAsMenuMinWidth: true,
+        multiSelect,
         onChange: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption | undefined) => {
             if (option) {
                 setSelectedKey(option.key);
@@ -198,6 +201,15 @@ export const accessibilityStates = () => {
     };
     return (
         <div>
+            <Stack horizontal tokens={stackTokens}>
+                <UICheckbox
+                    label="Multi Select"
+                    checked={multiSelect}
+                    onChange={(event: any, value: any) => {
+                        setMultiSelect(value);
+                    }}
+                />
+            </Stack>
             <Stack horizontal tokens={stackTokens}>
                 <table
                     style={{

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -185,7 +185,7 @@ export const openMenuOnClick = (): JSX.Element => (
 
 export const accessibilityStates = () => {
     const [multiSelect, setMultiSelect] = React.useState(false);
-    const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
+    const [selectedKey, setSelectedKey] = React.useState<number | string | number[] | string[]>('EE');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
         options: data,
@@ -194,7 +194,12 @@ export const accessibilityStates = () => {
         useComboBoxAsMenuMinWidth: true,
         multiSelect,
         onChange: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption | undefined) => {
-            if (option) {
+            if (Array.isArray(selectedKey)) {
+                const newKeys = [...selectedKey, option?.key].filter((k) =>
+                    option?.selected ? true : k !== option?.key
+                ) as string[];
+                setSelectedKey(newKeys);
+            } else if (option) {
                 setSelectedKey(option.key);
             }
         }
@@ -206,6 +211,11 @@ export const accessibilityStates = () => {
                     label="Multi Select"
                     checked={multiSelect}
                     onChange={(event: any, value: any) => {
+                        if (value && !Array.isArray(selectedKey)) {
+                            setSelectedKey([selectedKey as string]);
+                        } else if (!value && Array.isArray(selectedKey)) {
+                            setSelectedKey(selectedKey[0]);
+                        }
                         setMultiSelect(value);
                     }}
                 />

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -208,10 +208,21 @@ export const accessibilityStates = () => {
                     <tr>
                         <td
                             style={{
-                                minWidth: 100
+                                minWidth: 100,
+                                width: 150
                             }}></td>
-                        <td>Placeholder Text</td>
-                        <td>Input Text</td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Placeholder Text
+                        </td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Input Text
+                        </td>
                     </tr>
                     <tr>
                         <td>Regular</td>

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -1,5 +1,6 @@
 import type { SetStateAction } from 'react';
 import React, { useState } from 'react';
+import { Stack } from '@fluentui/react';
 import type { IComboBox, IComboBoxOption } from '@fluentui/react';
 
 import { UIComboBox } from '../src/components/UIComboBox';
@@ -180,3 +181,73 @@ export const openMenuOnClick = (): JSX.Element => (
         />
     </div>
 );
+
+export const accessibilityStates = () => {
+    const stackTokens = { childrenGap: 40 };
+    const testProps = {
+        options: data,
+        highlight: true,
+        allowFreeform: true,
+        useComboBoxAsMenuMinWidth: true
+    }
+    return (
+        <div>
+            <Stack horizontal tokens={stackTokens}>
+                <table
+                    style={{
+                        borderSpacing: 20,
+                        width: '100%',
+                        maxWidth: 750
+                    }}>
+                    <tr>
+                        <td
+                            style={{
+                                minWidth: 100
+                            }}></td>
+                        <td>Placeholder Text</td>
+                        <td>Input Text</td>
+                    </tr>
+                    <tr>
+                        <td>Regular</td>
+                        <td>
+                            <UIComboBox {...testProps} placeholder="Placeholder"></UIComboBox>
+                        </td>
+                        <td>
+                            <UIComboBox {...testProps} text="Dummy"></UIComboBox>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Error</td>
+                        <td>
+                            <UIComboBox
+                                {...testProps}
+                                placeholder="Placeholder"
+                                errorMessage="Dummy error"></UIComboBox>
+                        </td>
+                        <td>
+                            <UIComboBox {...testProps} errorMessage="Dummy error" selectedKey="EE"></UIComboBox>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Disabled</td>
+                        <td>
+                            <UIComboBox {...testProps} placeholder="Placeholder" disabled></UIComboBox>
+                        </td>
+                        <td>
+                            <UIComboBox {...testProps} selectedKey="EE" disabled></UIComboBox>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Read Only</td>
+                        <td>
+                            <UIComboBox {...testProps} placeholder="Placeholder" readOnly></UIComboBox>
+                        </td>
+                        <td>
+                            <UIComboBox {...testProps} selectedKey="EE" readOnly></UIComboBox>
+                        </td>
+                    </tr>
+                </table>
+            </Stack>
+        </div>
+    );
+};

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -183,13 +183,19 @@ export const openMenuOnClick = (): JSX.Element => (
 );
 
 export const accessibilityStates = () => {
+    const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
         options: data,
         highlight: true,
         allowFreeform: true,
-        useComboBoxAsMenuMinWidth: true
-    }
+        useComboBoxAsMenuMinWidth: true,
+        onChange: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption | undefined) => {
+            if (option) {
+                setSelectedKey(option.key);
+            }
+        }
+    };
     return (
         <div>
             <Stack horizontal tokens={stackTokens}>
@@ -213,7 +219,7 @@ export const accessibilityStates = () => {
                             <UIComboBox {...testProps} placeholder="Placeholder"></UIComboBox>
                         </td>
                         <td>
-                            <UIComboBox {...testProps} text="Dummy"></UIComboBox>
+                            <UIComboBox {...testProps} selectedKey={selectedKey}></UIComboBox>
                         </td>
                     </tr>
                     <tr>
@@ -225,7 +231,10 @@ export const accessibilityStates = () => {
                                 errorMessage="Dummy error"></UIComboBox>
                         </td>
                         <td>
-                            <UIComboBox {...testProps} errorMessage="Dummy error" selectedKey="EE"></UIComboBox>
+                            <UIComboBox
+                                {...testProps}
+                                errorMessage="Dummy error"
+                                selectedKey={selectedKey}></UIComboBox>
                         </td>
                     </tr>
                     <tr>
@@ -234,7 +243,7 @@ export const accessibilityStates = () => {
                             <UIComboBox {...testProps} placeholder="Placeholder" disabled></UIComboBox>
                         </td>
                         <td>
-                            <UIComboBox {...testProps} selectedKey="EE" disabled></UIComboBox>
+                            <UIComboBox {...testProps} selectedKey={selectedKey} disabled></UIComboBox>
                         </td>
                     </tr>
                     <tr>
@@ -243,7 +252,7 @@ export const accessibilityStates = () => {
                             <UIComboBox {...testProps} placeholder="Placeholder" readOnly></UIComboBox>
                         </td>
                         <td>
-                            <UIComboBox {...testProps} selectedKey="EE" readOnly></UIComboBox>
+                            <UIComboBox {...testProps} selectedKey={selectedKey} readOnly></UIComboBox>
                         </td>
                     </tr>
                 </table>

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -86,10 +86,21 @@ export const accessibilityStates = () => {
                     <tr>
                         <td
                             style={{
-                                minWidth: 100
+                                minWidth: 100,
+                                width: 150
                             }}></td>
-                        <td>Placeholder Text</td>
-                        <td>Input Text</td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Placeholder Text
+                        </td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Input Text
+                        </td>
                     </tr>
                     <tr>
                         <td>Regular</td>

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -73,7 +73,6 @@ export const accessibilityStates = () => {
         useComboBoxAsMenuMinWidth: true,
         multiSelect,
         onChange: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
-            console.log('aaaaaaaa');
             if (Array.isArray(selectedKey)) {
                 const newKeys = [...selectedKey, option?.key].filter((k) =>
                     option?.selected ? true : k !== option?.key

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Stack } from '@fluentui/react';
 import { UIDropdown } from '../src/components/UIDropdown';
 import { data, shortData } from '../test/__mock__/select-data';
 
@@ -57,3 +58,73 @@ export const UseDropdownAsMenuMinWidth = (): JSX.Element => (
         </div>
     </div>
 );
+
+export const accessibilityStates = () => {
+    const stackTokens = { childrenGap: 40 };
+    const testProps = {
+        options: data,
+        highlight: true,
+        allowFreeform: true,
+        useComboBoxAsMenuMinWidth: true
+    };
+    return (
+        <div>
+            <Stack horizontal tokens={stackTokens}>
+                <table
+                    style={{
+                        borderSpacing: 20,
+                        width: '100%',
+                        maxWidth: 750
+                    }}>
+                    <tr>
+                        <td
+                            style={{
+                                minWidth: 100
+                            }}></td>
+                        <td>Placeholder Text</td>
+                        <td>Input Text</td>
+                    </tr>
+                    <tr>
+                        <td>Regular</td>
+                        <td>
+                            <UIDropdown {...testProps} placeholder="Placeholder"></UIDropdown>
+                        </td>
+                        <td>
+                            <UIDropdown {...testProps} selectedKey="EE"></UIDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Error</td>
+                        <td>
+                            <UIDropdown
+                                {...testProps}
+                                placeholder="Placeholder"
+                                errorMessage="Dummy error"></UIDropdown>
+                        </td>
+                        <td>
+                            <UIDropdown {...testProps} errorMessage="Dummy error" selectedKey="EE"></UIDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Disabled</td>
+                        <td>
+                            <UIDropdown {...testProps} placeholder="Placeholder" disabled></UIDropdown>
+                        </td>
+                        <td>
+                            <UIDropdown {...testProps} selectedKey="EE" disabled></UIDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Read Only</td>
+                        <td>
+                            <UIDropdown {...testProps} placeholder="Placeholder" readOnly></UIDropdown>
+                        </td>
+                        <td>
+                            <UIDropdown {...testProps} selectedKey="EE" readOnly></UIDropdown>
+                        </td>
+                    </tr>
+                </table>
+            </Stack>
+        </div>
+    );
+};

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -63,8 +63,9 @@ export const UseDropdownAsMenuMinWidth = (): JSX.Element => (
 
 export const accessibilityStates = () => {
     const [multiSelect, setMultiSelect] = React.useState(false);
-    const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
+    const [selectedKey, setSelectedKey] = React.useState<number | string | number[] | string[]>('EE');
     const stackTokens = { childrenGap: 40 };
+    const selectedKeys = Array.isArray(selectedKey) ? selectedKey : undefined;
     const testProps = {
         options: data,
         highlight: true,
@@ -72,7 +73,13 @@ export const accessibilityStates = () => {
         useComboBoxAsMenuMinWidth: true,
         multiSelect,
         onChange: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
-            if (option) {
+            console.log('aaaaaaaa');
+            if (Array.isArray(selectedKey)) {
+                const newKeys = [...selectedKey, option?.key].filter((k) =>
+                    option?.selected ? true : k !== option?.key
+                ) as string[];
+                setSelectedKey(newKeys);
+            } else if (option) {
                 setSelectedKey(option.key);
             }
         }
@@ -83,6 +90,11 @@ export const accessibilityStates = () => {
                 label="Multi Select"
                 checked={multiSelect}
                 onChange={(event: any, value: any) => {
+                    if (value && !Array.isArray(selectedKey)) {
+                        setSelectedKey([selectedKey as string]);
+                    } else if (!value && Array.isArray(selectedKey)) {
+                        setSelectedKey(selectedKey[0]);
+                    }
                     setMultiSelect(value);
                 }}
             />
@@ -118,7 +130,10 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder"></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey={selectedKey}></UIDropdown>
+                            <UIDropdown
+                                {...testProps}
+                                selectedKey={selectedKey}
+                                selectedKeys={selectedKeys}></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -133,7 +148,8 @@ export const accessibilityStates = () => {
                             <UIDropdown
                                 {...testProps}
                                 errorMessage="Dummy error"
-                                selectedKey={selectedKey}></UIDropdown>
+                                selectedKey={selectedKey}
+                                selectedKeys={selectedKeys}></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -142,7 +158,11 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder" disabled></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey={selectedKey} disabled></UIDropdown>
+                            <UIDropdown
+                                {...testProps}
+                                selectedKey={selectedKey}
+                                selectedKeys={selectedKeys}
+                                disabled></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -151,7 +171,11 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder" readOnly></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey={selectedKey} readOnly></UIDropdown>
+                            <UIDropdown
+                                {...testProps}
+                                selectedKey={selectedKey}
+                                selectedKeys={selectedKeys}
+                                readOnly></UIDropdown>
                         </td>
                     </tr>
                 </table>

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Stack } from '@fluentui/react';
+import type { IDropdownOption } from '@fluentui/react';
 import { UIDropdown } from '../src/components/UIDropdown';
 import { data, shortData } from '../test/__mock__/select-data';
 
@@ -60,12 +61,18 @@ export const UseDropdownAsMenuMinWidth = (): JSX.Element => (
 );
 
 export const accessibilityStates = () => {
+    const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
         options: data,
         highlight: true,
         allowFreeform: true,
-        useComboBoxAsMenuMinWidth: true
+        useComboBoxAsMenuMinWidth: true,
+        onChange: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+            if (option) {
+                setSelectedKey(option.key);
+            }
+        }
     };
     return (
         <div>
@@ -90,7 +97,7 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder"></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey="EE"></UIDropdown>
+                            <UIDropdown {...testProps} selectedKey={selectedKey}></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -102,7 +109,10 @@ export const accessibilityStates = () => {
                                 errorMessage="Dummy error"></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} errorMessage="Dummy error" selectedKey="EE"></UIDropdown>
+                            <UIDropdown
+                                {...testProps}
+                                errorMessage="Dummy error"
+                                selectedKey={selectedKey}></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -111,7 +121,7 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder" disabled></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey="EE" disabled></UIDropdown>
+                            <UIDropdown {...testProps} selectedKey={selectedKey} disabled></UIDropdown>
                         </td>
                     </tr>
                     <tr>
@@ -120,7 +130,7 @@ export const accessibilityStates = () => {
                             <UIDropdown {...testProps} placeholder="Placeholder" readOnly></UIDropdown>
                         </td>
                         <td>
-                            <UIDropdown {...testProps} selectedKey="EE" readOnly></UIDropdown>
+                            <UIDropdown {...testProps} selectedKey={selectedKey} readOnly></UIDropdown>
                         </td>
                     </tr>
                 </table>

--- a/packages/ui-components/stories/UIDropdown.story.tsx
+++ b/packages/ui-components/stories/UIDropdown.story.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Stack } from '@fluentui/react';
 import type { IDropdownOption } from '@fluentui/react';
 import { UIDropdown } from '../src/components/UIDropdown';
+import { UICheckbox } from '../src/components/UICheckbox';
 import { data, shortData } from '../test/__mock__/select-data';
 
 import { initIcons } from '../src/components/Icons';
@@ -61,6 +62,7 @@ export const UseDropdownAsMenuMinWidth = (): JSX.Element => (
 );
 
 export const accessibilityStates = () => {
+    const [multiSelect, setMultiSelect] = React.useState(false);
     const [selectedKey, setSelectedKey] = React.useState<number | string>('EE');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
@@ -68,6 +70,7 @@ export const accessibilityStates = () => {
         highlight: true,
         allowFreeform: true,
         useComboBoxAsMenuMinWidth: true,
+        multiSelect,
         onChange: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
             if (option) {
                 setSelectedKey(option.key);
@@ -76,6 +79,13 @@ export const accessibilityStates = () => {
     };
     return (
         <div>
+            <UICheckbox
+                label="Multi Select"
+                checked={multiSelect}
+                onChange={(event: any, value: any) => {
+                    setMultiSelect(value);
+                }}
+            />
             <Stack horizontal tokens={stackTokens}>
                 <table
                     style={{

--- a/packages/ui-components/stories/UITextInput.story.tsx
+++ b/packages/ui-components/stories/UITextInput.story.tsx
@@ -74,10 +74,21 @@ export const accessibilityStates = () => {
                     <tr>
                         <td
                             style={{
-                                minWidth: 100
+                                minWidth: 100,
+                                width: 150
                             }}></td>
-                        <td>Placeholder Text</td>
-                        <td>Input Text</td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Placeholder Text
+                        </td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Input Text
+                        </td>
                     </tr>
                     <tr>
                         <td>Regular</td>

--- a/packages/ui-components/stories/UITextInput.story.tsx
+++ b/packages/ui-components/stories/UITextInput.story.tsx
@@ -3,6 +3,7 @@ import type { IStackTokens } from '@fluentui/react';
 import { Text, Stack, Separator } from '@fluentui/react';
 
 import { UITextInput } from '../src/components/UIInput';
+import { UICheckbox } from '../src/components/UICheckbox';
 import { initIcons } from '../src/components/Icons';
 
 export default { title: 'Basic Inputs/Input' };
@@ -40,6 +41,80 @@ export const defaultUsage = () => {
                 <UITextInput label="Enter your name" disabled></UITextInput>
             </Stack>
         </Stack>
+    );
+};
+
+export const accessibilityStates = () => {
+    const [multiline, setMultiline] = React.useState(false);
+    const testProps = { multiline };
+    return (
+        <div>
+            <Stack horizontal tokens={stackTokens}>
+                <UICheckbox
+                    label="Multi Line"
+                    checked={multiline}
+                    onChange={(event: any, value: any) => {
+                        setMultiline(value);
+                    }}
+                />
+            </Stack>
+            <Stack horizontal tokens={stackTokens}>
+                <table
+                    style={{
+                        borderSpacing: 20,
+                        width: '100%',
+                        maxWidth: 750
+                    }}>
+                    <tr>
+                        <td
+                            style={{
+                                minWidth: 100
+                            }}></td>
+                        <td>Placeholder Text</td>
+                        <td>Input Text</td>
+                    </tr>
+                    <tr>
+                        <td>Regular</td>
+                        <td>
+                            <UITextInput {...testProps} placeholder="Placeholder"></UITextInput>
+                        </td>
+                        <td>
+                            <UITextInput {...testProps} value="Content"></UITextInput>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Error</td>
+                        <td>
+                            <UITextInput
+                                {...testProps}
+                                placeholder="Placeholder"
+                                errorMessage="Dummy error"></UITextInput>
+                        </td>
+                        <td>
+                            <UITextInput {...testProps} errorMessage="Dummy error" value="Content"></UITextInput>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Disabled</td>
+                        <td>
+                            <UITextInput {...testProps} placeholder="Placeholder" disabled></UITextInput>
+                        </td>
+                        <td>
+                            <UITextInput {...testProps} value="Content" disabled></UITextInput>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Read Only</td>
+                        <td>
+                            <UITextInput {...testProps} placeholder="Placeholder" readOnly></UITextInput>
+                        </td>
+                        <td>
+                            <UITextInput {...testProps} value="Content" readOnly></UITextInput>
+                        </td>
+                    </tr>
+                </table>
+            </Stack>
+        </div>
     );
 };
 

--- a/packages/ui-components/stories/UITextInput.story.tsx
+++ b/packages/ui-components/stories/UITextInput.story.tsx
@@ -46,7 +46,13 @@ export const defaultUsage = () => {
 
 export const accessibilityStates = () => {
     const [multiline, setMultiline] = React.useState(false);
-    const testProps = { multiline };
+    const [value, setValue] = React.useState('Content');
+    const testProps = {
+        multiline,
+        onChange: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+            setValue(newValue || '');
+        }
+    };
     return (
         <div>
             <Stack horizontal tokens={stackTokens}>
@@ -79,7 +85,7 @@ export const accessibilityStates = () => {
                             <UITextInput {...testProps} placeholder="Placeholder"></UITextInput>
                         </td>
                         <td>
-                            <UITextInput {...testProps} value="Content"></UITextInput>
+                            <UITextInput {...testProps} value={value}></UITextInput>
                         </td>
                     </tr>
                     <tr>
@@ -91,7 +97,7 @@ export const accessibilityStates = () => {
                                 errorMessage="Dummy error"></UITextInput>
                         </td>
                         <td>
-                            <UITextInput {...testProps} errorMessage="Dummy error" value="Content"></UITextInput>
+                            <UITextInput {...testProps} errorMessage="Dummy error" value={value}></UITextInput>
                         </td>
                     </tr>
                     <tr>
@@ -100,7 +106,7 @@ export const accessibilityStates = () => {
                             <UITextInput {...testProps} placeholder="Placeholder" disabled></UITextInput>
                         </td>
                         <td>
-                            <UITextInput {...testProps} value="Content" disabled></UITextInput>
+                            <UITextInput {...testProps} value={value} disabled></UITextInput>
                         </td>
                     </tr>
                     <tr>
@@ -109,7 +115,7 @@ export const accessibilityStates = () => {
                             <UITextInput {...testProps} placeholder="Placeholder" readOnly></UITextInput>
                         </td>
                         <td>
-                            <UITextInput {...testProps} value="Content" readOnly></UITextInput>
+                            <UITextInput {...testProps} value={value} readOnly></UITextInput>
                         </td>
                     </tr>
                 </table>

--- a/packages/ui-components/stories/UITreedropdown.story.tsx
+++ b/packages/ui-components/stories/UITreedropdown.story.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Stack } from '@fluentui/react';
 import { UITreeDropdown } from '../src/components/UITreeDropdown';
 
 export default { title: 'Dropdowns/TreeDropdown' };
@@ -66,6 +67,86 @@ export const Message = (): JSX.Element => {
                 maxWidth={300}
                 errorMessage="Dummy error"
             />
+        </div>
+    );
+};
+
+export const accessibilityStates = () => {
+    const [selectedKey, setSelectedKey] = React.useState<string>('_Title1');
+    const stackTokens = { childrenGap: 40 };
+    const testProps = {
+        label: 'Label',
+        placeholderText: 'Select value',
+        items: data,
+        maxWidth: 300,
+        onParameterValueChange: (value) => console.log(value)
+    };
+    const changeableProps = {
+        ...testProps,
+        onParameterValueChange: (value) => setSelectedKey(value)
+    };
+
+    return (
+        <div>
+            <Stack horizontal tokens={stackTokens}>
+                <table
+                    style={{
+                        borderSpacing: 20,
+                        width: '100%',
+                        maxWidth: 750
+                    }}>
+                    <tr>
+                        <td
+                            style={{
+                                minWidth: 100
+                            }}></td>
+                        <td>Placeholder Text</td>
+                        <td>Input Text</td>
+                    </tr>
+                    <tr>
+                        <td>Regular</td>
+                        <td>
+                            <UITreeDropdown {...testProps} placeholderText="Placeholder"></UITreeDropdown>
+                        </td>
+                        <td>
+                            <UITreeDropdown {...changeableProps} value={selectedKey}></UITreeDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Error</td>
+                        <td>
+                            <UITreeDropdown
+                                {...testProps}
+                                placeholderText="Placeholder"
+                                errorMessage="Dummy error"></UITreeDropdown>
+                        </td>
+                        <td>
+                            <UITreeDropdown
+                                {...changeableProps}
+                                errorMessage="Dummy error"
+                                value={selectedKey}></UITreeDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Disabled</td>
+                        <td>
+                            <UITreeDropdown {...testProps} placeholderText="Placeholder" items={[]}></UITreeDropdown>
+                        </td>
+                        <td>
+                            <UITreeDropdown {...changeableProps} value={selectedKey} items={[]}></UITreeDropdown>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Read Only</td>
+                        <td>
+                            <UITreeDropdown {...testProps} placeholderText="Placeholder" readOnly></UITreeDropdown>
+                        </td>
+                        <td>
+                            <UITreeDropdown {...changeableProps} value={selectedKey} readOnly></UITreeDropdown>
+                        </td>
+                    </tr>
+                </table>
+            </Stack>
         </div>
     );
 };

--- a/packages/ui-components/stories/UITreedropdown.story.tsx
+++ b/packages/ui-components/stories/UITreedropdown.story.tsx
@@ -75,7 +75,6 @@ export const accessibilityStates = () => {
     const [selectedKey, setSelectedKey] = React.useState<string>('_Title1');
     const stackTokens = { childrenGap: 40 };
     const testProps = {
-        label: 'Label',
         placeholderText: 'Select value',
         items: data,
         maxWidth: 300,
@@ -98,10 +97,21 @@ export const accessibilityStates = () => {
                     <tr>
                         <td
                             style={{
-                                minWidth: 100
+                                minWidth: 100,
+                                width: 150
                             }}></td>
-                        <td>Placeholder Text</td>
-                        <td>Input Text</td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Placeholder Text
+                        </td>
+                        <td
+                            style={{
+                                width: '50%'
+                            }}>
+                            Input Text
+                        </td>
                     </tr>
                     <tr>
                         <td>Regular</td>

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -551,7 +551,7 @@ Object {
     Object {
       "backgroundColor": "var(--vscode-editor-inactiveSelectionBackground)",
       "borderRadius": 0,
-      "opacity": 0.4,
+      "opacity": 0.5,
     },
     undefined,
     undefined,
@@ -578,7 +578,7 @@ Object {
           "padding": "4px 0",
         },
         Object {
-          "opacity": "0.4",
+          "opacity": 0.5,
         },
         undefined,
       ],
@@ -852,7 +852,7 @@ Object {
     Object {
       "backgroundColor": "var(--vscode-editor-inactiveSelectionBackground)",
       "borderRadius": 0,
-      "opacity": 0.4,
+      "opacity": 0.5,
     },
     undefined,
     undefined,
@@ -879,7 +879,7 @@ Object {
           "padding": "4px 0",
         },
         Object {
-          "opacity": "0.4",
+          "opacity": 0.5,
         },
         undefined,
       ],

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<UIToggle /> Readonly input field with value 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    Object {
+      "backgroundColor": "var(--vscode-editor-background)",
+      "fontStyle": "italic",
+    },
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "borderColor": "var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    Object {
+      "borderStyle": "dashed",
+      "selectors": undefined,
+    },
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
 exports[`<UIToggle /> Styles - default 1`] = `
 Object {
   "errorMessage": Array [
@@ -56,7 +158,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
@@ -152,7 +254,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
@@ -248,7 +350,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
@@ -344,7 +446,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
@@ -541,15 +643,16 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
     undefined,
     Object {
+      "borderStyle": "dashed",
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-editorWidget-border)",
+          "borderColor": "var(--vscode-editorWidget-border)",
         },
       },
     },
@@ -643,7 +746,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
@@ -832,15 +935,16 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },
     undefined,
     Object {
+      "borderStyle": "dashed",
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-editorWidget-border)",
+          "borderColor": "var(--vscode-editorWidget-border)",
         },
       },
     },
@@ -932,7 +1036,7 @@ Object {
     Object {
       "selectors": Object {
         "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
+          "borderColor": "var(--vscode-focusBorder)",
         },
       },
     },

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -1,5 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<UIToggle /> Focus styles, "errorMessage=[object Object]" 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "borderColor": "var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    Object {
+      "selectors": Object {
+        ":after": Object {
+          "border": "1px solid var(var(--vscode-inputValidation-errorBorder))",
+        },
+      },
+    },
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Focus styles, "errorMessage=[object Object]" 2`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "borderColor": "var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    Object {
+      "selectors": Object {
+        ":after": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
 exports[`<UIToggle /> Readonly input field with value 1`] = `
 Object {
   "errorMessage": Array [

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -50,6 +50,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -149,6 +150,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -245,6 +247,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -341,6 +344,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -437,6 +441,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -535,6 +540,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -543,8 +549,8 @@ Object {
     },
     false,
     Object {
+      "backgroundColor": "var(--vscode-editor-inactiveSelectionBackground)",
       "borderRadius": 0,
-      "color": "var(--vscode-input-foreground)",
       "opacity": 0.4,
     },
     undefined,
@@ -634,6 +640,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -737,6 +744,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     Object {
       "height": 24,
@@ -837,10 +845,15 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     false,
     false,
-    false,
+    Object {
+      "backgroundColor": "var(--vscode-editor-inactiveSelectionBackground)",
+      "borderRadius": 0,
+      "opacity": 0.4,
+    },
     undefined,
     undefined,
     undefined,
@@ -930,6 +943,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     false,
     Object {
@@ -1031,6 +1045,7 @@ Object {
       "borderStyle": "solid",
       "borderWidth": 1,
       "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
     },
     false,
     Object {

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -23,10 +23,6 @@ Object {
       "color": "var(--vscode-input-foreground)",
       "fontSize": "13px",
       "fontWeight": "normal",
-      "height": 24,
-      "lineHeight": "normal",
-      "maxHeight": 24,
-      "minHeight": 24,
       "selectors": Object {
         "::placeholder": Object {
           "color": "var(--vscode-input-placeholderForeground)",
@@ -35,6 +31,10 @@ Object {
         },
       },
     },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -42,12 +42,18 @@ Object {
   "fieldGroup": Array [
     Object {
       "backgroundColor": "var(--vscode-input-background)",
-      "border": "1px solid var(--vscode-editorWidget-border)",
+      "borderColor": "var(--vscode-editorWidget-border)",
       "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
       "boxSizing": "initial",
+    },
+    Object {
       "height": 24,
       "maxHeight": 24,
       "minHeight": 24,
+    },
+    Object {
       "selectors": Object {
         "&:hover": Object {
           "border": "1px solid var(--vscode-focusBorder)",
@@ -113,10 +119,6 @@ Object {
       "color": "var(--vscode-input-foreground)",
       "fontSize": "13px",
       "fontWeight": "normal",
-      "height": 24,
-      "lineHeight": "normal",
-      "maxHeight": 24,
-      "minHeight": 24,
       "selectors": Object {
         "::placeholder": Object {
           "color": "var(--vscode-input-placeholderForeground)",
@@ -125,6 +127,10 @@ Object {
         },
       },
     },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -132,12 +138,18 @@ Object {
   "fieldGroup": Array [
     Object {
       "backgroundColor": "var(--vscode-input-background)",
-      "border": "1px solid var(--vscode-editorWidget-border)",
+      "borderColor": "var(--vscode-editorWidget-border)",
       "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
       "boxSizing": "initial",
+    },
+    Object {
       "height": 24,
       "maxHeight": 24,
       "minHeight": 24,
+    },
+    Object {
       "selectors": Object {
         "&:hover": Object {
           "border": "1px solid var(--vscode-focusBorder)",
@@ -203,10 +215,6 @@ Object {
       "color": "var(--vscode-input-foreground)",
       "fontSize": "13px",
       "fontWeight": "normal",
-      "height": 24,
-      "lineHeight": "normal",
-      "maxHeight": 24,
-      "minHeight": 24,
       "selectors": Object {
         "::placeholder": Object {
           "color": "var(--vscode-input-placeholderForeground)",
@@ -215,6 +223,10 @@ Object {
         },
       },
     },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -222,12 +234,18 @@ Object {
   "fieldGroup": Array [
     Object {
       "backgroundColor": "var(--vscode-input-background)",
-      "border": "1px solid var(--vscode-editorWidget-border)",
+      "borderColor": "var(--vscode-editorWidget-border)",
       "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
       "boxSizing": "initial",
+    },
+    Object {
       "height": 24,
       "maxHeight": 24,
       "minHeight": 24,
+    },
+    Object {
       "selectors": Object {
         "&:hover": Object {
           "border": "1px solid var(--vscode-focusBorder)",
@@ -293,10 +311,6 @@ Object {
       "color": "var(--vscode-input-foreground)",
       "fontSize": "13px",
       "fontWeight": "normal",
-      "height": 24,
-      "lineHeight": "normal",
-      "maxHeight": 24,
-      "minHeight": 24,
       "selectors": Object {
         "::placeholder": Object {
           "color": "var(--vscode-input-placeholderForeground)",
@@ -305,6 +319,10 @@ Object {
         },
       },
     },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
     undefined,
     undefined,
     undefined,
@@ -312,12 +330,18 @@ Object {
   "fieldGroup": Array [
     Object {
       "backgroundColor": "var(--vscode-input-background)",
-      "border": "1px solid var(--vscode-editorWidget-border)",
+      "borderColor": "var(--vscode-editorWidget-border)",
       "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
       "boxSizing": "initial",
+    },
+    Object {
       "height": 24,
       "maxHeight": 24,
       "minHeight": 24,
+    },
+    Object {
       "selectors": Object {
         "&:hover": Object {
           "border": "1px solid var(--vscode-focusBorder)",

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -383,3 +383,597 @@ Object {
   },
 }
 `;
+
+exports[`<UIToggle /> Styles - multiline=false, disabled=true, readOnly=undefined 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Styles - multiline=false, disabled=undefined, readOnly=true 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    Object {
+      "backgroundColor": "var(--vscode-editor-background)",
+      "fontStyle": "italic",
+    },
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-editorWidget-border)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Styles - multiline=false, disabled=undefined, readOnly=undefined 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Styles - multiline=true, disabled=true, readOnly=undefined 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Styles - multiline=true, disabled=undefined, readOnly=true 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    Object {
+      "backgroundColor": "var(--vscode-editor-background)",
+      "fontStyle": "italic",
+    },
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-editorWidget-border)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;
+
+exports[`<UIToggle /> Styles - multiline=true, disabled=undefined, readOnly=undefined 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 0,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "border": "1px solid var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        undefined,
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -418,8 +418,10 @@ Object {
     Object {
       "lineHeight": "normal",
     },
-    undefined,
-    undefined,
+    false,
+    Object {
+      "backgroundColor": "transparent",
+    },
     undefined,
     undefined,
   ],
@@ -437,14 +439,12 @@ Object {
       "maxHeight": 24,
       "minHeight": 24,
     },
+    false,
     Object {
-      "selectors": Object {
-        "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
-        },
-      },
+      "borderRadius": 0,
+      "color": "var(--vscode-input-foreground)",
+      "opacity": 0.4,
     },
-    undefined,
     undefined,
     undefined,
     undefined,
@@ -469,7 +469,9 @@ Object {
           "marginTop": 25,
           "padding": "4px 0",
         },
-        undefined,
+        Object {
+          "opacity": "0.4",
+        },
         undefined,
       ],
     },
@@ -514,7 +516,7 @@ Object {
     Object {
       "lineHeight": "normal",
     },
-    undefined,
+    false,
     undefined,
     Object {
       "backgroundColor": "var(--vscode-editor-background)",
@@ -619,7 +621,7 @@ Object {
     Object {
       "lineHeight": "normal",
     },
-    undefined,
+    false,
     undefined,
     undefined,
     undefined,
@@ -712,11 +714,15 @@ Object {
         },
       },
     },
+    false,
     Object {
-      "lineHeight": "normal",
+      "display": "flex",
+      "height": "auto",
+      "minHeight": "60px",
     },
-    undefined,
-    undefined,
+    Object {
+      "backgroundColor": "transparent",
+    },
     undefined,
     undefined,
   ],
@@ -729,19 +735,9 @@ Object {
       "borderWidth": 1,
       "boxSizing": "initial",
     },
-    Object {
-      "height": 24,
-      "maxHeight": 24,
-      "minHeight": 24,
-    },
-    Object {
-      "selectors": Object {
-        "&:hover": Object {
-          "border": "1px solid var(--vscode-focusBorder)",
-        },
-      },
-    },
-    undefined,
+    false,
+    false,
+    false,
     undefined,
     undefined,
     undefined,
@@ -766,7 +762,9 @@ Object {
           "marginTop": 25,
           "padding": "4px 0",
         },
-        undefined,
+        Object {
+          "opacity": "0.4",
+        },
         undefined,
       ],
     },
@@ -808,10 +806,12 @@ Object {
         },
       },
     },
+    false,
     Object {
-      "lineHeight": "normal",
+      "display": "flex",
+      "height": "auto",
+      "minHeight": "60px",
     },
-    undefined,
     undefined,
     Object {
       "backgroundColor": "var(--vscode-editor-background)",
@@ -828,11 +828,7 @@ Object {
       "borderWidth": 1,
       "boxSizing": "initial",
     },
-    Object {
-      "height": 24,
-      "maxHeight": 24,
-      "minHeight": 24,
-    },
+    false,
     Object {
       "selectors": Object {
         "&:hover": Object {
@@ -913,10 +909,12 @@ Object {
         },
       },
     },
+    false,
     Object {
-      "lineHeight": "normal",
+      "display": "flex",
+      "height": "auto",
+      "minHeight": "60px",
     },
-    undefined,
     undefined,
     undefined,
     undefined,
@@ -930,11 +928,7 @@ Object {
       "borderWidth": 1,
       "boxSizing": "initial",
     },
-    Object {
-      "height": 24,
-      "maxHeight": 24,
-      "minHeight": 24,
-    },
+    false,
     Object {
       "selectors": Object {
         "&:hover": Object {

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -601,4 +601,45 @@ describe('<UIComboBox />', () => {
             });
         }
     });
+
+    describe('Empty combobox classname', () => {
+        const testCases = [
+            {
+                text: undefined,
+                selectedKey: 'EE',
+                expected: false
+            },
+            {
+                text: undefined,
+                selectedKey: ['EE'],
+                expected: false
+            },
+            {
+                text: 'Dummy',
+                selectedKey: undefined,
+                expected: false
+            },
+            {
+                text: undefined,
+                selectedKey: undefined,
+                expected: true
+            },
+            {
+                text: undefined,
+                selectedKey: [],
+                expected: true
+            }
+        ];
+        for (const testCase of testCases) {
+            it(`"text=${testCase.text}", "selectedKey=${
+                Array.isArray(testCase.selectedKey) ? JSON.stringify(testCase.selectedKey) : testCase.selectedKey
+            }"`, () => {
+                wrapper.setProps({
+                    text: testCase.text,
+                    selectedKey: testCase.selectedKey
+                });
+                expect(wrapper.find('div.ts-ComboBox--empty').length).toEqual(testCase.expected ? 1 : 0);
+            });
+        }
+    });
 });

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -14,6 +14,7 @@ describe('<UIComboBox />', () => {
     const menuDropdownSelector = 'div.ts-Callout-Dropdown';
     const nonHighlighttItemSelector = `${menuDropdownSelector} .ms-ComboBox-optionsContainer .ms-Button--command .ms-ComboBox-optionText`;
     const highlightItemSelector = `${menuDropdownSelector} .ms-ComboBox-optionsContainer .ms-Button--command .ts-Menu-option`;
+    const inputSelector = 'input.ms-ComboBox-Input';
     initIcons();
 
     const openDropdown = (): void => {
@@ -423,7 +424,7 @@ describe('<UIComboBox />', () => {
                 }
                 // Open callout
                 openDropdown();
-                const input = wrapper.find('input.ms-ComboBox-Input');
+                const input = wrapper.find(inputSelector);
                 input.simulate('keyDown', { which: KeyCodes.down });
                 // Mock element
                 const element: HTMLElement = wrapper.find('.ts-ComboBox--selected').getDOMNode();
@@ -544,6 +545,17 @@ describe('<UIComboBox />', () => {
         }
     });
 
+    it('Test "disabled" property', () => {
+        wrapper.setProps({
+            disabled: true
+        });
+        const inputProps = wrapper.find(inputSelector)?.props();
+        expect(inputProps?.disabled).toEqual(undefined);
+        expect(inputProps?.readOnly).toEqual(true);
+        expect(inputProps?.tabIndex).toEqual(undefined);
+        expect(inputProps?.['aria-disabled']).toEqual(true);
+    });
+
     describe('Test "readonly" property', () => {
         const testCases = [
             {
@@ -566,7 +578,7 @@ describe('<UIComboBox />', () => {
                 disabled: true,
                 expected: {
                     readOnly: true,
-                    tabIndex: -1
+                    tabIndex: undefined
                 }
             },
             {

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -581,12 +581,23 @@ describe('<UIComboBox />', () => {
                 });
                 const autofill = wrapper.find(Autofill);
                 expect(autofill.length).toEqual(1);
-                expect(autofill.prop('readOnly')).toEqual(expected.readOnly);
-                expect(autofill.prop('tabIndex')).toEqual(expected.tabIndex);
+                const autofillProps = autofill.props();
+                expect(autofillProps.readOnly).toEqual(expected.readOnly);
+                expect(autofillProps.tabIndex).toEqual(expected.tabIndex);
                 const className = wrapper.find('.ts-ComboBox').prop('className');
                 expect(className?.includes('ts-ComboBox--readonly')).toEqual(
                     !testCase.disabled ? !!expected.readOnly : false
                 );
+                expect(className?.includes('ts-ComboBox--disabled')).toEqual(!!testCase.disabled);
+                // Additional properties
+                if (!testCase.disabled && expected.readOnly) {
+                    expect(autofillProps['aria-readonly']).toEqual(true);
+                    expect('aria-disabled' in autofillProps).toEqual(true);
+                    expect(autofillProps['aria-disabled']).toEqual(undefined);
+                } else {
+                    expect('aria-readonly' in autofillProps).toEqual(false);
+                    expect(autofillProps['aria-disabled']).toEqual(!!testCase.disabled);
+                }
             });
         }
     });

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -534,7 +534,7 @@ describe('<UIComboBox />', () => {
     describe('Test "isForceEnabled" property', () => {
         const testCases = [true, false];
         for (const testCase of testCases) {
-            it(`"isForceEnabled=${testCase}"`, () => {
+            it(`isForceEnabled=${testCase}`, () => {
                 wrapper.setProps({
                     options: [],
                     isForceEnabled: testCase

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -534,28 +534,59 @@ describe('<UIComboBox />', () => {
     describe('Test "readonly" property', () => {
         const testCases = [
             {
-                value: true,
-                expected: true
+                readOnly: true,
+                expected: {
+                    readOnly: true,
+                    tabIndex: undefined
+                }
             },
             {
-                value: undefined,
-                expected: undefined
+                readOnly: true,
+                tabIndex: 4,
+                expected: {
+                    readOnly: true,
+                    tabIndex: 4
+                }
             },
             {
-                value: false,
-                expected: false
+                readOnly: true,
+                disabled: true,
+                expected: {
+                    readOnly: true,
+                    tabIndex: -1
+                }
+            },
+            {
+                readOnly: undefined,
+                expected: {
+                    readOnly: false,
+                    tabIndex: undefined
+                }
+            },
+            {
+                readOnly: false,
+                expected: {
+                    readOnly: false,
+                    tabIndex: undefined
+                }
             }
         ];
         for (const testCase of testCases) {
-            it(`Click on input, "openMenuOnClick=${testCase.value}"`, () => {
+            it(`"readOnly=${testCase.readOnly}", "tabIndex=${testCase.tabIndex}", "disabled=${testCase.disabled}"`, () => {
+                const { expected } = testCase;
                 wrapper.setProps({
-                    readOnly: testCase.value
+                    readOnly: testCase.readOnly,
+                    ...(testCase.tabIndex && { tabIndex: testCase.tabIndex }),
+                    ...(testCase.disabled && { disabled: testCase.disabled })
                 });
                 const autofill = wrapper.find(Autofill);
                 expect(autofill.length).toEqual(1);
-                expect(autofill.prop('readOnly')).toEqual(testCase.value);
+                expect(autofill.prop('readOnly')).toEqual(expected.readOnly);
+                expect(autofill.prop('tabIndex')).toEqual(expected.tabIndex);
                 const className = wrapper.find('.ts-ComboBox').prop('className');
-                expect(className?.includes('ts-ComboBox--readonly')).toEqual(!!testCase.value);
+                expect(className?.includes('ts-ComboBox--readonly')).toEqual(
+                    !testCase.disabled ? !!expected.readOnly : false
+                );
             });
         }
     });

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -5,7 +5,7 @@ import { UIComboBox } from '../../../src/components/UIComboBox';
 import { data as originalData } from '../../__mock__/select-data';
 import { initIcons } from '../../../src/components/Icons';
 import type { IComboBox, IComboBoxOption } from '@fluentui/react';
-import { KeyCodes, ComboBox } from '@fluentui/react';
+import { KeyCodes, ComboBox, Autofill } from '@fluentui/react';
 
 const data = JSON.parse(JSON.stringify(originalData));
 
@@ -527,6 +527,35 @@ describe('<UIComboBox />', () => {
                 expect(wrapper.find(menuDropdownSelector).length).toEqual(0);
                 wrapper.find('input').simulate('click');
                 expect(wrapper.find(menuDropdownSelector).length).toEqual(testCase.expectOpen ? 1 : 0);
+            });
+        }
+    });
+
+    describe('Test "readonly" property', () => {
+        const testCases = [
+            {
+                value: true,
+                expected: true
+            },
+            {
+                value: undefined,
+                expected: undefined
+            },
+            {
+                value: false,
+                expected: false
+            }
+        ];
+        for (const testCase of testCases) {
+            it(`Click on input, "openMenuOnClick=${testCase.value}"`, () => {
+                wrapper.setProps({
+                    readOnly: testCase.value
+                });
+                const autofill = wrapper.find(Autofill);
+                expect(autofill.length).toEqual(1);
+                expect(autofill.prop('readOnly')).toEqual(testCase.value);
+                const className = wrapper.find('.ts-ComboBox').prop('className');
+                expect(className?.includes('ts-ComboBox--readonly')).toEqual(!!testCase.value);
             });
         }
     });

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -531,6 +531,19 @@ describe('<UIComboBox />', () => {
         }
     });
 
+    describe('Test "isForceEnabled" property', () => {
+        const testCases = [true, false];
+        for (const testCase of testCases) {
+            it(`"isForceEnabled=${testCase}"`, () => {
+                wrapper.setProps({
+                    options: [],
+                    isForceEnabled: testCase
+                });
+                expect(wrapper.find(ComboBox).prop('disabled')).toEqual(!testCase);
+            });
+        }
+    });
+
     describe('Test "readonly" property', () => {
         const testCases = [
             {

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -199,4 +199,71 @@ describe('<UIDropdown />', () => {
             expect(wrapper.find(buttonSelector).last().getDOMNode().getAttribute('title')).toEqual(null);
         });
     });
+
+    describe('Test "readonly" property', () => {
+        const testCases = [
+            {
+                readOnly: true,
+                expected: {
+                    readOnly: true
+                }
+            },
+            {
+                readOnly: true,
+                expected: {
+                    readOnly: true
+                }
+            },
+            {
+                readOnly: true,
+                disabled: true,
+                expected: {
+                    readOnly: true
+                }
+            },
+            {
+                readOnly: undefined,
+                expected: {
+                    readOnly: undefined
+                }
+            },
+            {
+                readOnly: false,
+                expected: {
+                    readOnly: false
+                }
+            }
+        ];
+        for (const testCase of testCases) {
+            it(`"readOnly=${testCase.readOnly}", "disabled=${testCase.disabled}"`, () => {
+                const { expected } = testCase;
+                wrapper.setProps({
+                    readOnly: testCase.readOnly,
+                    ...(testCase.disabled && { disabled: testCase.disabled })
+                });
+                const dropdown = wrapper.find(Dropdown);
+                expect(dropdown.length).toEqual(1);
+                const dropdownProps = dropdown.props();
+                expect(dropdownProps.disabled).toEqual(expected.readOnly);
+                const className = dropdownProps.className;
+                expect(className?.includes('ts-SelectBox--readonly')).toEqual(
+                    !testCase.disabled ? !!expected.readOnly : false
+                );
+                expect(className?.includes('ts-SelectBox--disabled')).toEqual(!!testCase.disabled);
+                // Additional properties
+                if (!testCase.disabled && expected.readOnly) {
+                    expect(dropdownProps.tabIndex).toEqual(0);
+                    expect(dropdownProps['data-is-focusable']).toEqual(true);
+                    expect(dropdownProps['aria-readonly']).toEqual(true);
+                    expect('aria-disabled' in dropdownProps).toEqual(true);
+                    expect(dropdownProps['aria-disabled']).toEqual(undefined);
+                } else {
+                    expect('tabIndex' in dropdownProps).toEqual(false);
+                    expect('data-is-focusable' in dropdownProps).toEqual(false);
+                    expect('aria-readonly' in dropdownProps).toEqual(false);
+                    expect('aria-disabled' in dropdownProps).toEqual(false);
+                }
+            });
+        }
+    });
 });

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -79,11 +79,15 @@ describe('<UIDropdown />', () => {
         expect(wrapper.find('.ts-Callout-Dropdown .ms-Dropdown-items .ms-Button--command').length).toBeGreaterThan(0);
     });
 
-    it('Test disabled selector', () => {
+    it('Test "disabled" property', () => {
         wrapper.setProps({
             disabled: true
         });
         expect(wrapper.find('.ts-SelectBox .ms-Dropdown.is-disabled').length).toEqual(1);
+        const dropdownProps = wrapper.find(Dropdown)?.props();
+        expect(dropdownProps?.disabled).toEqual(true);
+        expect(dropdownProps?.tabIndex).toEqual(0);
+        expect(dropdownProps?.['data-is-focusable']).toEqual(true);
     });
 
     it('Test className property', () => {
@@ -257,6 +261,11 @@ describe('<UIDropdown />', () => {
                     expect(dropdownProps['aria-readonly']).toEqual(true);
                     expect('aria-disabled' in dropdownProps).toEqual(true);
                     expect(dropdownProps['aria-disabled']).toEqual(undefined);
+                } else if (testCase.disabled) {
+                    expect(dropdownProps.tabIndex).toEqual(0);
+                    expect('data-is-focusable' in dropdownProps).toEqual(true);
+                    expect('aria-readonly' in dropdownProps).toEqual(false);
+                    expect('aria-disabled' in dropdownProps).toEqual(false);
                 } else {
                     expect('tabIndex' in dropdownProps).toEqual(false);
                     expect('data-is-focusable' in dropdownProps).toEqual(false);

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -278,7 +278,15 @@ describe('<UIDropdown />', () => {
                 expected: false
             },
             {
+                selectedKeys: ['EE'],
+                expected: false
+            },
+            {
                 selectedKey: [],
+                expected: true
+            },
+            {
+                selectedKeys: [],
                 expected: true
             },
             {
@@ -287,9 +295,10 @@ describe('<UIDropdown />', () => {
             }
         ];
         for (const testCase of testCases) {
-            it(`"selectedKey=${testCase.selectedKey}"`, () => {
+            it(`"selectedKey=${testCase.selectedKey}","selectedKeys=${JSON.stringify(testCase.selectedKeys)}"`, () => {
                 wrapper.setProps({
-                    selectedKey: testCase.selectedKey
+                    selectedKey: testCase.selectedKey,
+                    selectedKeys: testCase.selectedKeys
                 });
                 expect(wrapper.find('div.ts-SelectBox--empty').length).toEqual(testCase.expected ? 1 : 0);
             });

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -18,7 +18,7 @@ describe('<UIDropdown />', () => {
     };
 
     beforeEach(() => {
-        wrapper = Enzyme.mount(<UIDropdown options={data} />);
+        wrapper = Enzyme.mount(<UIDropdown options={data} selectedKey="EE" />);
     });
 
     afterEach(() => {
@@ -263,6 +263,35 @@ describe('<UIDropdown />', () => {
                     expect('aria-readonly' in dropdownProps).toEqual(false);
                     expect('aria-disabled' in dropdownProps).toEqual(false);
                 }
+            });
+        }
+    });
+
+    describe('Empty dropdown classname', () => {
+        const testCases = [
+            {
+                selectedKey: 'EE',
+                expected: false
+            },
+            {
+                selectedKey: ['EE'],
+                expected: false
+            },
+            {
+                selectedKey: [],
+                expected: true
+            },
+            {
+                selectedKey: undefined,
+                expected: true
+            }
+        ];
+        for (const testCase of testCases) {
+            it(`"selectedKey=${testCase.selectedKey}"`, () => {
+                wrapper.setProps({
+                    selectedKey: testCase.selectedKey
+                });
+                expect(wrapper.find('div.ts-SelectBox--empty').length).toEqual(testCase.expected ? 1 : 0);
             });
         }
     });

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -8,6 +8,11 @@ import { UITextInput } from '../../../src/components/UIInput';
 describe('<UIToggle />', () => {
     let wrapper: Enzyme.ReactWrapper<UITextInputProps>;
 
+    const getStyles = (): ITextFieldStyleProps => {
+        const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)({}) as ITextFieldStyleProps;
+        return styles;
+    };
+
     beforeEach(() => {
         wrapper = Enzyme.mount(<UITextInput />);
     });
@@ -21,39 +26,74 @@ describe('<UIToggle />', () => {
     });
 
     it('Styles - default', () => {
-        const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)({}) as ITextFieldStyleProps;
-        expect(styles).toMatchSnapshot();
+        expect(getStyles()).toMatchSnapshot();
     });
+
+    const testCases = [
+        // Single line
+        {
+            multiline: false,
+            disabled: undefined,
+            readOnly: undefined
+        },
+        {
+            multiline: false,
+            disabled: true,
+            readOnly: undefined
+        },
+        {
+            multiline: false,
+            disabled: undefined,
+            readOnly: true
+        },
+        // Multi line
+        {
+            multiline: true,
+            disabled: undefined,
+            readOnly: undefined
+        },
+        {
+            multiline: true,
+            disabled: true,
+            readOnly: undefined
+        },
+        {
+            multiline: true,
+            disabled: undefined,
+            readOnly: true
+        }
+    ];
+    for (const testCase of testCases) {
+        it(`Styles - multiline=${testCase.multiline}, disabled=${testCase.disabled}, readOnly=${testCase.readOnly}`, () => {
+            wrapper.setProps({
+                multiline: testCase.multiline,
+                disabled: testCase.disabled,
+                readOnly: testCase.readOnly
+            });
+            expect(getStyles()).toMatchSnapshot();
+        });
+    }
 
     describe('Styles - error message', () => {
         it('Error', () => {
             wrapper.setProps({
                 errorMessage: 'dummy'
             });
-            const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)(
-                {}
-            ) as ITextFieldStyleProps;
-            expect(styles).toMatchSnapshot();
+            expect(getStyles()).toMatchSnapshot();
         });
 
         it('Warning', () => {
             wrapper.setProps({
                 warningMessage: 'dummy'
             });
-            const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)(
-                {}
-            ) as ITextFieldStyleProps;
-            expect(styles).toMatchSnapshot();
+            expect(getStyles()).toMatchSnapshot();
         });
 
         it('Info', () => {
             wrapper.setProps({
                 infoMessage: 'dummy'
             });
-            const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)(
-                {}
-            ) as ITextFieldStyleProps;
-            expect(styles).toMatchSnapshot();
+            expect(getStyles()).toMatchSnapshot();
         });
 
         it('Error - custom component', async () => {

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -9,7 +9,8 @@ describe('<UIToggle />', () => {
     let wrapper: Enzyme.ReactWrapper<UITextInputProps>;
 
     const getStyles = (): ITextFieldStyleProps => {
-        const styles = (wrapper.find(TextField).props().styles as IStyleFunction<{}, {}>)({}) as ITextFieldStyleProps;
+        const textfieldProps = wrapper.find(TextField).props();
+        const styles = (textfieldProps.styles as IStyleFunction<{}, {}>)(textfieldProps) as ITextFieldStyleProps;
         return styles;
     };
 

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -86,6 +86,17 @@ describe('<UIToggle />', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
+    it('Disabled textfield, but input should be readonly', () => {
+        wrapper.setProps({
+            disabled: true,
+            value: 'test'
+        });
+        const inputProps = wrapper.find('input.ms-TextField-field')?.props();
+        expect(inputProps?.disabled).toEqual(undefined);
+        expect(inputProps?.readOnly).toEqual(true);
+        expect(inputProps?.['aria-disabled']).toEqual(true);
+    });
+
     const focusTestCases = [
         {
             errorMessage: true

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
-import type { IStyleFunction, ITextFieldStyleProps } from '@fluentui/react';
+import type { IStyleFunction, ITextFieldStyleProps, ITextFieldStyles } from '@fluentui/react';
 import { TextField } from '@fluentui/react';
 import type { UITextInputProps } from '../../../src/components/UIInput';
 import { UITextInput } from '../../../src/components/UIInput';
@@ -8,9 +8,12 @@ import { UITextInput } from '../../../src/components/UIInput';
 describe('<UIToggle />', () => {
     let wrapper: Enzyme.ReactWrapper<UITextInputProps>;
 
-    const getStyles = (): ITextFieldStyleProps => {
+    const getStyles = (additionalProps?: Partial<ITextFieldStyleProps>): ITextFieldStyles => {
         const textfieldProps = wrapper.find(TextField).props();
-        const styles = (textfieldProps.styles as IStyleFunction<{}, {}>)(textfieldProps) as ITextFieldStyleProps;
+        const styles = (textfieldProps.styles as IStyleFunction<{}, {}>)({
+            ...textfieldProps,
+            ...additionalProps
+        }) as ITextFieldStyles;
         return styles;
     };
 
@@ -82,6 +85,27 @@ describe('<UIToggle />', () => {
         });
         expect(getStyles()).toMatchSnapshot();
     });
+
+    const focusTestCases = [
+        {
+            errorMessage: true
+        },
+        {
+            errorMessage: false
+        }
+    ];
+    for (const errorMessage of focusTestCases) {
+        it(`Focus styles, "errorMessage=${errorMessage}"`, () => {
+            wrapper.setProps({
+                errorMessage: errorMessage.errorMessage ? 'dummy' : undefined
+            });
+            expect(
+                getStyles({
+                    focused: true
+                })
+            ).toMatchSnapshot();
+        });
+    }
 
     describe('Styles - error message', () => {
         it('Error', () => {

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -75,6 +75,14 @@ describe('<UIToggle />', () => {
         });
     }
 
+    it('Readonly input field with value', () => {
+        wrapper.setProps({
+            readOnly: true,
+            value: 'test'
+        });
+        expect(getStyles()).toMatchSnapshot();
+    });
+
     describe('Styles - error message', () => {
         it('Error', () => {
             wrapper.setProps({

--- a/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
@@ -684,4 +684,16 @@ describe('<UITreeDropdown />', () => {
             });
         }
     });
+
+    it('Property "readOnly"', () => {
+        wrapper.setProps({
+            readOnly: true
+        });
+
+        const textfield = wrapper.find(UITextInput);
+        expect(textfield.prop('readOnly')).toEqual(true);
+        // Dropdown menu should not be opened
+        openDropdown();
+        expect(wrapper.find(selectors.treeContextMenu).length).toEqual(0);
+    });
 });

--- a/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
@@ -73,7 +73,13 @@ describe('<UITreeDropdown />', () => {
     };
     const selectors = {
         highlightItem: '.ts-Menu-option--highlighted',
-        treeContextMenu: '.ui-treeDropDown-context-menu'
+        treeContextMenu: '.ui-treeDropDown-context-menu',
+        wrapper: {
+            disabled: 'div.ui-treeDropdown-wrapper.disabled',
+            readonly: 'div.ui-treeDropdown-wrapper.readonly',
+            open: 'div.ui-treeDropdown-wrapper-menu-open',
+            closed: 'div.ui-treeDropdown-wrapper-menu-close'
+        }
     };
 
     beforeEach(() => {
@@ -102,12 +108,21 @@ describe('<UITreeDropdown />', () => {
     });
 
     it('Open', () => {
+        // Initial state
+        expect(wrapper.find(selectors.wrapper.disabled).length).toEqual(0);
+        expect(wrapper.find(selectors.wrapper.closed).length).toEqual(1);
+        expect(wrapper.find(selectors.wrapper.open).length).toEqual(0);
+        // Open dropdown
         const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
         // Click on caret
         openDropdown();
         expect(wrapper.find(selectors.treeContextMenu).length).toBeGreaterThan(0);
         // Focus should be called for input
         expect(focusSpy).toBeCalledTimes(1);
+        // Check wrapper
+        expect(wrapper.find(selectors.wrapper.disabled).length).toEqual(0);
+        expect(wrapper.find(selectors.wrapper.closed).length).toEqual(0);
+        expect(wrapper.find(selectors.wrapper.open).length).toEqual(1);
     });
 
     it('Focus of input should select text', () => {
@@ -685,15 +700,25 @@ describe('<UITreeDropdown />', () => {
         }
     });
 
-    it('Property "readOnly"', () => {
+    it('Disabled state', () => {
+        expect(wrapper.find(selectors.wrapper.disabled).length).toEqual(0);
+        wrapper.setProps({
+            items: []
+        });
+        wrapper.update();
+        expect(wrapper.find(selectors.wrapper.disabled).length).toEqual(1);
+    });
+
+    it('ReadOnly state', () => {
+        expect(wrapper.find(selectors.wrapper.readonly).length).toEqual(0);
         wrapper.setProps({
             readOnly: true
         });
-
         const textfield = wrapper.find(UITextInput);
         expect(textfield.prop('readOnly')).toEqual(true);
         // Dropdown menu should not be opened
         openDropdown();
         expect(wrapper.find(selectors.treeContextMenu).length).toEqual(0);
+        expect(wrapper.find(selectors.wrapper.readonly).length).toEqual(1);
     });
 });

--- a/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UITreeDropdown.test.tsx
@@ -707,6 +707,10 @@ describe('<UITreeDropdown />', () => {
         });
         wrapper.update();
         expect(wrapper.find(selectors.wrapper.disabled).length).toEqual(1);
+        const inputProps = wrapper.find('input.ms-TextField-field')?.props();
+        expect(inputProps?.disabled).toEqual(undefined);
+        expect(inputProps?.readOnly).toEqual(true);
+        expect(inputProps?.['aria-disabled']).toEqual(true);
     });
 
     it('ReadOnly state', () => {


### PR DESCRIPTION
Task #801

Property `readOnly` is added or maintained for following components - `UITextInput`, `UIComboBox`, `UIDropdown`, `UITreeDropdown`

Additional changes applied to styling to match description from #801

Also added `Accessibility States` storybook examples for `UITextInput`, `UIComboBox`, `UIDropdown`, `UITreeDropdown`.

Screenshots from storybook:
Textfield:
![image](https://user-images.githubusercontent.com/90789422/210781017-bfd86d52-9163-490f-839b-b0267bc9e4d0.png)

ComboBox:
![image](https://user-images.githubusercontent.com/90789422/210781065-46e5543d-ecc3-49d8-a864-81f01c38ffe7.png)

Dropdown:
![image](https://user-images.githubusercontent.com/90789422/210781097-0beb2d95-4ecc-4d4b-96e6-1df5795b43ac.png)

TreeDropdown:
![image](https://user-images.githubusercontent.com/90789422/210781120-997fe33f-4f56-4a08-b3b3-bb6bbbaa23ff.png)
