### PR TITLE
fix(axios-ext): remove trailing slash in uaa url

### DIFF
--- a/.changeset/calm-walls-run.md
+++ b/.changeset/calm-walls-run.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux/axios-extension': patch
+'@sap-ux/deploy-tooling': patch
 ---
 
 remove trailing slash from uaa url

--- a/.changeset/curly-wombats-drop.md
+++ b/.changeset/curly-wombats-drop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+remove trailing slash from uaa url

--- a/packages/axios-extension/src/auth/uaa.ts
+++ b/packages/axios-extension/src/auth/uaa.ts
@@ -47,7 +47,7 @@ export class Uaa {
      * @returns uaa url
      */
     protected get url(): string {
-        return this.serviceInfo.uaa.url;
+        return this.serviceInfo.uaa.url.replace(/\/?$/, '');
     }
 
     /**

--- a/packages/axios-extension/test/auth/uaa.test.ts
+++ b/packages/axios-extension/test/auth/uaa.test.ts
@@ -93,4 +93,29 @@ describe('UAA', () => {
             await expect(uaaInstance().getAccessToken()).resolves.toEqual(accessToken);
         });
     });
+
+    describe('getAccessTokenWithClientCredentials', () => {
+        const accessToken = 'accessToken';
+        const refreshToken = 'refreshToken';
+        const mockedResponse = {
+            data: {
+                'access_token': accessToken,
+                'refresh_token': refreshToken
+            }
+        };
+
+        it('returns an access token using client credentials', async () => {
+            const axiosRequestSpy = jest.spyOn(axios, 'request').mockResolvedValueOnce(mockedResponse);
+            const uaaUrlSlash = 'https://some.url.with.slash/';
+            await expect(uaaInstance({ url: uaaUrlSlash }).getAccessTokenWithClientCredentials()).resolves.toEqual(
+                accessToken
+            );
+            expect(axiosRequestSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    'method': 'POST',
+                    'url': 'https://some.url.with.slash/oauth/token'
+                })
+            );
+        });
+    });
 });


### PR DESCRIPTION
#1100

The token request config hardcodes a `/` at the end of the uaa-url, e.g ```url: `${this.url}/oauth/token```, with the issue arising when the uaa-url passed to the axios-extension already has a trailing slash