### PR TITLE
fix(project-access): load module, avoid caching of non existing files

### DIFF
--- a/.changeset/lovely-plums-exist.md
+++ b/.changeset/lovely-plums-exist.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix for module loading after installation

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -10,6 +10,7 @@ export {
     getCapModelAndServices,
     getCapProjectType,
     getMtaPath,
+    getNodeModulesPath,
     getWebappPath,
     isCapJavaProject,
     isCapNodeJsProject,

--- a/packages/project-access/src/project/dependencies.ts
+++ b/packages/project-access/src/project/dependencies.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, join, parse } from 'path';
+import { FileName } from '../constants';
 import type { Package } from '../types';
 
 /**
@@ -9,3 +12,33 @@ import type { Package } from '../types';
  */
 export const hasDependency = (packageJson: Package, dependency: string): boolean =>
     !!(packageJson.dependencies?.[dependency] || packageJson.devDependencies?.[dependency]);
+
+/**
+ * Returns path to folder that hosts 'node_modules' used by project.
+ * Optionally, a module name can be passed to check for. This is
+ * useful to check if a module is hoisted in a mono repository.
+ *
+ * @param projectRoot - absolute path to root of the project/app.
+ * @param [module] -  optional module name to find in node_modules
+ * @returns - parent path of node_modules used by project or undefined if node module path was not found
+ */
+export function getNodeModulesPath(projectRoot: string, module?: string): string | undefined {
+    if (!isAbsolute(projectRoot)) {
+        return undefined;
+    }
+    const { root } = parse(projectRoot);
+    let currentDir = projectRoot;
+    let modulesPath;
+    while (currentDir !== root) {
+        let checkPath = join(currentDir, 'node_modules');
+        if (module) {
+            checkPath = join(checkPath, module, FileName.Package);
+        }
+        if (existsSync(checkPath)) {
+            modulesPath = currentDir;
+            break;
+        }
+        currentDir = dirname(currentDir);
+    }
+    return modulesPath;
+}

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -7,6 +7,7 @@ export {
     getCapEnvironment,
     readCapServiceMetadataEdmx
 } from './cap';
+export { getNodeModulesPath } from './dependencies';
 export { getAppProgrammingLanguage } from './info';
 export { loadModuleFromProject } from './module-loader';
 export { findAllApps, findFioriArtifacts, findProjectRoot, getAppRootFromWebappPath } from './search';

--- a/packages/project-access/src/project/module-loader.ts
+++ b/packages/project-access/src/project/module-loader.ts
@@ -1,17 +1,28 @@
+import { getNodeModulesPath } from './dependencies';
+
 /**
  * Load module from project or app. Throws error if module is not installed.
  *
+ * Note: Node's require.resolve() caches file access results in internal statCache, see:
+ * (https://github.com/nodejs/node/blob/d150316a8ecad1a9c20615ae62fcaf4f8d060dcc/lib/internal/modules/cjs/loader.js#L155)
+ * This means, if a module is not installed and require.resolve() is executed, it will never resolve, even after the
+ * module is installed later on. To prevent filling cjs loader's statCache with entries for non existing files,
+ * we check if the module exists using getNodeModulesPath() before require.resolve().
+ *
  * @param projectRoot - root path of the project/app.
- * @param moduleName - name of the npm module.
+ * @param moduleName - name of the node module.
  * @returns - loaded module.
  */
 export async function loadModuleFromProject<T>(projectRoot: string, moduleName: string): Promise<T> {
     let module: T;
     try {
+        if (!getNodeModulesPath(projectRoot, moduleName)) {
+            throw Error('Path to module not found.');
+        }
         const modulePath = require.resolve(moduleName, { paths: [projectRoot] });
         module = (await import(modulePath)) as T;
     } catch (error) {
-        throw Error(`Module '${moduleName}' not installed in project '${projectRoot}'`);
+        throw Error(`Module '${moduleName}' not installed in project '${projectRoot}'.\n${error.toString()}`);
     }
     return module;
 }

--- a/packages/project-access/src/project/mta.ts
+++ b/packages/project-access/src/project/mta.ts
@@ -11,9 +11,9 @@ import type { MtaPath } from '../types/mta';
  * a parent root folder for MTA project, and this project itself is configured
  * to have deploy target CF and user answered yes to "add to Managed App Router" question.
  *
