### PR TITLE
fix: build and editor script

### DIFF
--- a/.changeset/bright-fishes-fix.md
+++ b/.changeset/bright-fishes-fix.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': patch
+---
+
+Fix: build and editor script for generated projects

--- a/packages/adp-tooling/src/writer/index.ts
+++ b/packages/adp-tooling/src/writer/index.ts
@@ -62,7 +62,7 @@ export async function generate(basePath: string, config: AdpWriterConfig, fs?: E
                 rta: {
                     editors: [
                         {
-                            path: 'local/editor.html',
+                            path: '/local/editor.html',
                             developerMode: true
                         }
                     ]

--- a/packages/adp-tooling/templates/project/package.json
+++ b/packages/adp-tooling/templates/project/package.json
@@ -16,7 +16,7 @@
         "@ui5/cli": "^3.6.0"
     },
     "scripts": {
-        "build": "ui5 build --clean-dest",
+        "build": "ui5 build --exclude-task generateFlexChangesBundle generateComponentPreload --clean-dest",
         "start": "ui5 serve --open /test/flp.html#app-preview",
         "editor": "ui5 serve --open /local/editor.html"
     }

--- a/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
+++ b/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ dist/
         \\"@ui5/cli\\": \\"^3.6.0\\"
     },
     \\"scripts\\": {
-        \\"build\\": \\"ui5 build --clean-dest\\",
+        \\"build\\": \\"ui5 build --exclude-task generateFlexChangesBundle generateComponentPreload --clean-dest\\",
         \\"start\\": \\"ui5 serve --open /test/flp.html#app-preview\\",
         \\"editor\\": \\"ui5 serve --open /local/editor.html\\"
     }
@@ -55,7 +55,7 @@ server:
           ignoreCertErrors: false
         rta:
           editors:
-            - path: local/editor.html
+            - path: /local/editor.html
               developerMode: true
     - name: ui5-proxy-middleware
       afterMiddleware: preview-middleware


### PR DESCRIPTION
If you generate an adaptation project with the `npm init @sap-ux generate adpatation-project` command then you will have the following two problems:

Problem: The `npm run editor` is showing a 404
Reason: missing `/` in the `ui5.yaml`
Fix: add `/` to `ui5.yaml`

Problem: After adding a custom fragment to the project, `npm run build` will fail with an error when executing the `generateFlexChangesBundle` task
Reason: the task is not made for adaptation project
Fix: exclude task

Problem: After running `npm run build` the `dist` folder contains a useless `Component-preload.js` file
Reason: the `generateComponentPreload` task generates it
Fix: exclude task
