### PR TITLE
fix(env-check): use btp-utils to retrieve destinations

### DIFF
--- a/.changeset/short-snakes-perform.md
+++ b/.changeset/short-snakes-perform.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/environment-check': patch
+---
+
+Update to use listDestinations from @sap-ux/btp-utils


### PR DESCRIPTION
#945 

Update to use `listDestinations` from  `@sap-ux/btp-utils` rather than the `@sap/bas-sdk` api.