### PR TITLE
fix: cds dynamic import

### DIFF
--- a/.changeset/lemon-feet-crash.md
+++ b/.changeset/lemon-feet-crash.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+properly handle "@sap/cds" dynamic import

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -116,6 +116,7 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
  * @returns - environment config for CAP project
  */
 export async function getCapEnvironment(capProjectPath: string): Promise<CdsEnvironment> {
-    const cds = await loadModuleFromProject<CdsFacade>(capProjectPath, '@sap/cds');
+    const module = await loadModuleFromProject<CdsFacade | { default: CdsFacade }>(capProjectPath, '@sap/cds');
+    const cds: CdsFacade = 'default' in module ? module.default : module;
     return cds.env.for('cds', capProjectPath);
 }

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -146,12 +146,26 @@ describe('Test getCapEnvironment', () => {
         jest.restoreAllMocks();
     });
 
-    test('default export', async () => {
+    test('without default property', async () => {
         const forSpy = jest.fn();
         jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => {
             return Promise.resolve({
                 env: {
                     for: forSpy
+                }
+            });
+        });
+        await getCapEnvironment('PROJECT_ROOT');
+        expect(forSpy).toHaveBeenCalledWith('cds', 'PROJECT_ROOT');
+    });
+    test('default export', async () => {
+        const forSpy = jest.fn();
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => {
+            return Promise.resolve({
+                default: {
+                    env: {
+                        for: forSpy
+                    }
                 }
             });
         });


### PR DESCRIPTION
There is an issue when loading `@sap/cds` module dynamically, because some of it's API's are exposed as getters on a class, which does not work well with transpiled import from typescript. It uses `Object.prototype.hasOwnProperty` which returns `false` for such getters and thus causes errors in runtime.

However, it also exposes the whole object as `default` property and this seems to be safe to use.