- * @param projectPath Fiori app root folder
- * @param fs
- * @returns MtaPath
+ * @param projectPath - Fiori app root folder
+ * @param fs - optional mem-fs-editor instance
+ * @returns - MtaPath
  */
 export async function getMtaPath(projectPath: string, fs?: Editor): Promise<MtaPath | undefined> {
     const mtaPath = await findFileUp(FileName.MtaYaml, projectPath, fs);

--- a/packages/project-access/test/file/file-search.test.ts
+++ b/packages/project-access/test/file/file-search.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
-import { findFiles, findFilesByExtension, findFileUp, getFilePaths } from '../../src/file';
+import { getFilePaths } from '../../src';
+import { findFiles, findFilesByExtension, findFileUp } from '../../src/file';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
 

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -2,13 +2,16 @@ import { join } from 'path';
 import * as projectModuleMock from '../../src/project/module-loader';
 import type { Package } from '../../src';
 import { FileName } from '../../src/constants';
-import { isCapNodeJsProject, isCapJavaProject, getCapModelAndServices, getCapProjectType } from '../../src';
 import {
     getCapCustomPaths,
     getCapEnvironment,
-    readCapServiceMetadataEdmx,
-    toReferenceUri
-} from '../../src/project/cap';
+    isCapNodeJsProject,
+    isCapJavaProject,
+    getCapModelAndServices,
+    getCapProjectType,
+    readCapServiceMetadataEdmx
+} from '../../src';
+import { toReferenceUri } from '../../src/project/cap';
 import * as file from '../../src/file';
 import os from 'os';
 

--- a/packages/project-access/test/project/dependencies.test.ts
+++ b/packages/project-access/test/project/dependencies.test.ts
@@ -1,4 +1,6 @@
+import { join, sep } from 'path';
 import type { Package } from '../../src';
+import { getNodeModulesPath } from '../../src';
 import { hasDependency } from '../../src/project/dependencies';
 
 describe('Test hasDependency()', () => {
@@ -18,5 +20,23 @@ describe('Test hasDependency()', () => {
             devDependencies: { 'dev-dependency': '0.0.0' }
         } as Partial<Package>;
         expect(hasDependency(packageJson as Package, 'dep')).toBeFalsy();
+    });
+});
+
+describe('Test getNodeModulesPath()', () => {
+    test('Find node_modules parent of this module, should return root path to this module', () => {
+        expect(getNodeModulesPath(__dirname)?.split(sep).pop()).toBe('project-access');
+    });
+
+    test('Find node_modules parent of this module with a given module, should return root path', () => {
+        expect(getNodeModulesPath(__dirname, '@ui5/manifest')?.split(sep).pop()).toBe('project-access');
+    });
+
+    test('Find node_modules parent of this module with a non existing module, should return undefined', () => {
+        expect(getNodeModulesPath(__dirname, 'wrong-module')?.split(sep).pop()).toBe(undefined);
+    });
+
+    test('Find node_modules parent for relative path, should return undefined', () => {
+        expect(getNodeModulesPath(join('some/relative/path'))).toBe(undefined);
     });
 });

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -1,7 +1,6 @@
 import { basename, dirname, join } from 'path';
 import type { WorkspaceFolder } from '../../src';
-import { findAllApps, findProjectRoot, getAppRootFromWebappPath } from '../../src';
-import { findFioriArtifacts } from '../../src/project/search';
+import { findAllApps, findFioriArtifacts, findProjectRoot, getAppRootFromWebappPath } from '../../src';
 
 const testDataRoot = join(__dirname, '..', 'test-data');
 

--- a/packages/project-access/test/project/info.test.ts
+++ b/packages/project-access/test/project/info.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
-import { getAppProgrammingLanguage } from '../../src/project';
+import { getAppProgrammingLanguage } from '../../src';
 
 describe('Test getAppProgrammingLanguage()', () => {
     const sampleRoot = join(__dirname, '../test-data/project/info');


### PR DESCRIPTION
## Issue
https://github.com/SAP/open-ux-tools/issues/1153

## Description
Fix to avoid internal caching when calling `require.resolve()`. This pull requests implements the option, that check first if the module is installed before executing `require.resolve()` to get the module location. 
For details see description in ticket #1153 