### PR TITLE
Use relative path to work with cds-plugin-ui5

### DIFF
--- a/.changeset/many-singers-tease.md
+++ b/.changeset/many-singers-tease.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+FIX: use relative path to app to work with cds-plugin-ui5 in CAP projects

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -11,9 +11,10 @@ The `@sap-ux/preview-middleware` is a [Custom UI5 Server Middleware](https://sap
 | `flp.intent.object`    | `string`  | `app`            | Optional intent object                                                                                                              |
 | `flp.intent.action`    | `string`  | `preview`        | Optional intent action                                                                                                              |
 | `flp.apps`             | `array`   | `[]`             | Optional additional local apps that are available in local Fiori launchpad                                                          |
+| `flp.libs`             | `boolean` | `false`          | Optional flag to add a generic script fetching the paths of used libraries not available in UI5                                     |
 | `adp.target`           |           |                  | Required configuration for adaptation projects defining the connected backend                                                       |
 | `adp.ignoreCertErrors` | `boolean` | `false`          | Optional setting to ignore certification validation errors when working with e.g. development systems with self signed certificates |
-| `debug`                | `boolean` | false            | Enables debug output                                                                                                                |
+| `debug`                | `boolean` | `false`          | Enables debug output                                                                                                                |
 
 ### `flp.apps`
 Array of additional application configurations:

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -166,8 +166,10 @@ export class FlpSandbox {
         });
         // add route for locate-reuse-libs if requested
         if (this.config.libs && this.templateConfig.locateReuseLibsScript) {
-            const scriptPath = join(dirname(this.config.path), DEFAULT_LOCATE_LIBS_FILENAME);
-            this.router.get(scriptPath, (req: Request, res: Response) => {
+            const pathParts = this.config.path.split('/');
+            pathParts.pop();
+            pathParts.push(DEFAULT_LOCATE_LIBS_FILENAME);
+            this.router.get(pathParts.join('/'), (_req: Request, res: Response) => {
                 const script = readFileSync(join(__dirname, '../../templates/flp/locate-reuse-libs.js'), 'utf-8');
                 res.status(200).contentType('text/javascript').send(script);
             });

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -2,7 +2,7 @@ import type { ReaderCollection } from '@ui5/fs';
 import { render } from 'ejs';
 import type { Request, Response } from 'express';
 import { readFileSync } from 'fs';
-import { basename, dirname, join, relative } from 'path';
+import { dirname, join, relative } from 'path';
 import type { App, FlpConfig } from '../types';
 import { Router as createRouter, static as serveStatic, json } from 'express';
 import type { Logger } from '@sap-ux/logger';
@@ -20,11 +20,10 @@ const DEFAULT_THEME = 'sap_horizon';
  */
 const DEFAULT_PATH = '/test/flp.html';
 
-
 /**
  * Default name of the locate reuse libs script.
  */
-const DEFAULT_LOCATE_LIBS_FILENAME = 'locate-reuse-libs.js'
+const DEFAULT_LOCATE_LIBS_FILENAME = 'locate-reuse-libs.js';
 /**
  * Default intent
  */
@@ -120,7 +119,9 @@ export class FlpSandbox {
                 flex,
                 resources: { ...resources }
             },
-            locateReuseLibsScript: this.config.libs ? `./${DEFAULT_LOCATE_LIBS_FILENAME}` : await this.findLocateReuseLibsScript()
+            locateReuseLibsScript: this.config.libs
+                ? `./${DEFAULT_LOCATE_LIBS_FILENAME}`
+                : await this.findLocateReuseLibsScript()
         };
         this.addApp(manifest, {
             componentId,
@@ -129,6 +130,16 @@ export class FlpSandbox {
             intent: this.config.intent
         });
 
+        this.addStandardRoutes();
+        this.addRoutesForAdditionalApps();
+        this.logger.info(`Initialized for app ${manifest['sap.app'].id}`);
+        this.logger.debug(`Configured apps: ${JSON.stringify(this.templateConfig.apps)}`);
+    }
+
+    /**
+     * Add routes for html and scripts required for a local FLP.
+     */
+    private addStandardRoutes() {
         // add route for the sandbox.html
         this.router.get(this.config.path, (req: Request, res: Response & { _livereload?: boolean }) => {
             const config = { ...this.templateConfig };
@@ -161,10 +172,6 @@ export class FlpSandbox {
                 res.status(200).contentType('text/javascript').send(script);
             });
         }
-
-        this.addRoutesForAdditionalApps();
-        this.logger.info(`Initialized for app ${manifest['sap.app'].id}`);
-        this.logger.debug(`Configured apps: ${JSON.stringify(this.templateConfig.apps)}`);
     }
 
     /**

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -31,6 +31,10 @@ export interface FlpConfig {
     rta?: {
         layer?: UI5FlexLayer;
     };
+    /**
+     * Optional: if set to true then a locate-reuse-libs script will be attached to the html
+     */
+    libs?: boolean;
     apps: App[];
 }
 

--- a/packages/preview-middleware/templates/flp/locate-reuse-libs.js
+++ b/packages/preview-middleware/templates/flp/locate-reuse-libs.js
@@ -1,0 +1,195 @@
+(function (sap) {
+    var fioriToolsGetManifestLibs = function (manifestPath) {
+        var url = manifestPath;
+        var result = "";
+        // SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
+        var ui5Libs = [
+            "sap.apf",
+            "sap.base",
+            "sap.chart",
+            "sap.collaboration",
+            "sap.f",
+            "sap.fe",
+            "sap.fileviewer",
+            "sap.gantt",
+            "sap.landvisz",
+            "sap.m",
+            "sap.ndc",
+            "sap.ovp",
+            "sap.rules",
+            "sap.suite",
+            "sap.tnt",
+            "sap.ui",
+            "sap.uiext",
+            "sap.ushell",
+            "sap.uxap",
+            "sap.viz",
+            "sap.webanalytics",
+            "sap.zen"
+        ];
+        function getKeys(libOrComp, libOrCompKeysString) {
+            var libOrCompKeysStringTmp = libOrCompKeysString;
+            Object.keys(libOrComp).forEach(function (libOrCompKey) {
+                // ignore libs or Components that start with SAPUI5 delivered namespaces
+                if (!ui5Libs.some(function (substring) { return libOrCompKey === substring || libOrCompKey.startsWith(substring + "."); })) {
+                    if (libOrCompKeysStringTmp.length > 0) {
+                        libOrCompKeysStringTmp = libOrCompKeysStringTmp + "," + libOrCompKey;
+                    } else {
+                        libOrCompKeysStringTmp = libOrCompKey;
+                    }
+                }
+            });
+            return libOrCompKeysStringTmp;
+        }
+        return new Promise(function (resolve, reject) {
+            $.ajax(url)
+                .done(function (manifest) {
+                    if (manifest) {
+                        if (
+                            manifest["sap.ui5"] &&
+                            manifest["sap.ui5"].dependencies
+                        ) {
+                            if (manifest["sap.ui5"].dependencies.libs) {
+                                result = getKeys(manifest["sap.ui5"].dependencies.libs, result);
+                            }
+                            if (manifest["sap.ui5"].dependencies.components) {
+                                result = getKeys(manifest["sap.ui5"].dependencies.components, result);
+                            }
+                        }
+                        if (
+                            manifest["sap.ui5"] &&
+                            manifest["sap.ui5"].componentUsages
+                        ) {
+                            result = getKeys(manifest["sap.ui5"].componentUsages, result);
+                        }
+                    }
+                    resolve(result);
+                })
+                .fail(function () {
+                    reject(new Error("Could not fetch manifest at '" + manifestPath));
+                });
+        });
+    };
+    function registerModules(dataFromAppIndex) {
+        Object.keys(dataFromAppIndex).forEach(function (moduleDefinitionKey) {
+            var moduleDefinition = dataFromAppIndex[moduleDefinitionKey];
+            if (moduleDefinition && moduleDefinition.dependencies) {
+                moduleDefinition.dependencies.forEach(function (dependency) {
+                    if (dependency.url && dependency.url.length > 0 && dependency.type === "UI5LIB") {
+                        sap.ui.require(["sap/base/Log"], function (Log) {
+                            Log.info("Registering Library " +
+                                dependency.componentId +
+                                " from server " +
+                                dependency.url);
+                        });
+                        var compId = dependency.componentId.replace(/\./g, "/");
+                        var config = {
+                            paths: {
+                            }
+                        };
+                        config.paths[compId] = dependency.url;
+                        sap.ui.loader.config(config);
+                    }
+                });
+            }
+        });
+    }
+    /**
+     * Registers the module paths for dependencies of the given component.
+     * @param {string} manifestPath The the path to the app manifest path
+     * for which the dependencies should be registered.
+     * @returns {Promise} A promise which is resolved when the ajax request for
+     * the app-index was successful and the module paths were registered.
+     */
+    sap.registerComponentDependencyPaths = function (manifestPath) {
+
+        return fioriToolsGetManifestLibs(manifestPath).then(function (libs) {
+            if (libs && libs.length > 0) {
+                var url = "/sap/bc/ui2/app_index/ui5_app_info?id=" + libs;
+                var sapClient = "";
+
+                return new Promise(
+                    function (resolve) {
+                        sap.ui.require(["sap/base/util/UriParameters"], function (UriParameters) {
+                            sapClient = UriParameters.fromQuery(window.location.search).get("sap-client");
+                            if (sapClient && sapClient.length === 3) {
+                                url = url + "&sap-client=" + sapClient;
+                            }
+                            resolve(url);
+                        });
+                    }).then(function (url2) {
+                        return $.ajax(url2).done(function (data) {
+                            if (data) {
+                                registerModules(data);
+                            }
+                        });
+                    });
+            } else {
+                return undefined;
+            }
+        });
+    };
+})(sap);
+
+/*eslint-disable fiori-custom/sap-browser-api-warning, fiori-custom/sap-no-dom-access*/
+var currentScript = document.getElementById("locate-reuse-libs");
+if (!currentScript) {
+    currentScript = document.currentScript;
+}
+var manifestUri = currentScript.getAttribute("data-sap-ui-manifest-uri");
+var componentName = currentScript.getAttribute("data-sap-ui-componentName");
+var useMockserver = currentScript.getAttribute("data-sap-ui-use-mockserver");
+
+sap.registerComponentDependencyPaths(manifestUri)
+    .catch(function (error) {
+        sap.ui.require(["sap/base/Log"], function (Log) {
+            Log.error(error);
+        });
+    })
+    .finally(function () {
+
+        // setting the app title with internationalization 
+        sap.ui.getCore().attachInit(function () {
+            var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+            sap.ui.require(["sap/base/i18n/ResourceBundle"], function (ResourceBundle) {
+                var oResourceBundle = ResourceBundle.create({
+                    url: "i18n/i18n.properties",
+                    locale: sLocale
+                });
+                document.title = oResourceBundle.getText("appTitle");
+            });
+        });
+
+        if (componentName && componentName.length > 0) {
+            if (useMockserver && useMockserver === "true") {
+                sap.ui.getCore().attachInit(function () {
+                    sap.ui.require([componentName.replace(/\./g, "/") + "/localService/mockserver"], function (server) {
+                        // set up test service for local testing
+                        server.init();
+                        // initialize the ushell sandbox component
+                        sap.ushell.Container.createRenderer().placeAt("content");
+                    });
+                });
+            } else {
+                // Requiring the ComponentSupport module automatically executes the component initialisation for all declaratively defined components
+                sap.ui.require(["sap/ui/core/ComponentSupport"]);
+
+                // setting the app title with the i18n text 
+                sap.ui.getCore().attachInit(function () {
+                    var sLocale = sap.ui.getCore().getConfiguration().getLanguage();
+                    sap.ui.require(["sap/base/i18n/ResourceBundle"], function (ResourceBundle) {
+                        var oResourceBundle = ResourceBundle.create({
+                            url: "i18n/i18n.properties",
+                            locale: sLocale
+                        });
+                        document.title = oResourceBundle.getText("appTitle");
+                    });
+                });
+            }
+        } else {
+            sap.ui.getCore().attachInit(function () {
+                // initialize the ushell sandbox component
+                sap.ushell.Container.createRenderer().placeAt("content");
+            });
+        }
+    });

--- a/packages/preview-middleware/templates/flp/sandbox.html
+++ b/packages/preview-middleware/templates/flp/sandbox.html
@@ -40,10 +40,10 @@
         };
     </script>
 
