### PR TITLE
fix(ui5-proxy-middleware): support usage inside connect servers

### DIFF
--- a/.changeset/slow-kings-eat.md
+++ b/.changeset/slow-kings-eat.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-proxy-middleware': patch
+---
+
+Support usage when running in connect server like approuter

--- a/packages/ui5-proxy-middleware/src/base/utils.ts
+++ b/packages/ui5-proxy-middleware/src/base/utils.ts
@@ -185,7 +185,11 @@ export const setHtmlResponse = (res: any, html: string): void => {
         res.write(html);
         res.end();
     } else {
-        res.status(200).contentType('html').send(html);
+        res.writeHead(200, {
+            "Content-Type": "text/html"
+        });
+        res.write(html);
+        res.end();
     }
 };
 

--- a/packages/ui5-proxy-middleware/src/base/utils.ts
+++ b/packages/ui5-proxy-middleware/src/base/utils.ts
@@ -186,7 +186,7 @@ export const setHtmlResponse = (res: any, html: string): void => {
         res.end();
     } else {
         res.writeHead(200, {
-            "Content-Type": "text/html"
+            'Content-Type': 'text/html'
         });
         res.write(html);
         res.end();


### PR DESCRIPTION
When using the dev-approuter (https://www.npmjs.com/package/dev-approuter) to run UI5 and CAP applications inside the @sap/router from a monorepo then the server is using connect and not express. In those scenarios, similar like with livereload only the basic http response object from Node.js is available and the status function is not available which leads to an INTERNAL SERVER ERROR. By using the writeHead, write and end function of the response object the function is agnostic to the used server and works in both scenarios.