### PR TITLE
Disable unsupported configuration

### DIFF
--- a/.changeset/quiet-icons-accept.md
+++ b/.changeset/quiet-icons-accept.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+Disable unsupported mode to prevent incorrect changes

--- a/packages/preview-middleware/src/ui5/middleware.ts
+++ b/packages/preview-middleware/src/ui5/middleware.ts
@@ -45,6 +45,24 @@ async function initAdp(
 }
 
 /**
+ * The developer mode is only supported for adaptation projects, therefore, notify the user if it is wrongly configured and then disable it.
+ *
+ * @param config configurations from the ui5.yaml
+ * @param logger logger instance
+ */
+function sanitizeConfig(config: MiddlewareConfig, logger: ToolsLogger): void {
+    if (config.rta && config.adp === undefined) {
+        config.rta.editors.forEach((editor) => {
+            if (editor.developerMode) {
+                logger.error('developerMode is ONLY supported for SAP UI5 adaptation projects.');
+                logger.warn(`developerMode for ${editor.path} disabled`);
+                editor.developerMode = false;
+            }
+        });
+    }
+}
+
+/**
  * Create the router that is to be exposed as UI5 middleware.
  *
  * @param param0 parameters provider by UI5
@@ -61,6 +79,7 @@ async function createRouter(
     // setting defaults
     const config = options.configuration ?? {};
     config.flp ??= {};
+    sanitizeConfig(config, logger);
 
     // configure the FLP sandbox based on information from the manifest
     const flp = new FlpSandbox(config, resources.rootProject, middlewareUtil, logger);

--- a/packages/preview-middleware/src/ui5/middleware.ts
+++ b/packages/preview-middleware/src/ui5/middleware.ts
@@ -52,12 +52,12 @@ async function initAdp(
  */
 function sanitizeConfig(config: MiddlewareConfig, logger: ToolsLogger): void {
     if (config.rta && config.adp === undefined) {
-        config.rta.editors.forEach((editor) => {
+        config.rta.editors = config.rta.editors.filter((editor) => {
             if (editor.developerMode) {
                 logger.error('developerMode is ONLY supported for SAP UI5 adaptation projects.');
                 logger.warn(`developerMode for ${editor.path} disabled`);
-                editor.developerMode = false;
             }
+            return !editor.developerMode;
         });
     }
 }

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -97,6 +97,22 @@ describe('ui5/middleware', () => {
         await server.get('/test/flp.html').expect(404);
     });
 
+    test('unsupported editor config', async () => {
+        const path = '/test/editor.html';
+        const server = await getTestServer('simple-app', {
+            rta: {
+                layer: 'CUSTOMER_BASE',
+                editors: [
+                    {
+                        path,
+                        developerMode: true
+                    }
+                ]
+            }
+        });
+        await server.get(path).expect(404);
+    });
+
     test('adp config', async () => {
         const server = await getTestServer('adp', {
             adp: { target: { url } },


### PR DESCRIPTION
It was possible to configure the middleware to run an edit mode on a Fiori elements application that would result in incorrect and unsupported changes. This PR disables that possibility. 