### PR TITLE
feat(ui5-writer): use @sapui5/types with UI5 1.113 and newer

### DIFF
--- a/packages/ui5-application-writer/src/data/defaults.ts
+++ b/packages/ui5-application-writer/src/data/defaults.ts
@@ -6,6 +6,7 @@ import semVer from 'semver';
 import type { SemVer } from 'semver';
 import { t } from '../i18n';
 import merge from 'lodash/mergeWith';
+import { getTypesPackage } from '@sap-ux/ui5-config/src/utils';
 
 /**
  * Returns a package instance with default properties.
@@ -79,6 +80,7 @@ export function mergeUi5(ui5: Partial<UI5>, options?: Partial<AppOptions>): UI5 
     merged.descriptorVersion = getManifestVersion(merged.minUI5Version, ui5.descriptorVersion);
     merged.typesVersion =
         ui5.typesVersion ?? (options?.typescript ? getEsmTypesVersion : getTypesVersion)(merged.minUI5Version);
+    merged.typesPackage = getTypesPackage(merged.typesVersion);
     merged.ui5Theme = ui5.ui5Theme ?? 'sap_fiori_3';
     merged.ui5Libs = getUI5Libs(ui5.ui5Libs);
 

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -9,6 +9,7 @@ import { mergeWithDefaults } from './data';
 import { ui5TSSupport } from './data/ui5Libs';
 import { applyOptionalFeatures, enableTypescript as enableTypescriptOption } from './options';
 import { Ui5App } from './types';
+import { getTypesPackage } from '@sap-ux/ui5-config/src/utils';
 
 /**
  * Writes the template to the memfs editor instance.
@@ -115,10 +116,13 @@ async function enableTypescript(basePath: string, fs?: Editor): Promise<Editor> 
     const ui5Config = await UI5Config.newInstance(fs.read(ui5ConfigPath));
 
     const tmplPath = join(__dirname, '..', 'templates');
+    const typesVersion = getEsmTypesVersion(manifest['sap.ui5']?.dependencies?.minUI5Version);
+    const typesPackage = getTypesPackage(typesVersion);
     const ui5App = {
         app: manifest['sap.app'],
         ui5: {
-            typesVersion: getEsmTypesVersion(manifest['sap.ui5']?.dependencies?.minUI5Version)
+            typesPackage,
+            typesVersion
         }
     };
     await enableTypescriptOption({ basePath, fs, ui5Configs: [ui5Config], tmplPath, ui5App }, true);

--- a/packages/ui5-application-writer/src/types.ts
+++ b/packages/ui5-application-writer/src/types.ts
@@ -47,6 +47,7 @@ export interface UI5 {
     version: string;
     localVersion: string;
     typesVersion: string;
+    typesPackage: string;
     descriptorVersion: string;
     ui5Libs: string | string[];
     ui5Theme: string;

--- a/packages/ui5-application-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/package.json
@@ -6,7 +6,7 @@
         "prebuild": "npm run ts-typecheck"
     },
     "devDependencies": {
-        "@sapui5/ts-types-esm": "<%- ui5.typesVersion %>",
+        "<%- ui5.typesPackage %>": "<%- ui5.typesVersion %>",
         "ui5-tooling-transpile": "^0.7.10",
         "typescript": "^4.6.3",
         "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/tsconfig.json
@@ -15,7 +15,7 @@
             ]
         },
         "types": [
-            "@sapui5/ts-types-esm"
+            "<%- ui5.typesPackage %>"
         ]
     },
     "include": [

--- a/packages/ui5-application-writer/test/data.test.ts
+++ b/packages/ui5-application-writer/test/data.test.ts
@@ -29,6 +29,7 @@ describe('Setting defaults', () => {
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
                 typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -44,6 +45,7 @@ describe('Setting defaults', () => {
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
                 typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -59,6 +61,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.72.0',
                 descriptorVersion: '1.17.0',
                 typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -76,6 +79,7 @@ describe('Setting defaults', () => {
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
                 descriptorVersion: '1.12.0',
                 typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3_dark',
                 ui5Libs: defaultUI5Libs
             }
@@ -98,6 +102,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.80.0',
                 descriptorVersion: '1.12.1',
                 typesVersion: '1.95.0',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs.concat('sap.fe')
             }
@@ -115,6 +120,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.80.1',
                 descriptorVersion: '1.24.0',
                 typesVersion: '~1.80.1',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -132,6 +138,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.80.0',
                 descriptorVersion: '1.24.0',
                 typesVersion: '~1.80.0',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -150,6 +157,7 @@ describe('Setting defaults', () => {
                 minUI5Version: 'snapshot-1.80',
                 descriptorVersion: '1.24.0',
                 typesVersion: '~1.80.0',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -170,6 +178,7 @@ describe('Setting defaults', () => {
                 minUI5Version: 'snapshot-1.78.6',
                 descriptorVersion: '1.22.0',
                 typesVersion: '~1.78.6',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -187,6 +196,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.199.0',
                 descriptorVersion: '1.49.0',
                 typesVersion: `~1.199.0`,
+                typesPackage: UI5_DEFAULT.TYPES_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -204,6 +214,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.97.2',
                 descriptorVersion: '1.37.0',
                 typesVersion: '~1.97.2',
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }
@@ -221,6 +232,7 @@ describe('Setting defaults', () => {
                 minUI5Version: '1.28.0',
                 descriptorVersion: '1.12.0',
                 typesVersion: `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`,
+                typesPackage: UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME,
                 ui5Theme: 'sap_fiori_3',
                 ui5Libs: defaultUI5Libs
             }

--- a/packages/ui5-config/src/defaults.ts
+++ b/packages/ui5-config/src/defaults.ts
@@ -9,6 +9,9 @@ export const enum UI5_DEFAULT {
     TYPES_VERSION_SINCE = '1.76.0',
     ESM_TYPES_VERSION_SINCE = '1.94.0',
     TYPES_VERSION_BEST = '1.108.0',
+    NEW_TYPES_PACKAGE_SINCE = '1.113.0',
     MANIFEST_VERSION = '1.12.0',
-    BASE_COMPONENT = 'sap/ui/core/UIComponent'
+    BASE_COMPONENT = 'sap/ui/core/UIComponent',
+    TS_TYPES_ESM_PACKAGE_NAME = '@sapui5/ts-types-esm',
+    TYPES_PACKAGE_NAME = '@sapui5/types'
 }

--- a/packages/ui5-config/src/utils.ts
+++ b/packages/ui5-config/src/utils.ts
@@ -23,8 +23,8 @@ export function mergeObjects<B, E>(base: B, extension: E): B & E {
 
 /**
  * Get the best types version for the given minUI5Version within a selective range, starting at 1.90.0
- * for https://www.npmjs.com/package/@sapui5/ts-types-esm. For anything before use 1.90.0, and if no
- * minVersion is provided, use the latest LTS version (1.108.x).
+ * for https://www.npmjs.com/package/@sapui5/ts-types-esm or https://www.npmjs.com/package/@sapui5/types.
+ * For anything before use 1.90.0, and if no minVersion is provided, use the latest LTS version (1.108.x).
  *
  * @param minUI5Version the minimum UI5 version that needs to be supported
  * @returns semantic version representing the types version.
@@ -54,5 +54,22 @@ export function getTypesVersion(minUI5Version?: string) {
         return `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`;
     } else {
         return `~${semVer.major(version)}.${semVer.minor(version)}.${semVer.patch(version)}`;
+    }
+}
+
+/**
+ * Get the correct type package name for the given ui5Version.
+ * For anything before 1.113.0, use https://www.npmjs.com/package/@sapui5/ts-types-esm,
+ * otherwise use the new package https://www.npmjs.com/package/@sapui5/types.
+ *
+ * @param ui5Version the UI5 version to get the correct package for
+ * @returns string representing the types package name.
+ */
+export function getTypesPackage(ui5Version?: string) {
+    const version = semVer.coerce(ui5Version) ?? semVer.coerce(UI5_DEFAULT.TYPES_VERSION_BEST);
+    if (version && semVer.lt(version, UI5_DEFAULT.NEW_TYPES_PACKAGE_SINCE)) {
+        return UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME;
+    } else {
+        return UI5_DEFAULT.TYPES_PACKAGE_NAME;
     }
 }

