### PR TITLE
fix(fpm-writer): update template of typescript Controller Extension after changes in 'transform-ui5' settings(.babelrc.json)

### DIFF
--- a/.changeset/new-bags-obey.md
+++ b/.changeset/new-bags-obey.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix: generated typescript controller extension does not work with latest ui5-application-writer version

--- a/packages/fe-fpm-writer/templates/controller-extension/Controller.ts
+++ b/packages/fe-fpm-writer/templates/controller-extension/Controller.ts
@@ -6,7 +6,7 @@ import ExtensionAPI from 'sap/fe/<%- typeof extension === "object" ? `templates/
  * @controller
  */
 export default class <%- name %> extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.

--- a/packages/fe-fpm-writer/templates/controller-extension/ControllerExtension.d.ts
+++ b/packages/fe-fpm-writer/templates/controller-extension/ControllerExtension.d.ts
@@ -3,7 +3,7 @@
  */
 declare module 'sap/ui/core/mvc/ControllerExtension' {
     export default class ControllerExtension<API> {
-        static override: unknown;
+        static overrides: unknown;
         base: {
             getExtensionAPI(): API;
         }

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -565,7 +565,7 @@ export function onAppended() {
  */
 declare module 'sap/ui/core/mvc/ControllerExtension' {
     export default class ControllerExtension<API> {
-        static override: unknown;
+        static overrides: unknown;
         base: {
             getExtensionAPI(): API;
         }
@@ -583,7 +583,7 @@ import ExtensionAPI from 'sap/fe/templates/ObjectPage/ExtensionAPI';
  * @controller
  */
 export default class MyControllerExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/index.test.ts.snap
@@ -798,53 +798,6 @@ export function onPress(this: ExtensionAPI, event: UI5Event) {
 </core:FragmentDefinition>",
     "state": "modified",
   },
-  "ts/webapp/ext/sap.fe.d.ts": Object {
-    "contents": "import ExtensionAPI from 'sap/fe/core/ExtensionAPI';
-import Routing from 'sap/fe/core/controllerextensions/Routing';
-import EditFlow from 'sap/fe/core/controllerextensions/EditFlow';
-import IntentBasedNavigation from 'sap/fe/core/controllerextensions/IntentBasedNavigation';
-
-/**
- * Missing public properties (https://ui5.sap.com/#/api/sap.fe.core.ExtensionAPI)
- */
-interface ExtensionAPIProperties {
-    routing: Routing;
-    editFlow: EditFlow;
-    intentBasedNavigation: IntentBasedNavigation;
-}
-
-/**
- * Add missing public properties
- */
-declare module 'sap/fe/core/ExtensionAPI' {
-	export default interface ExtensionAPI extends ExtensionAPIProperties {}
-}
-
-/**
- * Add missing public properties
- */
-declare module 'sap/fe/templates/ObjectPage/ExtensionAPI' {
-	export default interface ExtensionAPI extends ExtensionAPIProperties {}
-}
-
-/**
- * Add missing public properties
- */
-declare module 'sap/fe/templates/ListReport/ExtensionAPI' {
-	export default interface ExtensionAPI extends ExtensionAPIProperties {}
-}
-
-/**
- * Enhancing the PageController type to simplify the work with the extension API
- */
-declare module 'sap/fe/core/PageController' {
-	export default interface PageController {
-		getExtensionAPI() : ExtensionAPI;
-	}
-}
-",
-    "state": "modified",
-  },
   "ts/webapp/manifest.json": Object {
     "contents": "{
   \\"_version\\": \\"1.32.0\\",
@@ -906,7 +859,7 @@ declare module 'sap/fe/core/PageController' {
       \\"css\\": []
     },
     \\"dependencies\\": {
-      \\"minUI5Version\\": \\"1.94.0\\",
+      \\"minUI5Version\\": \\"1.108.0\\",
       \\"libs\\": {
         \\"sap.ui.core\\": {},
         \\"sap.fe.templates\\": {}

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/package.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/package.json
@@ -16,7 +16,7 @@
     "@sap/ux-specification": "latest",
     "@sap-ux/ui5-middleware-fe-mockserver": "2",
     "@sapui5/ts-types-esm": "1.106.0",
-    "ui5-tooling-transpile": "^0.3.7",
+    "ui5-tooling-transpile": "^0.7.10",
     "typescript": "^4.6.3",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0"

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/tsconfig.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/tsconfig.json
@@ -17,7 +17,7 @@
     },
     "types": [ 
         "@sapui5/ts-types-esm" 
-    ]
+    ],
     "include": [
         "./webapp/**/*"
     ]

--- a/packages/fe-fpm-writer/test/test-input/basic-ts/webapp/manifest.json
+++ b/packages/fe-fpm-writer/test/test-input/basic-ts/webapp/manifest.json
@@ -56,7 +56,7 @@
             "css": []
         },
         "dependencies": {
-            "minUI5Version": "1.94.0",
+            "minUI5Version": "1.108.0",
             "libs": {
                 "sap.ui.core": {}
             }

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
@@ -639,7 +639,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller C
  */
 declare module 'sap/ui/core/mvc/ControllerExtension' {
     export default class ControllerExtension<API> {
-        static override: unknown;
+        static overrides: unknown;
         base: {
             getExtensionAPI(): API;
         }
@@ -691,7 +691,7 @@ import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -748,7 +748,7 @@ import ExtensionAPI from 'sap/fe/templates/ObjectPage/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -805,7 +805,7 @@ import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -862,7 +862,7 @@ import ExtensionAPI from 'sap/fe/core/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -919,7 +919,7 @@ import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -976,7 +976,7 @@ import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
@@ -1033,7 +1033,7 @@ import ExtensionAPI from 'sap/fe/templates/ObjectPage/ExtensionAPI';
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
-	static override = {
+	static overrides = {
 		/**
 		 * Called when a controller is instantiated and its View controls (if available) are already created.
 		 * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.


### PR DESCRIPTION
Root issue https://github.com/SAP/open-ux-tools/issues/987
Root PR was [#1020](https://github.com/SAP/open-ux-tools/pull/1020)
This PR fixes follow up issue in `fpm-writer`

Generated `controller.ts` by `fpm-writer` does not work using new configuration(#1020):
```
{
    "ignore": ["**/*.d.ts"],
    "presets": [
        [
            "transform-ui5",
            {
                "overridesToOverride": true
            }
        ],
        "@babel/preset-typescript"
    ]
}
```

Old version of `controller.ts` was:
```
export default class Global2 extends ControllerExtension<ExtensionAPI> {
        static override = {
            onInit(this: Global2) {
                const model = this.base.getExtensionAPI().getModel();
            }
        }
    }
```
Which gets transpiled into:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/fd2ede6d-e133-4630-8fc7-0d8e0381f7f3)
such combination does not works.

Working version with `overrides` instead of `override`:
```
export default class Global2 extends ControllerExtension<ExtensionAPI> {
        static overrides = {
            onInit(this: Global2) {
                const model = this.base.getExtensionAPI().getModel();
            }
        }
    }
```
Then it is transpiled to:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/dcb65e4d-50fa-41ac-b3d9-024abbd0461b)
