### PR TITLE
bug(ff-writer) fix worklist TS check for undefined

### DIFF
--- a/.changeset/wet-planets-promise.md
+++ b/.changeset/wet-planets-promise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-freestyle-writer': patch
+---
+
+fix worklist check for undefined

--- a/packages/fiori-freestyle-writer/templates/worklist/add/webapp/controller/Worklist.controller.ts
+++ b/packages/fiori-freestyle-writer/templates/worklist/add/webapp/controller/Worklist.controller.ts
@@ -84,8 +84,12 @@ export default class Worklist extends BaseController {
      *
      */
     public onRefresh() {
-        if (this.byId("table") && this.byId("table").getBinding("items")) {
-            this.byId("table").getBinding("items").refresh(false);
+        const tableId = this.byId("table");
+        if (tableId) {
+            const tableItems = tableId.getBinding("items");
+            if (tableItems) {
+                tableItems.refresh(false);
+            }
         }
     }
 

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -13589,8 +13589,12 @@ export default class Worklist extends BaseController {
      *
      */
     public onRefresh() {
-        if (this.byId(\\"table\\") && this.byId(\\"table\\").getBinding(\\"items\\")) {
-            this.byId(\\"table\\").getBinding(\\"items\\").refresh(false);
+        const tableId = this.byId(\\"table\\");
+        if (tableId) {
+            const tableItems = tableId.getBinding(\\"items\\");
+            if (tableItems) {
+                tableItems.refresh(false);
+            }
         }
     }
 


### PR DESCRIPTION
fix #882

Fixes error
```
> ff_worklist_ts1@0.0.1 ts-typecheck
> tsc --noEmit

webapp/controller/Worklist.controller.ts:87:35 - error TS2532: Object is possibly 'undefined'.

87         if (this.byId("table") && this.byId("table").getBinding("items")) {
                                     ~~~~~~~~~~~~~~~~~~

webapp/controller/Worklist.controller.ts:88:13 - error TS2532: Object is possibly 'undefined'.

88             this.byId("table").getBinding("items").refresh(false);
               ~~~~~~~~~~~~~~~~~~

webapp/controller/Worklist.controller.ts:88:13 - error TS2532: Object is possibly 'undefined'.

88             this.byId("table").getBinding("items").refresh(false);
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 3 errors in the same file, starting at: webapp/controller/Worklist.controller.ts:87

```