### PR TITLE
fix(pipeline): incorrect notification message in slack notification step 

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -146,9 +146,8 @@ jobs:
                 EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
                 echo "PUBLISHED_PACKAGES_MESSAGE<<$EOF" >> $GITHUB_ENV
                 # publishedPackages JSON format: '[{"name": "@sap-ux/axios-extension", "version": "1.0.2"}, {"name": "@sap-ux/fiori-freestyle-writer", "version": "0.15.12"}]'
-                echo "$(echo ${{ steps.changesetPublish.outputs.publishedPackages }} | jq --raw-output 'map("*" + .name + "*" + " - " + "<https://www.npmjs.com/package/" + .name + "|" + .version + ">") | join("\\n")')" >> $GITHUB_ENV
+                echo "$(echo '${{ steps.changesetPublish.outputs.publishedPackages }}' | jq --raw-output 'map("*" + .name + "*" + " - " + "<https://www.npmjs.com/package/" + .name + "|" + .version + ">") | join("\\n")')" >> $GITHUB_ENV
                 echo "$EOF" >> $GITHUB_ENV
-                echo "${{ env.PUBLISHED_PACKAGES_MESSAGE }}"
             - name: Send Slack notification
               if: steps.changesetPublish.outputs.published == 'true'
               uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
### Issue
The latest release commit triggered the Slack notification step in the CI/CD workflow. However, the Slack notification message did not contain any information about the packages that were published.

### Description

* Update CI/CD workflow to fix the issue with incorrect notification message

Here's a sample of how the notification should look if it works correctly.

<img width="659" alt="Screenshot 2023-03-07 at 11 23 31" src="https://user-images.githubusercontent.com/84985584/223529881-22b4cee4-9e7f-49f0-8656-f668d4ba2713.png">
