### PR TITLE
fix(deploy-tooling): Load dotenv when UI5 task is called

### DIFF
--- a/.changeset/young-waves-draw.md
+++ b/.changeset/young-waves-draw.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+Load dotenv when UI5 task is called

--- a/packages/deploy-tooling/src/ui5/index.ts
+++ b/packages/deploy-tooling/src/ui5/index.ts
@@ -4,6 +4,7 @@ import type { AbapDeployConfig } from '../types';
 import { NAME } from '../types';
 import { deploy, replaceEnvVariables, validateConfig } from '../base';
 import { createUi5Archive } from './archive';
+import { config as loadEnvConfig } from 'dotenv';
 
 /**
  * Custom task to upload the build result to the UI5 ABAP Repository.
@@ -13,6 +14,7 @@ import { createUi5Archive } from './archive';
  * @param params.options - project properties and configuration
  */
 async function task({ workspace, options }: TaskParameters<AbapDeployConfig>): Promise<void> {
+    loadEnvConfig();
     const logLevel = (options.configuration?.log as LogLevel) ?? LogLevel.Info;
     const logger = new ToolsLogger({
         transports: [new UI5ToolingTransport({ moduleName: `${NAME} ${options.projectName}` })],

--- a/packages/deploy-tooling/test/unit/ui5/index.test.ts
+++ b/packages/deploy-tooling/test/unit/ui5/index.test.ts
@@ -26,7 +26,7 @@ describe('ui5', () => {
         byGlob: jest.fn().mockReturnValue([
             {
                 getPath: () => `${projectName}/~path`,
-                getBuffer: () => Promise.resolve(Buffer.from('TestData'))
+                getBuffer: () => Promise.resolve(Buffer.from(''))
             }
         ])
     };

--- a/packages/deploy-tooling/test/unit/ui5/index.test.ts
+++ b/packages/deploy-tooling/test/unit/ui5/index.test.ts
@@ -3,6 +3,9 @@ import type { AbapDeployConfig } from '../../../src/types';
 import ui5Task from '../../../src/ui5';
 import { task } from '../../../src';
 import { mockedUi5RepoService } from '../../__mocks__';
+import { config } from 'dotenv';
+
+jest.mock('dotenv');
 
 describe('ui5', () => {
     const configuration: AbapDeployConfig = {
@@ -23,7 +26,7 @@ describe('ui5', () => {
         byGlob: jest.fn().mockReturnValue([
             {
                 getPath: () => `${projectName}/~path`,
-                getBuffer: () => Promise.resolve(Buffer.from(''))
+                getBuffer: () => Promise.resolve(Buffer.from('TestData'))
             }
         ])
     };
@@ -32,6 +35,7 @@ describe('ui5', () => {
     test('no errors', async () => {
         mockedUi5RepoService.deploy.mockResolvedValue(undefined);
         await task({ workspace, options } as any);
+        expect(config).toBeCalledTimes(1);
     });
 
     test('verify correct export', () => {


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1160

- added tests to ensure dotenv is called when task is called