-    <script src="/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
+    <script src="<%- basePath %>/test-resources/sap/ushell/bootstrap/sandbox.js" id="sap-ushell-bootstrap"></script>
     <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions="allow"'' is a NON-SECURE setting for test environments -->
     <script id="sap-ui-bootstrap"
-        src="/resources/sap-ui-core.js"
+        src="<%- basePath %>/resources/sap-ui-core.js"
         data-sap-ui-libs="<%- ui5.libs %>"
         data-sap-ui-async="true"
         data-sap-ui-preload="async"

--- a/packages/preview-middleware/test/fixtures/multi-app/package.json
+++ b/packages/preview-middleware/test/fixtures/multi-app/package.json
@@ -10,6 +10,7 @@
     "scripts": {
         "build": "ui5 build",
         "prestart": "cd ../../.. && pnpm build",
-        "start": "ui5 serve --open /test/flp.html"
+        "start": "ui5 serve --open /test/flp.html",
+        "rta": "pnpm prestart && ui5 serve --open /test/flp.html?fiori-tools-rta-mode=true#app-preview"
     }
 }

--- a/packages/preview-middleware/test/fixtures/multi-app/ui5.yaml
+++ b/packages/preview-middleware/test/fixtures/multi-app/ui5.yaml
@@ -16,6 +16,7 @@ server:
           afterMiddleware: compression
           configuration:
               flp:
