### PR TITLE
fix(project-access): usage of cds on windows

### DIFF
--- a/.changeset/tidy-balloons-confess.md
+++ b/.changeset/tidy-balloons-confess.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix for leading slashes on Windows

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -126,13 +126,16 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
 
 /**
  * Remove rogue '\\' - cds windows if needed.
- * Replaces all backslashes with forward slashes, removes double slashes, and trailing slashes
+ * Replaces all backslashes with forward slashes, removes double slashes, and trailing slashes.
  *
  * @param url - url to uniform
  * @returns - uniform url
  */
 function uniformUrl(url: string) {
-    return url.replace(/\\/g, '/').replace(/\/\//g, '/').replace(/(?:^\/)/g, '');
+    return url
+        .replace(/\\/g, '/')
+        .replace(/\/\//g, '/')
+        .replace(/(?:^\/)/g, '');
 }
 
 /**

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -109,9 +109,9 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
         join(projectRoot, capProjectPaths.db)
     ];
     const model = await cds.load(modelPaths);
-    let services = cds.compile.to['serviceinfo'](model, { root: projectRoot });
-    if (services?.map) {
-        services = services?.map((value) => {
+    let services = cds.compile.to.serviceinfo(model, { root: projectRoot }) ?? [];
+    if (services.map) {
+        services = services.map((value) => {
             return {
                 name: value.name,
                 urlPath: uniformUrl(value.urlPath)
@@ -126,12 +126,13 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
 
 /**
  * Remove rogue '\\' - cds windows if needed.
+ * Replaces all backslashes with forward slashes, removes double slashes, and trailing slashes
  *
  * @param url - url to uniform
  * @returns - uniform url
  */
 function uniformUrl(url: string) {
-    return url.replace(/\\/g, '/').replace(/\/\//g, '/');
+    return url.replace(/\\/g, '/').replace(/\/\//g, '/').replace(/(?:^\/)/g, '');
 }
 
 /**

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -89,14 +89,15 @@ describe('Test getCapModelAndServices()', () => {
             load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
             compile: {
                 to: {
-                    serviceinfo: jest.fn().mockImplementation(() => [{
-                        "name": "Forwardslash",
-                        "urlPath": "odata/service/with/forwardslash/",
-                    },
-                    {
-                        "name": "Backslash",
-                        "urlPath": "\\odata\\service\\with\\backslash/",
-                    },
+                    serviceinfo: jest.fn().mockImplementation(() => [
+                        {
+                            'name': 'Forwardslash',
+                            'urlPath': 'odata/service/with/forwardslash/'
+                        },
+                        {
+                            'name': 'Backslash',
+                            'urlPath': '\\odata\\service\\with\\backslash/'
+                        }
                     ])
                 }
             }
@@ -108,14 +109,17 @@ describe('Test getCapModelAndServices()', () => {
 
         // Check results
         expect(capMS).toEqual({
-            model: 'MODEL', services: [{
-                "name": "Forwardslash",
-                "urlPath": "odata/service/with/forwardslash/",
-            },
-            {
-                "name": "Backslash",
-                "urlPath": "odata/service/with/backslash/",
-            }]
+            model: 'MODEL',
+            services: [
+                {
+                    'name': 'Forwardslash',
+                    'urlPath': 'odata/service/with/forwardslash/'
+                },
+                {
+                    'name': 'Backslash',
+                    'urlPath': 'odata/service/with/backslash/'
+                }
+            ]
         });
         expect(cdsMock.load).toBeCalledWith([
             join('PROJECT_ROOT', 'APP'),

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -87,7 +87,19 @@ describe('Test getCapModelAndServices()', () => {
                 })
             },
             load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
-            compile: { to: { serviceinfo: jest.fn().mockImplementation(() => 'SERVICES') } }
+            compile: {
+                to: {
+                    serviceinfo: jest.fn().mockImplementation(() => [{
+                        "name": "Forwardslash",
+                        "urlPath": "odata/service/with/forwardslash/",
+                    },
+                    {
+                        "name": "Backslash",
+                        "urlPath": "\\odata\\service\\with\\backslash/",
+                    },
+                    ])
+                }
+            }
         };
         jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
 
@@ -95,7 +107,16 @@ describe('Test getCapModelAndServices()', () => {
         const capMS = await getCapModelAndServices('PROJECT_ROOT');
 
         // Check results
-        expect(capMS).toEqual({ model: 'MODEL', services: 'SERVICES' });
+        expect(capMS).toEqual({
+            model: 'MODEL', services: [{
+                "name": "Forwardslash",
+                "urlPath": "odata/service/with/forwardslash/",
+            },
+            {
+                "name": "Backslash",
+                "urlPath": "odata/service/with/backslash/",
+            }]
+        });
         expect(cdsMock.load).toBeCalledWith([
             join('PROJECT_ROOT', 'APP'),
             join('PROJECT_ROOT', 'SRV'),
@@ -104,7 +125,7 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
     });
 
-    test('cds v7 exports', async () => {
+    test('Get model and services, but services are empty', async () => {
         // Mock setup
         const cdsMock = {
             env: {
@@ -116,25 +137,21 @@ describe('Test getCapModelAndServices()', () => {
                     }
                 })
             },
-            load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
-            compile: { to: { serviceinfo: jest.fn().mockImplementation(() => 'SERVICES') } }
+            load: jest.fn().mockImplementation(() => Promise.resolve('MODEL_NO_SERVICES')),
+            compile: {
+                to: {
+                    serviceinfo: jest.fn().mockImplementation(() => null)
+                }
+            }
         };
-        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => {
-            return Promise.resolve({
-                default: cdsMock
-            });
-        });
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
+
         // Test execution
-        const capMS = await getCapModelAndServices('PROJECT_ROOT');
+        const capMS = await getCapModelAndServices('ROOT_PATH');
 
         // Check results
-        expect(capMS).toEqual({ model: 'MODEL', services: 'SERVICES' });
-        expect(cdsMock.load).toBeCalledWith([
-            join('PROJECT_ROOT', 'APP'),
-            join('PROJECT_ROOT', 'SRV'),
-            join('PROJECT_ROOT', 'DB')
-        ]);
-        expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
+        expect(capMS.services).toEqual([]);
+        expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: 'ROOT_PATH' });
     });
 });
 


### PR DESCRIPTION
## Issue

The service details return from module `@sap/cds` looks different on Windows than on MacOS or Linux:

**Windows**
![image](https://github.com/SAP/open-ux-tools/assets/66327622/b35c3d01-c725-4fe4-9812-f7b28bddf927)

**MacOS, Linux**
![image](https://github.com/SAP/open-ux-tools/assets/66327622/06f5a09b-46fd-4eaf-819a-6c55db905f8e)

While we did already a conversion from `\` -> `/` and removed double slashes, the leading slash was still in result of function call `getCapModelAndServices()`. The search for service removes leading and trailing slashes, so the mostly used function `readCapServiceMetadataEdmx()` was working as expected. This pull requests fixes the returned service of call `getCapModelAndServices()` and adds unit tests for the case with backslashes.

By the way the team of `@sap/cds` is informed and will provide a fix soon, goal is to return the service URL with forward slashes on any operating system.

