### PR TITLE
tbi: use platform independent UI5 CDN URLs

### DIFF
--- a/.changeset/unlucky-guests-wonder.md
+++ b/.changeset/unlucky-guests-wonder.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux/ui5-application-writer': patch
+'@sap-ux/ui5-library-writer': patch
+'@sap-ux/fe-fpm-writer': patch
+'@sap-ux/ui5-config': patch
+---
+
+use platform independent UI5 CDN URLs

--- a/packages/fe-fpm-writer/src/column/types.ts
+++ b/packages/fe-fpm-writer/src/column/types.ts
@@ -41,7 +41,7 @@ export interface CustomTableColumn extends CustomElement, EventHandler {
     control?: string;
     /**
      * A string type that represents CSS size values.
-     * Refer to https://openui5.hana.ondemand.com/api/sap.ui.core.CSSSize.
+     * Refer to https://sdk.openui5.org/api/sap.ui.core.CSSSize.
      */
     width?: string;
     /**

--- a/packages/ui5-application-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/index.test.ts.snap
@@ -82,7 +82,7 @@ server:
           path:
             - /resources
             - /test-resources
-          url: https://openui5.hana.ondemand.com
+          url: https://sdk.openui5.org
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/packages/ui5-application-writer/test/data.test.ts
+++ b/packages/ui5-application-writer/test/data.test.ts
@@ -39,7 +39,7 @@ describe('Setting defaults', () => {
             input: { framework: 'OpenUI5' },
             expected: {
                 framework: 'OpenUI5',
-                frameworkUrl: 'https://openui5.hana.ondemand.com',
+                frameworkUrl: 'https://sdk.openui5.org',
                 version: UI5_DEFAULT.DEFAULT_UI5_VERSION,
                 localVersion: UI5_DEFAULT.DEFAULT_LOCAL_UI5_VERSION,
                 minUI5Version: UI5_DEFAULT.MIN_UI5_VERSION,
@@ -55,7 +55,7 @@ describe('Setting defaults', () => {
             input: { framework: 'OpenUI5', version: '1.72.0' },
             expected: {
                 framework: 'OpenUI5',
-                frameworkUrl: 'https://openui5.hana.ondemand.com',
+                frameworkUrl: 'https://sdk.openui5.org',
                 version: '1.72.0',
                 localVersion: '1.72.0',
                 minUI5Version: '1.72.0',
@@ -88,7 +88,7 @@ describe('Setting defaults', () => {
         {
             input: {
                 ui5Libs: ['sap.m', 'sap.fe'],
-                frameworkUrl: 'https://sapui5.hana.ondemand.com/',
+                frameworkUrl: 'https://ui5.sap.com/',
                 descriptorVersion: '1.12.1',
                 typesVersion: '1.95.0',
                 minUI5Version: '1.80.0',
@@ -96,7 +96,7 @@ describe('Setting defaults', () => {
             },
             expected: {
                 framework: 'SAPUI5',
-                frameworkUrl: 'https://sapui5.hana.ondemand.com/',
+                frameworkUrl: 'https://ui5.sap.com/',
                 version: UI5_DEFAULT.DEFAULT_UI5_VERSION,
                 localVersion: '1.95.6',
                 minUI5Version: '1.80.0',

--- a/packages/ui5-config/src/defaults.ts
+++ b/packages/ui5-config/src/defaults.ts
@@ -5,7 +5,7 @@ export const enum UI5_DEFAULT {
     MIN_LOCAL_SAPUI5_VERSION = '1.76.0',
     MIN_LOCAL_OPENUI5_VERSION = '1.52.5',
     SAPUI5_CDN = 'https://ui5.sap.com',
-    OPENUI5_CDN = 'https://openui5.hana.ondemand.com',
+    OPENUI5_CDN = 'https://sdk.openui5.org',
     TYPES_VERSION_SINCE = '1.76.0',
     ESM_TYPES_VERSION_SINCE = '1.94.0',
     TYPES_VERSION_BEST = '1.108.0',

--- a/packages/ui5-library-writer/templates/common/src/baselibrary/themes/base/Example.less
+++ b/packages/ui5-library-writer/templates/common/src/baselibrary/themes/base/Example.less
@@ -1,4 +1,4 @@
-/* Theme Parameter Toolbox: https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/theming/webapp/index.html */
+/* Theme Parameter Toolbox: https://sdk.openui5.org/test-resources/sap/m/demokit/theming/webapp/index.html */
 
 .myLibPrefixExample,
 .myLibPrefixExampleHighlight {

--- a/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
@@ -266,7 +266,7 @@ ANY_TEXT=AnyText
     "state": "modified",
   },
   "com.sap.myui5lib/src/com/sap/myui5lib/themes/base/Example.less": Object {
-    "contents": "/* Theme Parameter Toolbox: https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/theming/webapp/index.html */
+    "contents": "/* Theme Parameter Toolbox: https://sdk.openui5.org/test-resources/sap/m/demokit/theming/webapp/index.html */
 
 .myLibPrefixExample,
 .myLibPrefixExampleHighlight {
@@ -877,7 +877,7 @@ ANY_TEXT=AnyText
     "state": "modified",
   },
   "com.sap.myui5tslib113/src/com/sap/myui5tslib113/themes/base/Example.less": Object {
-    "contents": "/* Theme Parameter Toolbox: https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/theming/webapp/index.html */
+    "contents": "/* Theme Parameter Toolbox: https://sdk.openui5.org/test-resources/sap/m/demokit/theming/webapp/index.html */
 
 .myLibPrefixExample,
 .myLibPrefixExampleHighlight {
@@ -1524,7 +1524,7 @@ ANY_TEXT=AnyText
     "state": "modified",
   },
   "com.sap.myui5tslib/src/com/sap/myui5tslib/themes/base/Example.less": Object {
-    "contents": "/* Theme Parameter Toolbox: https://openui5.hana.ondemand.com/test-resources/sap/m/demokit/theming/webapp/index.html */
+    "contents": "/* Theme Parameter Toolbox: https://sdk.openui5.org/test-resources/sap/m/demokit/theming/webapp/index.html */
 
 .myLibPrefixExample,
 .myLibPrefixExampleHighlight {


### PR DESCRIPTION
#1284 

Make use of https://ui5.sap.com/ and https://sdk.openui5.org/ instead of https://sapui5.hana.ondemand.com/ and https://openui5.hana.ondemand.com/
