### PR TITLE
fix(ui-components): Fix generic type for translation input entry

### DIFF
--- a/.changeset/fuzzy-spoons-chew.md
+++ b/.changeset/fuzzy-spoons-chew.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITranslationInput. Generic type for "entries" property("I18nBundle" type) - generic type is used as parameter when "onShowExistingEntry" is called.

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
@@ -14,7 +14,7 @@ import { UILoadButton } from './UILoadButton';
 
 import './UITranslationInput.scss';
 
-export interface UITranslationButtonProps<T extends TranslationEntry = TranslationEntry> extends UITranslationProps<T> {
+export interface UITranslationButtonProps<T extends TranslationEntry> extends UITranslationProps<T> {
     onUpdateValue?: (value: string) => void;
     suggestion: TranslationSuggest<T>;
 }
@@ -37,9 +37,7 @@ const getStringText = (property: keyof TranslationInputStrings, strings?: Transl
  * @param props Component properties.
  * @returns Component to render translation button with callout.
  */
-export const UITranslationButton = <T extends TranslationEntry = TranslationEntry>(
-    props: UITranslationButtonProps<T>
-): ReactElement => {
+export const UITranslationButton = <T extends TranslationEntry>(props: UITranslationButtonProps<T>): ReactElement => {
     const { id, strings, value, onCreateNewEntry, onUpdateValue, onShowExistingEntry, busy, suggestion } = props;
     const [isCalloutVisible, setCalloutVisible] = useState(false);
     // Callbacks

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
@@ -16,7 +16,7 @@ import './UITranslationInput.scss';
 
 export interface UITranslationButtonProps<T extends TranslationEntry = TranslationEntry> extends UITranslationProps<T> {
     onUpdateValue?: (value: string) => void;
-    suggestion: TranslationSuggest;
+    suggestion: TranslationSuggest<T>;
 }
 
 /**

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.tsx
@@ -3,13 +3,18 @@ import type { ReactElement } from 'react';
 import { UIDefaultButton } from '../UIButton';
 import { UICallout, UICalloutContentPadding } from '../UICallout';
 import { UiIcons } from '../Icons';
-import type { UITranslationProps, TranslationInputStrings, TranslationSuggest } from './UITranslationButton.types';
+import type {
+    UITranslationProps,
+    TranslationInputStrings,
+    TranslationSuggest,
+    TranslationEntry
+} from './UITranslationButton.types';
 import { SuggestValueType } from './UITranslationButton.types';
 import { UILoadButton } from './UILoadButton';
 
 import './UITranslationInput.scss';
 
-export interface UITranslationButtonProps extends UITranslationProps {
+export interface UITranslationButtonProps<T extends TranslationEntry = TranslationEntry> extends UITranslationProps<T> {
     onUpdateValue?: (value: string) => void;
     suggestion: TranslationSuggest;
 }
@@ -32,7 +37,9 @@ const getStringText = (property: keyof TranslationInputStrings, strings?: Transl
  * @param props Component properties.
  * @returns Component to render translation button with callout.
  */
-export function UITranslationButton(props: UITranslationButtonProps): ReactElement {
+export const UITranslationButton = <T extends TranslationEntry = TranslationEntry>(
+    props: UITranslationButtonProps<T>
+): ReactElement => {
     const { id, strings, value, onCreateNewEntry, onUpdateValue, onShowExistingEntry, busy, suggestion } = props;
     const [isCalloutVisible, setCalloutVisible] = useState(false);
     // Callbacks
@@ -100,4 +107,4 @@ export function UITranslationButton(props: UITranslationButtonProps): ReactEleme
             )}
         </div>
     );
-}
+};

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -36,7 +36,7 @@ export interface TranslationEntry {
 
 export type I18nBundle<T extends TranslationEntry = TranslationEntry> = Record<string, T[]>;
 
-export interface UITranslationProps<T extends TranslationEntry = TranslationEntry> {
+export interface UITranslationProps<T extends TranslationEntry> {
     value?: string;
     id: string;
     disabled?: boolean;
@@ -62,7 +62,7 @@ export enum SuggestValueType {
     New = 'New'
 }
 
-export type TranslationSuggestValue<T extends TranslationEntry = TranslationEntry> =
+export type TranslationSuggestValue<T extends TranslationEntry> =
     | TranslationSuggestValueNew
     | TranslationSuggestValueExisting<T>;
 
@@ -76,13 +76,12 @@ export interface TranslationSuggestValueNew extends TranslationSuggestValueBase 
     type: SuggestValueType.New;
 }
 
-export interface TranslationSuggestValueExisting<T extends TranslationEntry = TranslationEntry>
-    extends TranslationSuggestValueBase {
+export interface TranslationSuggestValueExisting<T extends TranslationEntry> extends TranslationSuggestValueBase {
     entry: T;
     type: SuggestValueType.Existing | SuggestValueType.Update;
 }
 
-export interface TranslationSuggest<T extends TranslationEntry = TranslationEntry> {
+export interface TranslationSuggest<T extends TranslationEntry> {
     tooltip: string;
     message?: React.ReactElement;
     suggest?: TranslationSuggestValue<T>;

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -66,18 +66,20 @@ export type TranslationSuggestValue<T extends TranslationEntry = TranslationEntr
     | TranslationSuggestValueNew
     | TranslationSuggestValueExisting<T>;
 
-export interface TranslationSuggestValueNew {
-    entry: TranslationEntry;
+interface TranslationSuggestValueBase {
     icon?: UiIcons;
-    type: SuggestValueType.New;
     i18n?: string;
 }
 
-export interface TranslationSuggestValueExisting<T extends TranslationEntry = TranslationEntry> {
+export interface TranslationSuggestValueNew extends TranslationSuggestValueBase {
+    entry: TranslationEntry;
+    type: SuggestValueType.New;
+}
+
+export interface TranslationSuggestValueExisting<T extends TranslationEntry = TranslationEntry>
+    extends TranslationSuggestValueBase {
     entry: T;
-    icon?: UiIcons;
     type: SuggestValueType.Existing | SuggestValueType.Update;
-    i18n?: string;
 }
 
 export interface TranslationSuggest<T extends TranslationEntry = TranslationEntry> {

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -62,10 +62,21 @@ export enum SuggestValueType {
     New = 'New'
 }
 
-export interface TranslationSuggestValue<T extends TranslationEntry = TranslationEntry> {
+export type TranslationSuggestValue<T extends TranslationEntry = TranslationEntry> =
+    | TranslationSuggestValueNew
+    | TranslationSuggestValueExisting<T>;
+
+export interface TranslationSuggestValueNew {
+    entry: TranslationEntry;
+    icon?: UiIcons;
+    type: SuggestValueType.New;
+    i18n?: string;
+}
+
+export interface TranslationSuggestValueExisting<T extends TranslationEntry = TranslationEntry> {
     entry: T;
     icon?: UiIcons;
-    type: SuggestValueType;
+    type: SuggestValueType.Existing | SuggestValueType.Update;
     i18n?: string;
 }
 

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts
@@ -34,14 +34,14 @@ export interface TranslationEntry {
     value: TranslationEntryValue;
 }
 
-export type I18nBundle = Record<string, TranslationEntry[]>;
+export type I18nBundle<T extends TranslationEntry = TranslationEntry> = Record<string, T[]>;
 
-export interface UITranslationProps {
+export interface UITranslationProps<T extends TranslationEntry = TranslationEntry> {
     value?: string;
     id: string;
     disabled?: boolean;
     // When entry exists in passed i18n entries and user clicked on show entry button
-    onShowExistingEntry?: (entry: TranslationEntry) => void;
+    onShowExistingEntry?: (entry: T) => void;
     // When creation of new i18n entry is requested
     onCreateNewEntry?: (entry: TranslationEntry) => void;
     // Loader indicator
@@ -62,15 +62,15 @@ export enum SuggestValueType {
     New = 'New'
 }
 
-export interface TranslationSuggestValue {
-    entry: TranslationEntry;
+export interface TranslationSuggestValue<T extends TranslationEntry = TranslationEntry> {
+    entry: T;
     icon?: UiIcons;
     type: SuggestValueType;
     i18n?: string;
 }
 
-export interface TranslationSuggest {
+export interface TranslationSuggest<T extends TranslationEntry = TranslationEntry> {
     tooltip: string;
     message?: React.ReactElement;
-    suggest?: TranslationSuggestValue;
+    suggest?: TranslationSuggestValue<T>;
 }

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -9,7 +9,8 @@ import type {
     TranslationSuggestValue,
     TranslationSuggest,
     I18nBundle,
-    TranslationTextPattern
+    TranslationTextPattern,
+    TranslationEntry
 } from './UITranslationButton.types';
 import { TranslationKeyGenerator, SuggestValueType } from './UITranslationButton.types';
 import {
@@ -22,7 +23,9 @@ import {
 import { defaultTranslationInputStrings } from './defaults';
 import { UIFormattedText, formatText } from './UIFormattedText';
 
-export interface UITranslationInputProps extends ITextFieldProps, UITranslationProps {
+export interface UITranslationInputProps<T extends TranslationEntry = TranslationEntry>
+    extends ITextFieldProps,
+        UITranslationProps<T> {
     id: string;
     // Existing I18n entries
     entries: I18nBundle;
@@ -45,7 +48,9 @@ export interface UITranslationInputProps extends ITextFieldProps, UITranslationP
  * @param props Properties of translation input component.
  * @returns Translation suggestion object.
  */
-const getTranslationSuggestion = (props: UITranslationInputProps): TranslationSuggest => {
+const getTranslationSuggestion = <T extends TranslationEntry = TranslationEntry>(
+    props: UITranslationInputProps<T>
+): TranslationSuggest => {
     const {
         value = '',
         allowedPatterns,
@@ -135,7 +140,9 @@ const getTranslationSuggestion = (props: UITranslationInputProps): TranslationSu
  * @param props Component properties.
  * @returns Component to render translation input.
  */
-export function UITranslationInput(props: UITranslationInputProps): ReactElement {
+export const UITranslationInput = <T extends TranslationEntry = TranslationEntry>(
+    props: UITranslationInputProps<T>
+): ReactElement => {
     const {
         id,
         className,
@@ -219,7 +226,7 @@ export function UITranslationInput(props: UITranslationInputProps): ReactElement
             className={classNames}
         />
     );
-}
+};
 
 UITranslationInput.defaultProps = {
     strings: defaultTranslationInputStrings

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -28,7 +28,7 @@ export interface UITranslationInputProps<T extends TranslationEntry = Translatio
         UITranslationProps<T> {
     id: string;
     // Existing I18n entries
-    entries: I18nBundle;
+    entries: I18nBundle<T>;
     // PascalCase or camelCase to be used for key generation
     // Default value is 'CamelCase'
     namingConvention?: TranslationKeyGenerator;
@@ -50,7 +50,7 @@ export interface UITranslationInputProps<T extends TranslationEntry = Translatio
  */
 const getTranslationSuggestion = <T extends TranslationEntry = TranslationEntry>(
     props: UITranslationInputProps<T>
-): TranslationSuggest => {
+): TranslationSuggest<T> => {
     const {
         value = '',
         allowedPatterns,
@@ -64,7 +64,7 @@ const getTranslationSuggestion = <T extends TranslationEntry = TranslationEntry>
     const i18nKey = extractI18nKey(value, allowedPatterns, allowedI18nPrefixes || [i18nPrefix]);
     let message = '';
     let tooltip = '';
-    let suggest: TranslationSuggestValue;
+    let suggest: TranslationSuggestValue<T>;
     if (i18nKey) {
         // There is already i18n binding as value
         const entry = getTranslationByKey(entries, i18nKey);

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationInput.tsx
@@ -23,9 +23,7 @@ import {
 import { defaultTranslationInputStrings } from './defaults';
 import { UIFormattedText, formatText } from './UIFormattedText';
 
-export interface UITranslationInputProps<T extends TranslationEntry = TranslationEntry>
-    extends ITextFieldProps,
-        UITranslationProps<T> {
+export interface UITranslationInputProps<T extends TranslationEntry> extends ITextFieldProps, UITranslationProps<T> {
     id: string;
     // Existing I18n entries
     entries: I18nBundle<T>;
@@ -48,7 +46,7 @@ export interface UITranslationInputProps<T extends TranslationEntry = Translatio
  * @param props Properties of translation input component.
  * @returns Translation suggestion object.
  */
-const getTranslationSuggestion = <T extends TranslationEntry = TranslationEntry>(
+const getTranslationSuggestion = <T extends TranslationEntry>(
     props: UITranslationInputProps<T>
 ): TranslationSuggest<T> => {
     const {

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
@@ -146,7 +146,10 @@ export const applyI18nPattern = (key: string, pattern: TranslationTextPattern, p
  * @param {string} key Search for key.
  * @returns {TranslationEntry | undefined} Key if value is found.
  */
-export const getTranslationByKey = (bundle: I18nBundle, key: string): TranslationEntry | undefined => {
+export const getTranslationByKey = <T extends TranslationEntry = TranslationEntry>(
+    bundle: I18nBundle<T>,
+    key: string
+): T | undefined => {
     const entries = bundle[key];
     if (entries?.length > 0) {
         return entries[0];
@@ -161,7 +164,10 @@ export const getTranslationByKey = (bundle: I18nBundle, key: string): Translatio
  * @param {string} value Search for value.
  * @returns {TranslationEntry | undefined} Key if value is found.
  */
-export const getTranslationByText = (bundle: I18nBundle, value: string): TranslationEntry | undefined => {
+export const getTranslationByText = <T extends TranslationEntry = TranslationEntry>(
+    bundle: I18nBundle<T>,
+    value: string
+): T | undefined => {
     for (const key in bundle) {
         const entries = bundle[key];
         if (entries.length) {

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
@@ -146,7 +146,7 @@ export const applyI18nPattern = (key: string, pattern: TranslationTextPattern, p
  * @param {string} key Search for key.
  * @returns {TranslationEntry | undefined} Key if value is found.
  */
-export const getTranslationByKey = <T extends TranslationEntry = TranslationEntry>(
+export const getTranslationByKey = <T extends TranslationEntry>(
     bundle: I18nBundle<T>,
     key: string
 ): T | undefined => {
@@ -164,7 +164,7 @@ export const getTranslationByKey = <T extends TranslationEntry = TranslationEntr
  * @param {string} value Search for value.
  * @returns {TranslationEntry | undefined} Key if value is found.
  */
-export const getTranslationByText = <T extends TranslationEntry = TranslationEntry>(
+export const getTranslationByText = <T extends TranslationEntry>(
     bundle: I18nBundle<T>,
     value: string
 ): T | undefined => {

--- a/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
+++ b/packages/ui-components/src/components/UITranslationInput/UITranslationUtils.ts
@@ -146,10 +146,7 @@ export const applyI18nPattern = (key: string, pattern: TranslationTextPattern, p
  * @param {string} key Search for key.
  * @returns {TranslationEntry | undefined} Key if value is found.
  */
-export const getTranslationByKey = <T extends TranslationEntry>(
-    bundle: I18nBundle<T>,
-    key: string
-): T | undefined => {
+export const getTranslationByKey = <T extends TranslationEntry>(bundle: I18nBundle<T>, key: string): T | undefined => {
     const entries = bundle[key];
     if (entries?.length > 0) {
         return entries[0];

--- a/packages/ui-components/stories/UITranslationInput.story.tsx
+++ b/packages/ui-components/stories/UITranslationInput.story.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { IStackTokens, setFocusVisibility } from '@fluentui/react';
+import { setFocusVisibility } from '@fluentui/react';
+import type { IStackTokens } from '@fluentui/react';
 import { Stack } from '@fluentui/react';
 import type { I18nBundle, TranslationEntry } from '../src/components/UITranslationInput';
 import { TranslationTextPattern, UITranslationInput } from '../src/components/UITranslationInput';
 import { initIcons, UiIcons } from '../src/components/Icons';
-import { ColumnControlType, UIColumn, UITable } from '../src/components/UITable';
+import { UITable } from '../src/components/UITable';
+import type { UIColumn } from '../src/components/UITable';
 import { UIIconButton } from '../src/components/UIButton';
 import { UICheckbox } from '../src/components/UICheckbox';
 
@@ -20,15 +22,21 @@ interface I18nTableProps {
     onDelete: (key: string) => void;
 }
 
+interface CustomTranslationEntry extends TranslationEntry {
+    dummyPath: string;
+}
+
 initIcons();
 
 const stackTokens: IStackTokens = { childrenGap: 40 };
 
 const I18N_BUNDLE_KEY = 'ui-components-i18n-bundle';
-const getI18nBundle = (): I18nBundle => {
-    let i18nBundle: I18nBundle = {};
+const getI18nBundle = (): I18nBundle<CustomTranslationEntry> => {
+    let i18nBundle: I18nBundle<CustomTranslationEntry> = {};
     try {
-        i18nBundle = JSON.parse(window.localStorage.getItem(I18N_BUNDLE_KEY) || '') as I18nBundle;
+        i18nBundle = JSON.parse(
+            window.localStorage.getItem(I18N_BUNDLE_KEY) || ''
+        ) as I18nBundle<CustomTranslationEntry>;
     } catch (e) {
         i18nBundle = {};
     }
@@ -49,12 +57,12 @@ export const translationInput = () => {
     };
     const onCreateNewEntry = (entry: TranslationEntry) => {
         if (!i18nBundle[entry.key.value]) {
-            i18nBundle[entry.key.value] = [entry];
+            i18nBundle[entry.key.value] = [{ ...entry, dummyPath: 'dddd' }];
             updateI18nBundle(i18nBundle);
             setI18nBundle({ ...i18nBundle });
         }
     };
-    const onShowExistingEntry = (entry: TranslationEntry) => {
+    const onShowExistingEntry = (entry: CustomTranslationEntry) => {
         const cell = document.querySelector(`div[data-i18n-key="${entry.key.value}"]`) as HTMLElement;
         (cell?.parentElement as HTMLElement).focus();
         setFocusVisibility(true, cell?.parentElement as HTMLElement);


### PR DESCRIPTION
Issue #997

Trying to improve interface of `UITranslationInput` to avoid casting like:
![image](https://user-images.githubusercontent.com/90789422/234951739-6c1b96d0-eb41-4197-ac57-19d041872323.png)

Root idea is that we can pass objeect like:
```
    key: {...}.
    value: {...},
    dummyProperty: string;
```
to `entries` property(interface of [Bundle](https://github.com/SAP/open-ux-tools/blob/main/packages/ui-components/src/components/UITranslationInput/UITranslationButton.types.ts#L32-L37)) 

In result once existing entry is found in bundle and user clicks on show button -> callback `onShowExistingEntry` returns reference to original object(with custom properties).
Current problem is that `onShowExistingEntry` is defined with strict type `TranslationEntry` as `onShowExistingEntry?: (entry: TranslationEntry) => void;`, but we need more generic type like:
```
export interface UITranslationProps<T extends TranslationEntry = TranslationEntry> {
    // When entry exists in passed i18n entries and user clicked on show entry button
    onShowExistingEntry?: (entry: T) => void;
```