### PR TITLE
fix(fe-fpm-writer): Edit for custom header section

### DIFF
--- a/.changeset/empty-turkeys-live.md
+++ b/.changeset/empty-turkeys-live.md
@@ -2,4 +2,4 @@
 '@sap-ux/fe-fpm-writer': patch
 ---
 
-Fix: Updated contents of default edit fragment for header custom section
+Correction for content of generated fragment for `templateEdit` property: Content is wrapped inside `sap.ui.layout.form.FormElement`

--- a/.changeset/empty-turkeys-live.md
+++ b/.changeset/empty-turkeys-live.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix: Updated contents of default edit fragment for header custom section

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -49,12 +49,12 @@ export function getDefaultFragmentContent(
         const handler = `${parts.join('/')}${isController ? '.controller' : ''}`;
         const requireAttr = `core:require="{ handler: '${handler}'}"`;
         if (prefferInput) {
-            content = `<Input ${requireAttr} label="${text}" change="handler.${method}" />`;
+            content = `<Input ${requireAttr} value="${text}" change="handler.${method}" />`;
         } else {
             content = `<Button ${requireAttr} text="${text}" press="handler.${method}" />`;
         }
     } else if (prefferInput) {
-        content = `<Input label="${text}" />`;
+        content = `<Input value="${text}" />`;
     } else {
         content = `<Text text="${text}" />`;
     }

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -164,7 +164,7 @@ export function generateCustomHeaderSection(
         if (editSection.path) {
             const viewPath = join(editSection.path, `${editSection.name}.fragment.xml`);
             if (!editor.exists(viewPath)) {
-                editor.copyTpl(getTemplatePath('common/FragmentWithVBox.xml'), viewPath, editSection);
+                editor.copyTpl(getTemplatePath('common/FragmentWithForm.xml'), viewPath, editSection);
             }
         }
     }

--- a/packages/fe-fpm-writer/templates/common/FragmentWithForm.xml
+++ b/packages/fe-fpm-writer/templates/common/FragmentWithForm.xml
@@ -1,0 +1,7 @@
+<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m" xmlns:f="sap.ui.layout.form"<%- typeof dependencies !== 'undefined' ? ` ${dependencies}` : '' %>>
+    <f:FormElement>
+        <f:fields>
+            <%- content %>
+        </f:fields>
+    </f:FormElement>
+</core:FragmentDefinition>

--- a/packages/fe-fpm-writer/test/integration/__snapshots__/basic-lrop-app.test.ts.snap
+++ b/packages/fe-fpm-writer/test/integration/__snapshots__/basic-lrop-app.test.ts.snap
@@ -81,10 +81,12 @@ Object {
     "state": "modified",
   },
   "js/webapp/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit.fragment.xml": Object {
-    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Input core:require=\\"{ handler: 'v4travel/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit'}\\" label=\\"MyCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
-	</VBox>
+    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <Input core:require=\\"{ handler: 'v4travel/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit'}\\" value=\\"MyCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+        </f:fields>
+    </f:FormElement>
 </core:FragmentDefinition>",
     "state": "modified",
   },
@@ -703,10 +705,12 @@ export function onPress(this: ExtensionAPI, event: UI5Event) {
     "state": "modified",
   },
   "ts/webapp/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit.fragment.xml": Object {
-    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Input core:require=\\"{ handler: 'v4travel/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit'}\\" label=\\"MyCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
-	</VBox>
+    "contents": "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <Input core:require=\\"{ handler: 'v4travel/ext/myCustomHeaderSectionEdit/MyCustomHeaderSectionEdit'}\\" value=\\"MyCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+        </f:fields>
+    </f:FormElement>
 </core:FragmentDefinition>",
     "state": "modified",
   },

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
@@ -154,10 +154,12 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 `;
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in different extension folders for version 1.86 4`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/different/NewCustomHeaderSectionEdit'}\\" label=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
-	</VBox>
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/different/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+        </f:fields>
+    </f:FormElement>
 </core:FragmentDefinition>"
 `;
 
@@ -312,10 +314,12 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 `;
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 4`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" label=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
-	</VBox>
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+        </f:fields>
+    </f:FormElement>
 </core:FragmentDefinition>"
 `;
 
@@ -380,10 +384,12 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 `;
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.98 4`] = `
-"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" label=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
-	</VBox>
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+        </f:fields>
+    </f:FormElement>
 </core:FragmentDefinition>"
 `;
 


### PR DESCRIPTION
Wrapped contents of `templateEdit` default fragment for header custom section with `FormElement`, because VBox is not valid for that.

Error in console:
![image](https://github.com/SAP/open-ux-tools/assets/122096996/2566f399-52b9-466e-84f2-6c933a7a8faf)
