### PR TITLE
fix: do not ignore row 0, test case

### DIFF
--- a/packages/ui-components/src/components/UITable/UITable.tsx
+++ b/packages/ui-components/src/components/UITable/UITable.tsx
@@ -128,7 +128,6 @@ export class UITable extends React.Component<UITableProps, UITableState> {
      * @param prevProps
      * @param prevState
      */
-    // eslint-disable-next-line sonarjs/cognitive-complexity
     componentDidUpdate(prevProps: UITableProps, prevState: UITableState): void {
         const scrollContainer = document.querySelector('.ms-ScrollablePane--contentContainer');
         if (scrollContainer) {
@@ -184,9 +183,15 @@ export class UITable extends React.Component<UITableProps, UITableState> {
                 this.props.showRowNumbers
             );
         }
+        this._restoreCaretPosition();
+    }
 
+    /**
+     * Restores the caret position. Caret position gets lost when validation finds issue in cell.
+     */
+    private _restoreCaretPosition(): void {
         const editedCell = this.state.editedCell;
-        if (this.caretPosition !== -1 && editedCell?.rowIndex && editedCell.column?.key) {
+        if (this.caretPosition !== -1 && typeof editedCell?.rowIndex === 'number' && editedCell.column?.key) {
             const cell = getCellFromCoords(
                 editedCell.rowIndex,
                 editedCell.column.key,
@@ -640,7 +645,7 @@ export class UITable extends React.Component<UITableProps, UITableState> {
             errorMessage = column.validate(value);
         }
         if (editedCell && editedCell.errorMessage !== errorMessage) {
-            if (editedCell.rowIndex && editedCell?.column?.key) {
+            if (typeof editedCell.rowIndex === 'number' && editedCell?.column?.key) {
                 const cell = getCellFromCoords(
                     editedCell.rowIndex,
                     editedCell.column.key,

--- a/packages/ui-components/test/unit/components/UITable.test.tsx
+++ b/packages/ui-components/test/unit/components/UITable.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as Enzyme from 'enzyme';
 import { KeyCodes } from '@fluentui/react';
 import { ColumnControlType, UITable } from '../../../src/components/UITable';
+import type { UIColumn } from '../../../src/components/UITable';
+import * as tableHelper from '../../../src/components/UITable/UITable-helper';
 
 describe('<UITable />', () => {
     const onSaveSpy = jest.fn();
@@ -76,6 +78,20 @@ describe('<UITable />', () => {
                 { key: 'LV', text: 'Latvia' }
             ]
         }
+    };
+
+    const columnValidate = {
+        key: 'validatecolumn',
+        name: 'validatecolumn',
+        fieldName: 'validate',
+        minWidth: 100,
+        maxWidth: 200,
+        isResizable: true,
+        editable: true,
+        validate: (value: any) => `Error: ${value}`,
+        iconName: undefined as any,
+        iconTooltip: undefined as any,
+        columnControlType: ColumnControlType.UITextInput
     };
 
     beforeEach(() => {
@@ -222,5 +238,34 @@ describe('<UITable />', () => {
         jest.runOnlyPendingTimers();
 
         wrapper.find('Dropdown').first().simulate('click');
+    });
+
+    it('Validate and focus', () => {
+        const wrapper = Enzyme.mount(
+            <UITable {...defaultProps} columns={[columnValidate]} items={[{ validate: 'invalid' }]} />
+        );
+
+        wrapper.find('.ms-DetailsRow-cell span').simulate('click');
+        const input = wrapper.find('.ms-DetailsRow-cell input.ms-TextField-field');
+        const mockCell = {
+            selectionStart: 99,
+            setSelectionRange: jest.fn()
+        };
+        const mockInput = {
+            querySelector: () => mockCell
+        };
+        jest.spyOn(tableHelper, 'getCellFromCoords').mockImplementation(
+            (rowIdx: number, columnKey: string, columns: UIColumn[], addOneToColIndex: boolean | undefined) => {
+                expect(rowIdx).toBe(0);
+                expect(columnKey).toBe('validatecolumn');
+                expect(columns).toBeDefined();
+                expect(addOneToColIndex).toBe(true);
+                mockCell.selectionStart++;
+                return mockInput as any;
+            }
+        );
+        input.simulate('change', { target: { value: 'stillinvalid' } });
+        jest.runOnlyPendingTimers();
+        expect(mockCell.setSelectionRange).toBeCalledWith(100, 100);
     });
 });


### PR DESCRIPTION
Fix for branch `jumping-cursor-in-edi-table`
- do not ignore row 0 when storing/restoring caret position
- add unit test case