### PR TITLE
fix(fpm-writer): allow to create custom section and subsection without 'position' property

### DIFF
--- a/.changeset/spicy-flies-happen.md
+++ b/.changeset/spicy-flies-happen.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix. Allow create custom section and subsection without position

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -14,7 +14,7 @@ export interface CustomSection extends CustomElement, EventHandler {
     /**
      * Defines the position of the section relative to other sections.
      */
-    position: Position;
+    position?: Position;
 
     /**
      * Optional control XML that will be generated into the fragment of section. If the property isn't provided then a sample control will be generated.

--- a/packages/fe-fpm-writer/templates/section/1.85/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.85/manifest.json
@@ -11,14 +11,14 @@
                                         "<%- name %>": {
                                             "name": "<%- ns %>.<%- name %>",
                                             "type": "XMLFragment",
-                                            "position": {
+                                            <%if (typeof position !== 'undefined') {%>"position": {
                                                 <% if (position.placement) { %> 
-                                                    "placement": "<%- position.placement %>", 
+                                                    "placement": "<%- position.placement %>"<% if (position.anchor) { %>,<% } %>
                                                 <% } %>
                                                 <% if (position.anchor) { %> 
                                                     "anchor": "<%- position.anchor %>" 
                                                 <% } %>
-                                            },
+                                            },<% } %>
                                             "title": "<%- title %>"
                                         }
                                     }

--- a/packages/fe-fpm-writer/templates/section/1.86/manifest.json
+++ b/packages/fe-fpm-writer/templates/section/1.86/manifest.json
@@ -10,14 +10,14 @@
                                     "sections": {
                                         "<%- name %>": {
                                             "template": "<%- ns %>.<%- name %>",
-                                            "position": {
+                                            <%if (typeof position !== 'undefined') {%>"position": {
                                                 <% if (position.placement) { %> 
-                                                    "placement": "<%- position.placement %>", 
+                                                    "placement": "<%- position.placement %>"<% if (position.anchor) { %>,<% } %>
                                                 <% } %>
                                                 <% if (position.anchor) { %> 
                                                     "anchor": "<%- position.anchor %>" 
                                                 <% } %>
-                                            },
+                                            },<% } %>
                                             "title": "<%- title %>"
                                         }
                                     }

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CustomSection generateCustomSection Test 'position' property. Create with anchor - 1.85 ui5 1`] = `
+Object {
+  "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "position": Object {
+    "anchor": "Dummy",
+    "placement": "Before",
+  },
+  "title": "New Custom Section",
+  "type": "XMLFragment",
+}
+`;
+
+exports[`CustomSection generateCustomSection Test 'position' property. Create with anchor - latest ui5 1`] = `
+Object {
+  "position": Object {
+    "anchor": "Dummy",
+    "placement": "Before",
+  },
+  "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "title": "New Custom Section",
+}
+`;
+
+exports[`CustomSection generateCustomSection Test 'position' property. Create without anchor - 1.85 ui5 1`] = `
+Object {
+  "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "position": Object {
+    "placement": "Before",
+  },
+  "title": "New Custom Section",
+  "type": "XMLFragment",
+}
+`;
+
+exports[`CustomSection generateCustomSection Test 'position' property. Create without anchor - latest ui5 1`] = `
+Object {
+  "position": Object {
+    "placement": "Before",
+  },
+  "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "title": "New Custom Section",
+}
+`;
+
+exports[`CustomSection generateCustomSection Test 'position' property. Create without position - 1.85 ui5 1`] = `
+Object {
+  "name": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "title": "New Custom Section",
+  "type": "XMLFragment",
+}
+`;
+
+exports[`CustomSection generateCustomSection Test 'position' property. Create without position - latest ui5 1`] = `
+Object {
+  "template": "sapux.fe.fpm.writer.test.extensions.custom.NewCustomSection",
+  "title": "New Custom Section",
+}
+`;
+
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom file and function names 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox>

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -379,5 +379,66 @@ describe('CustomSection', () => {
                 expect(result).toEqual(expectedAfterSave);
             });
         });
+
+        const positionTests = [
+            {
+                name: 'Create with anchor - latest ui5',
+                position: {
+                    placement: Placement.Before,
+                    anchor: 'Dummy'
+                }
+            },
+            {
+                name: 'Create without anchor - latest ui5',
+                position: {
+                    placement: Placement.Before
+                }
+            },
+            {
+                name: 'Create without position - latest ui5',
+                position: undefined
+            },
+            {
+                name: 'Create with anchor - 1.85 ui5',
+                position: {
+                    placement: Placement.Before,
+                    anchor: 'Dummy'
+                },
+                minUI5Version: '1.85.1'
+            },
+            {
+                name: 'Create without anchor - 1.85 ui5',
+                position: {
+                    placement: Placement.Before
+                },
+                minUI5Version: '1.85.1'
+            },
+            {
+                name: 'Create without position - 1.85 ui5',
+                position: undefined,
+                minUI5Version: '1.85.1'
+            }
+        ];
+        positionTests.forEach((testCase) => {
+            test(`Test 'position' property. ${testCase.name}`, () => {
+                generateCustomSection(
+                    testDir,
+                    {
+                        ...customSection,
+                        position: testCase.position,
+                        minUI5Version: testCase.minUI5Version
+                    },
+                    fs
+                );
+                const manifest = fs.readJSON(join(testDir, 'webapp/manifest.json')) as Manifest;
+                const options = manifest?.['sap.ui5']?.['routing']?.['targets']?.['sample']?.['options'] as Record<
+                    string,
+                    any
+                >;
+                const section =
+                    options?.['settings']?.['content']?.['body']?.['sections']?.['NewCustomSection'];
+                expect(section).toMatchSnapshot();
+            });
+        });
     });
 });

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -435,8 +435,7 @@ describe('CustomSection', () => {
                     string,
                     any
                 >;
-                const section =
-                    options?.['settings']?.['content']?.['body']?.['sections']?.['NewCustomSection'];
+                const section = options?.['settings']?.['content']?.['body']?.['sections']?.['NewCustomSection'];
                 expect(section).toMatchSnapshot();
             });
         });


### PR DESCRIPTION
Issue #1066

We noticed that it is not posible to create custom section without `position`, because it was considered as required property.
Making `position` property option similar like for custom actions.