### PR TITLE
fix(axios-extension): Apply additional info if endpoint is a destination

### DIFF
--- a/.changeset/dry-snails-dress.md
+++ b/.changeset/dry-snails-dress.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+Apply additional logging if the endpoint is a destination

--- a/packages/axios-extension/src/abap/message.ts
+++ b/packages/axios-extension/src/abap/message.ts
@@ -137,10 +137,11 @@ function logFullURL({
  * @param options.error error message returned from gateway
  * @param options.log logger to be used
  * @param options.host optional host name to pretty print links
+ * @param options.isDest optional value if additional info should be printed
  * @param showAllMessages optional, show all errors but restrict for certain flows i.e. test mode
  */
 export function prettyPrintError(
-    { error, log, host }: { error: ErrorMessage; log: Logger; host?: string },
+    { error, log, host, isDest }: { error: ErrorMessage; log: Logger; host?: string; isDest?: boolean },
     showAllMessages = true
 ): void {
     if (error) {
@@ -151,7 +152,7 @@ export function prettyPrintError(
             if (!entry.message.startsWith('<![CDATA')) {
                 logLevel(entry.severity, entry.message, log, true);
             }
-            logFullURL({ host, path: entry['longtext_url'], log });
+            logFullURL({ host, path: entry['longtext_url'], log, isDest });
         });
         if (showAllMessages && error.innererror?.Error_Resolution) {
             for (const key in error.innererror.Error_Resolution) {

--- a/packages/axios-extension/test/abap/message.test.ts
+++ b/packages/axios-extension/test/abap/message.test.ts
@@ -81,12 +81,12 @@ describe('message helpers', () => {
         };
         const errorMock = (log.error = jest.fn());
         const infoMock = (log.info = jest.fn());
-        prettyPrintError({ error, log, host });
+        prettyPrintError({ error, log, host, isDest: true });
         // log message, each resolution and each error detail
         expect(errorMock).toBeCalledTimes(
             1 + Object.keys(error.innererror.Error_Resolution).length + error.innererror.errordetails.length
         );
-        expect(infoMock).toBeCalledTimes(2);
+        expect(infoMock).toBeCalledTimes(3);
 
         // Restrict to only errordetails, typical for deployment with test mode enabled
         errorMock.mockReset();


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1257

- Additional flows need to have the info logger enabled, this helps the developer to understand the endpoint exposed needs to be updated locally to reflect their internal host
- Additiona tests added