### PR TITLE
fix: Trying to copy from a source that does not exist error

### DIFF
--- a/.changeset/ninety-students-yawn.md
+++ b/.changeset/ninety-students-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': patch
+---
+
+FIX: 'Trying to copy from a source that does not exist' error

--- a/packages/adp-tooling/package.json
+++ b/packages/adp-tooling/package.json
@@ -27,6 +27,7 @@
     },
     "files": [
         "LICENSE",
+        "templates",
         "dist",
         "ui5.yaml",
         "bin",


### PR DESCRIPTION
Feature: #971
Issue:when you execute `npm init @sap-ux@latest generate adaptation-project` and enter all data correctly, the following error is displayed: `Trying to copy from a source that does not exist: /xxx/.npm/_npx/b4bdc7e504f3256c/node_modules/@sap-ux/adp-tooling/templates/**/*.*`