### PR TITLE
Proposal for improvements for ui5-proxy

### DIFF
--- a/.changeset/large-bikes-matter.md
+++ b/.changeset/large-bikes-matter.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-proxy-middleware': minor
+---
+
+Use default config if none is provided.

--- a/packages/ui5-proxy-middleware/README.md
+++ b/packages/ui5-proxy-middleware/README.md
@@ -13,7 +13,19 @@ The `@sap-ux/ui5-proxy-middleware` is a [Custom UI5 Server Middleware](https://s
 | `directLoad` | false         | Defines whether the UI5 sources should be loaded directly from UI5 CDN |
 
 ## Usage
-In order to use the middleware this is the minimal configuration that you need to provide in the `ui5.yaml` of your application.
+In order to use the middleware this is the minimal configuration that you need to provide in the `ui5.yaml` of your application. All requests to `/resources` and `/test-resources` will be proxied to the latest UI5 version at https://ui5.sap.com.
+
+```yaml
+server:
+  customMiddleware:
+  - name: ui5-proxy-middleware
+    afterMiddleware: compression
+```
+
+## Examples
+
+### Defining url and path
+If you want to explicitly define paths that should be proxied to a specific server, the following configuration is required.
 
 ```Yaml
 server:
@@ -44,17 +56,6 @@ server:
 ```
 **NOTE: You can't mix both syntaxes!**
 
-Finally don't forget to add the following in your `package.json`.
-
-```JSON
-"ui5": {
-    "dependencies": [
-        "@sap-ux/ui5-proxy-middleware"
-    ]
-}
-```
-
-## Examples
 ### Loading a specific UI5 version
 To load a specific a UI5 version in your application you can use the `version` parameter, e.g.
 

--- a/packages/ui5-proxy-middleware/README.md
+++ b/packages/ui5-proxy-middleware/README.md
@@ -5,7 +5,7 @@ The `@sap-ux/ui5-proxy-middleware` is a [Custom UI5 Server Middleware](https://s
 ## Configuration Options
 | Option       | Default Value | Description |
 | ------------ | ------------- | ----------- |
-| `ui5`        | mandatory     | List of mount paths and target urls that should be handled by the proxy |
+| `ui5`        | `object`      | List of mount paths and target urls that should be handled by the proxy. If not provided then `/resources` and `/test-resources` are proxied to `https://ui5.sap.com` |
 | `version`    | `undefined`   | The UI5 version. If this property is not defined, then the `minUI5Version` from the `manifest.json` will be used |
 | `secure`     | true          | Defines if SSL certs should be verified |
 | `debug`      | false         | Enables debug output |

--- a/packages/ui5-proxy-middleware/src/base/utils.ts
+++ b/packages/ui5-proxy-middleware/src/base/utils.ts
@@ -38,7 +38,7 @@ export const proxyRequestHandler = (
     etag: string,
     logger: ToolsLogger
 ): void => {
-    logger.info(proxyReq.path);
+    logger.debug(proxyReq.path);
     if (proxyReq.getHeader('if-none-match') === etag) {
         res.statusCode = 304;
         res.end();

--- a/packages/ui5-proxy-middleware/src/ui5/middleware.ts
+++ b/packages/ui5-proxy-middleware/src/ui5/middleware.ts
@@ -116,7 +116,11 @@ module.exports = async ({ resources, options }: MiddlewareParameters<UI5ProxyCon
     }
 
     if (directLoad) {
-        const directLoadProxy = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        const directLoadProxy: RequestHandler = async (
+            req: Request,
+            res: Response,
+            next: NextFunction
+        ): Promise<void> => {
             try {
                 await injectScripts(req, res, next, ui5Configs);
             } catch (error) {

--- a/packages/ui5-proxy-middleware/src/ui5/middleware.ts
+++ b/packages/ui5-proxy-middleware/src/ui5/middleware.ts
@@ -116,18 +116,14 @@ module.exports = async ({ resources, options }: MiddlewareParameters<UI5ProxyCon
     }
 
     if (directLoad) {
-        const directLoadProxy: RequestHandler = async (
-            req: Request,
-            res: Response,
-            next: NextFunction
-        ): Promise<void> => {
+        const directLoadProxy = (async (req: Request, res: Response, next: NextFunction): Promise<void> => {
             try {
                 await injectScripts(req, res, next, ui5Configs);
             } catch (error) {
                 logger.error(error);
                 next(error);
             }
-        };
+        }) as RequestHandler;
 
         HTML_MOUNT_PATHS.forEach((path) => {
             routes.push({ route: path, handler: directLoadProxy });

--- a/packages/ui5-proxy-middleware/src/ui5/middleware.ts
+++ b/packages/ui5-proxy-middleware/src/ui5/middleware.ts
@@ -69,13 +69,14 @@ module.exports = async ({ resources, options }: MiddlewareParameters<UI5ProxyCon
         transports: [new UI5ToolingTransport({ moduleName: 'ui5-proxy-middleware' })]
     });
 
-    if (!options.configuration?.ui5) {
-        logger.error('Configuration missing, no proxy created.');
-        return (_req, _res, next) => next();
-    }
-
     dotenv.config();
-    const config = options.configuration;
+    const config: UI5ProxyConfig = {
+        ui5: {
+            path: ['/resources', '/test-resources'],
+            url: 'https://ui5.sap.com'
+        },
+        ...options.configuration
+    };
     let ui5Version: string = '';
     try {
         const manifest = await loadManifest(resources.rootProject);

--- a/packages/ui5-proxy-middleware/test/base/utils.test.ts
+++ b/packages/ui5-proxy-middleware/test/base/utils.test.ts
@@ -19,7 +19,7 @@ import * as baseUtils from '../../src/base/utils';
 import type { ProxyConfig } from '../../src/base/types';
 import type { IncomingMessage } from 'http';
 import { NullTransport, ToolsLogger } from '@sap-ux/logger';
-import { Manifest } from '@sap-ux/project-access';
+import type { Manifest } from '@sap-ux/project-access';
 
 describe('utils', () => {
     const existsMock = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -55,11 +55,11 @@ describe('utils', () => {
             end: jest.fn()
         };
         const logger = {
-            info: jest.fn()
+            debug: jest.fn()
         };
         proxyRequestHandler(proxyReq as any, res as any, etag, logger as any);
-        expect(logger.info).toHaveBeenCalledTimes(1);
-        expect(logger.info).toHaveBeenCalledWith('/mypath');
+        expect(logger.debug).toHaveBeenCalledTimes(1);
+        expect(logger.debug).toHaveBeenCalledWith('/mypath');
         expect(res.statusCode).toEqual(304);
         expect(res.end).toHaveBeenCalledTimes(1);
     });
@@ -307,7 +307,7 @@ describe('utils', () => {
         setHtmlResponse(res, html);
         expect(res.writeHead).toBeCalledTimes(1);
         expect(res.writeHead).toBeCalledWith(200, {
-            "Content-Type": "text/html"
+            'Content-Type': 'text/html'
         });
         expect(res.write).toHaveBeenCalledWith(html);
         expect(res.end).toBeCalledTimes(1);
@@ -458,7 +458,7 @@ describe('utils', () => {
         const respMock: Response = {} as Partial<Response> as Response;
         respMock.writeHead = jest.fn();
         respMock.write = jest.fn();
-        respMock.end =  jest.fn();
+        respMock.end = jest.fn();
 
         beforeEach(() => {
             nextMock.mockReset();
@@ -469,9 +469,9 @@ describe('utils', () => {
             await baseUtils.injectScripts({ baseUrl: 'index.html' } as any, respMock, nextMock, []);
             expect(respMock.writeHead).toBeCalledTimes(1);
             expect(respMock.writeHead).toBeCalledWith(200, {
-                "Content-Type": "text/html"
+                'Content-Type': 'text/html'
             });
-            expect(respMock.end).toHaveBeenCalled();        
+            expect(respMock.end).toHaveBeenCalled();
             expect(nextMock).not.toHaveBeenCalled();
         });
 


### PR DESCRIPTION
## Description
@zdravko-georgiev @cfg74 , as discussed, here are the improvements for the `ui5-proxy-middleware`.

* use `debug` logging for the logging of forwarded files because it is otherwise so chatty that you don't see any other logs from other middlewares
* use a default setting for ui5 so that for the default case nothing needs to be provided as config in the yaml
```js
{
    url: 'https://ui5.sap.com',
    path: ['/resources', '/test-resources']
}
```

## Changes
* fix for https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=SAP_open-ux-tools&open=AYfrPkWISN0lrgwATVQm
* changed log level for each loaded file from `info` to `debug`
* set default config if none is provided
* updated the readme