### PR TITLE
fix: CPE UI is not updated when changes are created or deleted

### DIFF
--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -86,6 +86,7 @@ function modifyRTAErrorMessage(errorMessage: string, id: string, type: string): 
  */
 export class ChangeService {
     private savedChanges: SavedPropertyChange[] = [];
+    private sendAction: (action: ExternalAction) => void;
     /**
      *
      * @param options ui5 adaptation options.
@@ -100,6 +101,7 @@ export class ChangeService {
      * @param subscribe subscriber function
      */
     public async init(sendAction: ActionSenderFunction, subscribe: SubscribeFunction): Promise<void> {
+        this.sendAction = sendAction;
         subscribe(async (action): Promise<void> => {
             if (changeProperty.match(action)) {
                 try {
@@ -127,6 +129,32 @@ export class ChangeService {
             }
         });
 
+        await this.fetchSavedChanges();
+        this.updateStack();
+
+        this.options.rta.attachUndoRedoStackModified(this.createOnStackChangeHandler());
+    }
+
+    /**
+     * Send update to the editor with modified stack.
+     *
+     * @param pendingChanges Changes that are waiting to be saved
+     */
+    private updateStack(pendingChanges: PendingChange[] = []) {
+        this.sendAction(
+            changeStackModified({
+                saved: this.savedChanges,
+                pending: pendingChanges
+            })
+        );
+    }
+
+    /**
+     * Fetches saved changes from the workspace.
+     *
+     * @returns Saved changes
+     */
+    private async fetchSavedChanges() {
         const savedChangesResponse = await fetch(FlexChangesEndPoints.changes + `?_=${Date.now()}`);
         const savedChanges = await savedChangesResponse.json();
         const changes = (
@@ -176,13 +204,7 @@ export class ChangeService {
                 .filter((change) => !!change) as SavedPropertyChange[]
         ).sort((a, b) => b.timestamp - a.timestamp);
         this.savedChanges = changes;
-        sendAction(
-            changeStackModified({
-                saved: changes,
-                pending: []
-            })
-        );
-        this.options.rta.attachUndoRedoStackModified(this.createOnStackChangeHandler(sendAction));
+        return changes;
     }
 
     /**
@@ -209,6 +231,9 @@ export class ChangeService {
             );
 
         await Promise.all(filesToDelete).catch((error) => Log.error(error));
+
+        await this.fetchSavedChanges();
+        this.updateStack();
     }
 
     /**
@@ -217,8 +242,8 @@ export class ChangeService {
      * @param sendAction send action method
      * @returns (event: sap.ui.base.Event) => void
      */
-    private createOnStackChangeHandler(sendAction: (action: ExternalAction) => void): (event: Event) => void {
-        return (): void => {
+    private createOnStackChangeHandler(): (event: Event) => void {
+        return async (): Promise<void> => {
             const stack = this.options.rta.getCommandStack();
             const allCommands = stack.getCommands();
             const executedCommands = stack.getAllExecutedCommands();
@@ -240,12 +265,12 @@ export class ChangeService {
             });
 
             activeChanges = activeChanges.filter((change): boolean => !!change);
-            sendAction(
-                changeStackModified({
-                    saved: this.savedChanges,
-                    pending: activeChanges
-                })
-            );
+
+            if (Array.isArray(allCommands) && allCommands.length === 0) {
+                await this.fetchSavedChanges();
+            }
+
+            this.updateStack(activeChanges);
         };
     }
 

--- a/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
@@ -426,7 +426,7 @@ describe('SelectionService', () => {
             })
         );
 
-        expect(fetchMock).toHaveBeenLastCalledWith('/preview/api/changes', {
+        expect(fetchMock).toHaveBeenNthCalledWith(2, '/preview/api/changes', {
             body: '{"fileName":"id_1640106755570_203_propertyChange"}',
             headers: { 'Content-Type': 'application/json' },
             method: 'DELETE'


### PR DESCRIPTION
Fix for #1440.

- **Refetches** saved changes from the workspace each time a file is **saved** or **deleted** to update the `Saved Changes panel` in the UI.