### PR TITLE
tbi(deploy-tooling): improve abap service provider error handling

### DIFF
--- a/.changeset/smart-crabs-cross.md
+++ b/.changeset/smart-crabs-cross.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+improve error handling for abap service provider

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -119,6 +119,11 @@ async function createAbapServiceProvider(
                 password: storedOpts.password
             };
         }
+        if ((storedOpts as unknown as ServiceAuth)?.serviceKeys) {
+            throw new Error(
+                'This is an ABAP Cloud system, please add the --cloud arg to ensure the correct deployment flow.'
+            );
+        }
     }
     return createForAbap(options);
 }

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -97,6 +97,16 @@ async function createAbapCloudServiceProvider(
 }
 
 /**
+ * Checks if credentials are of basic auth type.
+ *
+ * @param authOpts credential options
+ * @returns boolean
+ */
+function isBasicAuth(authOpts: BasicAuth | ServiceAuth | undefined): authOpts is BasicAuth {
+    return !!authOpts && (authOpts as BasicAuth).password !== undefined;
+}
+
+/**
  * Enhance axios options and create a service provider instance for an on-premise ABAP system.
  *
  * @param options - predefined axios options
@@ -112,14 +122,14 @@ async function createAbapServiceProvider(
         options.params['sap-client'] = target.client;
     }
     if (!options.auth) {
-        const storedOpts = await getCredentials<BasicAuth>(target);
-        if (storedOpts?.password) {
+        const storedOpts = await getCredentials<BasicAuth | ServiceAuth>(target);
+        if (isBasicAuth(storedOpts)) {
             options.auth = {
                 username: storedOpts.username,
                 password: storedOpts.password
             };
         }
-        if ((storedOpts as unknown as ServiceAuth)?.serviceKeys) {
+        if ((storedOpts as ServiceAuth)?.serviceKeys) {
             throw new Error(
                 'This is an ABAP Cloud system, please add the --cloud arg to ensure the correct deployment flow.'
             );

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -315,7 +315,7 @@ async function tryDeploy(
                 'Deployment in TestMode completed. A successful TestMode execution does not necessarily mean that your upload will be successful.'
             );
         } else {
-            logger.info('Successfully deployed.');
+            logger.info('Deployment Successful.');
         }
     } catch (error) {
         await handleError(TryCommands.Deploy, error, service, config, logger, archive);
@@ -351,7 +351,7 @@ async function tryUndeploy(service: Ui5AbapRepositoryService, config: AbapDeploy
                 'Undeployment in TestMode completed. A successful TestMode execution does not necessarily mean that your undeploy will be successful.'
             );
         } else {
-            logger.info('Successfully undeployed.');
+            logger.info('Undeployment Successful.');
         }
     } catch (error) {
         await handleError(TryCommands.UnDeploy, error, service, config, logger, Buffer.from(''));

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -169,6 +169,26 @@ describe('base/deploy', () => {
             });
         });
 
+        test('Throws error when cloud system read from store but cloud target is not specified in params', async () => {
+            mockedUi5RepoService.deploy.mockResolvedValue(undefined);
+            await deploy(archive, { app, target, yes: true }, nullLogger);
+            mockedStoreService.read.mockResolvedValueOnce({
+                serviceKeys: {
+                    'uaa': {},
+                    'url': 'https://mock-url.com'
+                }
+            });
+
+            try {
+                await deploy(archive, { app, target, yes: true }, nullLogger);
+                fail('Should have thrown an error');
+            } catch (error) {
+                expect(error.message).toBe(
+                    'This is an ABAP Cloud system, please add the --cloud arg to ensure the correct deployment flow.'
+                );
+            }
+        });
+
         test('Successful retry after known axios error', async () => {
             mockedUi5RepoService.deploy.mockResolvedValue(undefined);
             mockedUi5RepoService.deploy.mockRejectedValueOnce(axiosError(412));


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1089#issuecomment-1614595199

In the case the config does not specify `--cloud` and the target returns a abap cloud system, return an informative error.