### PR TITLE
Various fixes in UI5, FF and FE writers

### DIFF
--- a/.changeset/friendly-ties-decide.md
+++ b/.changeset/friendly-ties-decide.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/fiori-elements-writer': patch
+'@sap-ux/fiori-freestyle-writer': patch
+'@sap-ux/ui5-application-writer': patch
+---
+
+Align FF ListDetail temple between JS and TS and add test utils

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,6 +46,20 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "fiori-freestyle-writer: Debug Current Jest File with UX_DEBUG & UX_DEBUG_FULL",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "cwd": "${workspaceFolder}/packages/fiori-freestyle-writer",
+            "env": {
+                "UX_DEBUG": "false",
+                "UX_DEBUG_FULL": "false"
+            }
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "odata-service-writer: Debug Current Jest File",
             "program": "${workspaceFolder}/node_modules/.bin/jest",
             "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ When analyzing a problem, it is helpful to be able to debug the modules. How to 
 Each of the packages has an extensive set of unit tests covering as many as possible different scenarios, therefore, as a starting point for debugging, it is a good idea to use the tests. The easiest (but not the only) way to debug a specific test in VSCode is to open a `JavaScript Debug Terminal` and then go to the package that needs to be debugged. Using the debug terminal, execute all tests with `pnpm test` or a specific one, e.g. execute `pnpm test -- test/basic.test.ts` in the `fiori-freestyle-writer` directory (`./packages/fiori-freestyle-writer`). When running either of the commands in the debug terminal, breakpoints set in VSCode will be active.
 
 Additionally for the `*-writer` modules it is sometimes helpful to manually inspect the generated output of the unit tests on the filesystem. This can be achieved by setting the variable `UX_DEBUG` before running the tests e.g. in `fiori-freestyle-writer` run `UX_DEBUG=true pnpm test` and after the tests finish, the generated files can be found at `./test/test-output`.
