### PR TITLE
feat(ui-components) add the noOptionsMessage to UICreateSelect

### DIFF
--- a/.changeset/old-apricots-exist.md
+++ b/.changeset/old-apricots-exist.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/ui-components": patch
+---
+
+feat(ui-components) add the noOptionsMessage to UICreateSelect

--- a/packages/ui-components/src/components/UICreateSelect/UICreateSelect.tsx
+++ b/packages/ui-components/src/components/UICreateSelect/UICreateSelect.tsx
@@ -45,13 +45,14 @@ export interface UICreateSelectAccessors<Option> {
 
 export type UICreateSelectProps = {
     defaultMenuIsOpen?: boolean;
-    createText?: string;
     isClearable: boolean;
     isLoading: boolean;
     isDisabled: boolean;
     placeholder: string;
     value: UICreateSelectOptionEntry | undefined;
     options: UICreateSelectOptionEntry[];
+    createText?: string;
+    noOptionsMessage?: ((obj: { inputValue: string }) => React.ReactNode) | undefined;
     isValidNewOption?: (
         inputValue: string,
         selectValue: Options<UICreateSelectOptionEntry>,
@@ -167,6 +168,7 @@ export const UICreateSelect: FC<UICreateSelectProps> = (props: UICreateSelectPro
             onCreateOption={props.handleCreate}
             options={props.options}
             value={props.value}
+            noOptionsMessage={props.noOptionsMessage}
             formatCreateLabel={formatCreateLabel}
             components={{ ClearIndicator, DropdownIndicator, LoadingIndicator, Option }}
             unstyled={true}

--- a/packages/ui-components/stories/UICreateSelect.story.tsx
+++ b/packages/ui-components/stories/UICreateSelect.story.tsx
@@ -12,7 +12,7 @@ export default { title: 'Dropdowns/CreateSelect' };
 const stackTokens: IStackTokens = { childrenGap: 40 };
 
 export const CreateSelect = (): JSX.Element => {
-    const createOption = (label: string) => ({
+    const createOption = (label: string): UICreateSelectOptionEntry => ({
         label,
         value: label.toLowerCase().replace(/\W/g, '')
     });
@@ -21,6 +21,11 @@ export const CreateSelect = (): JSX.Element => {
     const [options, setOptions] = useState(defaultOptions);
     const [value, setValue] = useState<UICreateSelectOptionEntry>();
     const [selectedValue, setSelectedValue] = useState<UICreateSelectOptionEntry>();
+
+    const [isLoadingEmpty, setIsLoadingEmpty] = useState(false);
+    const [optionsEmpty, setOptionsEmpty] = useState<UICreateSelectOptionEntry[]>([]);
+    const [valueEmpty, setValueEmpty] = useState<UICreateSelectOptionEntry>();
+    const [selectedValueEmpty, setSelectedValueEmpty] = useState<UICreateSelectOptionEntry>();
 
     const handleCreate = (inputValue: string) => {
         const newOption = createOption(inputValue);
@@ -39,28 +44,101 @@ export const CreateSelect = (): JSX.Element => {
         setSelectedValue(val);
     };
 
-    return (
-        <div style={{ width: '300px' }}>
-            <div>
-                <div>
-                    <UILabel>UI Create Select</UILabel>
-                </div>
-                <UICreateSelect
-                    createText={'Add new value'}
-                    isClearable={true}
-                    isLoading={isLoading}
-                    isDisabled={false}
-                    isValidNewOption={(inputValue) => inputValue.length > 0}
-                    placeholder={'Search or enter a new value'}
-                    options={options}
-                    value={value}
-                    handleCreate={handleCreate}
-                    handleOnChange={handleChange}
-                />
-                <div style={{ padding: '20px 0', fontFamily: 'var(--vscode-font-family)', fontSize: '13px' }}>
-                    Value selected: <b>{selectedValue?.value}</b>
-                </div>
+    const handleCreateEmpty = (inputValue: string) => {
+        const newOption = createOption(inputValue);
+        setIsLoadingEmpty(true);
+        setValueEmpty(newOption);
+
+        setTimeout(() => {
+            setIsLoadingEmpty(false);
+            setOptionsEmpty((prev) => [...prev, newOption]);
+            setSelectedValueEmpty(newOption);
+        }, 1000);
+    };
+    const handleChangeEmpty = (newValue: UICreateSelectMultiValue<UICreateSelectOptionEntry>) => {
+        const val = newValue as unknown as UICreateSelectOptionEntry;
+        setValueEmpty(val);
+        setSelectedValueEmpty(val);
+    };
+
+    const generateNoOptionsMessage = (_obj: { inputValue: string }): React.ReactNode => {
+        return (
+            <div style={{ fontSize: '12px', display: 'flex', margin: '5px', padding: '0px 5px 0px 5px' }}>
+                Nothing there, just create new ones...
             </div>
-        </div>
+        );
+    };
+
+    return (
+        <Stack tokens={stackTokens}>
+            <Stack tokens={stackTokens}>
+                <Text variant={'large'} block>
+                    Create Select - default
+                </Text>
+                <Stack horizontal tokens={stackTokens} style={{ margin: 0, padding: 0 }}>
+                    <div style={{ width: '300px' }}>
+                        <div>
+                            <div>
+                                <UILabel>UI Create Select Label</UILabel>
+                            </div>
+                            <UICreateSelect
+                                createText={'Add new value'}
+                                isClearable={true}
+                                isLoading={isLoading}
+                                isDisabled={false}
+                                isValidNewOption={(inputValue) => inputValue.length > 0}
+                                placeholder={'Search or enter a new value'}
+                                options={options}
+                                value={value}
+                                handleCreate={handleCreate}
+                                handleOnChange={handleChange}
+                            />
+                            <div
+                                style={{
+                                    padding: '20px 0',
+                                    fontFamily: 'var(--vscode-font-family)',
+                                    fontSize: '13px'
+                                }}>
+                                Value selected: <b>{selectedValue?.value}</b>
+                            </div>
+                        </div>
+                    </div>
+                </Stack>
+
+                <Text variant={'large'} block>
+                    Create Select - no option by default
+                </Text>
+                <Stack horizontal tokens={stackTokens} style={{ margin: 0, padding: 0 }}>
+                    <div style={{ width: '300px' }}>
+                        <div>
+                            <div>
+                                <UILabel>UI Create Select Label</UILabel>
+                            </div>
+                            <UICreateSelect
+                                createText={'Add new qualifier'}
+                                isClearable={true}
+                                isLoading={isLoadingEmpty}
+                                isDisabled={false}
+                                isValidNewOption={(inputValue) => inputValue.length > 0}
+                                placeholder={'Search or enter a new qualifier value'}
+                                options={optionsEmpty}
+                                value={valueEmpty}
+                                noOptionsMessage={generateNoOptionsMessage}
+                                handleCreate={handleCreateEmpty}
+                                handleOnChange={handleChangeEmpty}
+                            />
+                            <div
+                                style={{
+                                    padding: '20px 0',
+                                    fontFamily: 'var(--vscode-font-family)',
+                                    fontSize: '13px'
+                                }}>
+                                Value selected: <b>{selectedValue?.value}</b>
+                            </div>
+                        </div>
+                    </div>
+                </Stack>
+            </Stack>
+        </Stack>
     );
 };


### PR DESCRIPTION
Add the `noOptionsMessage` props to UICreateSelect, to display information message when options menu is empty.

![CleanShot 2023-09-07 at 08 21 13](https://github.com/SAP/open-ux-tools/assets/526128/a36a82da-d66c-4df4-82b3-20949e3bd608)
