### PR TITLE
Chore - bump version of @sap-ux/eslint-plugin-fiori-tools used in templates

### DIFF
--- a/.changeset/tricky-pillows-suffer.md
+++ b/.changeset/tricky-pillows-suffer.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux/fiori-elements-writer': patch
+'@sap-ux/fiori-freestyle-writer': patch
+'@sap-ux/ui5-application-writer': patch
+'@sap-ux/ui5-library-writer': patch
+---
+
+Chore - bump version of @sap-ux/eslint-plugin-fiori-tools used in templates

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3680,7 +3680,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3695,7 +3695,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -17664,7 +17664,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -21158,7 +21158,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -24641,7 +24641,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1702,7 +1702,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -9135,7 +9135,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -749,7 +749,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -1390,7 +1390,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -72,7 +72,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -2739,7 +2739,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -5379,7 +5379,7 @@ archive.zip
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
     \\"@sapui5/ts-types\\": \\"1.71.15\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
@@ -7923,7 +7923,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -12966,7 +12966,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -16313,7 +16313,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/ui5-application-writer/templates/optional/eslint/package.json
+++ b/packages/ui5-application-writer/templates/optional/eslint/package.json
@@ -3,7 +3,7 @@
         "lint": "eslint ./"
     },
     "devDependencies": {
-        "@sap-ux/eslint-plugin-fiori-tools": "^0.1.0",
+        "@sap-ux/eslint-plugin-fiori-tools": "^0.2.0",
         "eslint": "7.32.0",
         "eslint-plugin-fiori-custom": "2.6.7",
         "@babel/eslint-parser": "7.14.7"

--- a/packages/ui5-application-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/package.json
@@ -11,6 +11,6 @@
         "typescript": "^4.6.3",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
-        "@sap-ux/eslint-plugin-fiori-tools": "^0.1.0"
+        "@sap-ux/eslint-plugin-fiori-tools": "^0.2.0"
     }
 }

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -46,7 +46,7 @@ archive.zip
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
     \\"@sapui5/ts-types\\": \\"1.71.15\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\"
   },
@@ -981,7 +981,7 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\"
   },
   \\"scripts\\": {
     \\"start\\": \\"ui5 serve --config=ui5.yaml --open index.html\\",
@@ -1104,7 +1104,7 @@ archive.zip
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",
     \\"@typescript-eslint/parser\\": \\"^5.59.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"ui5-tooling-modules\\": \\"^0.6.0\\"
   },
   \\"scripts\\": {

--- a/packages/ui5-library-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-library-writer/templates/optional/typescript/package.json
@@ -22,7 +22,7 @@
       "typescript": "^4.6.3",
       "@sap/ux-ui5-tooling": "1",
       "ui5-tooling-transpile": "^0.7.10",
-      "@sap-ux/eslint-plugin-fiori-tools": "^0.1.0"
+      "@sap-ux/eslint-plugin-fiori-tools": "^0.2.0"
     },
     "scripts": {
         "build": "run-p -l build-app build-interface",

--- a/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
@@ -604,7 +604,7 @@ module.exports = function (config) {
     \\"npm-run-all\\": \\"^4.1.5\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\"
   },
   \\"scripts\\": {
     \\"build\\": \\"run-p -l build-app build-interface\\",
@@ -1254,7 +1254,7 @@ module.exports = function (config) {
     \\"npm-run-all\\": \\"^4.1.5\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.1.0\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\"
   },
   \\"scripts\\": {
     \\"build\\": \\"run-p -l build-app build-interface\\",


### PR DESCRIPTION
Chore - bump version of @sap-ux/eslint-plugin-fiori-tools used in templates needed after https://github.com/SAP/open-ux-tools/pull/1008

