### PR TITLE
fix(deploy-tooling): Handle cli credentials

### DIFF
--- a/.changeset/poor-lions-serve.md
+++ b/.changeset/poor-lions-serve.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+fix issue cloud target systems

--- a/packages/deploy-tooling/src/cli/config.ts
+++ b/packages/deploy-tooling/src/cli/config.ts
@@ -136,7 +136,7 @@ function mergeTarget(baseTarget: AbapTarget, options: CliOptions) {
 }
 
 /**
- * Merge CLI and environment credentials.
+ * Merge CLI credentials.
  *
  * @param taskConfig - base configuration from the file
  * @param options - CLI options
@@ -144,12 +144,11 @@ function mergeTarget(baseTarget: AbapTarget, options: CliOptions) {
  */
 function mergeCredentials(taskConfig: AbapDeployConfig, options: CliOptions) {
     let credentials = taskConfig.credentials;
-    // Support CLI params and|or dotenv file
-    if (options.username || process.env.SERVICE_USERNAME) {
+    if (options.username || options.password) {
         credentials = {
             ...(credentials ?? {}),
-            username: options.username ?? process.env.SERVICE_USERNAME ?? '',
-            password: options.password ?? process.env.SERVICE_PASSWORD ?? ''
+            username: options.username ?? '',
+            password: options.password ?? ''
         };
     }
     return credentials;

--- a/packages/deploy-tooling/test/unit/cli/config.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/config.test.ts
@@ -109,9 +109,7 @@ describe('cli/config', () => {
             });
         });
 
-        test('Validate credentials using CLI', async () => {
-            // Reset env variables
-            process.env = env;
+        test('Validate merging credentials using config and cli options', async () => {
             const merged = await mergeConfig(
                 { ...config, credentials: { username: '~ShouldBeRemoved', password: '~ShouldBeRemoved' } },
                 {
@@ -125,15 +123,14 @@ describe('cli/config', () => {
             });
         });
 
-        test('Validate credentials using dotenv', async () => {
-            // Reset env variables
-            process.env = env;
-            process.env.SERVICE_USERNAME = '~DotEnvMyUsername';
-            process.env.SERVICE_PASSWORD = '~DotEnvMyPassword';
-            const merged = await mergeConfig(config, {} as CliOptions);
+        test('Validate credentials using only cli options', async () => {
+            const merged = await mergeConfig(config, {
+                username: 'env:DotEnvMyUsername',
+                password: 'env:DotEnvMyPassword'
+            } as CliOptions);
             expect(merged.credentials).toMatchObject({
-                username: '~DotEnvMyUsername',
-                password: '~DotEnvMyPassword'
+                username: 'env:DotEnvMyUsername',
+                password: 'env:DotEnvMyPassword'
             });
         });
     });


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1128

- Updated test cases
- Applied changset
- Reverting the `process.env.SERVICE_USERNAME` code since the correct way to use dotenv is to explicity request it using the `--username` cli param and unblock cloud target deployments which use the SERVICE_USERNAME env variable
- Correct flow, which is currently supported and is not impacted;

Sample .env file
```
XYZ_USER=<my_username>
XYZ_PASSWORD=<my_password>
```

Sample CLI deploy command
```bash
./bin/deploy --name ZJLONG0205 --package '$tmp' --transport '' --url 'https://myapi.hanavlab.ondemand.com/' --username  env:XYZ_USER  --password  env:XYZ_PASSWORD
```
