### PR TITLE
feat(preview-middleware): add an option for setting the UI5 theme

### DIFF
--- a/.changeset/stale-bears-switch.md
+++ b/.changeset/stale-bears-switch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+Add an option for setting the UI5 theme

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -13,6 +13,7 @@ It hosts a local Fiori launchpad based on your configuration as well as offers a
 | `flp.intent.action`    | `string`  | `preview`        | Optional intent action                                                                                                              |
 | `flp.apps`             | `array`   | `undefined`      | Optional additional local apps that are available in local Fiori launchpad                                                          |
 | `flp.libs`             | `boolean` | `undefined`      | Optional flag to add a generic script fetching the paths of used libraries not available in UI5. To disable set it to `false`, if not set, then the project is checked for a `load-reuse-libs` script and if available the libraries are fetched as well. |
+| `flp.ui5Theme`             | `string` | `undefined`      | Optional flag for setting the UI5 Theme. |
 | `adp.target`           |           |                  | Required configuration for adaptation projects defining the connected backend                                                       |
 | `adp.ignoreCertErrors` | `boolean` | `false`          | Optional setting to ignore certification validation errors when working with e.g. development systems with self signed certificates |
 | `rta`                  |           |                  | Optional configuration allowing to add mount points for runtime adaptation                                                          |

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -13,7 +13,7 @@ It hosts a local Fiori launchpad based on your configuration as well as offers a
 | `flp.intent.action`    | `string`  | `preview`        | Optional intent action                                                                                                              |
 | `flp.apps`             | `array`   | `undefined`      | Optional additional local apps that are available in local Fiori launchpad                                                          |
 | `flp.libs`             | `boolean` | `undefined`      | Optional flag to add a generic script fetching the paths of used libraries not available in UI5. To disable set it to `false`, if not set, then the project is checked for a `load-reuse-libs` script and if available the libraries are fetched as well. |
