### PR TITLE
fix(project-access): function to convert cds to edmx

### DIFF
--- a/.changeset/grumpy-maps-press.md
+++ b/.changeset/grumpy-maps-press.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': minor
+---
+
+Add functionality to convert CDS into EDMX

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -13,6 +13,7 @@ export {
     isCapJavaProject,
     isCapNodeJsProject,
     loadModuleFromProject,
+    readCapServiceMetadataEdmx,
     readUi5Yaml
 } from './project';
 export { getFilePaths } from './file';

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -151,8 +151,8 @@ function findServiceByUri(
     services: { name: string; urlPath: string }[],
     uri: string
 ): { name: string; urlPath: string } | undefined {
-    const searchUri = uri.replace(/[\\\/]/g, '/'); // replace all \ and / in service uri due to issues on Windows with backslashes
-    return services.find((srv: { name: string; urlPath: string }) => srv.urlPath.replace(/[\\\/]/g, '/') === searchUri);
+    const searchUri = uri.replace(/[\\/]/g, '/'); // replace all \ and / in service uri due to issues on Windows with backslashes
+    return services.find((srv: { name: string; urlPath: string }) => srv.urlPath.replace(/[\\/]/g, '/') === searchUri);
 }
 
 /**

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -151,8 +151,8 @@ function findServiceByUri(
     services: { name: string; urlPath: string }[],
     uri: string
 ): { name: string; urlPath: string } | undefined {
-    const searchUri = uri.replace(/\\|\//g, ''); // replace all \ and / in service uri due to issues on Windows with backslashes
-    return services.find((srv: { name: string; urlPath: string }) => srv.urlPath.replace(/\\|\//g, '') === searchUri);
+    const searchUri = uri.replace(/[\\\/]/g, '/'); // replace all \ and / in service uri due to issues on Windows with backslashes
+    return services.find((srv: { name: string; urlPath: string }) => srv.urlPath.replace(/[\\\/]/g, '/') === searchUri);
 }
 
 /**

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -10,6 +10,7 @@ interface CdsFacade {
     compile: {
         to: {
             serviceinfo: (model: csn, options?: { root?: string }) => ServiceInfo[];
+            edmx: (model: csn, options?: { service?: string; version?: 'v2' | 'v4' }) => Promise<string>;
         };
     };
 }
@@ -108,6 +109,50 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
         model,
         services
     };
+}
+
+/**
+ * Return the EDMX string of a CAP service.
+ *
+ * @param root - CAP project root where package.json resides
+ * @param uri - service path, e.g 'incident/'
+ * @param version - optional OData version v2 or v4
+ * @returns - string containing the edmx
+ */
+export async function readCapServiceMetadataEdmx(
+    root: string,
+    uri: string,
+    version: 'v2' | 'v4' = 'v4'
+): Promise<string> {
+    try {
+        const { model, services } = await getCapModelAndServices(root);
+        const service = findServiceByUri(services, uri);
+        if (!service) {
+            throw Error(`Service for uri: '${uri}' not found. Available services: ${JSON.stringify(services)}`);
+        }
+        const cds = await loadCdsModuleFromProject(root);
+        const edmx = cds.compile.to.edmx(model, { service: service.name, version });
+        return edmx;
+    } catch (error) {
+        throw Error(
+            `Error while reading CAP service metadata. Path: '${root}', service uri: '${uri}', error: '${error.toString()}'}`
+        );
+    }
+}
+
+/**
+ * Find a service in a list of services.
+ *
+ * @param services - list of services from cds.compile.to['serviceinfo'](model)
+ * @param uri - search uri (usually from data source in manifest.json)
+ * @returns - name and uri of the service, undefined if service not found
+ */
+function findServiceByUri(
+    services: { name: string; urlPath: string }[],
+    uri: string
+): { name: string; urlPath: string } | undefined {
+    const searchUri = uri.replace(/\\|\//g, ''); // replace all \ and / in service uri due to issues on Windows with backslashes
+    return services.find((srv: { name: string; urlPath: string }) => srv.urlPath.replace(/\\|\//g, '') === searchUri);
 }
 
 /**

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -4,7 +4,8 @@ export {
     getCapProjectType,
     isCapJavaProject,
     isCapNodeJsProject,
-    getCapEnvironment
+    getCapEnvironment,
+    readCapServiceMetadataEdmx
 } from './cap';
 export { getAppProgrammingLanguage } from './info';
 export { loadModuleFromProject } from './module-loader';


### PR DESCRIPTION
## Issue
https://github.com/SAP/open-ux-tools/issues/1098

## Description
Add 
```typescript 
async function readCapServiceMetadataEdmx(root: string, uri: string, version: 'v2' | 'v4' = 'v4'): Promise<string>
```
to module `@sap-ux/project-access`, which allows to convert a given service by `uri` from a CDS project into [EDMX](http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html).

This allows to have tools working in the same manner on project using EDMX and projects using CDS as data description format.

