### PR TITLE
feat(project-access): add getCdsFiles and getCdsRoots

### DIFF
--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -10,6 +10,8 @@ export {
     getCapEnvironment,
     getCapModelAndServices,
     getCapProjectType,
+    getCdsFiles,
+    getCdsRoots,
     getMtaPath,
     getNodeModulesPath,
     getWebappPath,

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -14,6 +14,12 @@ interface CdsFacade {
             edmx: (model: csn, options?: { service?: string; version?: 'v2' | 'v4' }) => Promise<string>;
         };
     };
+    resolve: ResolveWithCache;
+}
+
+interface ResolveWithCache {
+    (files: string | string[], options?: { skipModelCache: boolean }): string[];
+    cache: Record<string, { cached: Record<string, string[]>; paths: string[] }>;
 }
 
 interface ServiceInfo {
@@ -122,6 +128,91 @@ export async function getCapModelAndServices(projectRoot: string): Promise<{ mod
         model,
         services
     };
+}
+
+/**
+ * Returns a list of cds file paths (layers). By default return list of all, but you can also restrict it to one envRoot.
+ *
+ * @param projectRoot - root of the project, where the package.json is
+ * @param [ignoreErrors] - optionally, default is false; if set to true the thrown error will be checked for CDS file paths in model and returned
+ * @param [envRoot] - optionally, the root folder or CDS file to get the layer files
+ * @returns - array of strings containing cds file paths
+ */
+export async function getCdsFiles(
+    projectRoot: string,
+    ignoreErrors = false,
+    envRoot?: string | string[]
+): Promise<string[]> {
+    let cdsFiles: string[] = [];
+    try {
+        let csn;
+        envRoot ??= await getCdsRoots(projectRoot);
+        try {
+            const cds = await loadCdsModuleFromProject(projectRoot);
+            csn = await cds.load(envRoot);
+            cdsFiles = [...(csn['$sources'] ?? [])];
+        } catch (e) {
+            if (ignoreErrors && e.model?.sources && typeof e.model.sources === 'object') {
+                cdsFiles.push(...extractCdsFilesFromMessage(e.model.sources));
+            } else {
+                throw e;
+            }
+        }
+    } catch (error) {
+        throw Error(
+            `Error while retrieving the list of cds files for project ${projectRoot}, envRoot ${envRoot}. Error was: ${error}`
+        );
+    }
+    return cdsFiles;
+}
+
+/**
+ * Returns a list of filepaths to CDS files in root folders. Same what is done if you execute cds.resolve('*') on command line in a project.
+ *
+ * @param projectRoot - root of the project, where the package.json is
+ * @param [clearCache] - optionally, clear the cache, default false
+ * @returns - array of root paths
+ */
+export async function getCdsRoots(projectRoot: string, clearCache = false): Promise<string[]> {
+    const roots = [];
+    const capCustomPaths = await getCapCustomPaths(projectRoot);
+    const cdsEnvRoots = [capCustomPaths.db, capCustomPaths.srv, capCustomPaths.app, 'schema', 'services'];
+    // clear cache is enforced to also resolve newly created cds file at design time
+    const cds = await loadCdsModuleFromProject(projectRoot);
+    if (clearCache) {
+        cds.resolve.cache = {};
+    }
+    for (const cdsEnvRoot of cdsEnvRoots) {
+        const resolvedRoots =
+            cds.resolve(join(projectRoot, cdsEnvRoot), {
+                skipModelCache: true
+            }) || [];
+        for (const resolvedRoot of resolvedRoots) {
+            roots.push(resolvedRoot);
+        }
+    }
+    return roots;
+}
+
+/**
+ * When an error occurs while trying to read cds files, the error object contains the source file
+ * information. This function extracts this file paths.
+ *
+ * @param sources - map containing the file name
+ * @returns - array of strings containing cds file paths
+ */
+function extractCdsFilesFromMessage(sources: Record<string, { filename?: string }>): string[] {
+    const cdsFiles: string[] = [];
+    for (const source in sources) {
+        let filename = sources[source].filename;
+        if (typeof filename === 'string' && !filename.startsWith(sep)) {
+            filename = join(sep, filename);
+        }
+        if (filename) {
+            cdsFiles.push(filename);
+        }
+    }
+    return cdsFiles;
 }
 
 /**

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -2,6 +2,8 @@ export {
     getCapCustomPaths,
     getCapModelAndServices,
     getCapProjectType,
+    getCdsFiles,
+    getCdsRoots,
     isCapJavaProject,
     isCapNodeJsProject,
     getCapEnvironment,


### PR DESCRIPTION
Adding CAP-specific functions to `@sap-ux/project-access`. This functions are used in SAP  Fiori tools:

- `getCdsFiles()`
- `getCdsRoots()`