### PR TITLE
chore(cap-config-writer): update min version of cds-plugin-ui5

### DIFF
--- a/.changeset/lovely-beers-wink.md
+++ b/.changeset/lovely-beers-wink.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cap-config-writer': patch
+---
+
+Update minimum version of cds-plugin-ui5 to 0.2.1

--- a/packages/cap-config-writer/src/cap-config/package-json.ts
+++ b/packages/cap-config-writer/src/cap-config/package-json.ts
@@ -3,7 +3,7 @@ import { getCapCustomPaths } from '@sap-ux/project-access';
 import type { Package } from '@sap-ux/project-access';
 
 const minCdsVersion = '6.8.2';
-const minCdsPluginUi5Version = '0.1.4';
+const minCdsPluginUi5Version = '0.2.1';
 
 /**
  * Ensure a minimum version of @sap/cds in dependencies.

--- a/packages/cap-config-writer/test/unit/cap-config/index.test.ts
+++ b/packages/cap-config-writer/test/unit/cap-config/index.test.ts
@@ -17,7 +17,7 @@ describe('Test enableCdsUi5Plugin()', () => {
             },
             'workspaces': ['app/*'],
             'devDependencies': {
-                'cds-plugin-ui5': '^0.1.4'
+                'cds-plugin-ui5': '^0.2.1'
             }
         });
     });
@@ -39,7 +39,7 @@ describe('Test enableCdsUi5Plugin()', () => {
             },
             'workspaces': ['app/*'],
             'devDependencies': {
-                'cds-plugin-ui5': '^0.1.4'
+                'cds-plugin-ui5': '^0.2.1'
             }
         });
     });
@@ -53,7 +53,7 @@ describe('Test enableCdsUi5Plugin()', () => {
         });
         const fs = await enableCdsUi5Plugin(__dirname, memFs);
         const packageJson = fs.readJSON(join(__dirname, 'package.json')) as projectAccessMock.Package;
-        expect(packageJson.devDependencies).toEqual({ 'cds-plugin-ui5': '^0.1.4' });
+        expect(packageJson.devDependencies).toEqual({ 'cds-plugin-ui5': '^0.2.1' });
     });
 
     test('CAP with custom app path and mem-fs editor', async () => {


### PR DESCRIPTION
**Issue**
Related issue: https://github.com/SAP/open-ux-tools/issues/1041

**Description**
Module `cds-plugin-ui5` is used in CAP projects to be able to include app-specific UI5 middlewares when previewing an application. It can be added via command npm `@sap-ux/create add cds-plugin-ui5` or via the `fiori generator` when generating an application into a CAP project. This PR updates the minimum version of `cds-plugin-ui5` to `0.2.1`.