### PR TITLE
fix: cds v7 dynamic loading

### DIFF
--- a/.changeset/tricky-panthers-bathe.md
+++ b/.changeset/tricky-panthers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix "getCapModelAndServices" for CDS v7

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -94,7 +94,7 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
  * @returns {*}  {Promise<{ model: csn; services: ServiceInfo[] }>} - CAP Model and Services
  */
 export async function getCapModelAndServices(projectRoot: string): Promise<{ model: csn; services: ServiceInfo[] }> {
-    const cds = await loadModuleFromProject<CdsFacade>(projectRoot, '@sap/cds');
+    const cds = await loadCdsModuleFromProject(projectRoot);
     const capProjectPaths = await getCapCustomPaths(projectRoot);
     const modelPaths = [
         join(projectRoot, capProjectPaths.app),
@@ -114,13 +114,24 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
  * Get CAP CDS project environment config for project root.
  *
  * @param capProjectPath - project root of a CAP project
- * @returns - environment config for CAP project
+ * @returns - environment config for a CAP project
  */
 export async function getCapEnvironment(capProjectPath: string): Promise<CdsEnvironment> {
-    const module = await loadModuleFromProject<CdsFacade | { default: CdsFacade }>(capProjectPath, '@sap/cds');
-    const cds: CdsFacade = 'default' in module ? module.default : module;
+    const cds = await loadCdsModuleFromProject(capProjectPath);
     return cds.env.for('cds', capProjectPath);
 }
+
+/*
+* Load CAP CDS module for a project based on its root.
+*
+* @param capProjectPath - project root of a CAP project
+* @returns - CAP CDS module for a CAP project
+*/
+async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFacade> {
+   const module = await loadModuleFromProject<CdsFacade | { default: CdsFacade }>(capProjectPath, '@sap/cds');
+  return 'default' in module ? module.default : module;
+}
+
 
 /**
  * Get absolute path to a resource.

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -121,17 +121,16 @@ export async function getCapEnvironment(capProjectPath: string): Promise<CdsEnvi
     return cds.env.for('cds', capProjectPath);
 }
 
-/*
-* Load CAP CDS module for a project based on its root.
-*
-* @param capProjectPath - project root of a CAP project
-* @returns - CAP CDS module for a CAP project
-*/
+/**
+ * Load CAP CDS module for a project based on its root.
+ *
+ * @param capProjectPath - project root of a CAP project
+ * @returns - CAP CDS module for a CAP project
+ */
 async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFacade> {
-   const module = await loadModuleFromProject<CdsFacade | { default: CdsFacade }>(capProjectPath, '@sap/cds');
-  return 'default' in module ? module.default : module;
+    const module = await loadModuleFromProject<CdsFacade | { default: CdsFacade }>(capProjectPath, '@sap/cds');
+    return 'default' in module ? module.default : module;
 }
-
 
 /**
  * Get absolute path to a resource.

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -91,6 +91,39 @@ describe('Test getCapModelAndServices()', () => {
         ]);
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
     });
+
+    test('cds v7 exports', async () => {
+          // Mock setup
+           const cdsMock = {
+            env: {
+                'for': () => ({
+                    folders: {
+                        app: 'APP',
+                        db: 'DB',
+                        srv: 'SRV'
+                    }
+                })
+            },
+            load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
+            compile: { to: { serviceinfo: jest.fn().mockImplementation(() => 'SERVICES') } }
+        };
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => {
+            return Promise.resolve({
+                default: cdsMock
+            });
+        });
+         // Test execution
+        const capMS = await getCapModelAndServices('PROJECT_ROOT');
+
+        // Check results
+        expect(capMS).toEqual({ model: 'MODEL', services: 'SERVICES' });
+        expect(cdsMock.load).toBeCalledWith([
+            join('PROJECT_ROOT', 'APP'),
+            join('PROJECT_ROOT', 'SRV'),
+            join('PROJECT_ROOT', 'DB')
+        ]);
+        expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
+    });
 });
 
 describe('Test getCapCustomPaths()', () => {

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -93,8 +93,8 @@ describe('Test getCapModelAndServices()', () => {
     });
 
     test('cds v7 exports', async () => {
-          // Mock setup
-           const cdsMock = {
+        // Mock setup
+        const cdsMock = {
             env: {
                 'for': () => ({
                     folders: {
@@ -112,7 +112,7 @@ describe('Test getCapModelAndServices()', () => {
                 default: cdsMock
             });
         });
-         // Test execution
+        // Test execution
         const capMS = await getCapModelAndServices('PROJECT_ROOT');
 
         // Check results


### PR DESCRIPTION
Similar change to #1043.

Fixed issue where `getCapModelAndServices` was crashing when used in project with `@sap/cds` version 7.

Starting with version `7.0.0` of `@sap/cds` functions are only available under `default` export. In order try avoiding similar issues I created a utility function that properly loads the CDS module.