-| `flp.ui5Theme`             | `string` | `undefined`      | Optional flag for setting the UI5 Theme. |
+| `flp.theme`             | `string` | `undefined`      | Optional flag for setting the UI5 Theme. |
 | `adp.target`           |           |                  | Required configuration for adaptation projects defining the connected backend                                                       |
 | `adp.ignoreCertErrors` | `boolean` | `false`          | Optional setting to ignore certification validation errors when working with e.g. development systems with self signed certificates |
 | `rta`                  |           |                  | Optional configuration allowing to add mount points for runtime adaptation                                                          |

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -130,7 +130,7 @@ export class FlpSandbox {
         const flex = this.createFlexHandler();
         const supportedThemes: string[] = (manifest['sap.ui5']?.supportedThemes as []) ?? [DEFAULT_THEME];
         const ui5Theme =
-            this.config.ui5Theme || (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
+            this.config.ui5Theme ?? (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
         this.templateConfig = {
             basePath: relative(dirname(this.config.path), '/') ?? '.',
             apps: {},

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -109,7 +109,7 @@ export class FlpSandbox {
             intent: config.flp?.intent ?? DEFAULT_INTENT,
             apps: config.flp?.apps ?? [],
             libs: config.flp?.libs,
-            ui5Theme: config.flp?.ui5Theme
+            theme: config.flp?.theme
         };
         if (!this.config.path.startsWith('/')) {
             this.config.path = `/${this.config.path}`;
@@ -130,7 +130,7 @@ export class FlpSandbox {
         const flex = this.createFlexHandler();
         const supportedThemes: string[] = (manifest['sap.ui5']?.supportedThemes as []) ?? [DEFAULT_THEME];
         const ui5Theme =
-            this.config.ui5Theme ?? (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
+            this.config.theme ?? (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
         this.templateConfig = {
             basePath: relative(dirname(this.config.path), '/') ?? '.',
             apps: {},

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -130,7 +130,7 @@ export class FlpSandbox {
         const flex = this.createFlexHandler();
         const supportedThemes: string[] = (manifest['sap.ui5']?.supportedThemes as []) ?? [DEFAULT_THEME];
         const ui5Theme =
-            this.config.ui5Theme ?? supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0];
+            this.config.ui5Theme || (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
         this.templateConfig = {
             basePath: relative(dirname(this.config.path), '/') ?? '.',
             apps: {},

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -108,7 +108,8 @@ export class FlpSandbox {
             path: config.flp?.path ?? DEFAULT_PATH,
             intent: config.flp?.intent ?? DEFAULT_INTENT,
             apps: config.flp?.apps ?? [],
-            libs: config.flp?.libs
+            libs: config.flp?.libs,
+            ui5Theme: config.flp?.ui5Theme
         };
         if (!this.config.path.startsWith('/')) {
             this.config.path = `/${this.config.path}`;
@@ -128,12 +129,14 @@ export class FlpSandbox {
     async init(manifest: Manifest, componentId?: string, resources: Record<string, string> = {}): Promise<void> {
         const flex = this.createFlexHandler();
         const supportedThemes: string[] = (manifest['sap.ui5']?.supportedThemes as []) ?? [DEFAULT_THEME];
+        const ui5Theme =
+            this.config.ui5Theme ?? supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0];
         this.templateConfig = {
             basePath: relative(dirname(this.config.path), '/') ?? '.',
             apps: {},
             ui5: {
                 libs: Object.keys(manifest['sap.ui5']?.dependencies?.libs ?? {}).join(','),
-                theme: supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0],
+                theme: ui5Theme,
                 flex,
                 resources: {
                     ...resources,

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -43,7 +43,7 @@ export interface FlpConfig {
      */
     libs?: boolean;
     apps: App[];
-    ui5Theme?: string;
+    theme?: string;
 }
 
 /**

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -43,6 +43,7 @@ export interface FlpConfig {
      */
     libs?: boolean;
     apps: App[];
+    ui5Theme?: string;
 }
 
 /**

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -109,6 +109,37 @@ Object {
 }
 `;
 
+exports[`FlpSandbox init ui5Theme 1`] = `
+Object {
+  "apps": Object {
+    "app-preview": Object {
+      "additionalInformation": "SAPUI5.Component=test.fe.v2.app",
+      "applicationType": "URL",
+      "description": "This is a very simple application.",
+      "title": "My Simple App",
+      "url": "..",
+    },
+  },
+  "basePath": "..",
+  "locateReuseLibsScript": false,
+  "ui5": Object {
+    "flex": Array [
+      Object {
+        "applyConnector": "/preview/WorkspaceConnector",
+        "custom": true,
+        "writeConnector": "/preview/WorkspaceConnector",
+      },
+    ],
+    "libs": "sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template",
+    "resources": Object {
+      "open.ux.preview.client": "/preview/client",
+      "test.fe.v2.app": "..",
+    },
+    "theme": "sap_fiori_3",
+  },
+}
+`;
+
 exports[`FlpSandbox router GET /preview/api/changes 1`] = `"{\\"sap.ui.fl.myid\\":{\\"id\\":\\"myId\\"}}"`;
 
 exports[`FlpSandbox router WorkspaceConnector.js 1`] = `

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -60,7 +60,7 @@ describe('FlpSandbox', () => {
             const flpConfig: FlpConfig = {
                 path: 'my/custom/path',
                 intent: { object: 'movie', action: 'start' },
-                ui5Theme: 'sap_fiori_3',
+                theme: 'sap_fiori_3',
                 apps: [
                     {
                         target: '/other/app',
@@ -73,7 +73,7 @@ describe('FlpSandbox', () => {
             expect(flp.config.apps).toEqual(flpConfig.apps);
             expect(flp.config.intent).toStrictEqual({ object: 'movie', action: 'start' });
             expect(flp.router).toBeDefined();
-            expect(flp.config.ui5Theme).toEqual(flpConfig.ui5Theme);
+            expect(flp.config.theme).toEqual(flpConfig.theme);
         });
     });
 
@@ -95,7 +95,7 @@ describe('FlpSandbox', () => {
         });
 
         test('ui5Theme', async () => {
-            const flp = new FlpSandbox({ flp: { ui5Theme: 'sap_fiori_3' } }, mockProject, mockUtils, logger);
+            const flp = new FlpSandbox({ flp: { theme: 'sap_fiori_3' } }, mockProject, mockUtils, logger);
             const manifest = JSON.parse(readFileSync(join(fixtures, 'simple-app/webapp/manifest.json'), 'utf-8'));
             await flp.init(manifest);
             expect(flp.templateConfig).toMatchSnapshot();

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -94,6 +94,13 @@ describe('FlpSandbox', () => {
             expect(flp.templateConfig).toMatchSnapshot();
         });
 
+        test('ui5Theme', async () => {
+            const flp = new FlpSandbox({ flp: { ui5Theme: 'sap_fiori_3' } }, mockProject, mockUtils, logger);
+            const manifest = JSON.parse(readFileSync(join(fixtures, 'simple-app/webapp/manifest.json'), 'utf-8'));
+            await flp.init(manifest);
+            expect(flp.templateConfig).toMatchSnapshot();
+        });
+
         test('additional apps', async () => {
             const flp = new FlpSandbox(
                 {

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -60,6 +60,7 @@ describe('FlpSandbox', () => {
             const flpConfig: FlpConfig = {
                 path: 'my/custom/path',
                 intent: { object: 'movie', action: 'start' },
+                ui5Theme: 'sap_fiori_3',
                 apps: [
                     {
                         target: '/other/app',
@@ -72,6 +73,7 @@ describe('FlpSandbox', () => {
             expect(flp.config.apps).toEqual(flpConfig.apps);
             expect(flp.config.intent).toStrictEqual({ object: 'movie', action: 'start' });
             expect(flp.router).toBeDefined();
+            expect(flp.config.ui5Theme).toEqual(flpConfig.ui5Theme);
         });
     });
 


### PR DESCRIPTION
Adds a configuration option for setting the UI5 theme. This is useful when one wants to use the `preview-middleware` in an application with an older UI5 version that e.g. doesn't support the `sap_horizon` theme. 