### PR TITLE
Improving the @sap-ux/create readme

### DIFF
--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -4,27 +4,32 @@ Module which provides command line interface to configure features for SAP UX pr
 To see usage, run
 
 ```sh
-npm init @sap-ux 
+npm init @sap-ux@latest 
+# or
+npx @sap-ux/create@latest
 ```
 
 To avoid downloading and installing the module every time it is used, you might consider installing it globally or add it as `devDependency` to a project. Once installed, you can run it using
 
 ```sh
+# globally installed
+sap-ux
+# locally
 npx sap-ux
 ```
 
 ## add
-Calling `npx sap-ux add` allows adding a feature to a project.
+Calling `sap-ux add` allows adding a feature to a project.
 
 ## remove
-Calling `npx sap-ux remove` allows removing a feature to a project.
+Calling `sap-ux remove` allows removing a feature to a project.
 
 ## generate
-Calling `npx sap-ux generate` allows generating a new project.
+Calling `sap-ux generate` allows generating a new project.
 
 ### adaptation-project
-Calling `npx sap-ux generate adaptation-project` allows generating a new adaptation project. Without further parameters the CLI will prompt the required parameters `id`, `reference` and `url`. To run the prompt non-interactively, it is also possible to execute
+Calling `sap-ux generate adaptation-project` allows generating a new adaptation project. Without further parameters the CLI will prompt the required parameters `id`, `reference` and `url`. To run the prompt non-interactively, it is also possible to execute
 ```sh
-npx sap-ux generate adaptation-project --id my.adp --reference the.original.app --url http://my.sapsystem.example
+sap-ux generate adaptation-project --id my.adp --reference the.original.app --url http://my.sapsystem.example
 ```
 Additional options are `--skip-install` to skip running `npm install` after the project generation and `--simulate` to only simulate the files that would be generated instead of writing them to the file system.


### PR DESCRIPTION
I have noticed that if you use `npm init @sap-ux` it might use a previous version that you used before, therefore, it is best to add `@latest` to ensure the latest version is used.
This PR is just an update of the `README` , however, a follow up investigation is needed to better understand why and how and maybe improve it differently.