### PR TITLE
chore: add slack notification to release workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -138,3 +138,21 @@ jobs:
                   publish: pnpm ci:publish
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+            - name: Prepare Slack notification message
+              if: steps.changesets.outputs.published == 'true'
+              run: |
+                # Random delimiter required to support multi-line environment variable value
+                EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+                echo "PUBLISHED_PACKAGES_MESSAGE<<$EOF" >> $GITHUB_ENV
+                # publishedPackages JSON format: '[{"name": "@sap-ux/axios-extension", "version": "1.0.2"}, {"name": "@sap-ux/fiori-freestyle-writer", "version": "0.15.12"}]'
+                echo "$(echo ${{ steps.changesets.outputs.publishedPackages }} | jq --raw-output 'map("*" + .name + "*" + " - " + "<https://www.npmjs.com/package/" + .name + "|" + .version + ">") | join("\\n")')" >> $GITHUB_ENV
+                echo "$EOF" >> $GITHUB_ENV
+                echo "${{ env.PUBLISHED_PACKAGES_MESSAGE }}"
+            - name: Send Slack notification
+              if: steps.changesets.outputs.published == 'true'
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                payload: |
+                  {"text": ":rocket: The following packages were published to npmjs.com:\n${{ env.PUBLISHED_PACKAGES_MESSAGE }}" }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Description

* Add a Slack notification step to the CI/CD pipeline when packages are published to npmjs.com