### PR TITLE
fix(fpm-writer): Custom filter field. Custom filter field overwrites existing extension fragment file

### DIFF
--- a/.changeset/tidy-seahorses-move.md
+++ b/.changeset/tidy-seahorses-move.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Custom Filter Field. Fix for issue, when creation of custom filter field overwrites existing extension fragment file.

--- a/.changeset/tidy-seahorses-move.md
+++ b/.changeset/tidy-seahorses-move.md
@@ -2,4 +2,4 @@
 '@sap-ux/fe-fpm-writer': patch
 ---
 
-Custom Filter Field. Fix for issue, when creation of custom filter field overwrites existing extension fragment file.
+Fix. Avoid overwrite of existing extension fragment file while creating new filter field.

--- a/packages/fe-fpm-writer/src/filter/index.ts
+++ b/packages/fe-fpm-writer/src/filter/index.ts
@@ -81,7 +81,9 @@ export function generateCustomFilter(basePath: string, filterConfig: CustomFilte
 
     // create a fragment file
     const fragmentPath = join(config.path, `${config.fragmentFile}.fragment.xml`);
-    fs.copyTpl(getTemplatePath(`filter/fragment.xml`), fragmentPath, config);
+    if (!fs.exists(fragmentPath)) {
+        fs.copyTpl(getTemplatePath(`filter/fragment.xml`), fragmentPath, config);
+    }
 
     return fs;
 }

--- a/packages/fe-fpm-writer/test/unit/filter.test.ts
+++ b/packages/fe-fpm-writer/test/unit/filter.test.ts
@@ -297,5 +297,35 @@ describe('CustomFilter', () => {
                 expect(fs.read(getControllerPath(filter, languageConfig.typescript))).toMatchSnapshot();
             });
         });
+
+        test('Avoid overwrite for existing extension files', () => {
+            const fileName = 'Existing';
+            const target = join(testDir, 'different-folder');
+            const folder = join('ext', 'different');
+            // Copy manifest
+            fs.write(join(target, 'webapp/manifest.json'), testAppManifest);
+            // Prepare existing extension files
+            const fragmentPath = join(target, `webapp/${folder}/${fileName}.fragment.xml`);
+            fs.write(fragmentPath, 'fragmentContent');
+            const handlerPath = join(target, `webapp/${folder}/${fileName}.js`);
+            fs.write(handlerPath, 'handlerContent');
+            generateCustomFilter(
+                target,
+                {
+                    ...filter,
+                    folder,
+                    eventHandler: {
+                        fileName
+                    },
+                    fragmentFile: fileName
+                },
+                fs
+            );
+
+            expect(fs.exists(handlerPath)).toBe(true);
+            expect(fs.read(handlerPath)).toEqual('handlerContent');
+            expect(fs.exists(fragmentPath)).toBe(true);
+            expect(fs.read(fragmentPath)).toEqual('fragmentContent');
+        });
     });
 });


### PR DESCRIPTION
Issue #1336

Problem, if we have existing fragment.xml file in project and we pass path to such existing file using `generateCustomFilter`, then existing fragment file is overwritten with new content.

We avoid overwrite of existing fragments like codes here:
1. custom section -> https://github.com/SAP/open-ux-tools/blob/main/packages/fe-fpm-writer/src/section/index.ts#L166 https://github.com/SAP/open-ux-tools/blob/main/packages/fe-fpm-writer/src/section/index.ts#L115
2. custom page -> https://github.com/SAP/open-ux-tools/blob/main/packages/fe-fpm-writer/src/page/custom.ts#L92
3. handler files -> https://github.com/SAP/open-ux-tools/blob/main/packages/fe-fpm-writer/src/common/event-handler.ts#L90