### PR TITLE
Enhancing the preview-middleware to support edit modes 

### DIFF
--- a/.changeset/eleven-dryers-hear.md
+++ b/.changeset/eleven-dryers-hear.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': minor
+---
+
+Breaking change: separating preview from edit mode

--- a/.changeset/pretty-radios-tickle.md
+++ b/.changeset/pretty-radios-tickle.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': minor
+---
+
+Improving the generated ui5.yaml and package.json

--- a/packages/adp-tooling/src/writer/index.ts
+++ b/packages/adp-tooling/src/writer/index.ts
@@ -58,7 +58,15 @@ export async function generate(basePath: string, config: AdpWriterConfig, fs?: E
                 adp: {
                     target: fullConfig.target,
                     ignoreCertErrors: false
-                } as AdpPreviewConfig
+                } as AdpPreviewConfig,
+                rta: {
+                    editors: [
+                        {
+                            path: 'local/editor.html',
+                            developerMode: true
+                        }
+                    ]
+                }
             }
         },
         {

--- a/packages/adp-tooling/templates/package.json
+++ b/packages/adp-tooling/templates/package.json
@@ -10,14 +10,14 @@
     ],
     "dependencies": {},
     "devDependencies": {
-        "@sap-ux/backend-proxy-middleware": "^0.6.61",
-        "@sap-ux/preview-middleware": "^0.3.1",
-        "@sap-ux/ui5-proxy-middleware": "^1.1.31",
-        "@ui5/cli": "^3.3.2"
+        "@sap-ux/backend-proxy-middleware": "^0.6.68",
+        "@sap-ux/preview-middleware": "^0.5.0",
+        "@sap-ux/ui5-proxy-middleware": "^1.1.34",
+        "@ui5/cli": "^3.6.0"
     },
     "scripts": {
         "build": "ui5 build --clean-dest",
         "start": "ui5 serve --open /test/flp.html#app-preview",
-        "editor": "ui5 serve --open /test/flp.html?fiori-tools-rta-mode=forAdaptation#app-preview"
+        "editor": "ui5 serve --open /local/editor.html"
     }
 }

--- a/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
+++ b/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
@@ -23,15 +23,15 @@ dist/
     ],
     \\"dependencies\\": {},
     \\"devDependencies\\": {
-        \\"@sap-ux/backend-proxy-middleware\\": \\"^0.6.61\\",
-        \\"@sap-ux/preview-middleware\\": \\"^0.3.1\\",
-        \\"@sap-ux/ui5-proxy-middleware\\": \\"^1.1.31\\",
-        \\"@ui5/cli\\": \\"^3.3.2\\"
+        \\"@sap-ux/backend-proxy-middleware\\": \\"^0.6.68\\",
+        \\"@sap-ux/preview-middleware\\": \\"^0.5.0\\",
+        \\"@sap-ux/ui5-proxy-middleware\\": \\"^1.1.34\\",
+        \\"@ui5/cli\\": \\"^3.6.0\\"
     },
     \\"scripts\\": {
         \\"build\\": \\"ui5 build --clean-dest\\",
         \\"start\\": \\"ui5 serve --open /test/flp.html#app-preview\\",
-        \\"editor\\": \\"ui5 serve --open /test/flp.html?fiori-tools-rta-mode=forAdaptation#app-preview\\"
+        \\"editor\\": \\"ui5 serve --open /local/editor.html\\"
     }
 }
 ",
@@ -53,6 +53,10 @@ server:
           target:
             url: http://sap.example
           ignoreCertErrors: false
+        rta:
+          editors:
+            - path: local/editor.html
+              developerMode: true
     - name: ui5-proxy-middleware
       afterMiddleware: preview-middleware
       configuration:

