### PR TITLE
feat(env-check): add check for vscode insiders

### DIFF
--- a/.changeset/silly-dodos-speak.md
+++ b/.changeset/silly-dodos-speak.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/environment-check': minor
+---
+
+enhance env-check for vscode insiders

--- a/packages/environment-check/src/checks/get-installed.ts
+++ b/packages/environment-check/src/checks/get-installed.ts
@@ -46,12 +46,28 @@ async function getExtensionsBAS(): Promise<{ [id: string]: { version: string } }
 }
 
 /**
+ * Internal function to check if the module is being ran in VSCode Insiders.
+ *
+ * @returns boolean - if ran in insiders
+ */
+async function checkIsInsiders(): Promise<boolean> {
+    let isInsiders = false;
+    const processEnvProp = process.env['VSCODE_IPC_HOOK'] ?? process.env['TERM_PROGRAM_VERSION'];
+    if (processEnvProp?.includes('insider')) {
+        debugger;
+        isInsiders = true;
+    }
+    return isInsiders;
+}
+
+/**
  * Reads the list of extensions installed in vscode.
  *
  * @returns list of extension ids and versions
  */
 async function getExtensionsVSCode(): Promise<{ [id: string]: { version: string } }> {
-    const output = await spawnCommand('code', ['--list-extensions', '--show-versions']);
+    const isInsiders = await checkIsInsiders();
+    const output = await spawnCommand(isInsiders ? 'code-insiders' : 'code', ['--list-extensions', '--show-versions']);
     const versions = output
         .split('\n')
         .filter((ext) => ext.startsWith('SAP'))

--- a/packages/environment-check/src/checks/get-installed.ts
+++ b/packages/environment-check/src/checks/get-installed.ts
@@ -54,7 +54,6 @@ async function checkIsInsiders(): Promise<boolean> {
     let isInsiders = false;
     const processEnvProp = process.env['VSCODE_IPC_HOOK'] ?? process.env['TERM_PROGRAM_VERSION'];
     if (processEnvProp?.includes('insider')) {
-        debugger;
         isInsiders = true;
     }
     return isInsiders;

--- a/packages/environment-check/test/checks/get-installed.test.ts
+++ b/packages/environment-check/test/checks/get-installed.test.ts
@@ -8,6 +8,7 @@ import {
 import fs from 'fs';
 import { isAppStudio } from '@sap-ux/btp-utils';
 import { getLogger } from '../../src/logger';
+import type { Extension } from 'vscode';
 
 jest.mock('@sap-ux/btp-utils', () => ({
     isAppStudio: jest.fn()
@@ -70,12 +71,48 @@ describe('Test install functions', () => {
         jest.spyOn(fs, 'readdirSync').mockImplementation(() => {
             throw new Error('Could not read directory');
         });
-        const result = await getInstalledExtensions(logger);
+        const result = await getInstalledExtensions(undefined, logger);
         const messages = logger.getMessages();
         expect(result).toBe(undefined);
         expect(messages).toStrictEqual([
             { 'severity': 'error', 'text': 'Error retrieving installed extensions: Could not read directory' }
         ]);
+    });
+
+    test('getInstalledExtensions() (extensions passed in)', async () => {
+        mockIsAppStudio.mockReturnValue(true);
+        const expectedResult = {
+            'vscode-ui5-language-assistant': { version: '3.3.0' },
+            'sap-ux-application-modeler-extension': { version: '1.7.4' },
+            'yeoman-ui': { version: '1.7.11' }
+        };
+        const logger = getLogger();
+        const extensions = [
+            {
+                id: 'SAPOS.yeoman-ui',
+                packageJSON: {
+                    name: 'yeoman-ui',
+                    version: '1.7.11'
+                }
+            },
+            {
+                id: 'SAPSE.sap-ux-application-modeler-extension',
+                packageJSON: {
+                    name: 'sap-ux-application-modeler-extension',
+                    version: '1.7.4'
+                }
+            },
+            {
+                id: 'SAPSE.vscode-ui5-language-assistant',
+                packageJSON: {
+                    name: 'vscode-ui5-language-assistant',
+                    version: '3.3.0'
+                }
+            }
+        ] as any as readonly Extension<any>[];
+
+        const result = await getInstalledExtensions(extensions, logger);
+        expect(result).toStrictEqual(expectedResult);
     });
 
     test('getCFCliToolVersion()', async () => {

--- a/packages/environment-check/test/checks/get-installed.test.ts
+++ b/packages/environment-check/test/checks/get-installed.test.ts
@@ -200,4 +200,34 @@ describe('Test install functions', () => {
             { 'severity': 'error', 'text': 'Error retrieving process versions: spawn error' }
         ]);
     });
+
+    test('getInstalledExtensions() (VSCODE-Insiders)', async () => {
+        mockIsAppStudio.mockReturnValue(false);
+        process.env['VSCODE_IPC_HOOK'] = 'VSCode-main-insider';
+        const expectedResult = {
+            'yeoman-ui': { version: '2' },
+            'vscode-ui5-language-assistant': { version: '2' },
+            'xml-toolkit': { version: '2' }
+        };
+
+        const output = `SAPOS.yeoman-ui@2\nSAPOSS.vscode-ui5-language-assistant@2\nSAPOSS.xml-toolkit@2`;
+        jest.spyOn(command, 'spawnCommand').mockResolvedValueOnce(output);
+        const result = await getInstalledExtensions();
+        expect(result).toStrictEqual(expectedResult);
+    });
+
+    test('getInstalledExtensions() (VSCODE-Insiders 2)', async () => {
+        mockIsAppStudio.mockReturnValue(false);
+        process.env['TERM_PROGRAM_VERSION'] = '1.72.0-insider';
+        const expectedResult = {
+            'yeoman-ui': { version: '2' },
+            'vscode-ui5-language-assistant': { version: '2' },
+            'xml-toolkit': { version: '2' }
+        };
+
+        const output = `SAPOS.yeoman-ui@2\nSAPOSS.vscode-ui5-language-assistant@2\nSAPOSS.xml-toolkit@2`;
+        jest.spyOn(command, 'spawnCommand').mockResolvedValueOnce(output);
+        const result = await getInstalledExtensions();
+        expect(result).toStrictEqual(expectedResult);
+    });
 });


### PR DESCRIPTION
#860
https://github.com/SAP/open-ux-tools/issues/805

Provide the option to use the VSCode API and pass the installed extensions to `getEnvironment()`
Check `process.env` for indications that environment-check is being ran in VSCode Insiders, and return the correct extensions installed.