### PR TITLE
fix: allow to pass custom title when i18n resolved

### DIFF
--- a/.changeset/few-sloths-hunt.md
+++ b/.changeset/few-sloths-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITranslationInput. Fix - allow to pass custom "title" when i18n entry resolved

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -213,8 +213,8 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
 
     return (
         <UITextInput
-            title={title}
             {...props}
+            title={title}
             onRenderSuffix={value?.trim() ? onRenderSuffix : undefined}
             className={classNames}
         />

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -174,11 +174,12 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
     if (suggestion.suggest?.type === SuggestValueType.Existing && strings?.i18nEntryExistsInputTooltip) {
         // Change DOM id with additional suffix
         buttonId += '-navigate';
-        // Overwrite title with information about reference entry
-        title = formatText(strings.i18nEntryExistsInputTooltip, {
-            value: value || '',
-            translation: suggestion.suggest.entry.value.value
-        });
+        if (!title) {
+            title = formatText(strings.i18nEntryExistsInputTooltip, {
+                value: value || '',
+                translation: suggestion.suggest.entry.value.value
+            });
+        }
     }
 
     const onRenderSuffix = useCallback((): JSX.Element | null => {
@@ -212,8 +213,8 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
 
     return (
         <UITextInput
-            {...props}
             title={title}
+            {...props}
             onRenderSuffix={value?.trim() ? onRenderSuffix : undefined}
             className={classNames}
         />

--- a/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
+++ b/packages/ui-components/test/unit/components/UITranslationInput/UITranslationInput.test.tsx
@@ -414,4 +414,22 @@ describe('<UITranslationInput />', () => {
         clickI18nButton();
         expect(screen.getByText(acceptButtonLabel)).toBeDefined();
     });
+
+    test('Test "string" property', () => {
+        const externalTitle = 'dummy';
+        const { container } = render(
+            <UITranslationInput
+                id={id}
+                value={'{i18n>dummy1}'}
+                entries={entries}
+                allowedPatterns={[TranslationTextPattern.SingleBracketBinding]}
+                defaultPattern={TranslationTextPattern.SingleBracketBinding}
+                namingConvention={TranslationKeyGenerator.CamelCase}
+                title={externalTitle}
+                i18nPrefix={'i18n'}
+            />
+        );
+        // Check title
+        expect(container.querySelector(`${selectors.input} input`)?.getAttribute('title')).toEqual(externalTitle);
+    });
 });


### PR DESCRIPTION
# Issue

#23962

## Description

allow to pass custom "title" when i18n entry resolved
