### PR TITLE
fix(env-check): ignore empty folders in archive

### DIFF
--- a/.changeset/small-clouds-raise.md
+++ b/.changeset/small-clouds-raise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/environment-check': patch
+---
+
+Remove empty folders if ignored

--- a/packages/environment-check/src/archive/index.ts
+++ b/packages/environment-check/src/archive/index.ts
@@ -78,6 +78,7 @@ async function getFileList(cwd: string): Promise<string[]> {
         cwd,
         dot,
         ignore: ignore().add(ignores),
+        mark: true,
         skip
     });
     return files;

--- a/packages/environment-check/test/archive/index.test.ts
+++ b/packages/environment-check/test/archive/index.test.ts
@@ -60,11 +60,12 @@ describe('Test for archive project, archiveProject()', () => {
         expect(zipMock.file).toHaveBeenNthCalledWith(2, join('PROJECT_ROOT/FILE_TWO'), { 'name': 'FILE_TWO' });
         const [globPattern, globOptions] = mockGlob.mock.calls[0] as [
             string[],
-            { cwd: string; dot: boolean; skip: string[]; ignore: any }
+            { cwd: string; dot: boolean; skip: string[] | undefined; mark: boolean; ignore: any }
         ];
         expect(globPattern).toEqual(['**', '.cdsrc.json', '.extconfig.json']);
         expect(globOptions.cwd).toBe('PROJECT_ROOT');
         expect(globOptions.dot).toBe(false);
+        expect(globOptions.mark).toEqual(true);
         expect(globOptions.skip).toEqual(['**/node_modules/**']);
         expect(globOptions.ignore._rules.length).toBe(2);
     });
@@ -109,11 +110,12 @@ describe('Test for archive project, archiveProject()', () => {
         expect(zipMock.file).toHaveBeenNthCalledWith(2, join('PRJ_GITIGNORE/FILE_TWO'), { 'name': 'FILE_TWO' });
         const [globPattern, globOptions] = mockGlob.mock.calls[0] as [
             string[],
-            { cwd: string; dot: boolean; skip: string[] | undefined; ignore: any }
+            { cwd: string; dot: boolean; skip: string[] | undefined; mark: boolean; ignore: any }
         ];
         expect(globPattern).toEqual(['**']);
         expect(globOptions.cwd).toBe('PRJ_GITIGNORE');
         expect(globOptions.dot).toBe(true);
+        expect(globOptions.mark).toEqual(true);
         expect(globOptions.skip).toBe(undefined);
         expect(globOptions.ignore._rules.length).toBe(3);
         expect(globOptions.ignore._rules[0].pattern).toBe('excludedir/');


### PR DESCRIPTION
See https://github.com/SAP/open-ux-tools/issues/993.

Adding option `mark: true` to `glob` does the trick, it adds `/` to directories when comparing: https://github.com/kaelzhang/node-ignore#2-filenames-and-dirnames