### PR TITLE
Fix/1116/support cli credentials

### DIFF
--- a/.changeset/small-goats-jog.md
+++ b/.changeset/small-goats-jog.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': minor
+---
+
+suppor cli credentials

--- a/.changeset/small-goats-jog.md
+++ b/.changeset/small-goats-jog.md
@@ -2,4 +2,4 @@
 '@sap-ux/deploy-tooling': minor
 ---
 
-suppor cli credentials
+support cli credentials

--- a/packages/deploy-tooling/README.md
+++ b/packages/deploy-tooling/README.md
@@ -62,6 +62,8 @@ Options:
   --cloud                              target is an ABAP Cloud system
   --cloud-service-key <file-location>  JSON file location with the ABAP cloud service key.
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables. Secrets in your .env should not be committed to source control.
+  --service-username                   ABAP Service username
+  --service-password                   ABAP Service password
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --name <bsp-name>                    Project name of the app
   --strict-ssl                         Perform certificate validation (use --no-strict-ssl to deactivate it)
@@ -95,6 +97,8 @@ Options:
   --cloud                              target is an ABAP Cloud system
   --cloud-service-key <file-location>  JSON file location with the ABAP cloud service key.
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables
+  --service-username                   ABAP Service username
+  --service-password                   ABAP Service password
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --name <bsp-name>                    Project name of the app
   --strict-ssl                         Perform certificate validation (use --no-strict-ssl to deactivate it)

--- a/packages/deploy-tooling/README.md
+++ b/packages/deploy-tooling/README.md
@@ -62,8 +62,8 @@ Options:
   --cloud                              target is an ABAP Cloud system
   --cloud-service-key <file-location>  JSON file location with the ABAP cloud service key.
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables. Secrets in your .env should not be committed to source control.
-  --service-username                   ABAP Service username
-  --service-password                   ABAP Service password
+  --username                           ABAP Service username
+  --password                           ABAP Service password
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --name <bsp-name>                    Project name of the app
   --strict-ssl                         Perform certificate validation (use --no-strict-ssl to deactivate it)
@@ -97,8 +97,8 @@ Options:
   --cloud                              target is an ABAP Cloud system
   --cloud-service-key <file-location>  JSON file location with the ABAP cloud service key.
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables
-  --service-username                   ABAP Service username
-  --service-password                   ABAP Service password
+  --username                           ABAP Service username
+  --password                           ABAP Service password
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --name <bsp-name>                    Project name of the app
   --strict-ssl                         Perform certificate validation (use --no-strict-ssl to deactivate it)

