### PR TITLE
fix(sonar): promises should not be misused

### DIFF
--- a/.changeset/old-knives-roll.md
+++ b/.changeset/old-knives-roll.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-proxy-middleware': patch
+'@sap-ux/ui-components': patch
+---
+
+Fixes for 'promises should not be misused' sonar bugs

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
                         "disallowTypeAnnotations": true
                     }
                 ],
+                "@typescript-eslint/no-misused-promises": ["error", { "checksVoidReturn": false }],
                 "@typescript-eslint/no-use-before-define": ["error", "nofunc"],
                 "jsdoc/require-param-type": "off",
                 "jsdoc/require-returns-type": "off",

--- a/packages/ui-components/src/components/UITable/UITable-helper.tsx
+++ b/packages/ui-components/src/components/UITable/UITable-helper.tsx
@@ -155,15 +155,14 @@ export async function waitFor(selector: string) {
     return new Promise((resolve) => {
         if (el) {
             resolve(el);
-            return;
+        } else {
+            setTimeout(async () => {
+                const el2 = await waitFor(selector);
+                if (el2) {
+                    resolve(el2);
+                }
+            }, 100);
         }
-        setTimeout(async () => {
-            const el2 = await waitFor(selector);
-            if (el2) {
-                resolve(el2);
-                return;
-            }
-        }, 100);
     });
 }
 

--- a/packages/ui5-proxy-middleware/src/ui5/middleware.ts
+++ b/packages/ui5-proxy-middleware/src/ui5/middleware.ts
@@ -116,7 +116,12 @@ module.exports = async ({ resources, options }: MiddlewareParameters<UI5ProxyCon
 
     if (directLoad) {
         const directLoadProxy = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-            await injectScripts(req, res, next, ui5Configs);
+            try {
+                await injectScripts(req, res, next, ui5Configs);
+            } catch (error) {
+                logger.error(error);
+                next(error);
+            }
         };
 
         HTML_MOUNT_PATHS.forEach((path) => {


### PR DESCRIPTION
# Issue

#1159

Sonar Qube bugs:
1. Promise returned in function argument where a void return was expected.
Promises should not be misused [typescript:S6544](https://sonarcloud.io/organizations/sap-1/rules?open=typescript%3AS6544&rule_key=typescript%3AS6544)
`packages/.../src/components/UITable/UITable-helper.tsx`
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=SAP_open-ux-tools&open=AYfrPj_2SN0lrgwATVOw

2. Promise-returning function provided to property where a void return was expected.
Promises should not be misused [typescript:S6544](https://sonarcloud.io/organizations/sap-1/rules?open=typescript%3AS6544&rule_key=typescript%3AS6544)
`packages/ui5-proxy-middleware/src/ui5/middleware.ts`
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=SAP_open-ux-tools&open=AYfrPkWISN0lrgwATVQm

# Description
* Update sources to fix errors
* Add `eslint` rule `"@typescript-eslint/no-misused-promises"` to prevent future occurrences, but it doesn't seem to cover all cases from sonar cloud