--- a/packages/ui5-config/test/utils.test.ts
+++ b/packages/ui5-config/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { UI5_DEFAULT } from '../src/defaults';
-import { getEsmTypesVersion, getTypesVersion, mergeObjects } from '../src/utils';
+import { getEsmTypesVersion, getTypesPackage, getTypesVersion, mergeObjects } from '../src/utils';
 
 describe('mergeObjects', () => {
     const base = {
@@ -44,7 +44,7 @@ describe('mergeObjects', () => {
         expect(merged.scripts?.first).toBe(extension.scripts?.first);
     });
 });
-describe('getEsmTypesVersion, getTypesVersion', () => {
+describe('getEsmTypesVersion, getTypesVersion, getTypesPackage', () => {
     const esmTypesVersionSince = `~${UI5_DEFAULT.ESM_TYPES_VERSION_SINCE}`;
     const typesVersionBest = `~${UI5_DEFAULT.TYPES_VERSION_BEST}`;
     const minU5Version = `~${UI5_DEFAULT.TYPES_VERSION_SINCE}`;
@@ -85,13 +85,44 @@ describe('getEsmTypesVersion, getTypesVersion', () => {
         ['1.102-snapshot', '~1.102.0'],
         ['1.109-snapshot', '~1.109.0']
     ];
+    const getTypesPackageTestData: [any, string][] = [
+        [UI5_DEFAULT.MIN_UI5_VERSION, UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.70.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.71.1', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['metadata', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        [undefined, UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        // Following versions dont exist
+        ['1.72.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.73.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.74.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.75.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.83.0', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        [UI5_DEFAULT.TYPES_VERSION_BEST, UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.109.1', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.80-snapshot', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.102-snapshot', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        ['1.109-snapshot', UI5_DEFAULT.TS_TYPES_ESM_PACKAGE_NAME],
+        // Following versions should use the new package
+        ['1.113.0', UI5_DEFAULT.TYPES_PACKAGE_NAME],
+        ['1.114.0', UI5_DEFAULT.TYPES_PACKAGE_NAME]
+    ];
+
     // Tests validation of versions against known versions https://www.npmjs.com/package/@sapui5/ts-types-esm
-    test.each(tesTSTypesEsmData)('Types version for @sapui5/ts-types-esm: (%p, %p)', (input, expected) => {
-        expect(getEsmTypesVersion(input)).toEqual(expected);
-    });
+    test.each(tesTSTypesEsmData)(
+        'Types version for @sapui5/ts-types-esm and @sapui5/types: (%p, %p)',
+        (input, expected) => {
+            expect(getEsmTypesVersion(input)).toEqual(expected);
+        }
+    );
 
     // Tests validation of versions against known versions https://www.npmjs.com/package/@sapui5/ts-types
     test.each(testSTypesData)('Types version for @sapui5/ts-types: (%p, %p)', (input, expected) => {
         expect(getTypesVersion(input)).toEqual(expected);
+    });
+
+    // Tests validation of getting the correct types package name
+    test.each(getTypesPackageTestData)('Types package: (%p, %p)', (input, expected) => {
+        expect(getTypesPackage(input)).toEqual(expected);
     });
 });


### PR DESCRIPTION
As described in the [@sapui5/ts-types-esm README file](https://www.npmjs.com/package/@sapui5/ts-types-esm), `@sapui5/types` should be preferred for newer SAPUI5 versions.

This closes #999.