--- a/packages/deploy-tooling/src/cli/config.ts
+++ b/packages/deploy-tooling/src/cli/config.ts
@@ -159,11 +159,11 @@ export async function mergeConfig(taskConfig: AbapDeployConfig, options: CliOpti
     config.retry = process.env.NO_RETRY ? !process.env.NO_RETRY : mergeFlag(options.retry, taskConfig.retry);
 
     // Support CLI params and|or dotenv file
-    if (options.serviceUsername || process.env.SERVICE_USERNAME) {
+    if (options.username || process.env.SERVICE_USERNAME) {
         config.credentials = {
             ...(config.credentials || {}),
-            username: options.serviceUsername || process.env.SERVICE_USERNAME || '',
-            password: options.servicePassword || process.env.SERVICE_PASSWORD || ''
+            username: options.username || process.env.SERVICE_USERNAME || '',
+            password: options.password || process.env.SERVICE_PASSWORD || ''
         };
     }
 

--- a/packages/deploy-tooling/src/cli/config.ts
+++ b/packages/deploy-tooling/src/cli/config.ts
@@ -147,7 +147,7 @@ function mergeCredentials(taskConfig: AbapDeployConfig, options: CliOptions) {
     // Support CLI params and|or dotenv file
     if (options.username || process.env.SERVICE_USERNAME) {
         credentials = {
-            ...(credentials || {}),
+            ...(credentials ?? {}),
             username: options.username ?? process.env.SERVICE_USERNAME ?? '',
             password: options.password ?? process.env.SERVICE_PASSWORD ?? ''
         };

--- a/packages/deploy-tooling/src/cli/config.ts
+++ b/packages/deploy-tooling/src/cli/config.ts
@@ -158,6 +158,15 @@ export async function mergeConfig(taskConfig: AbapDeployConfig, options: CliOpti
     config.yes = mergeFlag(options.yes, taskConfig.yes);
     config.retry = process.env.NO_RETRY ? !process.env.NO_RETRY : mergeFlag(options.retry, taskConfig.retry);
 
+    // Support CLI params and|or dotenv file
+    if (options.serviceUsername || process.env.SERVICE_USERNAME) {
+        config.credentials = {
+            ...(config.credentials || {}),
+            username: options.serviceUsername || process.env.SERVICE_USERNAME || '',
+            password: options.servicePassword || process.env.SERVICE_PASSWORD || ''
+        };
+    }
+
     if (!options.archiveUrl && !options.archivePath && !options.archiveFolder) {
         options.archiveFolder = 'dist';
     }

--- a/packages/deploy-tooling/src/cli/config.ts
+++ b/packages/deploy-tooling/src/cli/config.ts
@@ -136,6 +136,26 @@ function mergeTarget(baseTarget: AbapTarget, options: CliOptions) {
 }
 
 /**
+ * Merge CLI and environment credentials.
+ *
+ * @param taskConfig - base configuration from the file
+ * @param options - CLI options
+ * @returns merged credentials
+ */
+function mergeCredentials(taskConfig: AbapDeployConfig, options: CliOptions) {
+    let credentials = taskConfig.credentials;
+    // Support CLI params and|or dotenv file
+    if (options.username || process.env.SERVICE_USERNAME) {
+        credentials = {
+            ...(credentials || {}),
+            username: options.username ?? process.env.SERVICE_USERNAME ?? '',
+            password: options.password ?? process.env.SERVICE_PASSWORD ?? ''
+        };
+    }
+    return credentials;
+}
+
+/**
  * Merge the configuration from the ui5*.yaml with CLI options.
  *
  * @param taskConfig - base configuration from the file
@@ -150,22 +170,13 @@ export async function mergeConfig(taskConfig: AbapDeployConfig, options: CliOpti
         transport: options.transport ?? taskConfig.app?.transport
     };
     const target = mergeTarget(taskConfig.target, options);
-    const config: AbapDeployConfig = { app, target, credentials: taskConfig.credentials };
+    const config: AbapDeployConfig = { app, target, credentials: mergeCredentials(taskConfig, options) };
     config.test = mergeFlag(options.test, taskConfig.test);
     config.safe = mergeFlag(options.safe, taskConfig.safe);
     config.keep = mergeFlag(options.keep, taskConfig.keep);
     config.strictSsl = mergeFlag(options.strictSsl, taskConfig.strictSsl);
     config.yes = mergeFlag(options.yes, taskConfig.yes);
     config.retry = process.env.NO_RETRY ? !process.env.NO_RETRY : mergeFlag(options.retry, taskConfig.retry);
-
-    // Support CLI params and|or dotenv file
-    if (options.username || process.env.SERVICE_USERNAME) {
-        config.credentials = {
-            ...(config.credentials || {}),
-            username: options.username || process.env.SERVICE_USERNAME || '',
-            password: options.password || process.env.SERVICE_PASSWORD || ''
-        };
-    }
 
     if (!options.archiveUrl && !options.archivePath && !options.archiveFolder) {
         options.archiveFolder = 'dist';

--- a/packages/deploy-tooling/src/cli/index.ts
+++ b/packages/deploy-tooling/src/cli/index.ts
@@ -45,14 +45,14 @@ export function createCommand(name: 'deploy' | 'undeploy'): Command {
         )
         .option('--transport <transport-request>', 'Transport number to record the change in the ABAP system')
         .addOption(
-            new Option('--service-username <service-username>', 'ABAP System username').conflicts([
+            new Option('--username <username>', 'ABAP System username').conflicts([
                 'cloudServiceKey',
                 'cloudServiceEnv',
                 'destination'
             ])
         )
         .addOption(
-            new Option('--service-password <service-password>', 'ABAP System password').conflicts([
+            new Option('--password <password>', 'ABAP System password').conflicts([
                 'cloudServiceKey',
                 'cloudServiceEnv',
                 'destination'

--- a/packages/deploy-tooling/src/cli/index.ts
+++ b/packages/deploy-tooling/src/cli/index.ts
@@ -44,6 +44,20 @@ export function createCommand(name: 'deploy' | 'undeploy'): Command {
             ).conflicts(['cloudServiceKey', 'destination'])
         )
         .option('--transport <transport-request>', 'Transport number to record the change in the ABAP system')
+        .addOption(
+            new Option('--service-username <service-username>', 'ABAP System username').conflicts([
+                'cloudServiceKey',
+                'cloudServiceEnv',
+                'destination'
+            ])
+        )
+        .addOption(
+            new Option('--service-password <service-password>', 'ABAP System password').conflicts([
+                'cloudServiceKey',
+                'cloudServiceEnv',
+                'destination'
+            ])
+        )
         .option('--name <bsp-name>', 'Project name of the app')
         .option('--strict-ssl', 'Perform certificate validation (use --no-strict-ssl to deactivate it)')
         .option(

--- a/packages/deploy-tooling/src/types/index.ts
+++ b/packages/deploy-tooling/src/types/index.ts
@@ -85,6 +85,6 @@ export interface CliOptions
     cloudServiceKey?: string;
     queryParams?: string;
     cloudServiceEnv?: boolean;
-    serviceUsername?: string;
-    servicePassword?: string;
+    username?: string;
+    password?: string;
 }

--- a/packages/deploy-tooling/src/types/index.ts
+++ b/packages/deploy-tooling/src/types/index.ts
@@ -85,4 +85,6 @@ export interface CliOptions
     cloudServiceKey?: string;
     queryParams?: string;
     cloudServiceEnv?: boolean;
+    serviceUsername?: string;
+    servicePassword?: string;
 }

--- a/packages/deploy-tooling/test/unit/cli/config.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/config.test.ts
@@ -82,7 +82,7 @@ describe('cli/config', () => {
             expect(merged.target.serviceKey).toEqual(JSON.parse(readFileSync(cloudServiceKey, 'utf-8')));
         });
 
-        test('validate reading of environment variables', async () => {
+        test('validate reading of environment variables supporting UAA', async () => {
             process.env.SERVICE_URL = 'http://service-url';
             process.env.SERVICE_UAA_URL = 'http://uaa-url';
             process.env.SERVICE_CLIENT_ID = 'MyClientId';
@@ -106,6 +106,34 @@ describe('cli/config', () => {
                     username: 'MyUsername'
                 },
                 url: config.target.url
+            });
+        });
+
+        test('Validate credentials using CLI', async () => {
+            // Reset env variables
+            process.env = env;
+            const merged = await mergeConfig(
+                { ...config, credentials: { username: '~ShouldBeRemoved', password: '~ShouldBeRemoved' } },
+                {
+                    serviceUsername: '~MyUsername',
+                    servicePassword: '~MyPassword'
+                } as CliOptions
+            );
+            expect(merged.credentials).toMatchObject({
+                username: '~MyUsername',
+                password: '~MyPassword'
+            });
+        });
+
+        test('Validate credentials using dotenv', async () => {
+            // Reset env variables
+            process.env = env;
+            process.env.SERVICE_USERNAME = '~DotEnvMyUsername';
+            process.env.SERVICE_PASSWORD = '~DotEnvMyPassword';
+            const merged = await mergeConfig(config, {} as CliOptions);
+            expect(merged.credentials).toMatchObject({
+                username: '~DotEnvMyUsername',
+                password: '~DotEnvMyPassword'
             });
         });
     });

--- a/packages/deploy-tooling/test/unit/cli/config.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/config.test.ts
@@ -115,8 +115,8 @@ describe('cli/config', () => {
             const merged = await mergeConfig(
                 { ...config, credentials: { username: '~ShouldBeRemoved', password: '~ShouldBeRemoved' } },
                 {
-                    serviceUsername: '~MyUsername',
-                    servicePassword: '~MyPassword'
+                    username: '~MyUsername',
+                    password: '~MyPassword'
                 } as CliOptions
             );
             expect(merged.credentials).toMatchObject({

--- a/packages/deploy-tooling/test/unit/cli/index.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/index.test.ts
@@ -180,7 +180,10 @@ describe('cli', () => {
         test.each([
             { params: ['--url', '~url', '--destination', '~dest'] },
             { params: ['--client', '001', '--destination', '~dest'] },
-            { params: ['--cloud', '--destination', '~dest'] }
+            { params: ['--cloud', '--destination', '~dest'] },
+            { params: ['--username', '~username', '--cloud-service-env'] },
+            { params: ['--username', '~username', '--cloud-service-key', '~path'] },
+            { params: ['--username', '~username', '--destination', '~dest'] }
         ])('conflicting options $params', ({ params }) => {
             cmd.parse(params, opts);
             expect(errorMock).toBeCalled();


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1116

- appended unit tests
- supports username | password as a CLI param which conflicts with other existing CLI params
- supports dotenv files
- Re-using the `process.env.SERVICE_USERNAME` name since this values is also used for cloud service env flow soo just being consistent
- Re-using `--username` since this is the same property name used if reading from a yaml configuration, as shown below


Existing/as-is flow supporting dotenv and yaml configuration
```
  customTasks:
    - name: deploy-to-abap
      afterTask: generateCachebusterInfo
      configuration:
        verbose: true
        target:
          url: https://myapabap-system.sap:44300
        credentials:
          username: env:XYZ_USER
          password: env:XYZ_PASSWORD
        app:
          name: ZTRAJL2403
          description: Test
          package: $tmp
          transport: Y12345
```
Existing deploy command;
```
./bin/undeploy -c ./ui5-deploy.yaml
```
dotnev file;
```
XYZ_USER=TESTNEW
XYZ_PASSWORD=TESTNEW
```

With the latest changes, to support the same flow using CLI params and no yaml configuration and re-using the same dotenv file as above;
```
./bin/undeploy --url https://myapabap-system.sap:44300 --name ZTRAJL2403 --description Test --package '$tmp' --transport Y12345 --username env:XYZ_USER --password env:XYZ_PASSWORD --verbose
```

Supporting dotenv file without username | password CLI params;

```
./bin/undeploy --url https://myapabap-system.sap:44300 --name ZTRAJL2403 --description Test --package '$tmp' --transport Y12345 --verbose
```
dotenv file is
```
SERVICE_USERNAME=TESTNEW
SERVICE_PASSWORD=TESTNEW
```