### PR TITLE
fix(environment-check): ignore `.git` folder for archive

### DIFF
--- a/.changeset/hungry-games-hug.md
+++ b/.changeset/hungry-games-hug.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/environment-check': patch
+---
+
+exclude `.git` folder in archive

--- a/packages/environment-check/src/archive/index.ts
+++ b/packages/environment-check/src/archive/index.ts
@@ -72,7 +72,9 @@ async function getFileList(cwd: string): Promise<string[]> {
     const hasGitignore = existsSync(gitignorePath);
     const globPattern = hasGitignore ? ['**'] : ['**', '.cdsrc.json', '.extconfig.json'];
     const dot = hasGitignore;
-    const ignores = hasGitignore ? (await promises.readFile(gitignorePath)).toString() : ['**/.env', '**/node_modules'];
+    const ignores = hasGitignore
+        ? `${(await promises.readFile(gitignorePath)).toString()}\n**/.git`
+        : ['**/.env', '**/.git', '**/node_modules'];
     const skip = hasGitignore ? undefined : ['**/node_modules/**'];
 
     const files = await glob(globPattern, {

--- a/packages/environment-check/test/archive/index.test.ts
+++ b/packages/environment-check/test/archive/index.test.ts
@@ -67,7 +67,8 @@ describe('Test for archive project, archiveProject()', () => {
         expect(globOptions.dot).toBe(false);
         expect(globOptions.mark).toEqual(true);
         expect(globOptions.skip).toEqual(['**/node_modules/**']);
-        expect(globOptions.ignore._rules.length).toBe(2);
+        expect(globOptions.ignore._rules.length).toBe(3);
+        expect(globOptions.ignore._rules[0].pattern).toBe('**/.git');
     });
 
     test('Archive sample project with default name and .gitignore (mocked, no real zip is created)', async () => {
@@ -117,10 +118,11 @@ describe('Test for archive project, archiveProject()', () => {
         expect(globOptions.dot).toBe(true);
         expect(globOptions.mark).toEqual(true);
         expect(globOptions.skip).toBe(undefined);
-        expect(globOptions.ignore._rules.length).toBe(3);
+        expect(globOptions.ignore._rules.length).toBe(4);
         expect(globOptions.ignore._rules[0].pattern).toBe('excludedir/');
         expect(globOptions.ignore._rules[1].pattern).toBe('excludefile');
         expect(globOptions.ignore._rules[2].pattern).toBe('**/nm');
+        expect(globOptions.ignore._rules[3].pattern).toBe('**/.git');
     });
 
     test('Archive sample project TEST (mocked, no real zip is created), should write to TEST.zip', async () => {

--- a/packages/environment-check/test/archive/index.test.ts
+++ b/packages/environment-check/test/archive/index.test.ts
@@ -68,7 +68,7 @@ describe('Test for archive project, archiveProject()', () => {
         expect(globOptions.mark).toEqual(true);
         expect(globOptions.skip).toEqual(['**/node_modules/**']);
         expect(globOptions.ignore._rules.length).toBe(3);
-        expect(globOptions.ignore._rules[0].pattern).toBe('**/.git');
+        expect(globOptions.ignore._rules[1].pattern).toBe('**/.git');
     });
 
     test('Archive sample project with default name and .gitignore (mocked, no real zip is created)', async () => {


### PR DESCRIPTION
#1087 

Ignores `.git` folder in project when archiving.