### PR TITLE
Fixed controller extension name longer than 64 chars error not showing up

### DIFF
--- a/.changeset/stale-papayas-do.md
+++ b/.changeset/stale-papayas-do.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+Fixed controller extension name longer than 64 chars error not showing up

--- a/.changeset/stale-papayas-do.md
+++ b/.changeset/stale-papayas-do.md
@@ -3,4 +3,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-Fixed controller extension name longer than 64 chars error not showing up
+Fixed controller extension/fragment name longer than 64 chars error not showing up

--- a/.changeset/stale-papayas-do.md
+++ b/.changeset/stale-papayas-do.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
 ---
 
 Fixed controller extension name longer than 64 chars error not showing up

--- a/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
@@ -83,6 +83,11 @@ export default abstract class BaseDialog extends Controller {
             return;
         }
 
+        if(fragmentName.length > 64) {
+            updateDialogState(ValueState.Error, 'A fragment file name cannot contain more than 64 characters.');
+            return;
+        }
+
         updateDialogState(ValueState.Success);
         this.model.setProperty('/newFragmentName', fragmentName);
     }

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -87,6 +87,10 @@ export default class ControllerExtension extends BaseDialog {
                 source.setValueState(ValueState.Error);
                 source.setValueStateText('The controller name cannot contain white spaces or special characters.');
                 this.dialog.getBeginButton().setEnabled(false);
+            } else if(controllerName.length > 64) {
+                source.setValueState(ValueState.Error);
+                source.setValueStateText('A controller file name cannot contain more than 64 characters.');
+                this.dialog.getBeginButton().setEnabled(false);
             } else {
                 this.dialog.getBeginButton().setEnabled(true);
                 source.setValueState(ValueState.None);

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -107,6 +107,11 @@ export default class ControllerExtension extends BaseDialog {
             );
             return;
         }
+        
+        updateDialogState(ValueState.Success);
+        this.model.setProperty('/newControllerName', controllerName);
+    }
+
 
     /**
      * Handles create button press

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -77,6 +77,8 @@ export default class ControllerExtension extends BaseDialog {
         if (controllerName.length <= 0) {
             updateDialogState(ValueState.None);
             this.model.setProperty('/newControllerName', null);
+            return;
+        }
 
         const fileExists = controllerList.some((f) => f.controllerName === `${controllerName}.js`);
 

--- a/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
@@ -256,7 +256,7 @@ describe('AddFragment', () => {
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
         });
 
-        test('sets error when the fragment name has more than 64 characters', () => {
+        test('sets error when the fragment name exceeds 64 characters', () => {
             const addFragment = new AddFragment(
                 'adp.extension.controllers.AddFragment',
                 {} as unknown as UI5Element,

--- a/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
@@ -1,5 +1,5 @@
 import type Dialog from 'sap/m/Dialog';
-import type Event from 'sap/ui/base/Event';
+import Event from 'sap/ui/base/Event';
 import type UI5Element from 'sap/ui/core/Element';
 import JSONModel from 'sap/ui/model/json/JSONModel';
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
@@ -255,6 +255,32 @@ describe('AddFragment', () => {
 
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
         });
+
+        test('sets error when the fragment name has more than 64 characters', () => {
+            const addFragment = new AddFragment(
+                'adp.extension.controllers.AddFragment',
+                {} as unknown as UI5Element,
+                {} as unknown as RuntimeAuthoring
+            );
+
+            const valueStateSpy = jest.fn().mockReturnValue({ setValueStateText: jest.fn() });
+            const event = {
+                getSource: jest.fn().mockReturnValue({
+                    getValue: jest.fn().mockReturnValue('thisisverylongnamethisisverylongnamethisisverylongnamethisisveryl'),
+                    setValueState: valueStateSpy
+                })
+            };
+
+            addFragment.model = testModel;
+            
+            addFragment.dialog = {
+                getBeginButton: jest.fn().mockReturnValue({ setEnabled: jest.fn() })
+            } as unknown as Dialog;
+
+            addFragment.onFragmentNameInputChange(event as unknown as Event);
+
+            expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
+        })
 
         test('sets create button to true when the fragment name is valid', () => {
             const addFragment = new AddFragment(

--- a/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
@@ -201,28 +201,29 @@ describe('ControllerExtension', () => {
         });
 
         test('sets error when the controller name exceeds 64 characters', () => {
-            const controllerExt = new ControllerExtension('adp.extension.controllers.ControllerExtension',
+            const controllerExt = new ControllerExtension(
+            'adp.extension.controllers.ControllerExtension',
             {} as unknown as UI5Element,
             {} as unknown as RuntimeAuthoring
             );
             
-            const valueStateSpy = jest.fn()
+            const valueStateSpy = jest.fn().mockReturnValue({ setValueStateText: jest.fn() });
             const event = {
                 getSource: jest.fn().mockReturnValue({
                     getValue: jest.fn().mockReturnValue('thisisverylongnamethisisverylongnamethisisverylongnamethisisveryl'),
                     setValueState: valueStateSpy,
-                    setValueStateText: jest.fn()
                 })
             };
 
             controllerExt.model = testModel;
+            
             controllerExt.dialog = {
                 getBeginButton: jest.fn().mockReturnValue({ setEnabled: jest.fn() })
             } as unknown as Dialog;
 
             controllerExt.onControllerNameInputChange(event as unknown as Event)
             
-            expect(valueStateSpy).toHaveBeenCalledWith('Error')
+            expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error)
         })
 
         test('sets create button to true when the controller name is valid', () => {

--- a/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
@@ -200,6 +200,31 @@ describe('ControllerExtension', () => {
             expect(valueStateSpy).toHaveBeenCalledWith('Error');
         });
 
+        test('sets error when the controller name exceeds 64 characters', () => {
+            const controllerExt = new ControllerExtension('adp.extension.controllers.ControllerExtension',
+            {} as unknown as UI5Element,
+            {} as unknown as RuntimeAuthoring
+            );
+            
+            const valueStateSpy = jest.fn()
+            const event = {
+                getSource: jest.fn().mockReturnValue({
+                    getValue: jest.fn().mockReturnValue('thisisverylongnamethisisverylongnamethisisverylongnamethisisveryl'),
+                    setValueState: valueStateSpy,
+                    setValueStateText: jest.fn()
+                })
+            };
+
+            controllerExt.model = testModel;
+            controllerExt.dialog = {
+                getBeginButton: jest.fn().mockReturnValue({ setEnabled: jest.fn() })
+            } as unknown as Dialog;
+
+            controllerExt.onControllerNameInputChange(event as unknown as Event)
+            
+            expect(valueStateSpy).toHaveBeenCalledWith('Error')
+        })
+
         test('sets create button to true when the controller name is valid', () => {
             const controllerExt = new ControllerExtension(
                 'adp.extension.controllers.ControllerExtension',


### PR DESCRIPTION
Bug fix for #1419 

- Added proper functionality to display error when name is over 64 characters long