### PR TITLE
fix(deploy-config): Add change set, updated unit test and code to handle error logging to support test mode

### DIFF
--- a/.changeset/funny-students-speak.md
+++ b/.changeset/funny-students-speak.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+Better error logging when test mode is enabled

--- a/packages/axios-extension/src/abap/message.ts
+++ b/packages/axios-extension/src/abap/message.ts
@@ -102,16 +102,23 @@ function logFullURL({ host, path, log }: { host: string; path?: string; log: Log
 }
 
 /**
- * Log Gateway errors returned from the S_MGW_ODATA_INNER_ERROR table which is a store of OData Inner Error data.
+ * Log Gateway errors returned from the S_MGW_ODATA_INNER_ERROR table which is a store of OData Inner Error data. In certain flows,
+ * for example, when test mode is enabled, not all error details should be displayed to the user and need to be restricted.
  *
  * @param  options options
  * @param options.error error message returned from gateway
  * @param options.log logger to be used
  * @param options.host optional host name to pretty print links
+ * @param showAllMessages optional, show all errors but restrict for certain flows i.e. test mode
  */
-export function prettyPrintError({ error, log, host }: { error: ErrorMessage; log: Logger; host?: string }): void {
+export function prettyPrintError(
+    { error, log, host }: { error: ErrorMessage; log: Logger; host?: string },
+    showAllMessages = true
+): void {
     if (error) {
-        log.error(error.message?.value || 'An unknown error occurred.');
+        if (showAllMessages) {
+            log.error(error.message?.value || 'An unknown error occurred.');
+        }
         if (error.innererror) {
             (error.innererror.errordetails || []).forEach((entry) => {
                 if (!entry.message.startsWith('<![CDATA')) {
@@ -119,8 +126,10 @@ export function prettyPrintError({ error, log, host }: { error: ErrorMessage; lo
                 }
                 logFullURL({ host, path: error['longtext_url'], log });
             });
-            for (const key in error.innererror.Error_Resolution || {}) {
-                log.error(`${key}: ${error.innererror.Error_Resolution[key]}`);
+            if (showAllMessages) {
+                for (const key in error.innererror.Error_Resolution || {}) {
+                    log.error(`${key}: ${error.innererror.Error_Resolution[key]}`);
+                }
             }
         }
     }

--- a/packages/axios-extension/src/abap/message.ts
+++ b/packages/axios-extension/src/abap/message.ts
@@ -119,17 +119,15 @@ export function prettyPrintError(
         if (showAllMessages) {
             log.error(error.message?.value || 'An unknown error occurred.');
         }
-        if (error.innererror) {
-            (error.innererror.errordetails || []).forEach((entry) => {
-                if (!entry.message.startsWith('<![CDATA')) {
-                    logLevel(entry.severity, entry.message, log, true);
-                }
-                logFullURL({ host, path: error['longtext_url'], log });
-            });
-            if (showAllMessages) {
-                for (const key in error.innererror.Error_Resolution || {}) {
-                    log.error(`${key}: ${error.innererror.Error_Resolution[key]}`);
-                }
+        (error.innererror?.errordetails || []).forEach((entry) => {
+            if (!entry.message.startsWith('<![CDATA')) {
+                logLevel(entry.severity, entry.message, log, true);
+            }
+            logFullURL({ host, path: error['longtext_url'], log });
+        });
+        if (showAllMessages && error.innererror?.Error_Resolution) {
+            for (const key in error.innererror.Error_Resolution) {
+                log.error(`${key}: ${error.innererror.Error_Resolution[key]}`);
             }
         }
     }

--- a/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
+++ b/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
@@ -170,11 +170,15 @@ export class Ui5AbapRepositoryService extends ODataService {
                     : '';
                 this.log.info(`App available at ${frontendUrl}${path}${query}`);
             } else {
-                prettyPrintError({
-                    error: this.getErrorMessageFromString(response?.data),
-                    log: this.log,
-                    host: frontendUrl
-                });
+                // Test mode returns a HTTP response code of 403 so we dont want to show all error messages
+                prettyPrintError(
+                    {
+                        error: this.getErrorMessageFromString(response?.data),
+                        log: this.log,
+                        host: frontendUrl
+                    },
+                    false
+                );
             }
             return response;
         } catch (error) {

--- a/packages/axios-extension/test/abap/message.test.ts
+++ b/packages/axios-extension/test/abap/message.test.ts
@@ -58,6 +58,11 @@ describe('message helpers', () => {
             1 + Object.keys(error.innererror.Error_Resolution).length + error.innererror.errordetails.length
         );
 
+        // Restrict to only errordetails, typical for deployment with test mode enabled
+        errorMock.mockReset();
+        prettyPrintError({ error, log, host }, false);
+        expect(errorMock).toBeCalledTimes(Object.keys(error.innererror.Error_Resolution).length);
+
         delete error.message;
         delete error.innererror.errordetails;
         delete error.innererror.Error_Resolution;

--- a/packages/axios-extension/test/abap/message.test.ts
+++ b/packages/axios-extension/test/abap/message.test.ts
@@ -64,8 +64,7 @@ describe('message helpers', () => {
         expect(errorMock).toBeCalledTimes(Object.keys(error.innererror.Error_Resolution).length);
 
         delete error.message;
-        delete error.innererror.errordetails;
-        delete error.innererror.Error_Resolution;
+        delete error.innererror;
         errorMock.mockReset();
         prettyPrintError({ error, log, host });
         expect(errorMock).toBeCalledTimes(1);


### PR DESCRIPTION


Fix for https://github.com/SAP/open-ux-tools/issues/1002

- updated unit tests
- added changeset
- change validated locally

Screenshot only showing the errordetails node being handled.

![Screenshot 2023-05-12 at 16 03 55](https://github.com/SAP/open-ux-tools/assets/4520960/e364bb57-70e7-4538-9c1c-04ba01e43659)

Sample error response;
```
{
    "code": "/UI5/UI5_REP_LOAD/004",
    "message":
    {
        "lang": "en",
        "value": "Test run has indicated no problems"
    },
    "innererror":
    {
        "application":
        {
            "component_id": "CA-UI5-ABA-SAR",
            "service_namespace": "/UI5/",
            "service_id": "ABAP_REPOSITORY_SRV",
            "service_version": "0001"
        },
        "transactionid": "0F61D5F13A6D0910F",
        "timestamp": "20230480",
        "Error_Resolution":
        {
            "SAP_Transaction": "For backend administrators: use ADT feed reader \"SAP Gateway Error Log\" or run transaction /IWFND/ERROR_LOG on SAP Gateway hub system and search for entries with the timestamp above for more details",
            "SAP_Note": "See SAP Note 1797736 for error analysis (https://service.sap.com/sap/support/notes/1797736)"
        },
        "errordetails":
        [
            {
                "ContentID": "",
                "code": "/UI5/UI5_REP_LOAD/004",
                "message": "Test run has indicated no problems",
                "propertyref": "",
                "severity": "success",
                "transition": false,
                "target": "ZJLONG0205"
            }
   ]
````