### PR TITLE
fix(yaml): do not throw errors for multi doc yaml

### DIFF
--- a/.changeset/cyan-donkeys-fail.md
+++ b/.changeset/cyan-donkeys-fail.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/yaml': patch
+---
+
+Do not throw exception for multi document yaml

--- a/packages/project-access/test/project/ui5-config.test.ts
+++ b/packages/project-access/test/project/ui5-config.test.ts
@@ -21,4 +21,10 @@ describe('Test getWebappPath()', () => {
             join(samplesRoot, 'custom-webapp-path', 'src', 'webapp')
         );
     });
+
+    test('Get webapp from app with custom webapp mapping in multi document yaml', async () => {
+        expect(await getWebappPath(join(samplesRoot, 'custom-webapp-path-multi-yaml'))).toEqual(
+            join(samplesRoot, 'custom-webapp-path-multi-yaml', 'src', 'webapp')
+        );
+    });
 });

--- a/packages/project-access/test/test-data/project/webapp-path/custom-webapp-path-multi-yaml/src/webapp/manifest.json
+++ b/packages/project-access/test/test-data/project/webapp-path/custom-webapp-path-multi-yaml/src/webapp/manifest.json
@@ -1,0 +1,6 @@
+{
+    "sap.app": {
+        "id": "custom-webapp-path",
+        "type": "application"
+    }
+}

--- a/packages/project-access/test/test-data/project/webapp-path/custom-webapp-path-multi-yaml/ui5.yaml
+++ b/packages/project-access/test/test-data/project/webapp-path/custom-webapp-path-multi-yaml/ui5.yaml
@@ -1,0 +1,6 @@
+resources:
+    configuration:
+        paths:
+            webapp: src/webapp
+---
+dummy: document

--- a/packages/yaml/src/yaml-document.ts
+++ b/packages/yaml/src/yaml-document.ts
@@ -45,9 +45,12 @@ export class YamlDocument {
             // yaml.parseAll('') does not create a new document
             this.documents.push(yaml.parseDocument(serializedYaml));
         }
-        if (this.documents[0].errors?.length > 0) {
+        const docsWithErrors = this.documents.filter((doc) => doc.errors.length > 0);
+        if (docsWithErrors.length > 0) {
             throw new YAMLError(
-                errorTemplate.yamlParsing + '\n' + this.documents[0].errors.map((e) => e.message).join(''),
+                errorTemplate.yamlParsing +
+                    '\n' +
+                    docsWithErrors.map((doc) => doc.errors.map((e) => e.message).join('')),
                 errorCode.yamlParsing
             );
         }

--- a/packages/yaml/test/yaml-document.test.ts
+++ b/packages/yaml/test/yaml-document.test.ts
@@ -4,7 +4,7 @@ import type { YAMLMap, YAMLSeq } from '../src';
 import { interpolate } from '../src/texts';
 
 describe('YamlDocument', () => {
-    it('throws an error when instatiated with malformed YAML contents', async () => {
+    it('throws an error when instantiated with malformed YAML contents', async () => {
         const serializedYaml = `
 foo:
   bar: 13
@@ -728,7 +728,7 @@ l1:
             expect(doc.toString()).toEqual(expectedValue);
         });
 
-        it('appends object with comment to existing emptysequence', async () => {
+        it('appends object with comment to existing empty sequence', async () => {
             const serializedYaml = `# Top comment
 
 key1: 42 # key1
@@ -1103,6 +1103,38 @@ seq1:
             ).toThrow(interpolate(errorTemplate.nodeNotAMap, { path }));
 
             expect(doc.toString().trim()).toEqual(serializedYaml);
+        });
+    });
+    describe('start empty yaml document', () => {
+        it('will create a document when providing an empty string', async () => {
+            const doc = await YamlDocument.newInstance(``);
+            doc.appendTo({ path: 'prop1', value: 'value1' });
+            expect(doc.toString()).toBe(`prop1:
+  - value1
+`);
+        });
+        it('will create a document when providing blank spaces', async () => {
+            const doc = await YamlDocument.newInstance(`       `);
+            doc.appendTo({ path: 'p', value: 'v' });
+            expect(doc.toString()).toBe(`p:
+  - v
+`);
+        });
+    });
+    describe('multiple yaml documents', () => {
+        it('will parse and serialize multiple documents', async () => {
+            const serializedYaml = `doc1:
+  prop1: value1
+---
+doc2:
+  prop2: value2`;
+            const doc = await YamlDocument.newInstance(serializedYaml);
+            expect(doc.toString()).toBe(`doc1:
+  prop1: value1
+---
+doc2:
+  prop2: value2
+`);
         });
     });
 });

--- a/packages/yaml/test/yaml-document.test.ts
+++ b/packages/yaml/test/yaml-document.test.ts
@@ -14,6 +14,22 @@ foo:
         expect(async () => await YamlDocument.newInstance(serializedYaml)).rejects.toThrow();
     });
 
+    it('throws an error containing messages for all documents', async () => {
+        expect(async () => await YamlDocument.newInstance(`- 1\n2\n---\n- 3\n4`)).rejects.toThrowError(
+            expect.objectContaining({
+                message: `Error parsing YAML document\nUnexpected scalar at node end at line 2, column 1:\n\n- 1\n2\n^\n,Unexpected scalar at node end at line 5, column 1:\n\n- 3\n4\n^\n`
+            })
+        );
+    });
+
+    it('throws an error containing message for erroneous document', async () => {
+        expect(async () => await YamlDocument.newInstance(`- 1\n---\n- 2\n3`)).rejects.toThrowError(
+            expect.objectContaining({
+                message: `Error parsing YAML document\nUnexpected scalar at node end at line 4, column 1:\n\n- 2\n3\n^\n`
+            })
+        );
+    });
+
     it('toString returns serialized contents, including comments', async () => {
         const serializedYaml = `# This is at the top
 


### PR DESCRIPTION
Issue https://github.com/SAP/open-ux-tools/issues/892

## Description
This PR fixes errors thrown in module `@sap-ux/yaml` when parsing multi document yaml strings. While it prepares for working with multiple documents, it does not provide full multi document capabilities. Full support of multi document yaml requires more technical evaluation and planing.

## Background
When running 
https://github.com/SAP/open-ux-tools/blob/41e234c0ba70425b42139a42218ece5a3562c032/packages/yaml/src/yaml-document.ts#L41-L47

with a `serializedYaml` containing [mulitple documents](https://www.yaml.info/learn/document.html), `this.document.error` contains at least one error with `code: 'MULTIPLE_DOCS'`. However, the document would still be parsed. Thus another possible fix for this would be to add an error filter to the constructor, like
`this.document.errors = this.document.errors?.filter((error) => error.code !== 'MULTIPLE_DOCS');`

Resulting constructor looks then like this:

```typescript
private constructor(serializedYaml: string) {
    this.document = yaml.parseDocument(serializedYaml);
    this.document.errors = this.document.errors?.filter((error) => error.code !== 'MULTIPLE_DOCS');
    if (this.document.errors?.length > 0) {
        throw new YAMLError(
            errorTemplate.yamlParsing + '\n' + this.document.errors.map((e) => e.message).join(''),
            errorCode.yamlParsing
        );
    }
}
```

However, this solution would have a flaw: 
When providing a yaml with multiple documents and calling `doc.toString()` at some point, only the first document is serialized.

The proposed solution on this PR also prepares for full support of multiple document yamls. For instance, the index of the document (currently fixed to `0`) could be optional parameter for function calls allowing to reference a specific document in the yaml.






