### PR TITLE
fix(ui-components): UIList. ListProps interface should be extended from fluent-ui IGroupedListProps

### DIFF
--- a/.changeset/serious-bobcats-listen.md
+++ b/.changeset/serious-bobcats-listen.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-components': patch
 ---
 
-UIList. Fix - ListProps interface is extended from flunet-ui IGroupedListProps
+UIList. Fix - ListProps interface is extended from fluent-ui IGroupedListProps

--- a/.changeset/serious-bobcats-listen.md
+++ b/.changeset/serious-bobcats-listen.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIList. Fix - ListProps interface is extended from flunet-ui IGroupedListProps

--- a/packages/ui-components/src/components/UIList/UIList.tsx
+++ b/packages/ui-components/src/components/UIList/UIList.tsx
@@ -5,14 +5,16 @@ import type {
     IGroupRenderProps,
     IGroupHeaderProps,
     IGroupHeaderStyles,
-    IListProps
+    IListProps,
+    IGroupedListProps
 } from '@fluentui/react';
 import { GroupedList } from '@fluentui/react';
 
 import { UiIcons } from '../Icons';
 
 import './UIList.scss';
-export interface ListProps {
+
+export interface ListProps extends IGroupedListProps {
     groups: IGroup[];
     groupProps?: IGroupRenderProps;
     items: never[];


### PR DESCRIPTION
Enhance props type for UIList -> ListProps.
ListProps should be extended from IGroupedListProps, because it allows to pass any property from IGroupedListProps -> https://github.com/SAP/open-ux-tools/blob/main/packages/ui-components/src/components/UIList/UIList.tsx#L138