### PR TITLE
fix(deploy-tooling): Update provider with credentials after a failed auth request

### DIFF
--- a/.changeset/lazy-hotels-applaud.md
+++ b/.changeset/lazy-hotels-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+Ensure provider is updated with credentials after 401 is returned

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -115,6 +115,8 @@ async function handle401Error(
         } else {
             config.credentials = credentials;
         }
+        // Need to re-init the provider with the updated credentials
+        provider = await createProvider(config, logger);
         await command(provider, config, logger, archive);
         return true;
     } else {

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -71,6 +71,7 @@ describe('base/deploy', () => {
         });
 
         test('Successful retry after known axios error', async () => {
+            mockCreateForAbap.mockClear();
             mockedUi5RepoService.deploy.mockResolvedValue(undefined);
             mockedUi5RepoService.deploy.mockRejectedValueOnce(axiosError(412));
             await deploy(archive, { app, target, yes: true }, nullLogger);
@@ -80,6 +81,7 @@ describe('base/deploy', () => {
             expect(mockCreateForAbap).toBeCalledWith(
                 expect.objectContaining({ auth: { password: '~password', username: '~username' } })
             );
+            expect(mockCreateForAbap).toBeCalledTimes(3);
         });
 
         test('Successful retry after known axios error (cloud target)', async () => {


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/1396

- tests updated

```
2023-10-23 22:49:46 info    abap-deploy-task: Please maintain correct credentials to avoid seeing this error
        (see help: https://www.npmjs.com/package/@sap/ux-ui5-tooling#setting-environment-variables-in-a-env-file) 
2023-10-23 22:49:46 info    abap-deploy-task: Please enter your credentials. 
✔ Username: … myusername
✔ Password: … *********************
2023-10-23 22:49:49 warn    abap-deploy-task: You chose not to validate SSL certificate. Please verify the server certificate is trustful before proceeding. See documentation for recommended configuration (https://help.sap.com/viewer/17d50220bcd848aa854c9c182d65b699/Latest/en-US/4b318bede7eb4021a8be385c46c74045.html). 
2023-10-23 22:49:49 debug   abap-deploy-task: Payload:
...
```
