### PR TITLE
fix: remove superfluous checks in template

### DIFF
--- a/packages/fe-fpm-writer/templates/common/EventHandler.js
+++ b/packages/fe-fpm-writer/templates/common/EventHandler.js
@@ -4,7 +4,7 @@ sap.ui.define([
     'use strict';
 
     return {
-        <%- (typeof eventHandlerFnName !== 'undefined' && eventHandlerFnName) || 'onPress' %>: function(oEvent) {
+        <%- eventHandlerFnName %>: function(oEvent) {
             MessageToast.show("Custom handler invoked.");
         }
     };

--- a/packages/fe-fpm-writer/templates/common/EventHandler.ts
+++ b/packages/fe-fpm-writer/templates/common/EventHandler.ts
@@ -8,6 +8,6 @@ import MessageToast from 'sap/m/MessageToast';
  * @param this reference to the 'this' that the event handler is bound to.
  * @param <%- parameters.name %> <%- parameters.description %>
  */
-export function <%- (typeof eventHandlerFnName !== 'undefined' && eventHandlerFnName) || 'onPress' %>(this: ExtensionAPI, <%- parameters.name %>: <%- parameters.importType %>) {
+export function <%- eventHandlerFnName %>(this: ExtensionAPI, <%- parameters.name %>: <%- parameters.importType %>) {
     MessageToast.show("Custom handler invoked.");
 }

--- a/packages/fe-fpm-writer/test/unit/action.test.ts
+++ b/packages/fe-fpm-writer/test/unit/action.test.ts
@@ -316,7 +316,7 @@ describe('CustomAction', () => {
                     const folder = join('ext', 'fragments');
                     const existingPath = join(testDir, 'webapp', folder, `${fileName}.js`);
                     // Generate handler with single method - content should be updated during generating of custom action
-                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath);
+                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, { eventHandlerFnName: 'onPress' });
                     // Create third action - append existing js file
                     const actionName = 'CustomAction2';
                     const fnName = 'onHandleSecondAction';

--- a/packages/fe-fpm-writer/test/unit/column.test.ts
+++ b/packages/fe-fpm-writer/test/unit/column.test.ts
@@ -271,7 +271,7 @@ describe('CustomAction', () => {
                     const folder = join('extensions', 'custom');
                     const existingPath = join(testDir, 'webapp', folder, `${fileName}.js`);
                     // Generate handler with single method - content should be updated during generating of custom column
-                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath);
+                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath,  { eventHandlerFnName: 'onPress' });
                     const fnName = 'onHandleSecondAction';
 
                     const extension = {

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -339,7 +339,7 @@ describe('CustomSection', () => {
                         }
                     };
                     // Generate handler with single method - content should be updated during generating of custom section
-                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath);
+                    fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath,  { eventHandlerFnName: 'onPress' });
 
                     generateCustomSectionWithEventHandler(id, extension, folder);
                     const xmlPath = join(testDir, 'webapp', folder, `${id}.fragment.xml`);

--- a/packages/fe-fpm-writer/test/unit/view.test.ts
+++ b/packages/fe-fpm-writer/test/unit/view.test.ts
@@ -296,7 +296,7 @@ describe('CustomView', () => {
                 const folder = join('extensions', 'custom');
                 const existingPath = join(testDir, 'webapp', folder, `${fileName}.controller.js`);
                 // Generate handler with single method - content should be updated during generating of custom view
-                fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath);
+                fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, { eventHandlerFnName: 'onPress' });
                 const fnName = 'onHandleSecondAction';
 
                 const extension = {


### PR DESCRIPTION
Removing superfluous checks in the template that make it unnecessarily complicated.
The code was detected while reviewing https://github.com/SAP/open-ux-tools/pull/985