### PR TITLE
Ui5 transpile updates

### DIFF
--- a/.changeset/clever-pants-pull.md
+++ b/.changeset/clever-pants-pull.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-writer': patch
+---
+
+Fix: incorrect settings for ui5-middleware-transpile

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/.babelrc.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/.babelrc.json
@@ -1,22 +1,25 @@
 {
-	"ignore": ["**/*.d.ts"],
-	"presets": [
-        "@babel/preset-env", 
+    "ignore": [
+        "**/*.d.ts"
+    ],
+    "presets": [
+        "@babel/preset-env",
         [
             "transform-ui5",
             {
                 "overridesToOverride": true
             }
         ],
-        "@babel/preset-typescript"],
-	"plugins": [
-		"transform-remove-console",
+        "@babel/preset-typescript"
+    ],
+    "plugins": [
+        "transform-remove-console",
         [
-			"transform-async-to-promises",
-			{
-				"inlineHelpers": true
-			}
-		]
-	],
-	"sourceMaps": true
+            "transform-async-to-promises",
+            {
+                "inlineHelpers": true
+            }
+        ]
+    ],
+    "sourceMaps": true
 }

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/.babelrc.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/.babelrc.json
@@ -1,12 +1,22 @@
 {
-    "ignore": ["**/*.d.ts"],
-    "presets": [
+	"ignore": ["**/*.d.ts"],
+	"presets": [
+        "@babel/preset-env", 
         [
             "transform-ui5",
             {
-                "addControllerStaticPropsToExtend": true
+                "overridesToOverride": true
             }
         ],
-        "@babel/preset-typescript"
-    ]
+        "@babel/preset-typescript"],
+	"plugins": [
+		"transform-remove-console",
+        [
+			"transform-async-to-promises",
+			{
+				"inlineHelpers": true
+			}
+		]
+	],
+	"sourceMaps": true
 }

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/tsconfig.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/tsconfig.json
@@ -1,22 +1,24 @@
 {
     "compilerOptions": {
-      "target": "es2015",
-      "module": "es2015",
-      "skipLibCheck": true,
-      "preserveConstEnums": true,
-      "inlineSourceMap": true,
-      "allowJs": true,
-      "strict": true,
-      "strictNullChecks": true,
-      "strictPropertyInitialization": false,
-      "moduleResolution": "node",
-      "rootDir": "webapp",
-      "outDir": "./dist",
-      "baseUrl": "./",
-      "paths": {
-        "v4travel/*": ["webapp/*"]
-      },
-      "types": [ "@sapui5/ts-types-esm" ]
+        "target": "es2022",
+        "module": "es2022",
+        "skipLibCheck": true,
+        "allowJs": true,
+        "strict": true,
+        "strictPropertyInitialization": false,
+        "moduleResolution": "node",
+        "rootDir": "./webapp",
+        "baseUrl": "./",
+        "paths": {
+            "v4travel/*": [
+                "./webapp/*"
+            ]
+        }
     },
-    "include": ["webapp/**/*"]
-  }
+    "types": [ 
+        "@sapui5/ts-types-esm" 
+    ]
+    "include": [
+        "./webapp/**/*"
+    ]
+}

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/ui5.yaml
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/ui5.yaml
@@ -27,14 +27,9 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
 builder:
   customTasks:
     - name: ui5-tooling-transpile-task
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3754,8 +3754,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -3781,9 +3779,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -3818,8 +3813,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -3838,9 +3831,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -3875,8 +3865,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -3885,9 +3873,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3703,22 +3703,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"fefeop2ts/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -3726,7 +3722,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3610,16 +3610,26 @@ exports[`Fiori Elements template: feopTemplate Generate files for template: fefe
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -3662,7 +3672,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.92\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3610,26 +3610,29 @@ exports[`Fiori Elements template: feopTemplate Generate files for template: fefe
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -3699,30 +3702,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"fefeop2ts/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"fefeop2ts/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3769,8 +3769,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -3796,9 +3794,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -3833,8 +3828,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -3853,9 +3846,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -3890,8 +3880,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -3900,9 +3888,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3718,22 +3718,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"fefpmts/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -3741,7 +3737,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3625,16 +3625,26 @@ exports[`Flexible Programming Model template: fpmTemplates Generate files for te
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -3677,7 +3687,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"latest\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.96.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3625,26 +3625,29 @@ exports[`Flexible Programming Model template: fpmTemplates Generate files for te
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -3714,30 +3717,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"fefpmts/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"fefpmts/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17683,22 +17683,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"lropV2_ts/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -17706,7 +17702,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -21180,22 +21176,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"lropV2_ts_ui5_1_108/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -21203,7 +21195,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -24666,22 +24658,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"lropV2_ts_ui5_1_111/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -24689,7 +24677,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17590,16 +17590,26 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -17642,7 +17652,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.77\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -21087,16 +21097,26 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -21139,7 +21159,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.108\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -24573,16 +24593,26 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -24625,7 +24655,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.111\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17737,8 +17737,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -17765,9 +17763,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -17803,8 +17798,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -17823,9 +17816,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -17861,8 +17851,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -17871,9 +17859,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -21244,8 +21229,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -21272,9 +21255,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -21310,8 +21290,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -21330,9 +21308,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -21368,8 +21343,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -21378,9 +21351,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -24740,8 +24710,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -24768,9 +24736,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -24806,8 +24771,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -24826,9 +24789,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -24864,8 +24824,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -24874,9 +24832,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17590,26 +17590,29 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -17679,30 +17682,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"lropV2_ts/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"lropV2_ts/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -21082,26 +21087,29 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -21171,30 +21179,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"lropV2_ts_ui5_1_108/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"lropV2_ts_ui5_1_108/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -24563,26 +24573,29 @@ exports[`Fiori Elements template: lropTemplates Generate files for template: lro
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -24652,30 +24665,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"lropV2_ts_ui5_1_111/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"lropV2_ts_ui5_1_111/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1725,22 +1725,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"feovp1/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -1748,7 +1744,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -9160,22 +9156,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"feovp2/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -9183,7 +9175,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1632,16 +1632,26 @@ exports[`Fiori Elements template: ovpTemplate Generate files for template: ovpV2
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1684,7 +1694,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.92\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -9067,16 +9077,26 @@ exports[`Fiori Elements template: ovpTemplate Generate files for template: ovpV4
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -9119,7 +9139,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.97\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.97.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1782,8 +1782,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -1809,9 +1807,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -1846,8 +1841,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -1866,9 +1859,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -1903,8 +1893,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -1913,9 +1901,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -9224,8 +9209,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -9251,9 +9234,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -9288,8 +9268,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -9308,9 +9286,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -9345,8 +9320,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -9355,9 +9328,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1632,26 +1632,29 @@ exports[`Fiori Elements template: ovpTemplate Generate files for template: ovpV2
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1721,30 +1724,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"feovp1/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"feovp1/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -9062,26 +9067,29 @@ exports[`Fiori Elements template: ovpTemplate Generate files for template: ovpV4
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -9151,30 +9159,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"feovp2/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"feovp2/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -680,16 +680,26 @@ exports[`Fiori freestyle template: basicTemplate Generate files for template: ba
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -731,7 +741,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -1324,16 +1334,26 @@ exports[`Fiori freestyle template: basicTemplate Generate files for template: ba
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1375,7 +1395,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -680,26 +680,29 @@ exports[`Fiori freestyle template: basicTemplate Generate files for template: ba
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -767,30 +770,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"nods1/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"nods1/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -1319,26 +1324,29 @@ exports[`Fiori freestyle template: basicTemplate Generate files for template: ba
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1406,30 +1414,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"nods1/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"nods1/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -771,22 +771,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"nods1/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -794,7 +790,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -1415,22 +1411,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"nods1/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -1438,7 +1430,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -826,8 +826,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -853,9 +851,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -890,8 +885,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -910,9 +903,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -947,8 +937,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -957,9 +945,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -1474,8 +1459,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -1501,9 +1484,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -1538,8 +1518,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -1558,9 +1536,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -1595,8 +1570,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -1605,9 +1578,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -4,16 +4,26 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -55,7 +65,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -2674,16 +2684,26 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -2725,7 +2745,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -7860,16 +7880,26 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -7911,7 +7941,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -95,22 +95,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"test/me/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -118,7 +114,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -2765,22 +2761,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"test/me/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -2788,7 +2780,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -7951,22 +7943,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"test/me/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -7974,7 +7962,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -4,26 +4,29 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -91,30 +94,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"test/me/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"test/me/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -2669,26 +2674,29 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -2756,30 +2764,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"test/me/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"test/me/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -5396,15 +5406,15 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"module\\": \\"none\\",
-    \\"noEmit\\": true,
-    \\"checkJs\\": true,
-    \\"allowJs\\": true,
-    \\"types\\": [
-      \\"@sapui5/ts-types\\"
-    ]
-  }
+    \\"compilerOptions\\": {
+        \\"module\\": \\"none\\",
+        \\"noEmit\\": true,
+        \\"checkJs\\": true,
+        \\"allowJs\\": true,
+        \\"types\\": [
+            \\"@sapui5/ts-types\\"
+        ]
+    }
 }",
     "state": "modified",
   },
@@ -7850,26 +7860,29 @@ exports[`Fiori freestyle template: listDetailTemplate Generate files for templat
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -7937,30 +7950,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"test/me/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"test/me/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -145,8 +145,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -172,9 +170,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -209,8 +204,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -229,9 +222,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -266,8 +256,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -276,9 +264,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -2825,8 +2810,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -2852,9 +2835,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -2889,8 +2869,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -2909,9 +2887,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -2946,8 +2921,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -2956,9 +2929,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -8021,8 +7991,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -8048,9 +8016,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -8085,8 +8050,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -8105,9 +8068,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -8142,8 +8102,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -8152,9 +8110,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -12895,16 +12895,26 @@ exports[`Fiori freestyle template: worklistTemplate Generate files for template:
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -12946,7 +12956,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -16245,16 +16255,26 @@ exports[`Fiori freestyle template: worklistTemplate Generate files for template:
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -16296,7 +16316,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -12986,22 +12986,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"wrk1/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -13009,7 +13005,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",
@@ -16336,22 +16332,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"wrk1/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -16359,7 +16351,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -13041,8 +13041,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -13071,9 +13069,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -13111,8 +13106,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -13131,9 +13124,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -13171,8 +13161,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -13181,9 +13169,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -16396,8 +16381,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: fiori-tools-proxy
@@ -16426,9 +16409,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -16466,8 +16446,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: sap-fe-mockserver
@@ -16486,9 +16464,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },
@@ -16526,8 +16501,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
 builder:
@@ -16536,9 +16509,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
 ",
     "state": "modified",
   },

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -12895,26 +12895,29 @@ exports[`Fiori freestyle template: worklistTemplate Generate files for template:
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -12982,30 +12985,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"wrk1/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"wrk1/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },
@@ -16240,26 +16245,29 @@ exports[`Fiori freestyle template: worklistTemplate Generate files for template:
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -16327,30 +16335,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"wrk1/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"wrk1/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/ui5-application-writer/src/data/ui5Libs.ts
+++ b/packages/ui5-application-writer/src/data/ui5Libs.ts
@@ -21,10 +21,7 @@ export const ui5TSSupport = {
         name: 'ui5-tooling-transpile-task',
         afterTask: 'replaceVersion',
         configuration: {
-            debug: true,
-            removeConsoleStatements: true,
-            transpileAsync: true,
-            transpileTypeScript: true
+            debug: true
         }
     },
     middleware: {
@@ -32,8 +29,6 @@ export const ui5TSSupport = {
         afterMiddleware: 'compression',
         configuration: {
             debug: true,
-            transpileAsync: true,
-            transpileTypeScript: true,
             excludePatterns: ['/Component-preload.js']
         }
     }

--- a/packages/ui5-application-writer/templates/optional/codeAssist/.eslintrc
+++ b/packages/ui5-application-writer/templates/optional/codeAssist/.eslintrc
@@ -1,10 +1,10 @@
 {
-  "root": true,
-  "plugins": [
-    "@sap/ui5-jsdocs"
-  ],
-  "extends": [
-    "plugin:@sap/ui5-jsdocs/recommended",
-    "eslint:recommended"
-  ]
+    "root": true,
+    "plugins": [
+        "@sap/ui5-jsdocs"
+    ],
+    "extends": [
+        "plugin:@sap/ui5-jsdocs/recommended",
+        "eslint:recommended"
+    ]
 }

--- a/packages/ui5-application-writer/templates/optional/codeAssist/tsconfig.json
+++ b/packages/ui5-application-writer/templates/optional/codeAssist/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "compilerOptions": {
-    "module": "none",
-    "noEmit": true,
-    "checkJs": true,
-    "allowJs": true,
-    "types": [
-      "@sapui5/ts-types"
-    ]
-  }
+    "compilerOptions": {
+        "module": "none",
+        "noEmit": true,
+        "checkJs": true,
+        "allowJs": true,
+        "types": [
+            "@sapui5/ts-types"
+        ]
+    }
 }

--- a/packages/ui5-application-writer/templates/optional/typescript/.babelrc.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/.babelrc.json
@@ -1,22 +1,25 @@
 {
-	"ignore": ["**/*.d.ts"],
-	"presets": [
-        "@babel/preset-env", 
+    "ignore": [
+        "**/*.d.ts"
+    ],
+    "presets": [
+        "@babel/preset-env",
         [
             "transform-ui5",
             {
                 "overridesToOverride": true
             }
         ],
-        "@babel/preset-typescript"],
-	"plugins": [
-		"transform-remove-console",
+        "@babel/preset-typescript"
+    ],
+    "plugins": [
+        "transform-remove-console",
         [
-			"transform-async-to-promises",
-			{
-				"inlineHelpers": true
-			}
-		]
-	],
-	"sourceMaps": true
+            "transform-async-to-promises",
+            {
+                "inlineHelpers": true
+            }
+        ]
+    ],
+    "sourceMaps": true
 }

--- a/packages/ui5-application-writer/templates/optional/typescript/.babelrc.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/.babelrc.json
@@ -1,12 +1,22 @@
 {
-    "ignore": ["**/*.d.ts"],
-    "presets": [
+	"ignore": ["**/*.d.ts"],
+	"presets": [
+        "@babel/preset-env", 
         [
             "transform-ui5",
             {
                 "overridesToOverride": true
             }
         ],
-        "@babel/preset-typescript"
-    ]
+        "@babel/preset-typescript"],
+	"plugins": [
+		"transform-remove-console",
+        [
+			"transform-async-to-promises",
+			{
+				"inlineHelpers": true
+			}
+		]
+	],
+	"sourceMaps": true
 }

--- a/packages/ui5-application-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/package.json
@@ -7,7 +7,7 @@
     },
     "devDependencies": {
         "@sapui5/ts-types-esm": "<%- ui5.typesVersion %>",
-        "ui5-tooling-transpile": "^0.7.8",
+        "ui5-tooling-transpile": "^0.7.10",
         "typescript": "^4.6.3",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",

--- a/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
@@ -1,21 +1,17 @@
 {
     "compilerOptions": {
-        "target": "es2015",
-        "module": "es2015",
+        "target": "es2022",
+        "module": "es2022",
         "skipLibCheck": true,
-        "preserveConstEnums": true,
-        "inlineSourceMap": true,
         "allowJs": true,
         "strict": true,
-        "strictNullChecks": true,
         "strictPropertyInitialization": false,
         "moduleResolution": "node",
-        "rootDir": "webapp",
-        "outDir": "./dist",
+        "rootDir": "./webapp",
         "baseUrl": "./",
         "paths": {
             "<%-app.id.replace(/\./g, '/') %>/*": [
-                "webapp/*"
+                "./webapp/*"
             ]
         },
         "types": [
@@ -23,6 +19,6 @@
         ]
     },
     "include": [
-        "webapp/**/*"
+        "./webapp/**/*"
     ]
 }

--- a/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
@@ -1,26 +1,28 @@
 {
-  "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "skipLibCheck": true,
-    "preserveConstEnums": true,
-    "inlineSourceMap": true,
-    "allowJs": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": false,
-    "moduleResolution": "node",
-    "rootDir": "webapp",
-    "outDir": "./dist",
-    "baseUrl": "./",
-    "paths": {
-      "<%-app.id.replace(/\./g, '/') %>/*": [
-        "webapp/*"
-      ]
+    "compilerOptions": {
+        "target": "es2015",
+        "module": "es2015",
+        "skipLibCheck": true,
+        "preserveConstEnums": true,
+        "inlineSourceMap": true,
+        "allowJs": true,
+        "strict": true,
+        "strictNullChecks": true,
+        "strictPropertyInitialization": false,
+        "moduleResolution": "node",
+        "rootDir": "webapp",
+        "outDir": "./dist",
+        "baseUrl": "./",
+        "paths": {
+            "<%-app.id.replace(/\./g, '/') %>/*": [
+                "webapp/*"
+            ]
+        },
+        "types": [
+            "@sapui5/ts-types-esm"
+        ]
     },
-    "types": [ "@sapui5/ts-types-esm" ]
-  },
-  "include": [
-    "webapp/**/*"
-  ]
+    "include": [
+        "webapp/**/*"
+    ]
 }

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -977,7 +977,7 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"latest\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -1037,16 +1037,26 @@ exports[`UI5 templates option: \`typescript, npm modules and Fiori tools\` 1`] =
 Object {
   ".babelrc.json": Object {
     "contents": "{
-    \\"ignore\\": [\\"**/*.d.ts\\"],
-    \\"presets\\": [
+	\\"ignore\\": [\\"**/*.d.ts\\"],
+	\\"presets\\": [
+        \\"@babel/preset-env\\", 
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"
-    ]
+        \\"@babel/preset-typescript\\"],
+	\\"plugins\\": [
+		\\"transform-remove-console\\",
+        [
+			\\"transform-async-to-promises\\",
+			{
+				\\"inlineHelpers\\": true
+			}
+		]
+	],
+	\\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1089,7 +1099,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"latest\\",
     \\"@sapui5/ts-types-esm\\": \\"~1.94.0\\",
-    \\"ui5-tooling-transpile\\": \\"^0.7.8\\",
+    \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
@@ -1165,8 +1175,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: ui5-tooling-modules-middleware
@@ -1178,9 +1186,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
     - name: ui5-tooling-modules-task
       afterTask: replaceVersion
       configuration: {}
@@ -1215,8 +1220,6 @@ server:
       afterMiddleware: compression
       configuration:
         debug: true
-        transpileAsync: true
-        transpileTypeScript: true
         excludePatterns:
           - /Component-preload.js
     - name: ui5-tooling-modules-middleware
@@ -1228,9 +1231,6 @@ builder:
       afterTask: replaceVersion
       configuration:
         debug: true
-        removeConsoleStatements: true
-        transpileAsync: true
-        transpileTypeScript: true
     - name: ui5-tooling-modules-task
       afterTask: replaceVersion
       configuration: {}

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -63,15 +63,15 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"module\\": \\"none\\",
-    \\"noEmit\\": true,
-    \\"checkJs\\": true,
-    \\"allowJs\\": true,
-    \\"types\\": [
-      \\"@sapui5/ts-types\\"
-    ]
-  }
+    \\"compilerOptions\\": {
+        \\"module\\": \\"none\\",
+        \\"noEmit\\": true,
+        \\"checkJs\\": true,
+        \\"allowJs\\": true,
+        \\"types\\": [
+            \\"@sapui5/ts-types\\"
+        ]
+    }
 }",
     "state": "modified",
   },
@@ -998,30 +998,32 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
 
 exports[`UI5 templates option: \`typescript and code assist\` to check for conflicts 2`] = `
 "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"app/with/namespace/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"app/with/namespace/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }"
 `;
 
@@ -1037,26 +1039,29 @@ exports[`UI5 templates option: \`typescript, npm modules and Fiori tools\` 1`] =
 Object {
   ".babelrc.json": Object {
     "contents": "{
-	\\"ignore\\": [\\"**/*.d.ts\\"],
-	\\"presets\\": [
-        \\"@babel/preset-env\\", 
+    \\"ignore\\": [
+        \\"**/*.d.ts\\"
+    ],
+    \\"presets\\": [
+        \\"@babel/preset-env\\",
         [
             \\"transform-ui5\\",
             {
                 \\"overridesToOverride\\": true
             }
         ],
-        \\"@babel/preset-typescript\\"],
-	\\"plugins\\": [
-		\\"transform-remove-console\\",
+        \\"@babel/preset-typescript\\"
+    ],
+    \\"plugins\\": [
+        \\"transform-remove-console\\",
         [
-			\\"transform-async-to-promises\\",
-			{
-				\\"inlineHelpers\\": true
-			}
-		]
-	],
-	\\"sourceMaps\\": true
+            \\"transform-async-to-promises\\",
+            {
+                \\"inlineHelpers\\": true
+            }
+        ]
+    ],
+    \\"sourceMaps\\": true
 }",
     "state": "modified",
   },
@@ -1122,30 +1127,32 @@ archive.zip
   },
   "tsconfig.json": Object {
     "contents": "{
-  \\"compilerOptions\\": {
-    \\"target\\": \\"es2015\\",
-    \\"module\\": \\"es2015\\",
-    \\"skipLibCheck\\": true,
-    \\"preserveConstEnums\\": true,
-    \\"inlineSourceMap\\": true,
-    \\"allowJs\\": true,
-    \\"strict\\": true,
-    \\"strictNullChecks\\": true,
-    \\"strictPropertyInitialization\\": false,
-    \\"moduleResolution\\": \\"node\\",
-    \\"rootDir\\": \\"webapp\\",
-    \\"outDir\\": \\"./dist\\",
-    \\"baseUrl\\": \\"./\\",
-    \\"paths\\": {
-      \\"app/with/namespace/*\\": [
-        \\"webapp/*\\"
-      ]
+    \\"compilerOptions\\": {
+        \\"target\\": \\"es2015\\",
+        \\"module\\": \\"es2015\\",
+        \\"skipLibCheck\\": true,
+        \\"preserveConstEnums\\": true,
+        \\"inlineSourceMap\\": true,
+        \\"allowJs\\": true,
+        \\"strict\\": true,
+        \\"strictNullChecks\\": true,
+        \\"strictPropertyInitialization\\": false,
+        \\"moduleResolution\\": \\"node\\",
+        \\"rootDir\\": \\"webapp\\",
+        \\"outDir\\": \\"./dist\\",
+        \\"baseUrl\\": \\"./\\",
+        \\"paths\\": {
+            \\"app/with/namespace/*\\": [
+                \\"webapp/*\\"
+            ]
+        },
+        \\"types\\": [
+            \\"@sapui5/ts-types-esm\\"
+        ]
     },
-    \\"types\\": [ \\"@sapui5/ts-types-esm\\" ]
-  },
-  \\"include\\": [
-    \\"webapp/**/*\\"
-  ]
+    \\"include\\": [
+        \\"webapp/**/*\\"
+    ]
 }",
     "state": "modified",
   },

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -999,22 +999,18 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
 exports[`UI5 templates option: \`typescript and code assist\` to check for conflicts 2`] = `
 "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"app/with/namespace/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -1022,7 +1018,7 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }"
 `;
