### PR TITLE
fix(deploy-tooling): handle 401 error for creating transport requests

### DIFF
--- a/.changeset/thick-books-poke.md
+++ b/.changeset/thick-books-poke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': minor
+---
+
+remove logs and fix 401 error handling

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -270,9 +270,9 @@ async function handle401Error(
             config.target.serviceKey.uaa.username = credentials.username;
             config.target.serviceKey.uaa.password = credentials.password;
         } else {
-            service.defaults.auth = credentials;
+            config.credentials = credentials;
         }
-        await deploymentCommands[command](provider, config, logger, archive);
+        await runCommand(command, config, logger, archive);
         return true;
     } else {
         return false;
@@ -345,28 +345,21 @@ export async function createTransportRequest(
     logger: Logger,
     provider?: AbapServiceProvider
 ): Promise<string> {
-    try {
-        if (!provider) {
-            provider = await getAbapServiceProvider(config, logger);
-        }
-        const adtService = await provider.getAdtService<TransportRequestService>(TransportRequestService);
-        logger.debug(`ADTService created for application ${config.app.name}, ${!adtService}.`);
-        const transportRequest = await adtService?.createTransportRequest({
-            packageName: config.app.package ?? '',
-            ui5AppName: config.app.name,
-            description: 'Created by @sap-ux/deploy-tooling'
-        });
-        if (transportRequest) {
-            logger.info(`Transport request ${transportRequest} created for application ${config.app.name}.`);
-            return transportRequest;
-        }
-        throw new Error(`Transport request could not be created for application ${config.app.name}.`);
-    } catch (e) {
-        logger.error(
-            `Transport request could not be created for application ${config.app.name}. Please create it manually and re-run deployment configuration for this project.`
-        );
-        throw e;
+    if (!provider) {
+        provider = await getAbapServiceProvider(config, logger);
     }
+    const adtService = await provider.getAdtService<TransportRequestService>(TransportRequestService);
+    logger.debug(`ADTService created for application ${config.app.name}: ${!!adtService}.`);
+    const transportRequest = await adtService?.createTransportRequest({
+        packageName: config.app.package ?? '',
+        ui5AppName: config.app.name,
+        description: 'Created by @sap-ux/deploy-tooling'
+    });
+    if (transportRequest) {
+        logger.info(`Transport request ${transportRequest} created for application ${config.app.name}.`);
+        return transportRequest;
+    }
+    throw new Error(`Transport request could not be created for application ${config.app.name}.`);
 }
 
 /**

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -349,7 +349,6 @@ export async function createTransportRequest(
         provider = await getAbapServiceProvider(config, logger);
     }
     const adtService = await provider.getAdtService<TransportRequestService>(TransportRequestService);
-    logger.debug(`ADTService created for application ${config.app.name}: ${!!adtService}.`);
     const transportRequest = await adtService?.createTransportRequest({
         packageName: config.app.package ?? '',
         ui5AppName: config.app.name,

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -198,6 +198,9 @@ describe('base/deploy', () => {
             mockedUi5RepoService.deploy.mockRejectedValueOnce(axiosError(401));
             prompts.inject(['~username', '~password']);
             await deploy(archive, { app, target, yes: true }, nullLogger);
+            expect(mockCreateForAbap).toBeCalledWith(
+                expect.objectContaining({ auth: { password: '~password', username: '~username' } })
+            );
         });
 
         test('Successful retry after known axios error (cloud target)', async () => {


### PR DESCRIPTION
#1112

Improves handling of retry for 401 errors. 

`createTransportRequest` still throws the error but no longer logs `Transport request could not be created for application ${config.app.name}. Please create it manually and re-run deployment configuration for this project.`, this error could be logged prematurely, in the case of NoAuth destinations, or if credentials are initially incorrect. 

The consuming code can handle the 401 and then pass the updated credentials to successfully create the TR.