### PR TITLE
feat: add silent mode

### DIFF
--- a/.changeset/thirty-walls-repair.md
+++ b/.changeset/thirty-walls-repair.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': minor
+---
+
+Add option for findProjectRoot function to not throw errors when no match is found

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -53,10 +53,14 @@ async function findAllManifest(wsFolders: WorkspaceFolder[] | string[] | undefin
  *
  * @param path path of a project file
  * @param sapuxRequired if true, only find sapux projects
+ * @param silent if true, then does not throw an error but returns an empty path
  */
-export async function findProjectRoot(path: string, sapuxRequired = true): Promise<string> {
+export async function findProjectRoot(path: string, sapuxRequired = true, silent = false): Promise<string> {
     const packageJson = await findFileUp(FileName.Package, path);
     if (!packageJson) {
+        if (silent) {
+            return '';
+        }
         throw new Error(
             `Could not find any project root for '${path}'. Search was done for ${
                 sapuxRequired ? 'Fiori elements' : 'All'

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -106,6 +106,11 @@ describe('Test findProjectRoot()', () => {
         }
     });
 
+    test('No package.json in silent mode should not throw', async () => {
+        const path = await findProjectRoot(join('/'), true, true);
+        expect(path).toStrictEqual('');
+    });
+
     test('No package.json, sapuxRequired: false, should throw error', async () => {
         try {
             await findProjectRoot(join('/'), false);


### PR DESCRIPTION
In some cases we need to perform multiple `findProjectRoot` to correctly identify project root (CDS project with multiple apps containing `package.json`) and having to wrap each call in a try-catch block makes it more difficult to use than it needs to be.

I've added another parameter `silent` which allows to suppress thrown errors. By default it is `false` and would not affect current users.