### PR TITLE
fix(project-access): do not throw error in silent mode

### DIFF
--- a/.changeset/tricky-wombats-remember.md
+++ b/.changeset/tricky-wombats-remember.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fixed silent mode throwing an error when sapuxRequired was set to true

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -71,7 +71,7 @@ export async function findProjectRoot(path: string, sapuxRequired = true, silent
     if (sapuxRequired) {
         const sapux = (await readJSON<Package>(packageJson)).sapux;
         if (!sapux) {
-            root = await findProjectRoot(dirname(root), sapuxRequired);
+            root = await findProjectRoot(dirname(root), sapuxRequired, silent);
         }
     }
     return root;

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -111,6 +111,11 @@ describe('Test findProjectRoot()', () => {
         expect(path).toStrictEqual('');
     });
 
+    test('package.json exists, but sapux is missing in silent mode should not throw', async () => {
+        const path = await findProjectRoot(__dirname, true, true);
+        expect(path).toStrictEqual('');
+    });
+
     test('No package.json, sapuxRequired: false, should throw error', async () => {
         try {
             await findProjectRoot(join('/'), false);


### PR DESCRIPTION
Follow up to #907

The `silent` parameter was not correctly passed in recursion call.