### PR TITLE
fix(ui-components): Cursor styling for UIFlexibleTable

### DIFF
--- a/.changeset/sharp-zoos-speak.md
+++ b/.changeset/sharp-zoos-speak.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIFlexibleTable. Fixed "undefined" error when "No data." row was clicked and dragged.

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.tsx
@@ -322,7 +322,7 @@ function getTableBody<T>(
 ): React.ReactNode {
     let tableBody: React.ReactNode;
     const { rows } = props.onBeforeTableRender ? props.onBeforeTableRender({ rows: props.rows }) : { rows: props.rows };
-    if (props.onTableReorder && !props.readonly) {
+    if (rows.length > 0 && props.onTableReorder && !props.readonly) {
         tableBody = (
             <List
                 values={rows}

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRowNoData.tsx
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTableRowNoData.tsx
@@ -26,7 +26,8 @@ export function UIFlexibleTableRowNoData(props: UIFlexibleTableRowNoDataProps) {
         <li
             className={rowClassName}
             style={{
-                textAlign: align
+                textAlign: align,
+                cursor: 'default'
             }}>
             {props.children}
         </li>

--- a/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
+++ b/packages/ui-components/test/unit/components/UIFlexibleTable.test.tsx
@@ -33,6 +33,7 @@ describe('<UIFlexibleTable />', () => {
         tableHeaderPrimaryAction: '.flexible-table-header-primary-actions .flexible-table-header-action',
         tableHeaderSecondaryAction: '.flexible-table-header-secondary-actions .flexible-table-header-action',
         content: '.flexible-table-content-table',
+        noData: '.flexible-table-content-table-row-no-data',
         row: '.flexible-table-content-table-row',
         rowHeader: '.flexible-table-content-table-row-header',
         rowTitleContainer: '.flexible-table-content-table-row-header-text-content',
@@ -123,6 +124,19 @@ describe('<UIFlexibleTable />', () => {
                 });
             });
             expect(wrapper.find(selectors.reverseBackground).length).toEqual(0);
+        });
+
+        it('Render table (no rows)', () => {
+            wrapper.setProps({
+                noDataText: 'No data.',
+                rows: []
+            });
+            expect(wrapper.exists()).toEqual(true);
+            expect(wrapper.find(selectors.content).length).toEqual(1);
+            expect(wrapper.find(selectors.row).length).toEqual(0);
+            const noData = wrapper.find(selectors.noData);
+            expect(noData.exists()).toEqual(true);
+            expect(noData.props().style?.cursor).toBe('default');
         });
 
         it('Render index column', () => {
@@ -891,7 +905,7 @@ describe('<UIFlexibleTable />', () => {
             wrapper.setProps({
                 noDataText
             });
-            const noData = wrapper.find('.flexible-table-content-table-row-no-data');
+            const noData = wrapper.find(selectors.noData);
             expect(noData.length).toEqual(1);
             expect(noData.text()).toEqual(noDataText);
         });
@@ -910,7 +924,7 @@ describe('<UIFlexibleTable />', () => {
                 noRowBackground: true,
                 noDataText
             });
-            expect(wrapper.find('.flexible-table-content-table-row-no-data.no-background').length).toEqual(1);
+            expect(wrapper.find(`${selectors.noData}.no-background`).length).toEqual(1);
         });
 
         it('"reverseBackground" ', () => {
@@ -919,7 +933,7 @@ describe('<UIFlexibleTable />', () => {
                 reverseBackground: true,
                 noDataText
             });
-            expect(wrapper.find('.flexible-table-content-table-row-no-data.reverse-background').length).toEqual(1);
+            expect(wrapper.find(`${selectors.noData}.reverse-background`).length).toEqual(1);
         });
     });
 });


### PR DESCRIPTION
Fixes cursor issue on table reordering.

Issue:
![1](https://user-images.githubusercontent.com/122096996/214337688-db6e9506-f38b-43cd-aca5-6b42891c9739.gif)
Fixed:
![2](https://user-images.githubusercontent.com/122096996/214337806-ad4faa99-7084-4e46-9233-ed69d91c563f.gif)

 