### PR TITLE
fix(deploy-tooling): Update createAbapServiceProvider to support service keys

### DIFF
--- a/.changeset/eighty-dragons-rescue.md
+++ b/.changeset/eighty-dragons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+support reading from secure store to retrieve service keys for onpremise abap systems

--- a/packages/deploy-tooling/test/__mocks__/index.ts
+++ b/packages/deploy-tooling/test/__mocks__/index.ts
@@ -27,3 +27,5 @@ export const mockIsAppStudio = isAppStudio as jest.Mock;
 export const mockListDestinations = listDestinations as jest.Mock;
 
 export const mockCreateForAbap = mockedAxiosExtension.createForAbap as jest.Mock;
+
+export const mockCreateForAbapOnCloud = mockedAxiosExtension.createForAbapOnCloud as jest.Mock;


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1089

- tested locally in vscode reading secure store
- updated test cases

Fiori UI project with scp: false but secure storage has service keys available for the onpremise ABAP system;
<img width="1219" alt="Screenshot 2023-06-30 at 12 44 03" src="https://github.com/SAP/open-ux-tools/assets/4520960/065c6912-4e68-474a-9419-7f9e4c96e389">


