### PR TITLE
Fix/1052/handle 401 undeployment

### DIFF
--- a/.changeset/forty-snails-judge.md
+++ b/.changeset/forty-snails-judge.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/axios-extension': patch
+'@sap-ux/deploy-tooling': patch
+---
+
+handle 401 for undeployment

--- a/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
+++ b/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
@@ -198,8 +198,8 @@ export class Ui5AbapRepositoryService extends ODataService {
     public async undeploy({ bsp, testMode = false }: UndeployConfig): Promise<AxiosResponse | undefined> {
         const config = this.createConfig(bsp.transport, testMode);
         const host = this.getAbapFrontendUrl();
+        const info: AppInfo = await this.getInfo(bsp.name);
         try {
-            const info: AppInfo = await this.getInfo(bsp.name);
             if (info) {
                 const response = await this.deleteRepoRequest(bsp.name, config);
                 if (response?.headers?.['sap-message']) {

--- a/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
+++ b/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
@@ -228,7 +228,7 @@ describe('Ui5AbapRepositoryService', () => {
         test('failed removal', async () => {
             nock(server)
                 .delete(`${Ui5AbapRepositoryService.PATH}/Repositories(%27${validApp}%27)?${updateParams}`)
-              .replyWithError('Failed');
+                .replyWithError('Failed');
             await expect(service.undeploy({ bsp: { name: validApp } })).rejects.toThrowError();
         });
 

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -26,6 +26,16 @@ import { promptConfirmation, promptCredentials, promptServiceKeys } from './prom
 type BasicAuth = Required<Pick<BackendSystem, 'username' | 'password'>>;
 type ServiceAuth = Required<Pick<BackendSystem, 'serviceKeys' | 'name'>> & { refreshToken?: string };
 
+const deploymentCommands = { tryUndeploy, tryDeploy };
+
+/**
+ * Internal deployment commands
+ */
+const enum TryCommands {
+    Deploy = 'tryDeploy',
+    UnDeploy = 'tryUndeploy'
+}
+
 /**
  * Check the secure storage if it has credentials for the given target.
  *
@@ -152,63 +162,71 @@ async function createDeployService(config: AbapDeployConfig, logger?: Logger): P
 }
 
 /**
- * Try executing the deployment command and handle known errors.
+ * Handle exceptions thrown, in some cases we to retry them.
  *
- * @param archive - archive file that is to be deployed
+ * @param command - the request type deploy | undeploy
+ * @param error - thrown error object
  * @param service - instance of the axios-extension deployment service
- * @param config - deployment configuration
+ * @param config - configuration used for the previous request
  * @param logger - reference to the logger instance
+ * @param archive - archive file that is to be deployed
  */
-async function tryDeploy(archive: Buffer, service: Ui5AbapRepositoryService, config: AbapDeployConfig, logger: Logger) {
-    try {
-        await service.deploy({ archive, bsp: config.app, testMode: config.test, safeMode: config.safe });
-    } catch (e) {
-        if (!config.noRetry && isAxiosError(e)) {
-            const success = await handleAxiosError(e.response, archive, service, config, logger);
-            if (success) {
-                return;
-            }
+async function handleError(
+    command: TryCommands,
+    error: Error,
+    service: Ui5AbapRepositoryService,
+    config: AbapDeployConfig,
+    logger: Logger,
+    archive: Buffer
+): Promise<void> {
+    if (!config.noRetry && isAxiosError(error)) {
+        const success = await handleAxiosError(command, error.response, service, config, logger, archive);
+        if (success) {
+            return;
         }
-        logger.error('Deployment has failed.');
-        logger.debug(getConfigForLogging(config));
-        if (!config.verbose) {
-            logger.error(
-                'Change logging level to debug your issue\n\t(see examples https://github.com/SAP/open-ux-tools/tree/main/packages/deploy-tooling#configuration-with-logging-enabled)'
-            );
-        }
-
-        throw e;
     }
+    logger.error(`${command === TryCommands.Deploy ? 'Deployment' : 'Undeployment'} has failed.`);
+    logger.debug(getConfigForLogging(config));
+    if (!config.verbose) {
+        logger.error(
+            'Change logging level to debug your issue\n\t(see examples https://github.com/SAP/open-ux-tools/tree/main/packages/deploy-tooling#configuration-with-logging-enabled)'
+        );
+    }
+    throw error;
 }
 
 /**
  * Main function for different deploy retry handling.
  *
+ * @param command - the request type deploy | undeploy
  * @param response - response of that triggered and axios error
- * @param archive - archive file that is to be deployed
  * @param service - instance of the axios-extension deployment service
  * @param config - configuration used for the previous request
  * @param logger - reference to the logger instance
+ * @param archive - archive file that is to be deployed
  * @returns true if the error was handled otherwise false is return or an error is raised
  */
 async function handleAxiosError(
+    command: TryCommands,
     response: AxiosError['response'],
-    archive: Buffer,
     service: Ui5AbapRepositoryService,
     config: AbapDeployConfig,
-    logger: Logger
+    logger: Logger,
+    archive: Buffer
 ): Promise<boolean> {
     switch (response?.status) {
         case 401:
-            logger.warn('Deployment failed with authentication error.');
+            logger.warn(
+                `${command === TryCommands.Deploy ? 'Deployment' : 'Undeployment'} failed with authentication error.`
+            );
             logger.info(
                 'Please maintain correct credentials to avoid seeing this error\n\t(see help: https://www.npmjs.com/package/@sap/ux-ui5-tooling#setting-environment-variables-in-a-env-file)'
             );
-            logger.info('Please enter your credentials for this deployment.');
+            logger.info('Please enter your credentials.');
             const credentials = await promptCredentials(service.defaults.auth?.username);
             if (Object.keys(credentials).length) {
                 service.defaults.auth = credentials;
-                await tryDeploy(archive, service, config, logger);
+                await deploymentCommands[command](service, config, logger, archive);
                 return true;
             } else {
                 return false;
@@ -216,13 +234,82 @@ async function handleAxiosError(
         case 412:
             logger.warn('An app in the same repository with different sap app id found.');
             if (config.yes || (await promptConfirmation('Do you want to overwrite (Y/n)?'))) {
-                await tryDeploy(archive, service, { ...config, safe: false, noRetry: true }, logger);
+                await deploymentCommands[command](service, { ...config, safe: false, noRetry: true }, logger, archive);
                 return true;
             } else {
                 return false;
             }
         default:
             return false;
+    }
+}
+
+/**
+ * Generate a Ui5AbapRepositoryService instance from the supplied deployment config.
+ *
+ * @param config - deployment configuration
+ * @param logger - reference to the logger instance
+ * @returns service returns the UI5 ABAP Repository service
+ */
+async function getAbapService(config: AbapDeployConfig, logger: Logger): Promise<Ui5AbapRepositoryService> {
+    const service = await createDeployService(config, logger);
+    service.log = logger;
+    if (!config.strictSsl) {
+        logger.warn(
+            'You chose not to validate SSL certificate. Please verify the server certificate is trustful before proceeding. See documentation for recommended configuration (https://help.sap.com/viewer/17d50220bcd848aa854c9c182d65b699/Latest/en-US/4b318bede7eb4021a8be385c46c74045.html).'
+        );
+    }
+    return service;
+}
+
+/**
+ * Generic method to run the deployment request i.e. deploy | undeploy.
+ *
+ * @param command - the request type deploy | undeploy to be executed
+ * @param config - deployment configuration
+ * @param logger - reference to the logger instance
+ * @param archive - archive file that is to be deployed
+ */
+async function runCommand(
+    command: TryCommands,
+    config: AbapDeployConfig,
+    logger: Logger,
+    archive: Buffer = Buffer.from('')
+): Promise<void> {
+    const service = await getAbapService(config, logger);
+    logger.info(
+        `Starting to ${command === TryCommands.Deploy ? 'deploy' : 'undeploy'}${
+            config.test === true ? ' in test mode' : ''
+        }.`
+    );
+    await deploymentCommands[command](service, config, logger, archive);
+}
+
+/**
+ * Try executing the deployment command and handle known errors.
+ *
+ * @param service - instance of the axios-extension deployment service
+ * @param config - deployment configuration
+ * @param logger - reference to the logger instance
+ * @param archive - archive file that is to be deployed
+ */
+async function tryDeploy(
+    service: Ui5AbapRepositoryService,
+    config: AbapDeployConfig,
+    logger: Logger,
+    archive: Buffer
+): Promise<void> {
+    try {
+        await service.deploy({ archive, bsp: config.app, testMode: config.test, safeMode: config.safe });
+        if (config.test === true) {
+            logger.info(
+                'Deployment in TestMode completed. A successful TestMode execution does not necessarily mean that your upload will be successful.'
+            );
+        } else {
+            logger.info('Successfully deployed.');
+        }
+    } catch (error) {
+        await handleError(TryCommands.Deploy, error, service, config, logger, archive);
     }
 }
 
@@ -237,40 +324,37 @@ export async function deploy(archive: Buffer, config: AbapDeployConfig, logger: 
     if (config.keep) {
         writeFileSync(`archive.zip`, archive);
     }
-    const service = await createDeployService(config, logger);
-    service.log = logger;
-    if (!config.strictSsl) {
-        logger.warn(
-            'You chose not to validate SSL certificate. Please verify the server certificate is trustful before proceeding. See documentation for recommended configuration (https://help.sap.com/viewer/17d50220bcd848aa854c9c182d65b699/Latest/en-US/4b318bede7eb4021a8be385c46c74045.html).'
-        );
-    }
-    logger.info(`Starting to deploy${config.test === true ? ' in test mode' : ''}.`);
-    await tryDeploy(archive, service, config, logger);
-    if (config.test === true) {
-        logger.info(
-            'Deployment in TestMode completed. A successful TestMode execution does not necessarily mean that your upload will be successful.'
-        );
-    } else {
-        logger.info('Successfully deployed.');
+    await runCommand(TryCommands.Deploy, config, logger, archive);
+}
+
+/**
+ * Try executing the undeployment command and handle known errors.
+ *
+ * @param service - instance of the axios-extension deployment service
+ * @param config - deployment configuration
+ * @param logger - reference to the logger instance
+ */
+async function tryUndeploy(service: Ui5AbapRepositoryService, config: AbapDeployConfig, logger: Logger): Promise<void> {
+    try {
+        await service.undeploy({ bsp: config.app, testMode: config.test });
+        if (config.test === true) {
+            logger.info(
+                'Undeployment in TestMode completed. A successful TestMode execution does not necessarily mean that your undeploy will be successful.'
+            );
+        } else {
+            logger.info('Successfully undeployed.');
+        }
+    } catch (error) {
+        await handleError(TryCommands.UnDeploy, error, service, config, logger, Buffer.from(''));
     }
 }
 
 /**
- * Deploy the given archive to the given target using the given app description.
+ * Undeploy the given project from the given target using the given app name.
  *
  * @param config - deployment configuration
  * @param logger - reference to the logger instance
  */
 export async function undeploy(config: AbapDeployConfig, logger: Logger): Promise<void> {
-    const service = await createDeployService(config, logger);
-    service.log = logger;
-    if (!config.strictSsl) {
-        logger.warn(
-            'You chose not to validate SSL certificate. Please verify the server certificate is trustful before proceeding. See documentation for recommended configuration (https://help.sap.com/viewer/17d50220bcd848aa854c9c182d65b699/Latest/en-US/4b318bede7eb4021a8be385c46c74045.html).'
-        );
-    }
-    logger.info(`Starting to undeploy${config.test === true ? ' in test mode' : ''}.`);
-    if (await service.undeploy({ bsp: config.app, testMode: config.test })) {
-        logger.info('Successfully undeployed.');
-    }
+    await runCommand(TryCommands.UnDeploy, config, logger);
 }


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1052

- undeployment flow is not handling failed 401 requests
- cleaned up code so both deployment and undeployment use the same error handlers and logging
- added unit tests
- changeset added

Note: axios-extension was changed so the getInfo method fails and doesnt log the error message which is handled by the calling client i.e. deploy-tooling. This is the same approach for deployment flow as well.

```
2023-06-01 09:42:44 warn    abap-deploy-task: You chose not to validate SSL certificate. Please verify the server certificate is trustful before proceeding. See documentation for recommended configuration (https://help.sap.com/viewer/17d50220bcd848aa854c9c182d65b699/Latest/en-US/4b318bede7eb4021a8be385c46c74045.html). 
2023-06-01 09:42:44 info    abap-deploy-task: Starting to undeploy. 
2023-06-01 09:42:44 debug   abap-deploy-task: Retrieving application ZJLONG0205, Error: Request failed with status code 401 
2023-06-01 09:42:44 warn    abap-deploy-task: Undeployment failed with authentication error. 
2023-06-01 09:42:44 info    abap-deploy-task: Please maintain correct credentials to avoid seeing this error
        (see help: https://www.npmjs.com/package/@sap/ux-ui5-tooling#setting-environment-variables-in-a-env-file) 
2023-06-01 09:42:44 info    abap-deploy-task: Please enter your credentials. 
✔ Username: … longjo
✔ Password: … *********************
2023-06-01 09:42:55 debug   abap-deploy-task: Retrieving application ZJLONG0205, Error: Request failed with status code 404 
2023-06-01 09:42:55 warn    abap-deploy-task: Application ZJLONG0205 not found, nothing to undeploy. 
2023-06-01 09:42:55 info    abap-deploy-task: Successfully undeployed. 

```