### PR TITLE
fix(backend-proxy-middleware): Enable FLP Embedded preview to load in case of encoding failure

### DIFF
--- a/.changeset/two-scissors-clap.md
+++ b/.changeset/two-scissors-clap.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/backend-proxy-middleware': patch
+---
+
+Fix - enables flp embedded preview to load in case of decoding failure

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -40,7 +40,7 @@ export const ProxyEventHandlers = {
      */
     onProxyReq(proxyReq: ClientRequest, _req?: IncomingMessage, _res?: ServerResponse, _options?: ServerOptions) {
         if (proxyReq.path?.includes('Fiorilaunchpad.html') && !proxyReq.headersSent) {
-            proxyReq.setHeader('accept-encoding', 'br');
+            proxyReq.setHeader('accept-encoding', '*');
         }
     },
 

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -120,7 +120,7 @@ describe('proxy', () => {
             expect(mockSetHeader).not.toBeCalled();
 
             onProxyReq({ path: 'hello/Fiorilaunchpad.html', setHeader: mockSetHeader } as ClientRequest);
-            expect(mockSetHeader).toBeCalled();
+            expect(mockSetHeader).toBeCalledWith('accept-encoding', '*');
         });
 
         test('onProxyRes', () => {


### PR DESCRIPTION
Fix for #937