@@ -1128,22 +1124,18 @@ archive.zip
   "tsconfig.json": Object {
     "contents": "{
     \\"compilerOptions\\": {
-        \\"target\\": \\"es2015\\",
-        \\"module\\": \\"es2015\\",
+        \\"target\\": \\"es2022\\",
+        \\"module\\": \\"es2022\\",
         \\"skipLibCheck\\": true,
-        \\"preserveConstEnums\\": true,
-        \\"inlineSourceMap\\": true,
         \\"allowJs\\": true,
         \\"strict\\": true,
-        \\"strictNullChecks\\": true,
         \\"strictPropertyInitialization\\": false,
         \\"moduleResolution\\": \\"node\\",
-        \\"rootDir\\": \\"webapp\\",
-        \\"outDir\\": \\"./dist\\",
+        \\"rootDir\\": \\"./webapp\\",
         \\"baseUrl\\": \\"./\\",
         \\"paths\\": {
             \\"app/with/namespace/*\\": [
-                \\"webapp/*\\"
+                \\"./webapp/*\\"
             ]
         },
         \\"types\\": [
@@ -1151,7 +1143,7 @@ archive.zip
         ]
     },
     \\"include\\": [
-        \\"webapp/**/*\\"
+        \\"./webapp/**/*\\"
     ]
 }",
     "state": "modified",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13045,8 +13045,8 @@ packages:
   /nimnjs/1.3.2:
     resolution: {integrity: sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==}
     dependencies:
-      nimn_schema_builder: 1.1.0
       nimn-date-parser: 1.0.0
+      nimn_schema_builder: 1.1.0
     dev: false
 
   /no-case/3.0.4:


### PR DESCRIPTION
The latest version of the `ui5-middleware-transpile` is using the `.bablrc` if it exists and ignores settings from the `ui5.yaml`, however, our generated projects contain a mix of both.
This PR 
* moves all settings into the `.babelrc` and thereby fixes #1035
* updates the patch version of the `ui5-tooling-transpile`
* applies consistent indentation