### PR TITLE
fix(ui-components)L UITranslationInput component wrong default accept label and missing tooltip for resolved input

### DIFF
--- a/.changeset/lemon-humans-attack.md
+++ b/.changeset/lemon-humans-attack.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITranslationInput. Rename accept button default text, add title to input with information about resolved i18n value

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { UIDefaultButton } from '../UIButton';
 import { UICallout, UICalloutContentPadding } from '../UICallout';
 import { UiIcons } from '../Icons';
-import type { UITranslationProps, TranslationButtonStrings, TranslationSuggest } from './UITranslationButton.types';
+import type { UITranslationProps, TranslationInputStrings, TranslationSuggest } from './UITranslationButton.types';
 import { SuggestValueType } from './UITranslationButton.types';
 import { UILoadButton } from './UILoadButton';
 
@@ -22,7 +22,7 @@ export interface UITranslationButtonProps extends UITranslationProps {
  * @param strings Map with all text properties.
  * @returns Resolved text.
  */
-const getStringText = (property: keyof TranslationButtonStrings, strings?: TranslationButtonStrings): string => {
+const getStringText = (property: keyof TranslationInputStrings, strings?: TranslationInputStrings): string => {
     return strings?.[property] || '';
 };
 

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
@@ -3,42 +3,15 @@ import type { ReactElement } from 'react';
 import { UIDefaultButton } from '../UIButton';
 import { UICallout, UICalloutContentPadding } from '../UICallout';
 import { UiIcons } from '../Icons';
-import { defaultTranslationButtonStrings } from './defaults';
-import type { UITranslationProps, TranslationButtonStrings, TranslationEntry } from './UITranslationButton.types';
-import { TranslationKeyGenerator } from './UITranslationButton.types';
-import {
-    extractI18nKey,
-    generateI18nKey,
-    applyI18nPattern,
-    getTranslationByKey,
-    getTranslationByText
-} from './UITranslationUtils';
-
-import './UITranslationInput.scss';
-import { UIFormattedText, formatText } from './UIFormattedText';
+import type { UITranslationProps, TranslationButtonStrings, TranslationSuggest } from './UITranslationButton.types';
+import { SuggestValueType } from './UITranslationButton.types';
 import { UILoadButton } from './UILoadButton';
 
-export enum SuggestValueType {
-    Existing = 'Existing',
-    Update = 'Update',
-    New = 'New'
-}
+import './UITranslationInput.scss';
 
-interface TranslationSuggestValue {
-    entry: TranslationEntry;
-    icon?: UiIcons;
-    type: SuggestValueType;
-    i18n?: string;
-}
-
-interface TranslationSuggest {
-    tooltip: string;
-    message?: React.ReactElement;
-    suggest?: TranslationSuggestValue;
-}
-
-interface UITranslationButtonProps extends UITranslationProps {
+export interface UITranslationButtonProps extends UITranslationProps {
     onUpdateValue?: (value: string) => void;
+    suggestion: TranslationSuggest;
 }
 
 /**
@@ -54,105 +27,14 @@ const getStringText = (property: keyof TranslationButtonStrings, strings?: Trans
 };
 
 /**
- * Method returns suggestion object with message and tooltip based on passed translation button props.
- *
- * @param props Properties of translation button component.
- * @returns Translation suggestion object.
- */
-const getTranslationSuggestion = (props: UITranslationButtonProps): TranslationSuggest => {
-    const {
-        value = '',
-        allowedPatterns,
-        entries,
-        strings = defaultTranslationButtonStrings,
-        namingConvention = TranslationKeyGenerator.CamelCase,
-        defaultPattern,
-        i18nPrefix,
-        allowedI18nPrefixes
-    } = props;
-    const i18nKey = extractI18nKey(value, allowedPatterns, allowedI18nPrefixes || [i18nPrefix]);
-    let message = '';
-    let tooltip = '';
-    let suggest: TranslationSuggestValue;
-    if (i18nKey) {
-        // There is already i18n binding as value
-        const entry = getTranslationByKey(entries, i18nKey);
-        if (entry) {
-            tooltip = strings.i18nEntryExistsTooltip;
-            suggest = {
-                entry,
-                type: SuggestValueType.Existing,
-                icon: UiIcons.WorldArrow
-            };
-        } else {
-            message = strings.i18nKeyMissingDescription;
-            tooltip = strings.i18nKeyMissingTooltip;
-            suggest = {
-                entry: {
-                    key: {
-                        value: i18nKey
-                    },
-                    value: {
-                        value: i18nKey
-                    }
-                },
-                type: SuggestValueType.New,
-                icon: UiIcons.WorldWarning
-            };
-        }
-    } else {
-        // Use generation format passed from outside or use default as 'Standard';
-        const existingEntry = getTranslationByText(entries, value);
-        if (existingEntry) {
-            message = strings.i18nReplaceWithExistingDescription;
-            tooltip = strings.i18nReplaceWithExistingTooltip;
-            suggest = {
-                entry: existingEntry,
-                type: SuggestValueType.Update
-            };
-        } else {
-            message = strings.i18nValueMissingDescription;
-            tooltip = strings.i18nValueMissingTooltip;
-            const key = generateI18nKey(value, namingConvention, entries);
-            suggest = {
-                entry: {
-                    key: {
-                        value: key
-                    },
-                    value: {
-                        value
-                    }
-                },
-                type: SuggestValueType.New
-            };
-        }
-    }
-    // I18n string to apply for input value
-    suggest.i18n = applyI18nPattern(suggest.entry.key.value, defaultPattern, i18nPrefix);
-    // Format message to show in callout
-    const messageValues = {
-        key: suggest.entry.key.value,
-        value: suggest.entry.value.value,
-        i18n: suggest.i18n
-    };
-    tooltip = formatText(tooltip, messageValues);
-    return {
-        message: <UIFormattedText values={messageValues}>{message}</UIFormattedText>,
-        tooltip,
-        suggest
-    };
-};
-
-/**
  * Component to render translation button to provide helper callout with i18n generation option.
  *
  * @param props Component properties.
  * @returns Component to render translation button with callout.
  */
 export function UITranslationButton(props: UITranslationButtonProps): ReactElement {
-    const { id, strings, value, onCreateNewEntry, onUpdateValue, onShowExistingEntry, busy } = props;
+    const { id, strings, value, onCreateNewEntry, onUpdateValue, onShowExistingEntry, busy, suggestion } = props;
     const [isCalloutVisible, setCalloutVisible] = useState(false);
-    const suggestion = getTranslationSuggestion(props);
     // Callbacks
     const onToggleCallout = useCallback((): void => {
         if (suggestion.suggest?.type === SuggestValueType.Existing) {
@@ -219,7 +101,3 @@ export function UITranslationButton(props: UITranslationButtonProps): ReactEleme
         </div>
     );
 }
-
-UITranslationButton.defaultProps = {
-    strings: defaultTranslationButtonStrings
-};

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -47,7 +47,7 @@ export interface UITranslationProps {
     // Loader indicator
     busy?: UILoadButtonBusyProps;
     // Opion to pass custom Texts for component's labels and tooltips
-    strings?: TranslationButtonStrings;
+    strings?: TranslationInputStrings;
 }
 
 export interface UILoadButtonBusyProps {

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -1,4 +1,6 @@
-export interface TranslationButtonStrings {
+import type { UiIcons } from '../Icons';
+
+export interface TranslationInputStrings {
     acceptButtonLabel: string;
     cancelButtonLabel: string;
     i18nEntryExistsTooltip: string;
@@ -8,6 +10,7 @@ export interface TranslationButtonStrings {
     i18nValueMissingDescription: string;
     i18nReplaceWithExistingTooltip: string;
     i18nReplaceWithExistingDescription: string;
+    i18nEntryExistsInputTooltip: string;
 }
 
 export enum TranslationKeyGenerator {
@@ -37,25 +40,12 @@ export interface UITranslationProps {
     value?: string;
     id: string;
     disabled?: boolean;
-    // Existing I18n entries
-    entries: I18nBundle;
     // When entry exists in passed i18n entries and user clicked on show entry button
     onShowExistingEntry?: (entry: TranslationEntry) => void;
     // When creation of new i18n entry is requested
     onCreateNewEntry?: (entry: TranslationEntry) => void;
-    // PascalCase or camelCase to be used for key generation
-    // Default value is 'CamelCase'
-    namingConvention?: TranslationKeyGenerator;
     // Loader indicator
     busy?: UILoadButtonBusyProps;
-    // Default i18n prefix for "SingleBracketBinding"
-    i18nPrefix: string;
-    // Option to pass multiple allowed prefixes - if not passed then single "i18nPrefix" considered as allowed
-    allowedI18nPrefixes?: string[];
-    // Default pattern
-    defaultPattern: TranslationTextPattern;
-    // Allowed pattern
-    allowedPatterns: TranslationTextPattern[];
     // Opion to pass custom Texts for component's labels and tooltips
     strings?: TranslationButtonStrings;
 }
@@ -64,4 +54,23 @@ export interface UILoadButtonBusyProps {
     busy?: boolean;
     // If true set, then default time is 500ms
     useMinWaitingTime?: boolean | number;
+}
+
+export enum SuggestValueType {
+    Existing = 'Existing',
+    Update = 'Update',
+    New = 'New'
+}
+
+export interface TranslationSuggestValue {
+    entry: TranslationEntry;
+    icon?: UiIcons;
+    type: SuggestValueType;
+    i18n?: string;
+}
+
+export interface TranslationSuggest {
+    tooltip: string;
+    message?: React.ReactElement;
+    suggest?: TranslationSuggestValue;
 }

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -2,12 +2,132 @@ import React, { useCallback } from 'react';
 import type { ReactElement } from 'react';
 import { UITextInput } from '../UIInput';
 import type { ITextFieldProps } from '../UIInput';
+import { UiIcons } from '../Icons';
 import { UITranslationButton } from './UITranslationButton';
-import type { UITranslationProps } from './UITranslationButton.types';
+import type {
+    UITranslationProps,
+    TranslationSuggestValue,
+    TranslationSuggest,
+    I18nBundle,
+    TranslationTextPattern
+} from './UITranslationButton.types';
+import { TranslationKeyGenerator, SuggestValueType } from './UITranslationButton.types';
+import {
+    extractI18nKey,
+    generateI18nKey,
+    applyI18nPattern,
+    getTranslationByKey,
+    getTranslationByText
+} from './UITranslationUtils';
+import { defaultTranslationInputStrings } from './defaults';
+import { UIFormattedText, formatText } from './UIFormattedText';
 
 export interface UITranslationInputProps extends ITextFieldProps, UITranslationProps {
     id: string;
+    // Existing I18n entries
+    entries: I18nBundle;
+    // PascalCase or camelCase to be used for key generation
+    // Default value is 'CamelCase'
+    namingConvention?: TranslationKeyGenerator;
+    // Default i18n prefix for "SingleBracketBinding"
+    i18nPrefix: string;
+    // Option to pass multiple allowed prefixes - if not passed then single "i18nPrefix" considered as allowed
+    allowedI18nPrefixes?: string[];
+    // Default pattern
+    defaultPattern: TranslationTextPattern;
+    // Allowed pattern
+    allowedPatterns: TranslationTextPattern[];
 }
+
+/**
+ * Method returns suggestion object with message and tooltip based on passed translation button props.
+ *
+ * @param props Properties of translation input component.
+ * @returns Translation suggestion object.
+ */
+const getTranslationSuggestion = (props: UITranslationInputProps): TranslationSuggest => {
+    const {
+        value = '',
+        allowedPatterns,
+        entries,
+        strings = defaultTranslationInputStrings,
+        namingConvention = TranslationKeyGenerator.CamelCase,
+        defaultPattern,
+        i18nPrefix,
+        allowedI18nPrefixes
+    } = props;
+    const i18nKey = extractI18nKey(value, allowedPatterns, allowedI18nPrefixes || [i18nPrefix]);
+    let message = '';
+    let tooltip = '';
+    let suggest: TranslationSuggestValue;
+    if (i18nKey) {
+        // There is already i18n binding as value
+        const entry = getTranslationByKey(entries, i18nKey);
+        if (entry) {
+            tooltip = strings.i18nEntryExistsTooltip;
+            suggest = {
+                entry,
+                type: SuggestValueType.Existing,
+                icon: UiIcons.WorldArrow
+            };
+        } else {
+            message = strings.i18nKeyMissingDescription;
+            tooltip = strings.i18nKeyMissingTooltip;
+            suggest = {
+                entry: {
+                    key: {
+                        value: i18nKey
+                    },
+                    value: {
+                        value: i18nKey
+                    }
+                },
+                type: SuggestValueType.New,
+                icon: UiIcons.WorldWarning
+            };
+        }
+    } else {
+        // Use generation format passed from outside or use default as 'Standard';
+        const existingEntry = getTranslationByText(entries, value);
+        if (existingEntry) {
+            message = strings.i18nReplaceWithExistingDescription;
+            tooltip = strings.i18nReplaceWithExistingTooltip;
+            suggest = {
+                entry: existingEntry,
+                type: SuggestValueType.Update
+            };
+        } else {
+            message = strings.i18nValueMissingDescription;
+            tooltip = strings.i18nValueMissingTooltip;
+            const key = generateI18nKey(value, namingConvention, entries);
+            suggest = {
+                entry: {
+                    key: {
+                        value: key
+                    },
+                    value: {
+                        value
+                    }
+                },
+                type: SuggestValueType.New
+            };
+        }
+    }
+    // I18n string to apply for input value
+    suggest.i18n = applyI18nPattern(suggest.entry.key.value, defaultPattern, i18nPrefix);
+    // Format message to show in callout
+    const messageValues = {
+        key: suggest.entry.key.value,
+        value: suggest.entry.value.value,
+        i18n: suggest.i18n
+    };
+    tooltip = formatText(tooltip, messageValues);
+    return {
+        message: <UIFormattedText values={messageValues}>{message}</UIFormattedText>,
+        tooltip,
+        suggest
+    };
+};
 
 /**
  * Component to render translation input with button to provide helper callout with i18n generation option.
@@ -17,7 +137,6 @@ export interface UITranslationInputProps extends ITextFieldProps, UITranslationP
  */
 export function UITranslationInput(props: UITranslationInputProps): ReactElement {
     const {
-        title,
         id,
         className,
         onChange,
@@ -31,8 +150,11 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
         namingConvention,
         onCreateNewEntry,
         onShowExistingEntry,
-        disabled
+        disabled,
+        strings
     } = props;
+
+    const suggestion = getTranslationSuggestion(props);
 
     let classNames = ' ui-translatable__input';
     // Custom external classes
@@ -46,23 +168,31 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
         },
         [onChange]
     );
+    // Generate DOM id for i18n button
+    let buttonId = `${id}-i18n`;
+    let title = props.title;
+    if (suggestion.suggest?.type === SuggestValueType.Existing && strings?.i18nEntryExistsInputTooltip) {
+        // Change DOM id with additional suffix
+        buttonId += '-navigate';
+        // Overwrite title with information about reference entry
+        title = formatText(strings.i18nEntryExistsInputTooltip, {
+            value: value || '',
+            translation: suggestion.suggest.entry.value.value
+        });
+    }
 
     const onRenderSuffix = useCallback((): JSX.Element | null => {
         return (
             <UITranslationButton
-                id={`${id}-i18n`}
+                id={buttonId}
                 value={value}
-                allowedPatterns={allowedPatterns}
-                defaultPattern={defaultPattern}
-                entries={entries}
                 busy={busy}
-                i18nPrefix={i18nPrefix}
-                allowedI18nPrefixes={allowedI18nPrefixes}
-                namingConvention={namingConvention}
                 onCreateNewEntry={onCreateNewEntry}
                 onShowExistingEntry={onShowExistingEntry}
                 onUpdateValue={onUpdateValue}
                 disabled={disabled}
+                strings={strings}
+                suggestion={suggestion}
             />
         );
     }, [
@@ -89,3 +219,7 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
         />
     );
 }
+
+UITranslationInput.defaultProps = {
+    strings: defaultTranslationInputStrings
+};

--- a/packages/ui-components/src/components/UITranslationInput/defaults.ts
+++ b/packages/ui-components/src/components/UITranslationInput/defaults.ts
@@ -1,7 +1,7 @@
-import type { TranslationButtonStrings } from './UITranslationButton.types';
+import type { TranslationInputStrings } from './UITranslationButton.types';
 
-export const defaultTranslationButtonStrings: TranslationButtonStrings = {
-    acceptButtonLabel: 'Accept',
+export const defaultTranslationInputStrings: TranslationInputStrings = {
+    acceptButtonLabel: 'Apply',
     cancelButtonLabel: 'Cancel',
     i18nKeyMissingTooltip: 'Text key or value is not available in i18n file.',
     i18nKeyMissingDescription: 'Generate a text key {{{key}}} with value {{{value}}} in i18n file.',
@@ -11,5 +11,6 @@ export const defaultTranslationButtonStrings: TranslationButtonStrings = {
         'Text key {{{key}}} for value {{{value}}} is available in i18n file. \nConsider substituting {{{value}}} by {{{i18n}}}.',
     i18nReplaceWithExistingDescription:
         'Text key {{{key}}} for value {{{value}}} is available in i18n file.Substitute {{{value}}} by {{{i18n}}}.',
-    i18nEntryExistsTooltip: 'Edit in source file'
+    i18nEntryExistsTooltip: 'Edit in source file',
+    i18nEntryExistsInputTooltip: "Value: '{{{value}}}'.\nTranslation: '{{{translation}}}'."
 };

--- a/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
+++ b/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { initIcons } from '../../../../src/components';
 import {
     UITranslationInput,
@@ -385,5 +385,33 @@ describe('<UITranslationInput />', () => {
             fireEvent.click(document.body);
             expect(document.querySelectorAll(selectors.callout).length).toEqual(0);
         });
+    });
+
+    test('Test "string" property', () => {
+        const acceptButtonLabel = 'Dummy accept';
+        render(
+            <UITranslationInput
+                id={id}
+                entries={entries}
+                allowedPatterns={[TranslationTextPattern.SingleBracketBinding]}
+                defaultPattern={TranslationTextPattern.SingleBracketBinding}
+                i18nPrefix={'i18n'}
+                value={'new value'}
+                strings={{
+                    acceptButtonLabel,
+                    cancelButtonLabel: '',
+                    i18nKeyMissingTooltip: '',
+                    i18nKeyMissingDescription: '',
+                    i18nValueMissingTooltip: '',
+                    i18nValueMissingDescription: '',
+                    i18nReplaceWithExistingTooltip: '',
+                    i18nReplaceWithExistingDescription: '',
+                    i18nEntryExistsTooltip: '',
+                    i18nEntryExistsInputTooltip: ''
+                }}
+            />
+        );
+        clickI18nButton();
+        expect(screen.getByText(acceptButtonLabel)).toBeDefined();
     });
 });

--- a/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
+++ b/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
@@ -21,6 +21,14 @@ describe('<UITranslationInput />', () => {
         loader: '.ms-Spinner'
     };
 
+    const getButtonIdSelector = (id: string, goToCode = false): string => {
+        id = `#${id}-i18n`;
+        if (goToCode) {
+            id += '-navigate';
+        }
+        return id;
+    };
+
     const clickI18nButton = (expectCallout = true) => {
         const openBtn = document.querySelector(selectors.button) as HTMLElement;
         fireEvent.click(openBtn);
@@ -59,6 +67,8 @@ describe('<UITranslationInput />', () => {
         );
         expect(container.querySelectorAll(selectors.input).length).toEqual(1);
         expect(container.querySelectorAll(selectors.button).length).toEqual(1);
+        expect(container.querySelectorAll(getButtonIdSelector(id, false)).length).toEqual(1);
+        expect(container.querySelectorAll(getButtonIdSelector(id, true)).length).toEqual(0);
         expect(container.querySelectorAll(`.${customClassName}`).length).toEqual(0);
 
         rerender(
@@ -199,7 +209,8 @@ describe('<UITranslationInput />', () => {
                 entry: {
                     key: 'dummy1',
                     value: 'dummy1 text'
-                }
+                },
+                title: "Value: '{i18n>dummy1}'.\nTranslation: 'dummy1 text'."
             }
         },
         {
@@ -212,7 +223,8 @@ describe('<UITranslationInput />', () => {
                 entry: {
                     key: 'Dummy1',
                     value: 'Dummy1 text'
-                }
+                },
+                title: "Value: '{i18n>Dummy1}'.\nTranslation: 'Dummy1 text'."
             }
         }
     ];
@@ -224,7 +236,7 @@ describe('<UITranslationInput />', () => {
             const onChangeMock = jest.fn();
             const onUpdateValueMock = jest.fn();
             const onShowExistingEntryMock = jest.fn();
-            render(
+            const { container } = render(
                 <UITranslationInput
                     id={id}
                     value={value}
@@ -244,11 +256,15 @@ describe('<UITranslationInput />', () => {
             expect(onCreateNewEntryMock).toBeCalledTimes(0);
             expect(onChangeMock).toBeCalledTimes(0);
             expect(onUpdateValueMock).toBeCalledTimes(0);
+            expect(container.querySelectorAll(getButtonIdSelector(id, false)).length).toEqual(0);
+            expect(container.querySelectorAll(getButtonIdSelector(id, true)).length).toEqual(1);
             expect(onShowExistingEntryMock).toBeCalledTimes(1);
             expect(onShowExistingEntryMock).toBeCalledWith({
                 'key': { 'value': result.entry.key },
                 'value': { 'value': result.entry.value }
             });
+            // Check title
+            expect(container.querySelector(`${selectors.input} input`)?.getAttribute('title')).toEqual(result.title);
         }
     );
 


### PR DESCRIPTION
Following issues were found as different:
1. Default text of accept button should be `Apply`:
![image](https://user-images.githubusercontent.com/90789422/217894608-c4265452-0b3e-4801-a84c-3a991d7a1695.png)
2. Following title/tooltip was missing:
![image](https://user-images.githubusercontent.com/90789422/217894888-8f52bbe5-d461-4362-841a-4f0f27c7543d.png)
3. Generate id for button with additional suffix `-navigate`