+                  libs: true
                   apps:
                       - local: ../simple-app
                         target: /apps/other-simple-app

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -8,7 +8,7 @@ Object {
       "applicationType": "URL",
       "description": "",
       "title": "my.id",
-      "url": "/",
+      "url": "..",
     },
     "myObject-action": Object {
       "additionalInformation": "SAPUI5.Component=test.fe.v2.other",
@@ -25,6 +25,7 @@ Object {
       "url": "/simple/app",
     },
   },
+  "basePath": "..",
   "locateReuseLibsScript": undefined,
   "ui5": Object {
     "flex": Array [
@@ -36,7 +37,7 @@ Object {
     ],
     "libs": "",
     "resources": Object {
-      "my.id": "/",
+      "my.id": "..",
       "test.fe.v2.app": "/simple/app",
       "test.fe.v2.other": "/yet/another/app",
     },
@@ -53,9 +54,10 @@ Object {
       "applicationType": "URL",
       "description": "",
       "title": "my.id",
-      "url": "/",
+      "url": "..",
     },
   },
+  "basePath": "..",
   "locateReuseLibsScript": undefined,
   "ui5": Object {
     "flex": Array [
@@ -67,7 +69,7 @@ Object {
     ],
     "libs": "",
     "resources": Object {
-      "my.id": "/",
+      "my.id": "..",
     },
     "theme": "sap_horizon",
   },
@@ -82,9 +84,10 @@ Object {
       "applicationType": "URL",
       "description": "This is a very simple application.",
       "title": "My Simple App",
-      "url": "/",
+      "url": "..",
     },
   },
+  "basePath": "..",
   "locateReuseLibsScript": undefined,
   "ui5": Object {
     "flex": Array [
@@ -96,7 +99,7 @@ Object {
     ],
     "libs": "sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template",
     "resources": Object {
-      "test.fe.v2.app": "/",
+      "test.fe.v2.app": "..",
     },
     "theme": "sap_horizon_dark",
   },
@@ -223,14 +226,14 @@ exports[`FlpSandbox router test/flp.html 1`] = `
                     }
                 }
             },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
         };
     </script>
 
-    <script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
     <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
     <script id=\\"sap-ui-bootstrap\\"
-        src=\\"/resources/sap-ui-core.js\\"
+        src=\\"../resources/sap-ui-core.js\\"
         data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
         data-sap-ui-async=\\"true\\"
         data-sap-ui-preload=\\"async\\"
@@ -238,7 +241,7 @@ exports[`FlpSandbox router test/flp.html 1`] = `
         data-sap-ui-compatVersion=\\"edge\\"
         data-sap-ui-language=\\"en\\"
         data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
-        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"/\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\">
     </script>
@@ -296,14 +299,14 @@ exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=forAdaptation 1`] 
                     }
                 }
             },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
         };
     </script>
 
-    <script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
     <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
     <script id=\\"sap-ui-bootstrap\\"
-        src=\\"/resources/sap-ui-core.js\\"
+        src=\\"../resources/sap-ui-core.js\\"
         data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
         data-sap-ui-async=\\"true\\"
         data-sap-ui-preload=\\"async\\"
@@ -311,7 +314,7 @@ exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=forAdaptation 1`] 
         data-sap-ui-compatVersion=\\"edge\\"
         data-sap-ui-language=\\"en\\"
         data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
-        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"/\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\">
     </script>
@@ -387,14 +390,14 @@ exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=true 1`] = `
                     }
                 }
             },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
         };
     </script>
 