+Additional checks can be performed on the generated projects by also setting `UX_DEBUG_FULL` e.g. `UX_DEBUG=true UX_DEBUG_FULL=true pnpm test`.
+This includes checks such as `npm install`, `npm run ts-typecheck`, `npm run lint` as appropriate to the project.
 
 ### Create changesets for feature or bug fix branches
 

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17588,8 +17588,8 @@ archive.zip
   \\"devDependencies\\": {
     \\"@ui5/cli\\": \\"^2.14.1\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
-    \\"@sap/ux-specification\\": \\"UI5-1.77\\",
-    \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
+    \\"@sap/ux-specification\\": \\"UI5-1.108\\",
+    \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
     \\"ui5-tooling-transpile\\": \\"^0.2.1\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.17.0\\",
@@ -17658,7 +17658,7 @@ metadata:
 type: application
 framework:
   name: SAPUI5
-  version: 1.77.2
+  version: 1.108.0
   libraries:
     - name: sap.m
     - name: sap.ui.core
@@ -20528,7 +20528,7 @@ appDescription=A Fiori application.",
   },
   "webapp/manifest.json": Object {
     "contents": "{
-  \\"_version\\": \\"1.21.0\\",
+  \\"_version\\": \\"1.48.0\\",
   \\"sap.app\\": {
     \\"id\\": \\"lropV2_ts\\",
     \\"type\\": \\"application\\",
@@ -20591,7 +20591,7 @@ appDescription=A Fiori application.",
   \\"sap.ui5\\": {
     \\"flexEnabled\\": true,
     \\"dependencies\\": {
-      \\"minUI5Version\\": \\"1.77.2\\",
+      \\"minUI5Version\\": \\"1.108.0\\",
       \\"libs\\": {
         \\"sap.m\\": {},
         \\"sap.ui.core\\": {},
@@ -21009,8 +21009,6 @@ if (parseInt(version[0], 10) <= 1 && parseInt(version[1], 10) < 78) {
             sap.ushell.Container.createRenderer().placeAt(\\"content\\");
         });
     </script>
-    <!-- relevant for version < 1.78.0 only -->
-	<script src=\\"changes_preview.js\\"></script>
 </head>
 
 <!-- UI Content -->

--- a/packages/fiori-elements-writer/test/alp.test.ts
+++ b/packages/fiori-elements-writer/test/alp.test.ts
@@ -2,13 +2,14 @@ import type { FioriElementsApp } from '../src';
 import { generate, TemplateType, LROPSettings } from '../src';
 import { join } from 'path';
 import { removeSync } from 'fs-extra';
-import { testOutputDir, debug, getTestData, feBaseConfig } from './common';
+import { testOutputDir, debug, getTestData, feBaseConfig, projectChecks } from './common';
 import type { OdataService } from '@sap-ux/odata-service-writer';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { ALPSettings, ALPSettingsV2, ALPSettingsV4 } from '../src/types';
 import { TableSelectionMode, TableType, WorklistSettings } from '../src/types';
 
 const TEST_NAME = 'alpTemplates';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori Elements template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -95,6 +96,8 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-elements-writer/test/feop.test.ts
+++ b/packages/fiori-elements-writer/test/feop.test.ts
@@ -2,10 +2,11 @@ import type { FioriElementsApp } from '../src';
 import { generate, TemplateType } from '../src';
 import { join } from 'path';
 import { removeSync } from 'fs-extra';
-import { testOutputDir, debug, feBaseConfig, v4TemplateSettings, v4Service } from './common';
+import { testOutputDir, debug, feBaseConfig, v4TemplateSettings, v4Service, projectChecks } from './common';
 import type { FEOPSettings } from '../src/types';
 
 const TEST_NAME = 'feopTemplate';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori Elements template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -56,6 +57,8 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-elements-writer/test/fpm.test.ts
+++ b/packages/fiori-elements-writer/test/fpm.test.ts
@@ -2,9 +2,10 @@ import type { FioriElementsApp, FPMSettings } from '../src';
 import { generate, TemplateType, ValidationError } from '../src';
 import { join } from 'path';
 import { removeSync } from 'fs-extra';
-import { testOutputDir, debug, feBaseConfig, v4Service, v2Service } from './common';
+import { testOutputDir, debug, feBaseConfig, v4Service, v2Service, projectChecks } from './common';
 
 const TEST_NAME = 'fpmTemplates';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Flexible Programming Model template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -64,6 +65,8 @@ describe(`Flexible Programming Model template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 

--- a/packages/fiori-elements-writer/test/lrop.test.ts
+++ b/packages/fiori-elements-writer/test/lrop.test.ts
@@ -9,10 +9,12 @@ import {
     v4TemplateSettings,
     v4Service,
     v2TemplateSettings,
-    v2Service
+    v2Service,
+    projectChecks
 } from './common';
 
 const TEST_NAME = 'lropTemplates';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 jest.mock('read-pkg-up', () => ({
     sync: jest.fn().mockReturnValue({
@@ -161,7 +163,7 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
                         settings: v2TemplateSettings
                     },
                     ui5: {
-                        version: '1.77.2' // flex changes preview should be included with this version
+                        version: '1.108.0'
                     },
                     appOptions: {
                         typescript: true
@@ -188,6 +190,8 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-elements-writer/test/ovp.test.ts
+++ b/packages/fiori-elements-writer/test/ovp.test.ts
@@ -2,12 +2,13 @@ import type { FioriElementsApp } from '../src';
 import { generate, TemplateType } from '../src';
 import { join } from 'path';
 import { removeSync } from 'fs-extra';
-import { testOutputDir, getTestData, debug, feBaseConfig } from './common';
+import { testOutputDir, getTestData, debug, feBaseConfig, projectChecks } from './common';
 import type { OdataService } from '@sap-ux/odata-service-writer';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { OVPSettings } from '../src/types';
 
 const TEST_NAME = 'ovpTemplate';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori Elements template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -80,6 +81,8 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-elements-writer/test/worklist.test.ts
+++ b/packages/fiori-elements-writer/test/worklist.test.ts
@@ -9,11 +9,13 @@ import {
     feBaseConfig,
     v2TemplateSettings,
     v4TemplateSettings,
-    v4Service
+    v4Service,
+    projectChecks
 } from './common';
 import type { WorklistSettings } from '../src/types';
 
 const TEST_NAME = 'worklistTemplate';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori Elements template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -65,6 +67,8 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/List.controller.js
+++ b/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/List.controller.js
@@ -69,7 +69,7 @@ sap.ui.define([
 
             this.getView().addEventDelegate({
                 onBeforeFirstShow: function () {
-                    this.getOwnerComponent().oListSelector.setBoundMasterList(oList);
+                    this.getOwnerComponent().oListSelector.setBoundList(oList);
                 }.bind(this)
             });
 

--- a/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/ListSelector.js
+++ b/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/ListSelector.js
@@ -7,7 +7,7 @@
     return BaseObject.extend("<%- app.id %>.controller.ListSelector", {
 
         /**
-         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
          * function.
          * @class
          * @public
@@ -18,7 +18,7 @@
                 this._fnResolveListHasBeenSet = fnResolveListHasBeenSet;
             }.bind(this));
             // This promise needs to be created in the constructor, since it is allowed to
-            // invoke selectItem functions before calling setBoundMasterList
+            // invoke selectItem functions before calling setBoundList
             this.oWhenListLoadingIsDone = new Promise(function (fnResolve, fnReject) {
                 this._oWhenListHasBeenSet
                     .then(function (oList) {
@@ -46,7 +46,7 @@
          * @param {sap.m.List} oList The list all the select functions will be invoked on.
          * @public
          */
-        setBoundMasterList : function (oList) {
+        setBoundList : function (oList) {
             this._oList = oList;
             this._fnResolveListHasBeenSet(oList);
         },

--- a/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/ListSelector.ts
+++ b/packages/fiori-freestyle-writer/templates/listdetail/add/webapp/controller/ListSelector.ts
@@ -10,11 +10,11 @@ export default class ListSelector extends UI5Object {
 
     protected readonly oWhenListLoadingIsDone: Promise<any>;
     protected readonly _oWhenListHasBeenSet: Promise<any>;
-    protected list: List;
+    protected _oList: List;
     protected _fnResolveListHasBeenSet: any;
 
     /**
-     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
      * function.
      */
      constructor() {
@@ -26,14 +26,14 @@ export default class ListSelector extends UI5Object {
         // invoke selectItem functions before calling setBoundList
         this.oWhenListLoadingIsDone = new Promise(function (this: ListSelector, resolve: Function, reject: Function) {
             this._oWhenListHasBeenSet
-                .then(function (this: ListSelector, list: List) {
-                    list.getBinding("items")?.attachEventOnce("dataReceived",
+                .then(function (this: ListSelector, oList: List) {
+                    oList.getBinding("items")?.attachEventOnce("dataReceived",
                         function (this: ListSelector) {
-                            if (this.list.getItems().length) {
-                                resolve({ list });
+                            if (this._oList.getItems().length) {
+                                resolve({ oList });
                             } else {
                                 // No items in the list
-                                reject({ list });
+                                reject({ oList });
                             }
                         }.bind(this)
                     );
@@ -47,9 +47,9 @@ export default class ListSelector extends UI5Object {
      * @param list The list all the select functions will be invoked on.
      *
      */
-     public setBoundList(list: List) {
-        this.list = list;
-        this._fnResolveListHasBeenSet(list);
+     public setBoundList(oList: List) {
+        this._oList = oList;
+        this._fnResolveListHasBeenSet(oList);
     }
 
     /**
@@ -62,20 +62,20 @@ export default class ListSelector extends UI5Object {
 
         this.oWhenListLoadingIsDone.then(
             function (this: ListSelector) {
-                const list = this.list;
-                if (list.getMode() === "None") {
+                const oList = this._oList;
+                if (oList.getMode() === "None") {
                     return;
                 }
 
                 // skip update if the current selection is already matching the object path
-                const selectedItem = list.getSelectedItem();
+                const selectedItem = oList.getSelectedItem();
                 if (selectedItem && selectedItem.getBindingContext()!.getPath() === path) {
                     return;
                 }
 
-                list.getItems().some(function (oItem: ListItemBase) {
+                oList.getItems().some(function (oItem: ListItemBase) {
                     if (oItem.getBindingContext() && oItem.getBindingContext()!.getPath() === path) {
-                        list.setSelectedItem(oItem);
+                        oList.setSelectedItem(oItem);
                         return true;
                     }
                 });
@@ -91,8 +91,8 @@ export default class ListSelector extends UI5Object {
      * Does not trigger 'selectionChange' event on list, though.
      */
     public async clearListSelection() {
-        //use promise to make sure that 'this.list' is available
+        //use promise to make sure that 'this._oList' is available
         await this._oWhenListHasBeenSet;
-        this.list.removeSelections(true);
+        this._oList.removeSelections(true);
     }
 }

--- a/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/index.test.ts.snap
@@ -1999,7 +1999,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
 
             this.getView().addEventDelegate({
                 onBeforeFirstShow: function () {
-                    this.getOwnerComponent().oListSelector.setBoundMasterList(oList);
+                    this.getOwnerComponent().oListSelector.setBoundList(oList);
                 }.bind(this)
             });
 
@@ -2299,7 +2299,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
     return BaseObject.extend(\\"test.me.controller.ListSelector\\", {
 
         /**
-         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
          * function.
          * @class
          * @public
@@ -2310,7 +2310,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
                 this._fnResolveListHasBeenSet = fnResolveListHasBeenSet;
             }.bind(this));
             // This promise needs to be created in the constructor, since it is allowed to
-            // invoke selectItem functions before calling setBoundMasterList
+            // invoke selectItem functions before calling setBoundList
             this.oWhenListLoadingIsDone = new Promise(function (fnResolve, fnReject) {
                 this._oWhenListHasBeenSet
                     .then(function (oList) {
@@ -2338,7 +2338,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
          * @param {sap.m.List} oList The list all the select functions will be invoked on.
          * @public
          */
-        setBoundMasterList : function (oList) {
+        setBoundList : function (oList) {
             this._oList = oList;
             this._fnResolveListHasBeenSet(oList);
         },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -1100,11 +1100,11 @@ export default class ListSelector extends UI5Object {
 
     protected readonly oWhenListLoadingIsDone: Promise<any>;
     protected readonly _oWhenListHasBeenSet: Promise<any>;
-    protected list: List;
+    protected _oList: List;
     protected _fnResolveListHasBeenSet: any;
 
     /**
-     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
      * function.
      */
      constructor() {
@@ -1116,14 +1116,14 @@ export default class ListSelector extends UI5Object {
         // invoke selectItem functions before calling setBoundList
         this.oWhenListLoadingIsDone = new Promise(function (this: ListSelector, resolve: Function, reject: Function) {
             this._oWhenListHasBeenSet
-                .then(function (this: ListSelector, list: List) {
-                    list.getBinding(\\"items\\")?.attachEventOnce(\\"dataReceived\\",
+                .then(function (this: ListSelector, oList: List) {
+                    oList.getBinding(\\"items\\")?.attachEventOnce(\\"dataReceived\\",
                         function (this: ListSelector) {
-                            if (this.list.getItems().length) {
-                                resolve({ list });
+                            if (this._oList.getItems().length) {
+                                resolve({ oList });
                             } else {
                                 // No items in the list
-                                reject({ list });
+                                reject({ oList });
                             }
                         }.bind(this)
                     );
@@ -1137,9 +1137,9 @@ export default class ListSelector extends UI5Object {
      * @param list The list all the select functions will be invoked on.
      *
      */
-     public setBoundList(list: List) {
-        this.list = list;
-        this._fnResolveListHasBeenSet(list);
+     public setBoundList(oList: List) {
+        this._oList = oList;
+        this._fnResolveListHasBeenSet(oList);
     }
 
     /**
@@ -1152,20 +1152,20 @@ export default class ListSelector extends UI5Object {
 
         this.oWhenListLoadingIsDone.then(
             function (this: ListSelector) {
-                const list = this.list;
-                if (list.getMode() === \\"None\\") {
+                const oList = this._oList;
+                if (oList.getMode() === \\"None\\") {
                     return;
                 }
 
                 // skip update if the current selection is already matching the object path
-                const selectedItem = list.getSelectedItem();
+                const selectedItem = oList.getSelectedItem();
                 if (selectedItem && selectedItem.getBindingContext()!.getPath() === path) {
                     return;
                 }
 
-                list.getItems().some(function (oItem: ListItemBase) {
+                oList.getItems().some(function (oItem: ListItemBase) {
                     if (oItem.getBindingContext() && oItem.getBindingContext()!.getPath() === path) {
-                        list.setSelectedItem(oItem);
+                        oList.setSelectedItem(oItem);
                         return true;
                     }
                 });
@@ -1181,9 +1181,9 @@ export default class ListSelector extends UI5Object {
      * Does not trigger 'selectionChange' event on list, though.
      */
     public async clearListSelection() {
-        //use promise to make sure that 'this.list' is available
+        //use promise to make sure that 'this._oList' is available
         await this._oWhenListHasBeenSet;
-        this.list.removeSelections(true);
+        this._oList.removeSelections(true);
     }
 }",
     "state": "modified",
@@ -2664,6 +2664,7 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".eslintrc": Object {
     "contents": "{
+  \\"root\\": true,
   \\"plugins\\": [
     \\"@sap/ui5-jsdocs\\",
     \\"eslint-plugin-fiori-custom\\"
@@ -2713,7 +2714,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
-    \\"@sapui5/ts-types\\": \\"1.71.18\\",
+    \\"@sapui5/ts-types\\": \\"1.71.15\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.2.1\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
@@ -3398,7 +3399,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
 
             this.getView().addEventDelegate({
                 onBeforeFirstShow: function () {
-                    this.getOwnerComponent().oListSelector.setBoundMasterList(oList);
+                    this.getOwnerComponent().oListSelector.setBoundList(oList);
                 }.bind(this)
             });
 
@@ -3666,7 +3667,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
     return BaseObject.extend(\\"test.me.controller.ListSelector\\", {
 
         /**
-         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+         * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
          * function.
          * @class
          * @public
@@ -3677,7 +3678,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
                 this._fnResolveListHasBeenSet = fnResolveListHasBeenSet;
             }.bind(this));
             // This promise needs to be created in the constructor, since it is allowed to
-            // invoke selectItem functions before calling setBoundMasterList
+            // invoke selectItem functions before calling setBoundList
             this.oWhenListLoadingIsDone = new Promise(function (fnResolve, fnReject) {
                 this._oWhenListHasBeenSet
                     .then(function (oList) {
@@ -3705,7 +3706,7 @@ function (UIComponent, Device, models, ListSelector, ErrorHandler) {
          * @param {sap.m.List} oList The list all the select functions will be invoked on.
          * @public
          */
-        setBoundMasterList : function (oList) {
+        setBoundList : function (oList) {
             this._oList = oList;
             this._fnResolveListHasBeenSet(oList);
         },
@@ -6208,11 +6209,11 @@ export default class ListSelector extends UI5Object {
 
     protected readonly oWhenListLoadingIsDone: Promise<any>;
     protected readonly _oWhenListHasBeenSet: Promise<any>;
-    protected list: List;
+    protected _oList: List;
     protected _fnResolveListHasBeenSet: any;
 
     /**
-     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundMasterList
+     * Provides a convenience API for selecting list items. All the functions will wait until the initial load of the a List passed to the instance by the setBoundList
      * function.
      */
      constructor() {
@@ -6224,14 +6225,14 @@ export default class ListSelector extends UI5Object {
         // invoke selectItem functions before calling setBoundList
         this.oWhenListLoadingIsDone = new Promise(function (this: ListSelector, resolve: Function, reject: Function) {
             this._oWhenListHasBeenSet
-                .then(function (this: ListSelector, list: List) {
-                    list.getBinding(\\"items\\")?.attachEventOnce(\\"dataReceived\\",
+                .then(function (this: ListSelector, oList: List) {
+                    oList.getBinding(\\"items\\")?.attachEventOnce(\\"dataReceived\\",
                         function (this: ListSelector) {
-                            if (this.list.getItems().length) {
-                                resolve({ list });
+                            if (this._oList.getItems().length) {
+                                resolve({ oList });
                             } else {
                                 // No items in the list
-                                reject({ list });
+                                reject({ oList });
                             }
                         }.bind(this)
                     );
@@ -6245,9 +6246,9 @@ export default class ListSelector extends UI5Object {
      * @param list The list all the select functions will be invoked on.
      *
      */
-     public setBoundList(list: List) {
-        this.list = list;
-        this._fnResolveListHasBeenSet(list);
+     public setBoundList(oList: List) {
+        this._oList = oList;
+        this._fnResolveListHasBeenSet(oList);
     }
 
     /**
@@ -6260,20 +6261,20 @@ export default class ListSelector extends UI5Object {
 
         this.oWhenListLoadingIsDone.then(
             function (this: ListSelector) {
-                const list = this.list;
-                if (list.getMode() === \\"None\\") {
+                const oList = this._oList;
+                if (oList.getMode() === \\"None\\") {
                     return;
                 }
 
                 // skip update if the current selection is already matching the object path
-                const selectedItem = list.getSelectedItem();
+                const selectedItem = oList.getSelectedItem();
                 if (selectedItem && selectedItem.getBindingContext()!.getPath() === path) {
                     return;
                 }
 
-                list.getItems().some(function (oItem: ListItemBase) {
+                oList.getItems().some(function (oItem: ListItemBase) {
                     if (oItem.getBindingContext() && oItem.getBindingContext()!.getPath() === path) {
-                        list.setSelectedItem(oItem);
+                        oList.setSelectedItem(oItem);
                         return true;
                     }
                 });
@@ -6289,9 +6290,9 @@ export default class ListSelector extends UI5Object {
      * Does not trigger 'selectionChange' event on list, though.
      */
     public async clearListSelection() {
-        //use promise to make sure that 'this.list' is available
+        //use promise to make sure that 'this._oList' is available
         await this._oWhenListHasBeenSet;
-        this.list.removeSelections(true);
+        this._oList.removeSelections(true);
     }
 }",
     "state": "modified",

--- a/packages/fiori-freestyle-writer/test/basic.test.ts
+++ b/packages/fiori-freestyle-writer/test/basic.test.ts
@@ -5,8 +5,10 @@ import { removeSync } from 'fs-extra';
 import { testOutputDir, debug } from './common';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { BasicAppSettings } from '../src/types';
+import { projectChecks } from './common';
 
 const TEST_NAME = 'basicTemplate';
+jest.setTimeout(120000); // Needed when debug.enabled
 
 jest.mock('read-pkg-up', () => ({
     sync: jest.fn().mockReturnValue({
@@ -128,6 +130,8 @@ describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 

--- a/packages/fiori-freestyle-writer/test/common.ts
+++ b/packages/fiori-freestyle-writer/test/common.ts
@@ -5,6 +5,10 @@ import { readFileSync } from 'fs';
 import { sample } from './sample/metadata';
 import { create as createStore } from 'mem-fs';
 import { create } from 'mem-fs-editor';
+import type { FreestyleApp } from '../src';
+import { promisify } from 'util';
+import { exec as execCP } from 'child_process';
+const exec = promisify(execCP);
 
 export const testOutputDir = join(__dirname, '/test-output');
 
@@ -15,13 +19,14 @@ export const debug = prepareDebug();
  *          object.enabled debug enabled boolean
  *          object.outputDir output directory
  */
-export function prepareDebug(): { enabled: boolean; outputDir: string } {
+export function prepareDebug(): { enabled: boolean; outputDir: string; debugFull: boolean } {
     const debug = !!process.env['UX_DEBUG'];
+    const debugFull = !!process.env['UX_DEBUG_FULL'];
 
     if (debug) {
         console.log(testOutputDir);
     }
-    return { enabled: debug, outputDir: testOutputDir };
+    return { enabled: debug, outputDir: testOutputDir, debugFull };
 }
 
 export const commonConfig = {
@@ -60,4 +65,40 @@ export const getMetadata = (serviceName: string) => {
     }
 
     return sampleTestStore.write(metadataPath, readFileSync(metadataPath));
+};
+
+export const projectChecks = async (
+    rootPath: string,
+    config: FreestyleApp<unknown>,
+    debugFull = false
+): Promise<void> => {
+    if (debugFull && (config.appOptions?.typescript || config.appOptions?.eslint)) {
+        // Do additonal checks on generated projects
+        const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+        let npmResult;
+        try {
+            // Do npm install
+            npmResult = await exec(`${npm} install`, { cwd: rootPath });
+            console.log('stdout:', npmResult.stdout);
+            console.log('stderr:', npmResult.stderr);
+
+            // run checks on the project
+            // Check TS Types
+            if (config.appOptions?.typescript) {
+                npmResult = await exec(`${npm} run ts-typecheck`, { cwd: rootPath });
+                console.log('stdout:', npmResult.stdout);
+                console.log('stderr:', npmResult.stderr);
+            }
+            // Check Eslint
+            if (config.appOptions?.eslint) {
+                npmResult = await exec(`${npm} run lint`, { cwd: rootPath });
+                console.log('stdout:', npmResult.stdout);
+                console.log('stderr:', npmResult.stderr);
+            }
+        } catch (error) {
+            console.log('stdout:', error?.stdout);
+            console.log('stderr:', error?.stderr);
+            expect(error).toBeUndefined();
+        }
+    }
 };

--- a/packages/fiori-freestyle-writer/test/listdetail.test.ts
+++ b/packages/fiori-freestyle-writer/test/listdetail.test.ts
@@ -4,9 +4,11 @@ import { join } from 'path';
 import type { ListDetailSettings } from '../src/types';
 import { TemplateType } from '../src/types';
 import { removeSync } from 'fs-extra';
-import { commonConfig, northwind, debug, testOutputDir } from './common';
+import { commonConfig, northwind, debug, testOutputDir, projectChecks } from './common';
 
 const TEST_NAME = 'listDetailTemplate';
+
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -92,13 +94,15 @@ describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
         const testPath = join(curTestOutPath, name);
         const fs = await generate(join(testPath), config);
         expect(fs.dump(testPath)).toMatchSnapshot();
-        return new Promise((resolve) => {
+        return new Promise(async (resolve) => {
             // write out the files for debugging
             if (debug?.enabled) {
                 fs.commit(resolve);
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/fiori-freestyle-writer/test/worklist.test.ts
+++ b/packages/fiori-freestyle-writer/test/worklist.test.ts
@@ -2,11 +2,12 @@ import type { FreestyleApp } from '../src';
 import { generate, TemplateType } from '../src';
 import { join } from 'path';
 import { removeSync } from 'fs-extra';
-import { testOutputDir, debug, getMetadata } from './common';
+import { testOutputDir, debug, getMetadata, projectChecks } from './common';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { WorklistSettings } from '../src/types';
 
 const TEST_NAME = 'worklistTemplate';
+jest.setTimeout(120000); // Needed when debug.debugFull
 
 describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
     const curTestOutPath = join(testOutputDir, TEST_NAME);
@@ -164,6 +165,8 @@ describe(`Fiori freestyle template: ${TEST_NAME}`, () => {
             } else {
                 resolve(true);
             }
+        }).then(async () => {
+            await projectChecks(testPath, config, debug?.debugFull);
         });
     });
 });

--- a/packages/ui5-application-writer/src/data/defaults.ts
+++ b/packages/ui5-application-writer/src/data/defaults.ts
@@ -60,7 +60,7 @@ export const enum UI5_DEFAULT {
     SAPUI5_CDN = 'https://ui5.sap.com',
     OPENUI5_CDN = 'https://openui5.hana.ondemand.com',
     TYPES_VERSION_SINCE = '1.76.0',
-    TYPES_VERSION_PREVIOUS = '1.71.18',
+    TYPES_VERSION_PREVIOUS = '1.71.15',
     TYPES_VERSION_BEST = '1.108.0',
     ESM_TYPES_VERSION_SINCE = '1.94.0',
     MANIFEST_VERSION = '1.12.0',

--- a/packages/ui5-application-writer/templates/optional/codeAssist/.eslintrc
+++ b/packages/ui5-application-writer/templates/optional/codeAssist/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "plugins": [
     "@sap/ui5-jsdocs"
   ],

--- a/packages/ui5-application-writer/templates/optional/eslint/.eslintrc
+++ b/packages/ui5-application-writer/templates/optional/eslint/.eslintrc
@@ -1,4 +1,5 @@
-{
+{ 
+  "root": true,
   "plugins": [
     "eslint-plugin-fiori-custom"
   ],

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -4,6 +4,7 @@ exports[`UI5 templates generates options: \`codeAssist, eslint, sapux\` 1`] = `
 Object {
   ".eslintrc": Object {
     "contents": "{
+  \\"root\\": true,
   \\"plugins\\": [
     \\"@sap/ui5-jsdocs\\",
     \\"eslint-plugin-fiori-custom\\"
@@ -54,7 +55,7 @@ archive.zip
     \\"@sap/ux-specification\\": \\"latest\\",
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
-    \\"@sapui5/ts-types\\": \\"1.71.18\\",
+    \\"@sapui5/ts-types\\": \\"1.71.15\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.2.1\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\"
   },


### PR DESCRIPTION
changes for https://github.com/SAP/open-ux-tools/issues/915 
- Align FF ListDetail template between JS and TS (impacts unit tests) 
- Add `projectChecks` called in FE and FF tests when env `UX_DEBUG_FULL=true`
    - runs `npm run install` , `npm run lint` or `npm run ts-typecheck` as appropriate to speed up manual regression testing
- Add `root: true`   to all template `.eslintrc` for consistency (and allow tests above to run with inheriting eslint config from above.
- "fix" ui5 version used in TS FE V2 tests to use a version that contains the types for FE V2.
- - fix TYPES_VERSION_PREVIOUS from `1.71.18` to `1.71.15` as `1.71.18` does not exist in https://www.npmjs.com/package/@sapui5/ts-types?activeTab=versions 