### PR TITLE
fix(ui-components): UIActionButton. Remove forced color for inner icon

### DIFF
--- a/.changeset/smooth-ways-smoke.md
+++ b/.changeset/smooth-ways-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIActionButton. Remove forced color for inner icon - icon will be taken from individual icon styles

--- a/packages/ui-components/src/components/UIButton/UIActionButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIActionButton.tsx
@@ -62,21 +62,13 @@ export class UIActionButton extends React.Component<IButtonProps, {}> {
                 backgroundColor: 'transparent',
 
                 selectors: {
-                    color: 'var(--vscode-foreground)',
-                    'svg > path, svg > rect': {
-                        fill: 'var(--vscode-foreground)'
-                    }
+                    color: 'var(--vscode-foreground)'
                 }
             },
             icon: {
                 height: 16,
                 lineHeight: 16,
                 marginLeft: -3,
-                selectors: {
-                    'svg > path, svg > rect': {
-                        fill: 'var(--vscode-foreground)'
-                    }
-                },
                 position: 'relative',
                 top: 1
             },

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -127,7 +127,13 @@ export const defaultUsage = (): JSX.Element => {
                         iconProps={{
                             iconName: UiIcons.Bulb
                         }}>
-                        Action
+                        Disabled action
+                    </UIActionButton>
+                    <UIActionButton
+                        iconProps={{
+                            iconName: UiIcons.CopyToClipboard
+                        }}>
+                        Icon with different color
                     </UIActionButton>
                 </Stack>
             </Stack>

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -118,22 +118,29 @@ export const defaultUsage = (): JSX.Element => {
                 <Stack horizontal tokens={stackTokens}>
                     <UIActionButton
                         iconProps={{
+                            iconName: UiIcons.Calendar
+                        }}>
+                        Standard Action
+                    </UIActionButton>
+                    <UIActionButton
+                        disabled={true}
+                        iconProps={{
+                            iconName: UiIcons.Calendar
+                        }}>
+                        Disabled action
+                    </UIActionButton>
+                    <UIActionButton
+                        iconProps={{
                             iconName: UiIcons.Bulb
                         }}>
-                        Action
+                        Icon with color
                     </UIActionButton>
                     <UIActionButton
                         disabled={true}
                         iconProps={{
                             iconName: UiIcons.Bulb
                         }}>
-                        Disabled action
-                    </UIActionButton>
-                    <UIActionButton
-                        iconProps={{
-                            iconName: UiIcons.CopyToClipboard
-                        }}>
-                        Icon with different color
+                        Disabled icon with color
                     </UIActionButton>
                 </Stack>
             </Stack>

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -127,7 +127,7 @@ export const defaultUsage = (): JSX.Element => {
                         iconProps={{
                             iconName: UiIcons.Calendar
                         }}>
-                        Disabled action
+                        Standard Action - disabled
                     </UIActionButton>
                     <UIActionButton
                         iconProps={{
@@ -140,7 +140,7 @@ export const defaultUsage = (): JSX.Element => {
                         iconProps={{
                             iconName: UiIcons.Bulb
                         }}>
-                        Disabled icon with color
+                        Icon with color - disabled
                     </UIActionButton>
                 </Stack>
             </Stack>

--- a/packages/ui-components/test/unit/components/UIActionButton.test.tsx
+++ b/packages/ui-components/test/unit/components/UIActionButton.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { UiIcons, initIcons, UIActionButton } from '../../../src/components';
+
+describe('<UIActionButton />', () => {
+    initIcons();
+
+    const selectors = {
+        button: '.ms-Button.ms-Button--action',
+        icon: '.ms-Icon svg'
+    };
+    const getStyle = (element: Element): CSSStyleDeclaration => {
+        return window.getComputedStyle(element);
+    };
+    it('Render button', () => {
+        const { container } = render(
+            <UIActionButton
+                iconProps={{
+                    iconName: UiIcons.CopyToClipboard
+                }}
+                text="Copy"></UIActionButton>
+        );
+
+        const buttons = container.querySelectorAll(selectors.button);
+        expect(buttons.length).toEqual(1);
+        let style = getStyle(buttons[0]);
+        expect(style.height).toEqual('22px');
+
+        const icons = container.querySelectorAll(selectors.icon);
+        expect(icons.length).toEqual(1);
+        // First child should take 'path' element - color should not be overwritten
+        style = getStyle(icons[0]?.firstChild as Element);
+        expect(style.fill).toEqual('');
+    });
+});


### PR DESCRIPTION
Problem reported by @aislingnoone , that color of icons in UIActionButton is always with `var(--vscode-foreground)`:
![image](https://user-images.githubusercontent.com/90789422/213393207-4ab3e57a-5d82-4110-94eb-b4fb95405f33.png)

But expected is:
![image](https://user-images.githubusercontent.com/90789422/213393323-825bb12b-de5c-4bd8-ab4e-7295a135a3ff.png)


Updated storybook with:
![image](https://user-images.githubusercontent.com/90789422/213394385-3b19fde6-5786-41a5-a859-0d86cf561046.png)
