### PR TITLE
fix(ui-components): UITextInput. Background color issue for readonly fields

### DIFF
--- a/.changeset/loud-phones-kick.md
+++ b/.changeset/loud-phones-kick.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITextInput. Background color issue for read only input field

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -117,6 +117,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                     // Read only container - disable hover style
                     this.props.readOnly && {
                         borderStyle: COLOR_STYLES.readOnly.borderStyle,
+                        backgroundColor: COLOR_STYLES.readOnly.backgroundColor,
                         // No hover efect on input without value
                         selectors: !this.props.value
                             ? {

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -272,6 +272,7 @@ Object {
     },
     undefined,
     Object {
+      "backgroundColor": "var(--vscode-editor-background)",
       "borderStyle": "dashed",
       "selectors": undefined,
     },
@@ -862,6 +863,7 @@ Object {
     },
     undefined,
     Object {
+      "backgroundColor": "var(--vscode-editor-background)",
       "borderStyle": "dashed",
       "selectors": Object {
         "&:hover": Object {
@@ -1161,6 +1163,7 @@ Object {
     },
     undefined,
     Object {
+      "backgroundColor": "var(--vscode-editor-background)",
       "borderStyle": "dashed",
       "selectors": Object {
         "&:hover": Object {


### PR DESCRIPTION
Scenario is when we overwrite css with style like(maybe more cases with other style variations):
```
.ms-TextField-fieldGroup { align-items: center; }
```

then readonly field looks following:
![image](https://user-images.githubusercontent.com/90789422/215110340-80e579b6-1a64-4826-80c6-04d654e2149d.png)

Applying same read-only background for container as well