### PR TITLE
fix(ui-components): Cursor styling when doing reordering in Table

### DIFF
--- a/.changeset/sixty-years-float.md
+++ b/.changeset/sixty-years-float.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIFlexibleTable. Added "grab" icon for cursor when table reordering is enabled. Cursor icon changes to "default" when reordering is disabled, "grabbing" icon is displayed if reordering is started.

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.tsx
@@ -195,12 +195,19 @@ export function UIFlexibleTable<T>(props: UIFlexibleTableProps<T>): React.ReactE
                 </UIFlexibleTableRowNoData>
             );
         }
+        const getCursorStyle = () => {
+            let cursorIcon = 'default';
+            if (props.onTableReorder) {
+                cursorIcon = params.isDragged ? 'grabbing' : 'grab';
+            }
+            return cursorIcon;
+        };
         return (
             <ul
                 ref={params.props.ref}
                 className={`flexible-table-content-table${params.isDragged ? ' dragged' : ''}`}
                 style={{
-                    cursor: params.isDragged ? 'grabbing' : 'default',
+                    cursor: getCursorStyle(),
                     maxHeight: props.maxScrollableContentHeight ? `${props.maxScrollableContentHeight}px` : undefined
                 }}>
                 {children}

--- a/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
+++ b/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
@@ -516,6 +516,7 @@ describe('<UIFlexibleTable />', () => {
                 downButtonsFound.forEach((button, idx) => {
                     expect(button.getElement().props.className.includes('is-disabled') === (idx === 2)).toBeTruthy();
                 });
+                expect(wrapper.find(selectors.content).props().style?.cursor).toBe('grab');
             });
             it('move up/down not rendered', () => {
                 wrapper.setProps({
@@ -525,6 +526,7 @@ describe('<UIFlexibleTable />', () => {
                 const downButtonsFound = wrapper.find(selectors.downArrow);
                 expect(upButtonsFound.length).toBe(0);
                 expect(downButtonsFound.length).toBe(0);
+                expect(wrapper.find(selectors.content).props().style?.cursor).toBe('default');
             });
 
             it('move up/down disabled for new line item index 1(2nd row) with tooltip', () => {


### PR DESCRIPTION
Updates cursor styling for table.

Updates this:

![1](https://user-images.githubusercontent.com/122096996/211056490-88016ead-ac69-4577-b5da-41392e3a7376.gif)


To this:

![2](https://user-images.githubusercontent.com/122096996/211056507-a0de9e9b-a5e2-411e-b88d-57db986faaa9.gif)
