### PR TITLE
fix(ui-components): Update dialogs/callout border radius to follow latest VSCode

### DIFF
--- a/.changeset/sour-monkeys-joke.md
+++ b/.changeset/sour-monkeys-joke.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-components': patch
 ---
 
-UIDialog, UICallout, UIContextualMenu, dropdown menues - apply border radius. 4px for UIDialog and UICallout. 2px for contextual and dropdown menues
+UIDialog, UICallout, UIContextualMenu, dropdown menus - apply border radius. 4px for UIDialog and UICallout. 2px for contextual and dropdown menus

--- a/.changeset/sour-monkeys-joke.md
+++ b/.changeset/sour-monkeys-joke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIDialog, UICallout, UIContextualMenu, dropdown menues - apply border radius. 4px for UIDialog and UICallout. 2px for contextual and dropdown menues

--- a/packages/ui-components/src/components/UICallout/UICallout.tsx
+++ b/packages/ui-components/src/components/UICallout/UICallout.tsx
@@ -18,7 +18,8 @@ export const CALLOUT_STYLES = {
     boxShadow:
         '0 2px 6px rgb(0 0 0 / 20%), 0 0 0 1px var(--vscode-contrastBorder, var(--vscode-editorSuggestWidget-border))',
     text: 'var(--vscode-editorSuggestWidget-foreground)',
-    font: 'var(--vscode-font-family)'
+    font: 'var(--vscode-font-family)',
+    borderRadius: 4
 };
 
 export enum UICalloutContentPadding {
@@ -51,7 +52,7 @@ export const getCalloutStyle = (props: UICalloutProps): ICalloutContentStyles =>
         root: {
             boxShadow: CALLOUT_STYLES.boxShadow,
             backgroundColor: 'transparent',
-            borderRadius: 0,
+            borderRadius: CALLOUT_STYLES.borderRadius,
             ...extractRawStyles(props.styles, 'root')
         },
         beak: {
@@ -61,13 +62,14 @@ export const getCalloutStyle = (props: UICalloutProps): ICalloutContentStyles =>
         },
         beakCurtain: {
             backgroundColor: CALLOUT_STYLES.background,
+            borderRadius: CALLOUT_STYLES.borderRadius,
             ...extractRawStyles(props.styles, 'beakCurtain')
         },
         calloutMain: {
             backgroundColor: CALLOUT_STYLES.background,
             color: CALLOUT_STYLES.text,
             fontFamily: CALLOUT_STYLES.font,
-            borderRadius: 0,
+            borderRadius: CALLOUT_STYLES.borderRadius,
             minWidth: props.calloutMinWidth ?? 300,
             boxSizing: 'border-box',
             padding: CALLOUT_CONTENT_PADDING.get(props.contentPadding || UICalloutContentPadding.None),

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.scss
@@ -148,10 +148,14 @@
 }
 
 .ts-Callout-Dropdown {
+    border: $dropdown-input-border-width solid $menu-border-color;
+    box-sizing: border-box;
+    border-radius: $menu-border-radius;
+    // Hide overflow to correctly see browser scrollbar and borders after applying border-radius
+    overflow: hidden;
     .ms-Callout-main {
         background: $menu-background;
-        border: $dropdown-input-border-width solid $menu-border-color;
-        box-sizing: border-box;
+        border: none;
         border-radius: 0;
     }
     // Combobox list items

--- a/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.scss
+++ b/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.scss
@@ -36,10 +36,10 @@
     box-shadow: none;
     background: $menu-background;
     border: 1px solid $menu-border-color;
-    border-radius: 0;
+    border-radius: $menu-border-radius;
 
     .ms-Callout-main {
-        border-radius: 0;
+        border-radius: $menu-border-radius;
         background: $menu-background;
         // workaround. resolves callout root element borders being cut or invisible
         transform: translateZ(0);

--- a/packages/ui-components/src/components/UIContextualMenu/_variables.scss
+++ b/packages/ui-components/src/components/UIContextualMenu/_variables.scss
@@ -4,6 +4,7 @@
 $menu-background: var(--vscode-menu-background, var(--vscode-input-background));
 $menu-color: var(--vscode-editorSuggestWidget-foreground);
 $menu-border-color: var(--vscode-focusBorder);
+$menu-border-radius: 2px;
 
 $menu-item-height: 22px;
 $menu-item-horizontal-padding: 8px;

--- a/packages/ui-components/src/components/UIDialog/UIDialog.tsx
+++ b/packages/ui-components/src/components/UIDialog/UIDialog.tsx
@@ -32,6 +32,7 @@ export const DIALOG_STYLES = {
     background: 'var(--vscode-editorWidget-background)',
     boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.3)',
     borderColor: 'var(--vscode-editorWidget-border)',
+    borderRadius: 4,
     vPadding: 20,
     vPaddingHalf: 10,
     hPadding: 45,
@@ -268,7 +269,7 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
                     backgroundColor: DIALOG_STYLES.background,
                     border: `1px solid ${DIALOG_STYLES.borderColor}`,
                     boxShadow: DIALOG_STYLES.boxShadow,
-                    borderRadius: 0,
+                    borderRadius: DIALOG_STYLES.borderRadius,
                     minHeight: 100,
                     ...(scrollArea === UIDialogScrollArea.Content && {
                         overflow: 'hidden',

--- a/packages/ui-components/test/unit/components/UICallout.test.tsx
+++ b/packages/ui-components/test/unit/components/UICallout.test.tsx
@@ -25,18 +25,22 @@ describe('<UICallout />', () => {
 
     it('Should render a UITooltip component', () => {
         expect(wrapper.find('.ms-Callout').length).toEqual(1);
+        const style = getCalloutStyles();
+        expect(style.root?.['borderRadius']).toEqual(4);
+        expect(style.beakCurtain?.['borderRadius']).toEqual(4);
+        expect(style.calloutMain?.['borderRadius']).toEqual(4);
     });
 
     it('Property "contentPadding"', () => {
         // Default - None
         let style = getCalloutStyles();
-        expect(style.calloutMain['padding']).toEqual(undefined);
+        expect(style.calloutMain?.['padding']).toEqual(undefined);
         // Standard
         wrapper.setProps({
             contentPadding: UICalloutContentPadding.Standard
         });
         style = getCalloutStyles();
-        expect(style.calloutMain['padding']).toEqual(8);
+        expect(style.calloutMain?.['padding']).toEqual(8);
     });
 
     it('Overwrite styles', () => {
@@ -62,10 +66,10 @@ describe('<UICallout />', () => {
             styles: expectStyles
         });
         const style = getCalloutStyles();
-        expect(style.root[property]).toEqual(expectStyles.root[property]);
-        expect(style.beak[property]).toEqual(expectStyles.beak[property]);
-        expect(style.beakCurtain[property]).toEqual(expectStyles.beakCurtain[property]);
-        expect(style.calloutMain[property]).toEqual(expectStyles.calloutMain[property]);
-        expect(style.container[property]).toEqual(expectStyles.container[property]);
+        expect(style.root?.[property]).toEqual(expectStyles.root[property]);
+        expect(style.beak?.[property]).toEqual(expectStyles.beak[property]);
+        expect(style.beakCurtain?.[property]).toEqual(expectStyles.beakCurtain[property]);
+        expect(style.calloutMain?.[property]).toEqual(expectStyles.calloutMain[property]);
+        expect(style.container?.[property]).toEqual(expectStyles.container[property]);
     });
 });

--- a/packages/ui-components/test/unit/components/UIDialog.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDialog.test.tsx
@@ -283,7 +283,7 @@ describe('<UIDialog />', () => {
                   },
                   "backgroundColor": "var(--vscode-editorWidget-background)",
                   "border": "1px solid var(--vscode-editorWidget-border)",
-                  "borderRadius": 0,
+                  "borderRadius": 4,
                   "boxShadow": "0px 4px 10px rgba(0, 0, 0, 0.3)",
                   "minHeight": 100,
                   "overflow": "hidden",
@@ -350,7 +350,7 @@ describe('<UIDialog />', () => {
                 Object {
                   "backgroundColor": "var(--vscode-editorWidget-background)",
                   "border": "1px solid var(--vscode-editorWidget-border)",
-                  "borderRadius": 0,
+                  "borderRadius": 4,
                   "boxShadow": "0px 4px 10px rgba(0, 0, 0, 0.3)",
                   "minHeight": 100,
                 }


### PR DESCRIPTION
Issue #1406 

Changes requested by @gpeuc
To be sync with VSCode updates/latest changes:
1. UIDialog, UICallout, UITooltip - border-radius 4px; https://github.com/SAP/open-ux-tools/pull/1407/commits/8e78d9ae3941ab8e83ca69b543df7aa20e6efb02
![image](https://github.com/SAP/open-ux-tools/assets/90789422/1f00c6b0-37e8-4a0c-a603-ca316ef999d4)

![image](https://github.com/SAP/open-ux-tools/assets/90789422/a2b99449-06ac-4687-92a9-166b41f7e5ce)

2. Dropdown menues and contextual menues - border-radius 2px; https://github.com/SAP/open-ux-tools/pull/1407/commits/5552aaf0a1ded6e27b5aad91b482a89584f9efc1
![image](https://github.com/SAP/open-ux-tools/assets/90789422/bf221d92-8219-498d-88d6-bf0431ae8348)

![image](https://github.com/SAP/open-ux-tools/assets/90789422/bd6ccc9d-d1e5-4e9e-8723-b40e6c41b068)
