### PR TITLE
fix(env-check): more robust unit test

### DIFF
--- a/packages/environment-check/test/checks/get-installed.test.ts
+++ b/packages/environment-check/test/checks/get-installed.test.ts
@@ -196,9 +196,10 @@ describe('Test install functions', () => {
     test('getFioriGenVersion() (not installed) (BAS)', async () => {
         mockIsAppStudio.mockReturnValue(true);
         jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+        jest.spyOn(command, 'spawnCommand').mockResolvedValue('MOCK_NPM_ROOT');
 
         const result = await getFioriGenVersion();
-        expect(result).toStrictEqual('Not installed or not found');
+        expect(result).toStrictEqual(t('info.notInstalledOrNotFound'));
     });
 
     test('getFioriGenVersion() (BAS) installed to NODE_PATH location', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13183,8 +13183,8 @@ packages:
   /nimnjs/1.3.2:
     resolution: {integrity: sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==}
     dependencies:
-      nimn_schema_builder: 1.1.0
       nimn-date-parser: 1.0.0
+      nimn_schema_builder: 1.1.0
     dev: false
 
   /no-case/3.0.4:


### PR DESCRIPTION
Unit tests for module `@sap-ux/environment-check` run unstable on Windows environment, e.g.:

![image](https://user-images.githubusercontent.com/66327622/221932999-9f215cd7-53d7-4bb8-97b7-238b72fb2e48.png)
https://cloud.nx.app/runs/ZmxKq3vkit/task/@sap-ux%2Fenvironment-check:test

I was not able to reproduce this issue locally on MacOS environment. Manual review of the code that is tested in the failed unit test brought this to my attention:

https://github.com/SAP/open-ux-tools/blob/7892e8f0d68761e06491bb6d87fe2f69e65e6bc8/packages/environment-check/src/checks/get-installed.ts#L142

While command 
```
npm root -g
```
should be fast, my assumption is, in certain cases it takes longer and exceeds the jest timeout of 5 seconds. 
With this PR command `npm root -g` is mocked. Additionally, I made sure the text to test for is also using the i18n text.