--- a/packages/preview-middleware-client/.eslintrc.js
+++ b/packages/preview-middleware-client/.eslintrc.js
@@ -11,7 +11,14 @@ module.exports = {
             requireParamType: false,
             requireReturn: false,
             requireReturnType: false
-        }]
+        }],
+        '@typescript-eslint/no-unused-vars': [
+            'error',
+            {
+                varsIgnorePattern: '^_',
+                argsIgnorePattern: '^_'
+            }
+        ]
     },
     overrides: [
         {

--- a/packages/preview-middleware-client/jest.config.js
+++ b/packages/preview-middleware-client/jest.config.js
@@ -1,7 +1,8 @@
 const config = require('../../jest.base');
 config.testEnvironment = 'jsdom';
 config.moduleNameMapper = {
-    '^sap/(.+)$': `<rootDir>/test/__mock__/sap/$1.ts`
+    '^sap/(.+)$': '<rootDir>/test/__mock__/sap/$1.ts',
+    '^mock/(.+)$': '<rootDir>/test/__mock__/$1.ts'
 };
 config.transform = {
     '^.+\\.ts$': [

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -11,7 +11,7 @@
     "private": true,
     "main": "dist/index.js",
     "scripts": {
-        "build": "tsc && ui5 build --clean-dest --exclude-task=* --include-task=ui5-tooling-transpile-task",
+        "build": "tsc --noEmit && ui5 build --clean-dest --exclude-task=* --include-task=ui5-tooling-transpile-task",
         "clean": "rimraf --glob dist coverage *.tsbuildinfo",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -11,7 +11,7 @@
     "private": true,
     "main": "dist/index.js",
     "scripts": {
-        "build": "tsc --noEmit && ui5 build --clean-dest --exclude-task=* --include-task=ui5-tooling-transpile-task",
+        "build": "tsc --noEmit && ui5 build --clean-dest --exclude-task minify --exclude-task generateComponentPreload",
         "clean": "rimraf --glob dist coverage *.tsbuildinfo",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -1,0 +1,8 @@
+import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
+import init from '../cpe/init';
+
+export default function(rta: RuntimeAuthoring) {
+    // custom adaptation project plugin code goes here
+    // also initialize the editor
+    init(rta);
+}

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -1,8 +1,10 @@
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
 import init from '../cpe/init';
+import log from 'sap/base/Log';
 
 export default function(rta: RuntimeAuthoring) {
     // custom adaptation project plugin code goes here
+    log.debug('ADP init executed.');
     // also initialize the editor
     init(rta);
 }

--- a/packages/preview-middleware-client/src/cpe/init.ts
+++ b/packages/preview-middleware-client/src/cpe/init.ts
@@ -1,5 +1,7 @@
+import log from 'mock/sap/base/Log';
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
 
 export default function(_rta: RuntimeAuthoring) {
     // custom rta plugin code goes here
+    log.debug('Editor init executed.');
 }

--- a/packages/preview-middleware-client/src/cpe/init.ts
+++ b/packages/preview-middleware-client/src/cpe/init.ts
@@ -1,7 +1,7 @@
 import log from 'sap/base/Log';
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
 
-export default function(_rta: RuntimeAuthoring) {
+export default function(rta: RuntimeAuthoring) {
     // custom rta plugin code goes here
-    log.debug('Editor init executed.');
+    log.debug(`Editor start with following settings: ${rta.getFlexSettings()}}`);
 }

--- a/packages/preview-middleware-client/src/cpe/init.ts
+++ b/packages/preview-middleware-client/src/cpe/init.ts
@@ -1,4 +1,4 @@
-import log from 'mock/sap/base/Log';
+import log from 'sap/base/Log';
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
 
 export default function(_rta: RuntimeAuthoring) {

--- a/packages/preview-middleware-client/src/cpe/init.ts
+++ b/packages/preview-middleware-client/src/cpe/init.ts
@@ -1,0 +1,5 @@
+import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
+
+export default function(_rta: RuntimeAuthoring) {
+    // custom rta plugin code goes here
+}

--- a/packages/preview-middleware-client/src/flp/init.ts
+++ b/packages/preview-middleware-client/src/flp/init.ts
@@ -1,5 +1,6 @@
 import Log from 'sap/base/Log';
 import type AppLifeCycle from 'sap/ushell/services/AppLifeCycle';
+import type { RTAPlugin, StartAdaptation } from 'sap/ui/rta/api/startAdaptation';
 import IconPool from 'sap/ui/core/IconPool';
 import ResourceBundle from 'sap/base/i18n/ResourceBundle';
 import UriParameters from 'sap/base/util/UriParameters';
@@ -184,13 +185,19 @@ export function configure({ appUrls, flex }: { appUrls?: string | null; flex?: s
             const serviceInstance = await sap.ushell.Container.getServiceAsync<AppLifeCycle>('AppLifeCycle');
             serviceInstance.attachAppLoaded(event => {
                 const oView = event.getParameter('componentInstance');
-                sap.ui.require(['sap/ui/rta/api/startAdaptation'], function (startAdaptation: (opts: object) => void) {
+                const requiredLibs = ['sap/ui/rta/api/startAdaptation'];
+                const flexSettings = JSON.parse(flex);
+                if (flexSettings.pluginScript) {
+                    requiredLibs.push(flexSettings.pluginScript);
+                    delete flexSettings.pluginScript;
+                }
+                sap.ui.require(requiredLibs, function (startAdaptation: StartAdaptation, pluginScript?: RTAPlugin) {
                     const options = {
                         rootControl: oView,
                         validateAppVersion: false,
-                        flexSettings: JSON.parse(flex)
+                        flexSettings
                     };
-                    startAdaptation(options);
+                    startAdaptation(options, pluginScript);
                 });
             });
         });

--- a/packages/preview-middleware-client/test/__mock__/sap/ui/rta/RuntimeAuthoring.ts
+++ b/packages/preview-middleware-client/test/__mock__/sap/ui/rta/RuntimeAuthoring.ts
@@ -1,0 +1,8 @@
+import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
+
+const RuntimeAuthoringMock = {
+    getService: jest.fn(),
+    getCommandStack: jest.fn()
+};
+
+export default RuntimeAuthoringMock as unknown as RuntimeAuthoring & typeof RuntimeAuthoringMock;

--- a/packages/preview-middleware-client/test/__mock__/sap/ui/rta/RuntimeAuthoring.ts
+++ b/packages/preview-middleware-client/test/__mock__/sap/ui/rta/RuntimeAuthoring.ts
@@ -2,7 +2,8 @@ import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
 
 const RuntimeAuthoringMock = {
     getService: jest.fn(),
-    getCommandStack: jest.fn()
+    getCommandStack: jest.fn(),
+    getFlexSettings: jest.fn()
 };
 
 export default RuntimeAuthoringMock as unknown as RuntimeAuthoring & typeof RuntimeAuthoringMock;

--- a/packages/preview-middleware-client/test/__mock__/window.ts
+++ b/packages/preview-middleware-client/test/__mock__/window.ts
@@ -1,0 +1,28 @@
+export const fetchMock = jest.fn();
+export const sapCoreMock = {
+    byId: jest.fn(),
+    getComponent: jest.fn(),
+    getConfiguration: () => ({
+        getLanguage: jest.fn()
+    })
+};
+export const sapMock = {
+    ui: {
+        getCore: jest.fn().mockReturnValue(sapCoreMock),
+        require: {
+            toUrl: jest.fn()
+        },
+        loader: {
+            config: jest.fn()
+        }
+    },
+    ushell: {
+        Container: {
+            createRenderer: jest.fn().mockReturnValue({ placeAt: jest.fn() }),
+            attachRendererCreatedEvent: jest.fn().mockImplementation((cb: () => Promise<void>) => cb())
+        }
+    }
+};
+
+window.fetch = fetchMock;
+window.sap = sapMock as unknown as typeof sap;

--- a/packages/preview-middleware-client/test/unit/adp/init.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/init.test.ts
@@ -1,0 +1,10 @@
+import log from 'mock/sap/base/Log';
+import init from '../../../src/adp/init';
+import rtaMock from 'mock/sap/ui/rta/RuntimeAuthoring';
+
+describe('adp', () => {
+    test('init', () => {
+        init(rtaMock);
+        expect(log.debug).toBeCalledTimes(2);
+    });
+});

--- a/packages/preview-middleware-client/test/unit/cpe/init.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/init.test.ts
@@ -1,0 +1,10 @@
+import log from 'mock/sap/base/Log';
+import init from '../../../src/cpe/init';
+import rtaMock from 'mock/sap/ui/rta/RuntimeAuthoring';
+
+describe('cpe', () => {
+    test('init', () => {
+        init(rtaMock);
+        expect(log.debug).toBeCalled();
+    });
+});

--- a/packages/preview-middleware-client/test/unit/flp/init.test.ts
+++ b/packages/preview-middleware-client/test/unit/flp/init.test.ts
@@ -1,29 +1,7 @@
-window.sap = {
-    ui: {
-        require: {
-            toUrl: jest.fn()
-        } as any,
-        getCore: () => ({
-            getConfiguration: () => ({
-                getLanguage: jest.fn()
-            })
-        }),
-        loader: {
-            config: jest.fn()
-        }
-    } as any,
-    ushell: {
-        Container: {
-            createRenderer: jest.fn().mockReturnValue({ placeAt: jest.fn() }),
-            attachRendererCreatedEvent: jest.fn().mockImplementation((cb: () => Promise<void>) => cb())
-        }
-    }
-} as any;
-window.fetch = jest.fn();
-
-import { configure, init, registerComponentDependencyPaths, registerSAPFonts, setI18nTitle } from '../../src/flp/init';
-import IconPoolMock from '../__mock__/sap/ui/core/IconPool';
-import { mockBundle } from '../__mock__/sap/base/i18n/ResourceBundle';
+import { configure, init, registerComponentDependencyPaths, registerSAPFonts, setI18nTitle } from '../../../src/flp/init';
+import IconPoolMock from 'mock/sap/ui/core/IconPool';
+import { mockBundle } from 'mock/sap/base/i18n/ResourceBundle';
+import { fetchMock } from 'mock/window';
 
 describe('flp/init', () => {
     test('registerSAPFonts', () => {
@@ -39,7 +17,6 @@ describe('flp/init', () => {
     });
 
     describe('registerComponentDependencyPaths', () => {
-        const fetchMock = fetch as jest.Mock;
         const loaderMock = sap.ui.loader.config as jest.Mock;
         const testManifest = {
             'sap.ui5': {

--- a/packages/preview-middleware-client/tsconfig.json
+++ b/packages/preview-middleware-client/tsconfig.json
@@ -6,6 +6,7 @@
     "types"
   ],
   "compilerOptions": {
+    "lib": ["ES2020", "DOM"],
     "target": "es2022",
     "module": "es2022",
     "skipLibCheck": true,
@@ -20,11 +21,14 @@
     "paths": {
       "open/ux/preview/client/*": [
         "./src/*"
+      ],"mock/*": [
+        "./test/__mock__/*"
       ]
     },
     "types": [
       "@sapui5/types",
-      "jest"
+      "jest",
+      "node"
     ]
   },
   "references": [

--- a/packages/preview-middleware-client/types/sap.ui.rta.d.ts
+++ b/packages/preview-middleware-client/types/sap.ui.rta.d.ts
@@ -103,6 +103,13 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
         getService: <T>(name: 'outline' | string) => Promise<T>;
         getSelection: () => ElementOverlay[];
         getDefaultPlugins: () => { contextMenu: ContextMenu };
+        getFlexSettings: () => { 
+            layer: string;
+            developerMode: boolean;
+            baseId: string;
+            namespace: string;
+            projectId?: string;
+        }
     }
 
     export default RuntimeAuthoring;

--- a/packages/preview-middleware-client/types/sap.ui.rta.d.ts
+++ b/packages/preview-middleware-client/types/sap.ui.rta.d.ts
@@ -37,17 +37,7 @@ declare module 'sap/ui/rta/command/CommandFactory' {
     import type BaseCommand from 'sap/ui/rta/command/BaseCommand';
     import type DesignTimeMetadata from 'sap/ui/dt/DesignTimeMetadata';
     import type Element from 'sap/ui/core/Element';
-    import type { Layer } from 'sap/ui/fl';
-
-    export interface FlexSettings {
-        layer: Layer;
-        developerMode: boolean;
-        baseId?: string;
-        projectId?: string;
-        scenario?: string;
-        namespace?: string;
-        rootNamespace?: string;
-    }
+    import type { FlexSettings } from 'sap/ui/rta/RuntimeAuthoring';
 
     interface CommandFactory {
         getCommandFor<T extends BaseCommand = BaseCommand>(
@@ -89,6 +79,17 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
     import type Stack from 'sap/ui/rta/command/Stack';
     import type ElementOverlay from 'sap/ui/dt/ElementOverlay';
     import type ContextMenu from 'sap/ui/dt/plugin/ContextMenu';
+    import type { Layer } from 'sap/ui/fl';
+
+    export interface FlexSettings {
+        layer: Layer;
+        developerMode: boolean;
+        baseId?: string;
+        projectId?: string;
+        scenario?: string;
+        namespace?: string;
+        rootNamespace?: string;
+    }
 
     export type SelectionChangeEvent = Event<SelectionChangeParams>;
     export interface SelectionChangeParams {
@@ -103,13 +104,7 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
         getService: <T>(name: 'outline' | string) => Promise<T>;
         getSelection: () => ElementOverlay[];
         getDefaultPlugins: () => { contextMenu: ContextMenu };
-        getFlexSettings: () => { 
-            layer: string;
-            developerMode: boolean;
-            baseId: string;
-            namespace: string;
-            projectId?: string;
-        }
+        getFlexSettings: () => FlexSettings
     }
 
     export default RuntimeAuthoring;

--- a/packages/preview-middleware-client/types/sap.ui.rta.d.ts
+++ b/packages/preview-middleware-client/types/sap.ui.rta.d.ts
@@ -1,7 +1,8 @@
 declare module 'sap/ui/rta/command/BaseCommand' {
     import type Element from 'sap/ui/core/Element';
+    import type ManagedObject from 'sap/ui/base/ManagedObject';
 
-    interface BaseCommand {
+   interface BaseCommand extends ManagedObject {
         execute(): Promise<void>;
         getElement(): Element;
     }
@@ -49,9 +50,6 @@ declare module 'sap/ui/rta/command/CommandFactory' {
     }
 
     interface CommandFactory {
-        /**
-         *
-         */
         getCommandFor<T extends BaseCommand = BaseCommand>(
             control: Element | string,
             commandType: string,
@@ -78,14 +76,8 @@ declare module 'sap/ui/rta/command/OutlineService' {
         icon?: string;
     }
 
-    /**
-     *
-     */
     interface OutlineService {
         get(): Promise<OutlineViewNode[]>;
-        /**
-         *
-         */
         attachEvent<T>(eventName: string, handler: (params: T) => void): void;
     }
 
@@ -98,8 +90,13 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
     import type ElementOverlay from 'sap/ui/dt/ElementOverlay';
     import type ContextMenu from 'sap/ui/dt/plugin/ContextMenu';
 
-    interface RuntimeAuthoring {
-        attachSelectionChange(handler: (event: Event) => void): void;
+    export type SelectionChangeEvent = Event<SelectionChangeParams>;
+    export interface SelectionChangeParams {
+        selection: ElementOverlay[];
+    }
+
+   interface RuntimeAuthoring {
+        attachSelectionChange(handler: (event: SelectionChangeEvent) => void): void;
         attachModeChanged: (handler: (event: Event) => void) => void;
         attachUndoRedoStackModified: (handler: (event: Event) => void) => void;
         getCommandStack: () => Stack;
@@ -109,4 +106,15 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
     }
 
     export default RuntimeAuthoring;
+}
+
+declare module 'sap/ui/rta/api/startAdaptation' {
+    import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
+    
+    export type RTAPlugin = (rta: RuntimeAuthoring) => void;
+    export type StartAdaptation = (options: object, plugin?: RTAPlugin) => void;
+
+    const startAdaptation: StartAdaptation;
+
+    export default startAdaptation;
 }

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -97,7 +97,8 @@ server:
     configuration:
       rta:
         layer: CUSTOMER_BASE
-        - path: /local/variant-editor.html
+        editors:
+          - path: /local/variant-editor.html
 ```
 
 
@@ -114,8 +115,9 @@ server:
           url: http://sap.example
         ignoreCertErrors: true
       rta:
-        - path: /adp/editor.html
-          developerMode: true
+        editors:
+          - path: /adp/editor.html
+            developerMode: true
 ```
 
 ### Programmatic Usage

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -11,10 +11,15 @@ It hosts a local Fiori launchpad based on your configuration as well as offers a
 | `flp.intent`           |           |                  | Optional intent to be used for the application                                                                                      |
 | `flp.intent.object`    | `string`  | `app`            | Optional intent object                                                                                                              |
 | `flp.intent.action`    | `string`  | `preview`        | Optional intent action                                                                                                              |
-| `flp.apps`             | `array`   | `[]`             | Optional additional local apps that are available in local Fiori launchpad                                                          |
-| `flp.libs`             | `boolean` | `undefined`      | Optional flag to add a generic script fetching the paths of used libraries not available in UI5. To disable set it to `false`, if not set, then the project is checked for a `load-reuse-libs` script and if available the libraries are fetched as well.                                    |
+| `flp.apps`             | `array`   | `undefined`      | Optional additional local apps that are available in local Fiori launchpad                                                          |
+| `flp.libs`             | `boolean` | `undefined`      | Optional flag to add a generic script fetching the paths of used libraries not available in UI5. To disable set it to `false`, if not set, then the project is checked for a `load-reuse-libs` script and if available the libraries are fetched as well. |
 | `adp.target`           |           |                  | Required configuration for adaptation projects defining the connected backend                                                       |
 | `adp.ignoreCertErrors` | `boolean` | `false`          | Optional setting to ignore certification validation errors when working with e.g. development systems with self signed certificates |
+| `rta`                  |           |                  | Optional configuration allowing to add mount points for runtime adaptation                                                          |
+| `rta.layer`            | `string`  | `(calculated)`   | Optional property for defining the runtime adaptation layer for changes (default is `CUSTOMER_BASE` or read from the project for adaptation projects) |
+| `rta.editors`          | `array`   | `undefined`      | Optional list of mount points for editing                                                                                           |
+
+
 | `debug`                | `boolean` | `false`          | Enables debug output                                                                                                                |
 
 ### `flp.apps`
@@ -34,6 +39,13 @@ Array of additional application configurations:
 | `destination` | `string` mandatory (if no url) | Required if the backend system is available as destination in SAP Business Application Studio.                                                  |
 | `client`      | `string` optional              | sap-client parameter                                                                                                                            |
 | `scp`         | `boolean` optional             | If set to true the proxy will execute the required OAuth routine for the ABAP environment on SAP BTP                                            |
+
+### `rta.editors`
+| Option          | Type               | Description                                                                                    |
+| --------------- | -------------------| -----------------------------------------------------------------------------------------------|
+| `path`          | `string` mandatory | The mount point to be used for the editor.                                                     |
+| `developerMode` | `boolean` optional | Enables/disables the runtime adaptation developer mode (only supported for adaptation projects |
+
 
 ## Usage
 The middleware can be used without configuration. However, since the middleware intercepts a few requests that might otherwise be handled by a different middleware, it is strongly recommended to run other file serving middlewares after the `preview-middleware` e.g. `backend-proxy-middleware` and `ui5-proxy-middleware` (and the corresponding middlewares in the `@sap/ux-ui5-tooling`).
@@ -75,8 +87,22 @@ server:
           target: /apps/other-app
 ```
 
+### Runtime Adaptation Support
+If you want to create variants as part of your application, then you can create an additional mount point allowing to created and edit variants.
+```Yaml
+server:
+  customMiddleware:
+  - name: preview-middleware
+    afterMiddleware: compression
+    configuration:
+      rta:
+        layer: CUSTOMER_BASE
+        - path: /local/variant-editor.html
+```
+
+
 ### Adaptation Project
-If you want to use the middleware in an adaption project, the additional `adp` object needs to be configured. This example would preview a local adaptation project merged with its reference application from the target system at `http://sap.example` and it will ignore certification validation errors.
+If you want to use the middleware in an adaption project, the additional `adp` object needs to be configured. This example would preview a local adaptation project merged with its reference application from the target system at `http://sap.example` and it will ignore certification validation errors. For adaptation projects, it is also recommended to add the `rta` configuration allowing to edit the project.
 ```Yaml
 server:
   customMiddleware:
@@ -87,11 +113,15 @@ server:
         target: 
           url: http://sap.example
         ignoreCertErrors: true
+      rta:
+        - path: /adp/editor.html
+          developerMode: true
 ```
+
 ### Programmatic Usage
 Alternatively you can use the underlying middleware fuction programmatically, e.g. for the case when you want to incorporate the `preview-middleware` functionality in your own middleware.
 
-```
+```typescript
 import { FlpSandbox } from '@sap-ux/preview-middleware';
 const flp = new FlpSandbox(flpConfig, rootProject, middlewareUtil, logger);
 const files = await resources.rootProject.byGlob('/manifest.json');
@@ -99,7 +129,7 @@ flp.init(JSON.parse(await files[0].getString()));
 
 return flp.router
 ```
-- `flpConfig` - the FLP configuration
+- `flpConfig` - the middleware configuration
 - `rootProject` - [Reader](https://sap.github.io/ui5-tooling/stable/api/@ui5_fs_AbstractReader.html) to access resources of the root project
 - `middlewareUtil` - [MiddlewareUtil](https://sap.github.io/ui5-tooling/v3/api/@ui5_server_middleware_MiddlewareUtil.html) of the UI5 server
 - `logger` - Logger instance for use in the middleware.

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -39,7 +39,6 @@
     "dependencies": {
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/adp-tooling": "workspace:*",
-        "@sap-ux/control-property-editor": "workspace:*",
         "ejs": "3.1.7"
     },
     "devDependencies": {

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -39,6 +39,7 @@
     "dependencies": {
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/adp-tooling": "workspace:*",
+        "@sap-ux/control-property-editor": "workspace:*",
         "ejs": "3.1.7"
     },
     "devDependencies": {

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -17,7 +17,7 @@
         "start:fixture": "ui5 serve --config test/fixtures/simple-app/ui5.yaml",
         "build": "npm-run-all -l -p build:middleware build:client",
         "build:middleware": "tsc --build",
-        "build:client": "copyfiles --exclude **/*-dbg.js --up 4 \"./node_modules/@private/preview-middleware-client/dist/**/*\" \"./dist/client\"",
+        "build:client": "pnpm -C ../preview-middleware-client run build && copyfiles --exclude **/*-dbg.js --up 4 \"./node_modules/@private/preview-middleware-client/dist/**/*\" \"./dist/client\"",
         "watch": "tsc --watch",
         "clean": "rimraf dist test/test-output coverage *.tsbuildinfo",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -3,7 +3,7 @@ import { render } from 'ejs';
 import type { Request, RequestHandler, Response, Router } from 'express';
 import { readFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
-import type { App, FlpConfig } from '../types';
+import type { App, FlpConfig, MiddlewareConfig, RtaConfig } from '../types';
 import { Router as createRouter, static as serveStatic, json } from 'express';
 import type { Logger } from '@sap-ux/logger';
 import { deleteChange, readChanges, writeChange } from './flex';
@@ -75,6 +75,7 @@ export interface TemplateConfig {
     flex?: {
         layer: UI5FlexLayer;
         developerMode: boolean;
+        pluginScript?: string;
     };
     locateReuseLibsScript?: boolean;
 }
@@ -85,6 +86,7 @@ export interface TemplateConfig {
 export class FlpSandbox {
     protected templateConfig: TemplateConfig;
     public readonly config: FlpConfig;
+    public readonly rta?: RtaConfig;
     public readonly router: EnhancedRouter;
 
     /**
@@ -96,22 +98,22 @@ export class FlpSandbox {
      * @param logger logger instance
      */
     constructor(
-        config: Partial<FlpConfig>,
+        config: Partial<MiddlewareConfig>,
         private readonly project: ReaderCollection,
         private readonly utils: MiddlewareUtils,
         private readonly logger: Logger
     ) {
         this.config = {
-            path: config.path ?? DEFAULT_PATH,
-            intent: config.intent ?? DEFAULT_INTENT,
-            apps: config.apps ?? [],
-            rta: config.rta,
-            libs: config.libs
+            path: config.flp?.path ?? DEFAULT_PATH,
+            intent: config.flp?.intent ?? DEFAULT_INTENT,
+            apps: config.flp?.apps ?? [],
+            libs: config.flp?.libs
         };
         if (!this.config.path.startsWith('/')) {
             this.config.path = `/${this.config.path}`;
         }
-        logger.debug(`Config: ${JSON.stringify(this.config)}`);
+        this.rta = config.rta;
+        logger.debug(`Config: ${JSON.stringify({ flp: this.config, rta: this.rta })}`);
         this.router = createRouter();
     }
 
@@ -147,9 +149,52 @@ export class FlpSandbox {
         });
 
         this.addStandardRoutes();
+        if (this.rta) {
+            this.addEditorRoutes(this.rta);
+        }
         this.addRoutesForAdditionalApps();
         this.logger.info(`Initialized for app ${manifest['sap.app'].id}`);
         this.logger.debug(`Configured apps: ${JSON.stringify(this.templateConfig.apps)}`);
+    }
+
+    /**
+     * Add additional routes for configured editors.
+     *
+     * @param rta runtime authoring configuration
+     */
+    private addEditorRoutes(rta: RtaConfig) {
+        const cpe = dirname(require.resolve('@sap-ux/control-property-editor'));
+        for (const editor of rta.editors) {
+            let previewUrl = editor.path;
+            if (editor.developerMode) {
+                let path = dirname(editor.path);
+                if (!path.endsWith('/')) {
+                    path = `${path}/`;
+                }
+                previewUrl = `${path}_inner.html`;
+                editor.pluginScript ??= 'open/ux/preview/client/cpe/init';
+
+                this.router.get(editor.path, async (_req: Request, res: Response) => {
+                    const template = readFileSync(join(__dirname, '../../templates/flp/editor.html'), 'utf-8');
+                    const html = render(template, {
+                        previewUrl: `${previewUrl}?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#${this.config.intent.object}-${this.config.intent.action}`
+                    });
+                    res.status(200).contentType('html').send(html);
+                });
+                this.router.use(`${path}editor`, serveStatic(cpe));
+            }
+            this.router.get(previewUrl, async (_req: Request, res: Response) => {
+                const config = { ...this.templateConfig };
+                config.flex = {
+                    layer: rta.layer,
+                    developerMode: editor.developerMode === true,
+                    pluginScript: editor.pluginScript
+                };
+                const template = readFileSync(join(__dirname, '../../templates/flp/sandbox.html'), 'utf-8');
+                const html = render(template, config);
+                res.status(200).contentType('html').send(html);
+            });
+        }
     }
 
     /**
@@ -161,19 +206,6 @@ export class FlpSandbox {
 
         // add route for the sandbox.html
         this.router.get(this.config.path, (async (req: Request, res: Response & { _livereload?: boolean }) => {
-            const config = { ...this.templateConfig };
-            const fioriToolsRtaMode = req.query['fiori-tools-rta-mode'];
-            if (fioriToolsRtaMode) {
-                if (this.config.rta?.layer) {
-                    config.flex = {
-                        layer: this.config.rta?.layer,
-                        developerMode: fioriToolsRtaMode === 'forAdaptation'
-                    };
-                } else {
-                    this.logger.error('Fiori tools RTA mode could not be started because the RTA layer is missing.');
-                }
-            }
-
             // warn the user if a file with the same name exists in the filesystem
             const file = await this.project.byPath(this.config.path);
             if (file) {
@@ -181,7 +213,7 @@ export class FlpSandbox {
             }
 
             const template = readFileSync(join(__dirname, '../../templates/flp/sandbox.html'), 'utf-8');
-            const html = render(template, config);
+            const html = render(template, this.templateConfig);
             // if livereload is enabled, don't send it but let other middleware modify the content
             if (res._livereload) {
                 res.write(html);

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -73,6 +73,7 @@ export interface TemplateConfig {
         resources: Record<string, string>;
     };
     flex?: {
+        [key: string]: unknown;
         layer: UI5FlexLayer;
         developerMode: boolean;
         pluginScript?: string;
@@ -147,9 +148,10 @@ export class FlpSandbox {
             local: '.',
             intent: this.config.intent
         });
-
         this.addStandardRoutes();
         if (this.rta) {
+            this.rta.options ??= {};
+            this.rta.options.baseId = componentId ?? manifest['sap.app'].id;
             this.addEditorRoutes(this.rta);
         }
         this.addRoutesForAdditionalApps();
@@ -180,6 +182,7 @@ export class FlpSandbox {
                 const config = { ...this.templateConfig };
                 config.flex = {
                     layer: rta.layer,
+                    ...rta.options,
                     developerMode: editor.developerMode === true,
                     pluginScript: editor.pluginScript
                 };

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -166,13 +166,8 @@ export class FlpSandbox {
         for (const editor of rta.editors) {
             let previewUrl = editor.path;
             if (editor.developerMode) {
-                let path = dirname(editor.path);
-                if (!path.endsWith('/')) {
-                    path = `${path}/`;
-                }
-                previewUrl = `${path}_inner.html`;
+                previewUrl = `${previewUrl}.inner.html`;
                 editor.pluginScript ??= 'open/ux/preview/client/cpe/init';
-
                 this.router.get(editor.path, async (_req: Request, res: Response) => {
                     const template = readFileSync(join(__dirname, '../../templates/flp/editor.html'), 'utf-8');
                     const html = render(template, {

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -163,7 +163,6 @@ export class FlpSandbox {
      * @param rta runtime authoring configuration
      */
     private addEditorRoutes(rta: RtaConfig) {
-        const cpe = dirname(require.resolve('@sap-ux/control-property-editor'));
         for (const editor of rta.editors) {
             let previewUrl = editor.path;
             if (editor.developerMode) {
@@ -181,7 +180,6 @@ export class FlpSandbox {
                     });
                     res.status(200).contentType('html').send(html);
                 });
-                this.router.use(`${path}editor`, serveStatic(cpe));
             }
             this.router.get(previewUrl, async (_req: Request, res: Response) => {
                 const config = { ...this.templateConfig };

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -168,15 +168,15 @@ export class FlpSandbox {
             if (editor.developerMode) {
                 previewUrl = `${previewUrl}.inner.html`;
                 editor.pluginScript ??= 'open/ux/preview/client/cpe/init';
-                this.router.get(editor.path, async (_req: Request, res: Response) => {
+                this.router.get(editor.path, (async (_req: Request, res: Response) => {
                     const template = readFileSync(join(__dirname, '../../templates/flp/editor.html'), 'utf-8');
                     const html = render(template, {
                         previewUrl: `${previewUrl}?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#${this.config.intent.object}-${this.config.intent.action}`
                     });
                     res.status(200).contentType('html').send(html);
-                });
+                }) as RequestHandler);
             }
-            this.router.get(previewUrl, async (_req: Request, res: Response) => {
+            this.router.get(previewUrl, (async (_req: Request, res: Response) => {
                 const config = { ...this.templateConfig };
                 config.flex = {
                     layer: rta.layer,
@@ -186,7 +186,7 @@ export class FlpSandbox {
                 const template = readFileSync(join(__dirname, '../../templates/flp/sandbox.html'), 'utf-8');
                 const html = render(template, config);
                 res.status(200).contentType('html').send(html);
-            });
+            }) as RequestHandler);
         }
     }
 

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -24,6 +24,7 @@ export interface App {
 
 export interface RtaConfig {
     layer: UI5FlexLayer;
+    options?: { [key: string]: unknown };
     editors: {
         path: string;
         developerMode?: boolean;

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -22,15 +22,21 @@ export interface App {
     intent?: Intent;
 }
 
+export interface RtaConfig {
+    layer: UI5FlexLayer;
+    editors: {
+        path: string;
+        developerMode?: boolean;
+        pluginScript?: string;
+    }[];
+}
+
 /**
  * FLP preview configuration.
  */
 export interface FlpConfig {
     path: string;
     intent: Intent;
-    rta?: {
-        layer?: UI5FlexLayer;
-    };
     /**
      * Optional: if set to true then a locate-reuse-libs script will be attached to the html
      */
@@ -41,8 +47,9 @@ export interface FlpConfig {
 /**
  * Middleware configuration.
  */
-export interface Config {
+export interface MiddlewareConfig {
     flp?: Partial<FlpConfig>;
+    rta?: RtaConfig;
     adp?: AdpPreviewConfig;
     debug?: boolean;
 }

--- a/packages/preview-middleware/src/ui5/middleware.ts
+++ b/packages/preview-middleware/src/ui5/middleware.ts
@@ -2,9 +2,8 @@ import { LogLevel, ToolsLogger, UI5ToolingTransport } from '@sap-ux/logger';
 import type { RequestHandler } from 'express';
 import type { MiddlewareParameters } from '@ui5/server';
 import { FlpSandbox } from '../base/flp';
-import type { AdpPreviewConfig } from '@sap-ux/adp-tooling';
-import type { Config } from '../types';
-import { AdpPreview } from '@sap-ux/adp-tooling';
+import type { MiddlewareConfig } from '../types';
+import { AdpPreview, type AdpPreviewConfig } from '@sap-ux/adp-tooling';
 import type { ReaderCollection } from '@ui5/fs';
 
 /**
@@ -20,7 +19,9 @@ async function initAdp(rootProject: ReaderCollection, config: AdpPreviewConfig, 
     if (appVariant) {
         const adp = new AdpPreview(config, rootProject, logger);
         const layer = await adp.init(JSON.parse(await appVariant.getString()));
-        flp.config.rta = { layer };
+        if (flp.rta) {
+            flp.rta.layer = layer;
+        }
         await flp.init(adp.descriptor.manifest, adp.descriptor.name, adp.resources);
         flp.router.use(adp.descriptor.url, adp.proxy.bind(adp) as RequestHandler);
     } else {
@@ -38,13 +39,16 @@ async function initAdp(rootProject: ReaderCollection, config: AdpPreviewConfig, 
  * @param logger logger instance
  * @returns a router
  */
-async function createRouter({ resources, options, middlewareUtil }: MiddlewareParameters<Config>, logger: ToolsLogger) {
+async function createRouter(
+    { resources, options, middlewareUtil }: MiddlewareParameters<MiddlewareConfig>,
+    logger: ToolsLogger
+) {
     // setting defaults
     const config = options.configuration ?? {};
     config.flp ??= {};
 
     // configure the FLP sandbox based on information from the manifest
-    const flp = new FlpSandbox(config.flp, resources.rootProject, middlewareUtil, logger);
+    const flp = new FlpSandbox(config, resources.rootProject, middlewareUtil, logger);
 
     if (config.adp) {
         await initAdp(resources.rootProject, config.adp, flp, logger);
@@ -67,7 +71,7 @@ async function createRouter({ resources, options, middlewareUtil }: MiddlewarePa
  * @param params middleware configuration
  * @returns a promise for the request handler
  */
-module.exports = async (params: MiddlewareParameters<Config>): Promise<RequestHandler> => {
+module.exports = async (params: MiddlewareParameters<MiddlewareConfig>): Promise<RequestHandler> => {
     const logger = new ToolsLogger({
         transports: [new UI5ToolingTransport({ moduleName: 'preview-middleware' })],
         logLevel: params.options.configuration?.debug ? LogLevel.Debug : LogLevel.Info

--- a/packages/preview-middleware/src/ui5/middleware.ts
+++ b/packages/preview-middleware/src/ui5/middleware.ts
@@ -18,9 +18,14 @@ async function initAdp(rootProject: ReaderCollection, config: AdpPreviewConfig, 
     const appVariant = await rootProject.byPath('/manifest.appdescr_variant');
     if (appVariant) {
         const adp = new AdpPreview(config, rootProject, logger);
-        const layer = await adp.init(JSON.parse(await appVariant.getString()));
+        const variant = JSON.parse(await appVariant.getString());
+        const layer = await adp.init(variant);
+        logger.warn(variant);
         if (flp.rta) {
             flp.rta.layer = layer;
+            flp.rta.options = {
+                projectId: variant.id
+            };
             for (const editor of flp.rta.editors) {
                 editor.pluginScript ??= 'open/ux/preview/client/adp/init';
             }

--- a/packages/preview-middleware/src/ui5/middleware.ts
+++ b/packages/preview-middleware/src/ui5/middleware.ts
@@ -21,6 +21,9 @@ async function initAdp(rootProject: ReaderCollection, config: AdpPreviewConfig, 
         const layer = await adp.init(JSON.parse(await appVariant.getString()));
         if (flp.rta) {
             flp.rta.layer = layer;
+            for (const editor of flp.rta.editors) {
+                editor.pluginScript ??= 'open/ux/preview/client/adp/init';
+            }
         }
         await flp.init(adp.descriptor.manifest, adp.descriptor.name, adp.resources);
         flp.router.use(adp.descriptor.url, adp.proxy.bind(adp) as RequestHandler);

--- a/packages/preview-middleware/templates/flp/editor.html
+++ b/packages/preview-middleware/templates/flp/editor.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta name="description" content="Web page for rendering SAP Fiori Tools Control Property Editor" />
+        <link rel="shortcut icon" type="image/x-icon" href="./editor/favicon.ico" />
+        <link rel="stylesheet" type="text/css" href="./editor/app.css" />
+        <title>Control Property Editor</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <script type="module">
+            import { start } from './editor/app.js';
+            start({
+                previewUrl: '<%- previewUrl %>',
+                rootElementId: 'root'
+            });
+        </script>
+    </body>
+</html>

--- a/packages/preview-middleware/templates/flp/editor.html
+++ b/packages/preview-middleware/templates/flp/editor.html
@@ -4,20 +4,25 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
-        <meta name="description" content="Web page for rendering SAP Fiori Tools Control Property Editor" />
+        <meta name="description" content="Web page for rendering Open UX Tools Control Property Editor" />
         <link rel="shortcut icon" type="image/x-icon" href="./editor/favicon.ico" />
         <link rel="stylesheet" type="text/css" href="./editor/app.css" />
         <title>Control Property Editor</title>
+        <style>
+            body, html {
+                margin: 0;
+                padding: 0;
+                height: 100%;
+                overflow: hidden;
+            }
+            iframe {
+                width: 100%;
+                height: 100%;
+                border: none;
+            }
+        </style>
     </head>
     <body>
-        <noscript>You need to enable JavaScript to run this app.</noscript>
-        <div id="root"></div>
-        <script type="module">
-            import { start } from './editor/app.js';
-            start({
-                previewUrl: '<%- previewUrl %>',
-                rootElementId: 'root'
-            });
-        </script>
+        <iframe src="<%- previewUrl %>"></iframe>
     </body>
 </html>

--- a/packages/preview-middleware/test/fixtures/adp/ui5.yaml
+++ b/packages/preview-middleware/test/fixtures/adp/ui5.yaml
@@ -12,6 +12,9 @@ server:
         adp:
           target:
             url: http://example.sap
+        rta:
+          editors:
+          - path: /adp/editor.html
     - name: ui5-proxy-middleware
       afterMiddleware: preview-middleware
       configuration:

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -190,144 +190,7 @@ exports[`FlpSandbox router WorkspaceConnector.js 1`] = `
 );"
 `;
 
-exports[`FlpSandbox router test/flp.html 1`] = `
-"<!DOCTYPE HTML>
-<html lang=\\"en\\">
-<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
-
-<head>
-    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-    <meta charset=\\"UTF-8\\">
-    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
-    <title>Local FLP Sandbox</title>
-
-    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
-
-         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
-
-         The fiori2 renderer will render the shell header allowing, for instance,
-         testing of additional application setting buttons.
-
-         The navigation target resolution service is configured in a way that the empty URL hash is
-         resolved to our own application.
-
-         This example uses relative path references for the SAPUI5 resources and test-resources;
-         it might be necessary to adapt them depending on the target runtime platform.
-         The sandbox platform is restricted to development or demo use cases and must NOT be used
-         for productive scenarios.
-    -->
-    <script type=\\"text/javascript\\">
-        window[\\"sap-ushell-config\\"] = {
-            defaultRenderer: \\"fiori2\\",
-            renderers: {
-                fiori2: {
-                    componentData: {
-                        config: {
-                            search: \\"hidden\\",
-                            enableSearch: false
-                        }
-                    }
-                }
-            },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
-        };
-    </script>
-
-    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
-    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
-    <script id=\\"sap-ui-bootstrap\\"
-        src=\\"../resources/sap-ui-core.js\\"
-        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
-        data-sap-ui-async=\\"true\\"
-        data-sap-ui-preload=\\"async\\"
-        data-sap-ui-theme=\\"sap_horizon_dark\\"
-        data-sap-ui-compatVersion=\\"edge\\"
-        data-sap-ui-language=\\"en\\"
-        data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
-        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
-        data-sap-ui-frameOptions=\\"allow\\"
-        data-sap-ui-xx-componentPreload=\\"off\\"
-        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">
-    </script>
-</head>
-
-<!-- UI Content -->
-<body class=\\"sapUiBody\\" id=\\"content\\">
-</body>
-
-</html>"
-`;
-
-exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=forAdaptation 1`] = `
-"<!DOCTYPE HTML>
-<html lang=\\"en\\">
-<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
-
-<head>
-    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-    <meta charset=\\"UTF-8\\">
-    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
-    <title>Local FLP Sandbox</title>
-
-    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
-
-         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
-
-         The fiori2 renderer will render the shell header allowing, for instance,
-         testing of additional application setting buttons.
-
-         The navigation target resolution service is configured in a way that the empty URL hash is
-         resolved to our own application.
-
-         This example uses relative path references for the SAPUI5 resources and test-resources;
-         it might be necessary to adapt them depending on the target runtime platform.
-         The sandbox platform is restricted to development or demo use cases and must NOT be used
-         for productive scenarios.
-    -->
-    <script type=\\"text/javascript\\">
-        window[\\"sap-ushell-config\\"] = {
-            defaultRenderer: \\"fiori2\\",
-            renderers: {
-                fiori2: {
-                    componentData: {
-                        config: {
-                            search: \\"hidden\\",
-                            enableSearch: false
-                        }
-                    }
-                }
-            },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
-        };
-    </script>
-
-    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
-    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
-    <script id=\\"sap-ui-bootstrap\\"
-        src=\\"../resources/sap-ui-core.js\\"
-        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
-        data-sap-ui-async=\\"true\\"
-        data-sap-ui-preload=\\"async\\"
-        data-sap-ui-theme=\\"sap_horizon_dark\\"
-        data-sap-ui-compatVersion=\\"edge\\"
-        data-sap-ui-language=\\"en\\"
-        data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
-        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
-        data-sap-ui-frameOptions=\\"allow\\"
-        data-sap-ui-xx-componentPreload=\\"off\\"
-        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
-        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":true}'>
-    </script>
-</head>
-
-<!-- UI Content -->
-<body class=\\"sapUiBody\\" id=\\"content\\">
-</body>
-
-</html>"
-`;
-
-exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=true 1`] = `
+exports[`FlpSandbox router rta 1`] = `
 "<!DOCTYPE HTML>
 <html lang=\\"en\\">
 <!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
@@ -386,6 +249,101 @@ exports[`FlpSandbox router test/flp.html?fiori-tools-rta-mode=true 1`] = `
         data-sap-ui-xx-componentPreload=\\"off\\"
         data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
         data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":false}'>
+    </script>
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>"
+`;
+
+exports[`FlpSandbox router rta with developerMode=true 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+    <head>
+        <meta charset=\\"utf-8\\" />
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
+        <meta name=\\"theme-color\\" content=\\"#000000\\" />
+        <meta name=\\"description\\" content=\\"Web page for rendering SAP Fiori Tools Control Property Editor\\" />
+        <link rel=\\"shortcut icon\\" type=\\"image/x-icon\\" href=\\"./editor/favicon.ico\\" />
+        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"./editor/app.css\\" />
+        <title>Control Property Editor</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id=\\"root\\"></div>
+        <script type=\\"module\\">
+            import { start } from './editor/app.js';
+            start({
+                previewUrl: '/my/_inner.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#app-preview',
+                rootElementId: 'root'
+            });
+        </script>
+    </body>
+</html>
+"
+`;
+
+exports[`FlpSandbox router test/flp.html 1`] = `
+"<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+        };
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">
     </script>
 </head>
 

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -248,7 +248,7 @@ exports[`FlpSandbox router rta 1`] = `
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\"
         data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
-        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":false}'>
+        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"baseId\\":\\"test.fe.v2.app\\",\\"developerMode\\":false}'>
     </script>
 </head>
 
@@ -349,7 +349,7 @@ exports[`FlpSandbox router rta with developerMode=true 2`] = `
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\"
         data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
-        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/preview/client/cpe/init\\"}'>
+        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"baseId\\":\\"test.fe.v2.app\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/preview/client/cpe/init\\"}'>
     </script>
 </head>
 
@@ -418,7 +418,7 @@ exports[`FlpSandbox router rta with developerMode=true and plugin 1`] = `
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\"
         data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
-        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/tools/plugin\\"}'>
+        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"baseId\\":\\"test.fe.v2.app\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/tools/plugin\\"}'>
     </script>
 </head>
 

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -285,10 +285,148 @@ exports[`FlpSandbox router rta with developerMode=true 1`] = `
         </style>
     </head>
     <body>
-        <iframe src=\\"/my/_inner.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#app-preview\\"></iframe>
+        <iframe src=\\"/my/editor.html.inner.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#app-preview\\"></iframe>
     </body>
 </html>
 "
+`;
+
+exports[`FlpSandbox router rta with developerMode=true 2`] = `
+"<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+        };
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
+        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/preview/client/cpe/init\\"}'>
+    </script>
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>"
+`;
+
+exports[`FlpSandbox router rta with developerMode=true and plugin 1`] = `
+"<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+        };
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-flexibilityServices='[{\\"applyConnector\\":\\"/preview/WorkspaceConnector\\",\\"writeConnector\\":\\"/preview/WorkspaceConnector\\",\\"custom\\":true}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\"
+        data-open-ux-preview-flex-settings='{\\"layer\\":\\"CUSTOMER_BASE\\",\\"developerMode\\":true,\\"pluginScript\\":\\"open/ux/tools/plugin\\"}'>
+    </script>
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>"
 `;
 
 exports[`FlpSandbox router test/flp.html 1`] = `

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -266,21 +266,26 @@ exports[`FlpSandbox router rta with developerMode=true 1`] = `
         <meta charset=\\"utf-8\\" />
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\" />
         <meta name=\\"theme-color\\" content=\\"#000000\\" />
-        <meta name=\\"description\\" content=\\"Web page for rendering SAP Fiori Tools Control Property Editor\\" />
+        <meta name=\\"description\\" content=\\"Web page for rendering Open UX Tools Control Property Editor\\" />
         <link rel=\\"shortcut icon\\" type=\\"image/x-icon\\" href=\\"./editor/favicon.ico\\" />
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"./editor/app.css\\" />
         <title>Control Property Editor</title>
+        <style>
+            body, html {
+                margin: 0;
+                padding: 0;
+                height: 100%;
+                overflow: hidden;
+            }
+            iframe {
+                width: 100%;
+                height: 100%;
+                border: none;
+            }
+        </style>
     </head>
     <body>
-        <noscript>You need to enable JavaScript to run this app.</noscript>
-        <div id=\\"root\\"></div>
-        <script type=\\"module\\">
-            import { start } from './editor/app.js';
-            start({
-                previewUrl: '/my/_inner.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#app-preview',
-                rootElementId: 'root'
-            });
-        </script>
+        <iframe src=\\"/my/_inner.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#app-preview\\"></iframe>
     </body>
 </html>
 "

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -142,11 +142,16 @@ describe('FlpSandbox', () => {
                         layer: 'CUSTOMER_BASE',
                         editors: [
                             {
+                                path: '/my/rta.html'
+                            },
+                            {
                                 path: '/my/editor.html',
                                 developerMode: true
                             },
                             {
-                                path: '/my/rta.html'
+                                path: '/with/plugin.html',
+                                developerMode: true,
+                                pluginScript: 'open/ux/tools/plugin'
                             }
                         ]
                     }
@@ -182,7 +187,15 @@ describe('FlpSandbox', () => {
         });
 
         test('rta with developerMode=true', async () => {
-            const response = await server.get('/my/editor.html').expect(200);
+            let response = await server.get('/my/editor.html').expect(200);
+            expect(response.text).toMatchSnapshot();
+            response = await server.get('/my/editor.html.inner.html').expect(200);
+            expect(response.text).toMatchSnapshot();
+        });
+
+        test('rta with developerMode=true and plugin', async () => {
+            await server.get('/with/plugin.html').expect(200);
+            const response = await server.get('/with/plugin.html.inner.html').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -57,7 +57,7 @@ describe('FlpSandbox', () => {
         });
 
         test('advanced config', () => {
-            const config: FlpConfig = {
+            const flpConfig: FlpConfig = {
                 path: 'my/custom/path',
                 intent: { object: 'movie', action: 'start' },
                 apps: [
@@ -67,9 +67,9 @@ describe('FlpSandbox', () => {
                     }
                 ]
             };
-            const flp = new FlpSandbox(config, mockProject, mockUtils, logger);
-            expect(flp.config.path).toBe(`/${config.path}`);
-            expect(flp.config.apps).toEqual(config.apps);
+            const flp = new FlpSandbox({ flp: flpConfig }, mockProject, mockUtils, logger);
+            expect(flp.config.path).toBe(`/${flpConfig.path}`);
+            expect(flp.config.apps).toEqual(flpConfig.apps);
             expect(flp.config.intent).toStrictEqual({ object: 'movie', action: 'start' });
             expect(flp.router).toBeDefined();
         });
@@ -95,20 +95,22 @@ describe('FlpSandbox', () => {
         test('additional apps', async () => {
             const flp = new FlpSandbox(
                 {
-                    apps: [
-                        {
-                            target: '/simple/app',
-                            local: join(fixtures, 'simple-app')
-                        },
-                        {
-                            target: '/yet/another/app',
-                            local: join(fixtures, 'multi-app'),
-                            intent: {
-                                object: 'myObject',
-                                action: 'action'
+                    flp: {
+                        apps: [
+                            {
+                                target: '/simple/app',
+                                local: join(fixtures, 'simple-app')
+                            },
+                            {
+                                target: '/yet/another/app',
+                                local: join(fixtures, 'multi-app'),
+                                intent: {
+                                    object: 'myObject',
+                                    action: 'action'
+                                }
                             }
-                        }
-                    ]
+                        ]
+                    }
                 },
                 mockProject,
                 mockUtils,
@@ -128,14 +130,25 @@ describe('FlpSandbox', () => {
         beforeAll(async () => {
             const flp = new FlpSandbox(
                 {
-                    apps: [
-                        {
-                            target: '/yet/another/app',
-                            local: join(fixtures, 'multi-app')
-                        }
-                    ],
+                    flp: {
+                        apps: [
+                            {
+                                target: '/yet/another/app',
+                                local: join(fixtures, 'multi-app')
+                            }
+                        ]
+                    },
                     rta: {
-                        layer: 'CUSTOMER_BASE'
+                        layer: 'CUSTOMER_BASE',
+                        editors: [
+                            {
+                                path: '/my/editor.html',
+                                developerMode: true
+                            },
+                            {
+                                path: '/my/rta.html'
+                            }
+                        ]
                     }
                 },
                 mockProject,
@@ -163,13 +176,13 @@ describe('FlpSandbox', () => {
             expect(logger.warn).toBeCalled();
         });
 
-        test('test/flp.html?fiori-tools-rta-mode=true', async () => {
-            const response = await server.get('/test/flp.html?fiori-tools-rta-mode=true').expect(200);
+        test('rta', async () => {
+            const response = await server.get('/my/rta.html').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 
-        test('test/flp.html?fiori-tools-rta-mode=forAdaptation', async () => {
-            const response = await server.get('/test/flp.html?fiori-tools-rta-mode=forAdaptation').expect(200);
+        test('rta with developerMode=true', async () => {
+            const response = await server.get('/my/editor.html').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import supertest from 'supertest';
 import * as previewMiddleware from '../../../src/ui5/middleware';
-import type { Config } from '../../../src/types';
+import type { MiddlewareConfig } from '../../../src/types';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import nock from 'nock';
@@ -18,7 +18,7 @@ jest.mock('@sap-ux/store', () => {
     };
 });
 
-async function getRouter(fixture?: string, configuration: Partial<Config> = {}): Promise<EnhancedRouter> {
+async function getRouter(fixture?: string, configuration: Partial<MiddlewareConfig> = {}): Promise<EnhancedRouter> {
     return await (previewMiddleware as any).default({
         options: { configuration },
         resources: {
@@ -53,7 +53,7 @@ async function getRouter(fixture?: string, configuration: Partial<Config> = {}):
 }
 
 // middleware function wrapper for testing to simplify tests
-async function getTestServer(fixture?: string, configuration: Partial<Config> = {}): Promise<any> {
+async function getTestServer(fixture?: string, configuration: Partial<MiddlewareConfig> = {}): Promise<any> {
     const router = await getRouter(fixture, configuration);
     const app = express();
     app.use(router);

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -98,8 +98,15 @@ describe('ui5/middleware', () => {
     });
 
     test('adp config', async () => {
-        const server = await getTestServer('adp', { adp: { target: { url } } });
+        const server = await getTestServer('adp', {
+            adp: { target: { url } },
+            rta: {
+                layer: 'CUSTOMER_BASE',
+                editors: [{ path: '/adp/editor.html' }]
+            }
+        });
         await server.get('/test/flp.html').expect(200);
+        await server.get('/adp/editor.html').expect(200);
     });
 
     test('invalid adp config', async () => {

--- a/packages/preview-middleware/tsconfig.json
+++ b/packages/preview-middleware/tsconfig.json
@@ -1,26 +1,26 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": [
-        "../../types/ui5.d.ts",
-        "src",
-        "src/**/*.json"
-    ],
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist"
+  "extends": "../../tsconfig.json",
+  "include": [
+    "../../types/ui5.d.ts",
+    "src",
+    "src/**/*.json"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {
+      "path": "../adp-tooling"
     },
-    "references": [
-        {
-            "path": "../adp-tooling"
-        },
-        {
-            "path": "../logger"
-        },
-        {
-            "path": "../project-access"
-        },
-        {
-            "path": "../store"
-        }
-    ]
+    {
+      "path": "../logger"
+    },
+    {
+      "path": "../project-access"
+    },
+    {
+      "path": "../store"
+    }
+  ]
 }


### PR DESCRIPTION
## Description
Please note this is a breaking change because the possibility to change the generated html based on url parameter to use one endpoint for preview and editing has been removed. Instead, from now on, only the yaml configuration affects the generated templates and url parameters affect the runtime behavior.

## Changes
* `preview-middleware-client`
  * added placeholder for `adp` (adaptation projects) and `cpe` (control property editor) 
  * improved the jest test setup
*  `preview-middleware`
  * remove modification of the generated html based on url parameter
  * enhance config with an `rta` object allowing to define mount points for editing 
* `adp-tooling`
  * updated the generator template to use the new `preview-middleware` version and configuration 
