### PR TITLE
feat(project-access): add path to manifest.appdescr_variant to search…

### DIFF
--- a/.changeset/clean-mails-act.md
+++ b/.changeset/clean-mails-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': minor
+---
+
+Add path to manifest.appdescr_variant to search results of search for adaptation projects

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -276,7 +276,7 @@ async function filterAdaptations(pathMap: FileMapAndCache): Promise<AdaptationRe
     for (const manifestAppDescrVar of manifestAppDescrVars) {
         const adpPath = await findFileUp('.adp', dirname(manifestAppDescrVar));
         if (adpPath && (await fileExists(join(adpPath, FileName.AdaptationConfig)))) {
-            results.push({ appRoot: dirname(adpPath) });
+            results.push({ appRoot: dirname(adpPath), manifestAppdescrVariantPath: manifestAppDescrVar });
         }
     }
     return results;

--- a/packages/project-access/src/types/find/index.ts
+++ b/packages/project-access/src/types/find/index.ts
@@ -38,6 +38,11 @@ export interface AdaptationResults {
      * Root of the adapted application where package.json and ui5.yaml resides.
      */
     appRoot: string;
+
+    /**
+     * Path to manifest.appdescr_variant
+     */
+    manifestAppdescrVariantPath: string;
 }
 
 /**

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -179,7 +179,13 @@ describe('Test findFioriArtifacts()', () => {
         });
         expect(result.applications?.length).toBeGreaterThan(0);
         expect(result.adaptations).toEqual([
-            { appRoot: join(testDataRoot, 'project/find-all-apps/adaptations/valid-adaptation') }
+            {
+                appRoot: join(testDataRoot, 'project/find-all-apps/adaptations/valid-adaptation'),
+                manifestAppdescrVariantPath: join(
+                    testDataRoot,
+                    'project/find-all-apps/adaptations/valid-adaptation/webapp/manifest.appdescr_variant'
+                )
+            }
         ]);
         expect(result.extensions).toEqual([
             {


### PR DESCRIPTION
Ticket https://github.com/SAP/open-ux-tools/issues/1037

Add path to `manifest.appdescr_variant` to search results of search for adaptation projects.