### PR TITLE
Removing types version workaround

### DIFF
--- a/.changeset/nice-ears-push.md
+++ b/.changeset/nice-ears-push.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-config': minor
+---
+
+Removed types determination workaround.

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3690,7 +3690,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"latest\\",
-    \\"@sapui5/ts-types-esm\\": \\"~1.96.0\\",
+    \\"@sapui5/ts-types-esm\\": \\"~1.96.11\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -24636,7 +24636,7 @@ archive.zip
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"@sap/ux-specification\\": \\"UI5-1.111\\",
-    \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
+    \\"@sapui5/ts-types-esm\\": \\"~1.111.0\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -1385,7 +1385,7 @@ archive.zip
   \\"devDependencies\\": {
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
-    \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
+    \\"@sapui5/ts-types-esm\\": \\"~1.108.1\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -5378,7 +5378,7 @@ archive.zip
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
-    \\"@sapui5/ts-types\\": \\"1.71.15\\",
+    \\"@sapui5/ts-types\\": \\"~1.76.0\\",
     \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\",

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -16308,7 +16308,7 @@ archive.zip
   \\"devDependencies\\": {
     \\"@ui5/cli\\": \\"^3.0.0\\",
     \\"@sap/ux-ui5-tooling\\": \\"1\\",
-    \\"@sapui5/ts-types-esm\\": \\"~1.108.0\\",
+    \\"@sapui5/ts-types-esm\\": \\"~1.108.1\\",
     \\"ui5-tooling-transpile\\": \\"^0.7.10\\",
     \\"typescript\\": \\"^4.6.3\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^5.59.0\\",

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -45,7 +45,7 @@ archive.zip
     \\"@sap/ux-specification\\": \\"latest\\",
     \\"eslint\\": \\"7.32.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
-    \\"@sapui5/ts-types\\": \\"1.71.15\\",
+    \\"@sapui5/ts-types\\": \\"~1.76.0\\",
     \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.2.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\"

--- a/packages/ui5-application-writer/test/data.test.ts
+++ b/packages/ui5-application-writer/test/data.test.ts
@@ -28,7 +28,7 @@ describe('Setting defaults', () => {
                 localVersion: UI5_DEFAULT.DEFAULT_LOCAL_UI5_VERSION,
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
-                typesVersion: `${UI5_DEFAULT.TYPES_VERSION_PREVIOUS}`,
+                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -43,7 +43,7 @@ describe('Setting defaults', () => {
                 localVersion: UI5_DEFAULT.DEFAULT_LOCAL_UI5_VERSION,
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
-                typesVersion: `${UI5_DEFAULT.TYPES_VERSION_PREVIOUS}`,
+                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -58,7 +58,7 @@ describe('Setting defaults', () => {
                 localVersion: '1.72.0',
                 minUI5Version: '1.72.0',
                 descriptorVersion: '1.17.0',
-                typesVersion: `${UI5_DEFAULT.TYPES_VERSION_PREVIOUS}`,
+                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -75,7 +75,7 @@ describe('Setting defaults', () => {
                 localVersion: UI5_DEFAULT.DEFAULT_LOCAL_UI5_VERSION,
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
-                typesVersion: `${UI5_DEFAULT.TYPES_VERSION_PREVIOUS}`,
+                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
                 ui5Theme: 'sap_fiori_3_dark',
                 ui5Libs: defaultUI5Libs
             }
@@ -186,7 +186,7 @@ describe('Setting defaults', () => {
                 localVersion: '1.199.0',
                 minUI5Version: '1.199.0',
                 descriptorVersion: '1.49.0',
-                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_BEST}`,
+                typesVersion: `~1.199.0`,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -220,7 +220,7 @@ describe('Setting defaults', () => {
                 localVersion: '1.76.0',
                 minUI5Version: '1.28.0',
                 descriptorVersion: '1.12.0',
-                typesVersion: `${UI5_DEFAULT.TYPES_VERSION_PREVIOUS}`,
+                typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }

--- a/packages/ui5-config/src/defaults.ts
+++ b/packages/ui5-config/src/defaults.ts
@@ -7,10 +7,8 @@ export const enum UI5_DEFAULT {
     SAPUI5_CDN = 'https://ui5.sap.com',
     OPENUI5_CDN = 'https://openui5.hana.ondemand.com',
     TYPES_VERSION_SINCE = '1.76.0',
-    TYPES_VERSION_BEST_MIN = '1.102.0',
-    TYPES_VERSION_PREVIOUS = '1.71.15',
-    TYPES_VERSION_BEST = '1.108.0',
     ESM_TYPES_VERSION_SINCE = '1.94.0',
+    TYPES_VERSION_BEST = '1.108.0',
     MANIFEST_VERSION = '1.12.0',
     BASE_COMPONENT = 'sap/ui/core/UIComponent'
 }

--- a/packages/ui5-config/src/utils.ts
+++ b/packages/ui5-config/src/utils.ts
@@ -23,21 +23,20 @@ export function mergeObjects<B, E>(base: B, extension: E): B & E {
 
 /**
  * Get the best types version for the given minUI5Version within a selective range, starting at 1.90.0
- * for https://www.npmjs.com/package/@sapui5/ts-types-esm
- * For the latest versions the LTS S/4 on-premise version (1.102.x) is used, for anything before we
- * match the versions as far back as available.
+ * for https://www.npmjs.com/package/@sapui5/ts-types-esm. For anything before use 1.90.0, and if no
+ * minVersion is provided, use the latest LTS version (1.108.x).
  *
  * @param minUI5Version the minimum UI5 version that needs to be supported
  * @returns semantic version representing the types version.
  */
 export function getEsmTypesVersion(minUI5Version?: string) {
     const version = semVer.coerce(minUI5Version);
-    if (!version || semVer.gte(version, UI5_DEFAULT.TYPES_VERSION_BEST_MIN)) {
+    if (!version) {
         return `~${UI5_DEFAULT.TYPES_VERSION_BEST}`;
+    } else if (semVer.lt(version, UI5_DEFAULT.ESM_TYPES_VERSION_SINCE)) {
+        return `~${UI5_DEFAULT.ESM_TYPES_VERSION_SINCE}`;
     } else {
-        return semVer.gte(version, UI5_DEFAULT.ESM_TYPES_VERSION_SINCE)
-            ? `~${semVer.major(version)}.${semVer.minor(version)}.0`
-            : `~${UI5_DEFAULT.ESM_TYPES_VERSION_SINCE}`;
+        return `~${semVer.major(version)}.${semVer.minor(version)}.${semVer.patch(version)}`;
     }
 }
 
@@ -51,11 +50,9 @@ export function getTypesVersion(minUI5Version?: string) {
     const version = semVer.coerce(minUI5Version);
     if (!version) {
         return `~${UI5_DEFAULT.TYPES_VERSION_BEST}`;
-    } else if (semVer.gte(version, UI5_DEFAULT.TYPES_VERSION_BEST)) {
-        return `~${UI5_DEFAULT.TYPES_VERSION_BEST}`;
+    } else if (semVer.lt(version, UI5_DEFAULT.TYPES_VERSION_SINCE)) {
+        return `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`;
     } else {
-        return semVer.gte(version, UI5_DEFAULT.TYPES_VERSION_SINCE)
-            ? `~${semVer.major(version)}.${semVer.minor(version)}.${semVer.patch(version)}`
-            : UI5_DEFAULT.TYPES_VERSION_PREVIOUS;
+        return `~${semVer.major(version)}.${semVer.minor(version)}.${semVer.patch(version)}`;
     }
 }

--- a/packages/ui5-config/test/utils.test.ts
+++ b/packages/ui5-config/test/utils.test.ts
@@ -47,7 +47,7 @@ describe('mergeObjects', () => {
 describe('getEsmTypesVersion, getTypesVersion', () => {
     const esmTypesVersionSince = `~${UI5_DEFAULT.ESM_TYPES_VERSION_SINCE}`;
     const typesVersionBest = `~${UI5_DEFAULT.TYPES_VERSION_BEST}`;
-    const minU5Version = UI5_DEFAULT.TYPES_VERSION_PREVIOUS;
+    const minU5Version = `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`;
     const tesTSTypesEsmData: [any, string][] = [
         [UI5_DEFAULT.MIN_UI5_VERSION, esmTypesVersionSince],
         ['1', esmTypesVersionSince],
@@ -59,14 +59,14 @@ describe('getEsmTypesVersion, getTypesVersion', () => {
         ['1.80-snapshot', esmTypesVersionSince],
         ['metadata', typesVersionBest],
         [undefined, typesVersionBest],
-        ['1.109.1', typesVersionBest],
+        ['1.109.1', '~1.109.1'],
         [UI5_DEFAULT.TYPES_VERSION_BEST, typesVersionBest],
-        ['1.109-snapshot', typesVersionBest],
+        ['1.109-snapshot', '~1.109.0'],
         ['1.80-snapshot', esmTypesVersionSince],
-        ['1.102-snapshot', typesVersionBest],
+        ['1.102-snapshot', '~1.102.0'],
         ['1.91.0', '~1.94.0']
     ];
-    const tesTSTypesData: [any, string][] = [
+    const testSTypesData: [any, string][] = [
         [UI5_DEFAULT.MIN_UI5_VERSION, minU5Version],
         ['1', minU5Version],
         ['1.70.0', minU5Version],
@@ -80,10 +80,10 @@ describe('getEsmTypesVersion, getTypesVersion', () => {
         ['1.75.0', minU5Version],
         ['1.83.0', '~1.83.0'],
         [UI5_DEFAULT.TYPES_VERSION_BEST, typesVersionBest],
-        ['1.109.1', typesVersionBest],
+        ['1.109.1', '~1.109.1'],
         ['1.80-snapshot', '~1.80.0'],
         ['1.102-snapshot', '~1.102.0'],
-        ['1.109-snapshot', typesVersionBest]
+        ['1.109-snapshot', '~1.109.0']
     ];
     // Tests validation of versions against known versions https://www.npmjs.com/package/@sapui5/ts-types-esm
     test.each(tesTSTypesEsmData)('Types version for @sapui5/ts-types-esm: (%p, %p)', (input, expected) => {
@@ -91,7 +91,7 @@ describe('getEsmTypesVersion, getTypesVersion', () => {
     });
 
     // Tests validation of versions against known versions https://www.npmjs.com/package/@sapui5/ts-types
-    test.each(tesTSTypesData)('Types version for @sapui5/ts-types: (%p, %p)', (input, expected) => {
+    test.each(testSTypesData)('Types version for @sapui5/ts-types: (%p, %p)', (input, expected) => {
         expect(getTypesVersion(input)).toEqual(expected);
     });
 });


### PR DESCRIPTION
A few months ago we implemented an algorithm to detect the best possible UI5 types library version based on internal knowledge of fixes and downports to specific versions. The problematic versions are now out of support so that the downports are not required anymore and that we can use the latest available version.

This PR removes that algorithm and goes back to a simple version mapping.