-    <script src=\\"/test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
     <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
     <script id=\\"sap-ui-bootstrap\\"
-        src=\\"/resources/sap-ui-core.js\\"
+        src=\\"../resources/sap-ui-core.js\\"
         data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
         data-sap-ui-async=\\"true\\"
         data-sap-ui-preload=\\"async\\"
@@ -402,7 +405,7 @@ exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=true 1`] = `
         data-sap-ui-compatVersion=\\"edge\\"
         data-sap-ui-language=\\"en\\"
         data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
-        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"/\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-resourceroots='{\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\">
     </script>

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -55,7 +55,7 @@ describe('FlpSandbox', () => {
 
         test('advanced config', () => {
             const config: FlpConfig = {
-                path: '/my/custom/path',
+                path: 'my/custom/path',
                 intent: { object: 'movie', action: 'start' },
                 apps: [
                     {
@@ -65,7 +65,7 @@ describe('FlpSandbox', () => {
                 ]
             };
             const flp = new FlpSandbox(config, mockProject, mockUtils, logger);
-            expect(flp.config.path).toBe(config.path);
+            expect(flp.config.path).toBe(`/${config.path}`);
             expect(flp.config.apps).toEqual(config.apps);
             expect(flp.config.intent).toStrictEqual({ object: 'movie', action: 'start' });
             expect(flp.router).toBeDefined();

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -86,7 +86,7 @@ describe('ui5/middleware', () => {
         const path = '/my/preview/is/here.html';
         const server = await getTestServer('simple-app', { flp: { path, libs: true } });
         await server.get(path).expect(200);
-        await server.get(join(dirname(path), 'locate-reuse-libs.js')).expect(200);
+        await server.get('/my/preview/is/locate-reuse-libs.js').expect(200);
         await server.get('/test/flp.html').expect(404);
     });
 

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -4,7 +4,7 @@ import * as previewMiddleware from '../../../src/ui5/middleware';
 import type { Config } from '../../../src/types';
 import type { Resource } from '@ui5/fs';
 import { readFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import nock from 'nock';
 
 jest.mock('@sap-ux/store', () => {

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -4,7 +4,7 @@ import * as previewMiddleware from '../../../src/ui5/middleware';
 import type { Config } from '../../../src/types';
 import type { Resource } from '@ui5/fs';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import nock from 'nock';
 
 jest.mock('@sap-ux/store', () => {
@@ -79,12 +79,14 @@ describe('ui5/middleware', () => {
     test('no config', async () => {
         const server = await getTestServer('simple-app');
         await server.get('/test/flp.html').expect(200);
+        await server.get('/test/locate-reuse-libs.js').expect(404);
     });
 
     test('simple config', async () => {
         const path = '/my/preview/is/here.html';
-        const server = await getTestServer('simple-app', { flp: { path } });
+        const server = await getTestServer('simple-app', { flp: { path, libs: true } });
         await server.get(path).expect(200);
+        await server.get(join(dirname(path), 'locate-reuse-libs.js')).expect(200);
         await server.get('/test/flp.html').expect(404);
     });
 


### PR DESCRIPTION
This PR fixes the usage of the `preview-middleware` in a CAP project using the `cds-plugin-ui5`. In such a setup, the app is not hosted at the root but at a subfolder, so references to UI5 or the app need to be relative from the html file.
Also enables loading the `locate-reuse-libs.js` script on-the-fly when programmatically configured.