### PR TITLE
feat(ui5-library-inquirer): Support caller prompt module integration

### DIFF
--- a/.changeset/strange-frogs-sit.md
+++ b/.changeset/strange-frogs-sit.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-library-inquirer': minor
+---
+
+Adds support for prompt module integration from calling generator

--- a/packages/ui5-library-inquirer/README.md
+++ b/packages/ui5-library-inquirer/README.md
@@ -15,7 +15,7 @@ Pnpm
 
 ## Usage
 
-Example with Yeoman generator :
+Example with Yeoman generator no options, e.g. cli prompting only :
 
 ```javascript
 import Generator from 'yeoman-generator';
@@ -31,6 +31,51 @@ export default class UI5LibraryGenerator extends Generator {
 
     public async prompting(): Promise<void> {
         const answers = await prompt();
+        Object.assign(this.answers, answers);
+    }
+
+     public async writing(): Promise<void> {
+        const ui5Lib: UI5LibConfig = {
+            libraryName: this.answers.libraryName,
+            namespace: this.answers.namespace,
+            framework: 'SAPUI5',
+            frameworkVersion: this.answers.ui5Version,
+            author: 'Fiori tools',
+            typescript: this.answers.enableTypescript
+        };
+
+        try {
+            await generate(this.answers.targetFolder, ui5Lib, this.fs);
+        } catch (e) {}
+    }
+}
+```
+
+Example with Yeoman generator passing options with adaptor, e.g. @sap-devx/yeoman-ui integration :
+
+```javascript
+import Generator from 'yeoman-generator';
+import { generate, type UI5LibConfig } from '@sap-ux/ui5-library-writer';
+import { prompt, type UI5LibraryAnswers } from '@sap-ux/ui5-library-inquirer';
+
+export default class UI5LibraryGenerator extends Generator {
+    answers: UI5LibraryAnswers = {};
+    targetFolder: string;
+ 
+    constructor(args: string | string[], opts: Generator.GeneratorOptions) {
+        super(args, opts);
+        this.targetFolder = opts.targetFolder;
+    }
+
+    public async prompting(): Promise<void> {
+        const answers = await prompt(
+            {
+                targetFolder: this.targetFolder,
+                includeSeparators: true,
+                useAutocomplete: false
+            },
+            this.env?.adapter
+        );
         Object.assign(this.answers, answers);
     }
 

--- a/packages/ui5-library-inquirer/README.md
+++ b/packages/ui5-library-inquirer/README.md
@@ -51,7 +51,7 @@ export default class UI5LibraryGenerator extends Generator {
 }
 ```
 
-Example with Yeoman generator passing options with adaptor, e.g. @sap-devx/yeoman-ui integration :
+Example with Yeoman generator passing options with adapter, e.g. @sap-devx/yeoman-ui integration :
 
 ```javascript
 import Generator from 'yeoman-generator';

--- a/packages/ui5-library-inquirer/package.json
+++ b/packages/ui5-library-inquirer/package.json
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
         "@types/inquirer-autocomplete-prompt": "2.0.1",
-        "@types/inquirer": "8.2.7"
+        "@types/inquirer": "8.2.6"
     },
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/ui5-library-inquirer/src/index.ts
+++ b/packages/ui5-library-inquirer/src/index.ts
@@ -1,7 +1,7 @@
 import { getUI5Versions, type UI5VersionFilterOptions } from '@sap-ux/ui5-info';
 import inquirer, { type Question } from 'inquirer';
 import { getQuestions } from './prompts';
-import type { InquirerAdaptor, UI5LibraryAnswers, UI5LibraryPromptOptions } from './types';
+import type { InquirerAdapter, UI5LibraryAnswers, UI5LibraryPromptOptions } from './types';
 import autocomplete from 'inquirer-autocomplete-prompt';
 
 /**
@@ -27,19 +27,19 @@ async function getPrompts(promptOptions?: UI5LibraryPromptOptions): Promise<Ques
 /**
  * Prompt for ui5 library generation inputs.
  *
- * @param promptOptions - options that can control some of the prompt behaviour. See {@link UI5LibraryPromptOptions} for details
- * @param adaptor - optionally provide references to a calling inquirer instance, this supports integration to Yeoman generators, for example
+ * @param promptOptions - options that can control some of the prompt behavior. See {@link UI5LibraryPromptOptions} for details
+ * @param adapter - optionally provide references to a calling inquirer instance, this supports integration to Yeoman generators, for example
  * @returns the prompt answers
  */
-async function prompt(promptOptions?: UI5LibraryPromptOptions, adaptor?: InquirerAdaptor): Promise<UI5LibraryAnswers> {
+async function prompt(promptOptions?: UI5LibraryPromptOptions, adapter?: InquirerAdapter): Promise<UI5LibraryAnswers> {
     const ui5LibPrompts = await exports.getPrompts(promptOptions);
-    const pm = adaptor ? adaptor.promptModule : inquirer;
+    const pm = adapter ? adapter.promptModule : inquirer;
 
     if (promptOptions?.useAutocomplete) {
         pm.registerPrompt('autocomplete', autocomplete);
     }
 
-    return adaptor ? adaptor.prompt(ui5LibPrompts) : inquirer.prompt(ui5LibPrompts);
+    return adapter ? adapter.prompt(ui5LibPrompts) : inquirer.prompt(ui5LibPrompts);
 }
 
 export { getPrompts, prompt, type UI5LibraryPromptOptions, type UI5LibraryAnswers };

--- a/packages/ui5-library-inquirer/src/index.ts
+++ b/packages/ui5-library-inquirer/src/index.ts
@@ -1,7 +1,7 @@
 import { getUI5Versions, type UI5VersionFilterOptions } from '@sap-ux/ui5-info';
 import inquirer, { type Question } from 'inquirer';
 import { getQuestions } from './prompts';
-import type { UI5LibraryAnswers, UI5LibraryPromptOptions } from './types';
+import type { InquirerAdaptor, UI5LibraryAnswers, UI5LibraryPromptOptions } from './types';
 import autocomplete from 'inquirer-autocomplete-prompt';
 
 /**
@@ -28,15 +28,18 @@ async function getPrompts(promptOptions?: UI5LibraryPromptOptions): Promise<Ques
  * Prompt for ui5 library generation inputs.
  *
  * @param promptOptions - options that can control some of the prompt behaviour. See {@link UI5LibraryPromptOptions} for details
+ * @param adaptor - optionally provide references to a calling inquirer instance, this supports integration to Yeoman generators, for example
  * @returns the prompt answers
  */
-async function prompt(promptOptions?: UI5LibraryPromptOptions): Promise<UI5LibraryAnswers> {
+async function prompt(promptOptions?: UI5LibraryPromptOptions, adaptor?: InquirerAdaptor): Promise<UI5LibraryAnswers> {
     const ui5LibPrompts = await exports.getPrompts(promptOptions);
+    const pm = adaptor ? adaptor.promptModule : inquirer;
 
     if (promptOptions?.useAutocomplete) {
-        inquirer.registerPrompt('autocomplete', autocomplete);
+        pm.registerPrompt('autocomplete', autocomplete);
     }
-    return inquirer.prompt(ui5LibPrompts);
+
+    return adaptor ? adaptor.prompt(ui5LibPrompts) : inquirer.prompt(ui5LibPrompts);
 }
 
 export { getPrompts, prompt, type UI5LibraryPromptOptions, type UI5LibraryAnswers };

--- a/packages/ui5-library-inquirer/src/types.ts
+++ b/packages/ui5-library-inquirer/src/types.ts
@@ -35,7 +35,7 @@ export interface UI5VersionChoice extends ListChoiceOptions {
     value: string; // UI5 semantic version
 }
 
-export interface InquirerAdaptor {
+export interface InquirerAdapter {
     prompt: PromptFunction;
     promptModule: PromptModule;
 }

--- a/packages/ui5-library-inquirer/src/types.ts
+++ b/packages/ui5-library-inquirer/src/types.ts
@@ -3,7 +3,9 @@ import type {
     InputQuestion as BaseInputQuestion,
     ListQuestion as BaseListQuestion,
     Answers,
-    ListChoiceOptions
+    ListChoiceOptions,
+    PromptFunction,
+    PromptModule
 } from 'inquirer';
 
 export interface UI5LibraryAnswers {
@@ -31,6 +33,11 @@ export interface UI5LibraryPromptOptions {
 
 export interface UI5VersionChoice extends ListChoiceOptions {
     value: string; // UI5 semantic version
+}
+
+export interface InquirerAdaptor {
+    prompt: PromptFunction;
+    promptModule: PromptModule;
 }
 
 /**

--- a/packages/ui5-library-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-library-inquirer/test/unit/prompts/prompts.test.ts
@@ -1,5 +1,5 @@
 import { getQuestions } from '../../../src/prompts';
-import * as utiility from '../../../src/prompts/utility';
+import * as utility from '../../../src/prompts/utility';
 import { t } from '../../../src/i18n';
 import { join } from 'path';
 import type { UI5VersionChoice } from '../../../src/types';
@@ -41,8 +41,8 @@ describe('getPrompts', () => {
         }
     ];
 
-    it('getQuestions, no options specfied', () => {
-        const ui5VersGroupedSpy = jest.spyOn(utiility, 'ui5VersionsGrouped').mockReturnValueOnce(ui5VersionsGrouped);
+    it('getQuestions, no options specified', () => {
+        const ui5VersGroupedSpy = jest.spyOn(utility, 'ui5VersionsGrouped').mockReturnValueOnce(ui5VersionsGrouped);
 
         // Not passing any versions as internally called function `ui5VersionsGrouped` is mocked
         const projectQuestions = getQuestions([]);
@@ -62,7 +62,7 @@ describe('getPrompts', () => {
             breadcrumb: true,
             mandatory: true
         });
-        // Validtors are fully tested in `@sap-ux/project-input-validators`
+        // Validators are fully tested in `@sap-ux/project-input-validators`
         const validateLibModNameSpy = jest.spyOn(projectInputValidators, 'validateLibModuleName').mockReturnValue(true);
         expect(libNameQ.validate('library1')).toEqual(true);
         expect(validateLibModNameSpy).toHaveBeenCalledWith('library1');
@@ -114,7 +114,7 @@ describe('getPrompts', () => {
     });
 
     it('getQuestions, test options', () => {
-        const ui5VersGroupedSpy = jest.spyOn(utiility, 'ui5VersionsGrouped').mockReturnValueOnce(ui5VersionsGrouped);
+        const ui5VersGroupedSpy = jest.spyOn(utility, 'ui5VersionsGrouped').mockReturnValueOnce(ui5VersionsGrouped);
 
         /**
          * Option: targetFolder
@@ -168,7 +168,7 @@ describe('getPrompts', () => {
                 }
             }
         ];
-        const searchChoicesSpy = jest.spyOn(utiility, 'searchChoices').mockReturnValue(filteredUI5Versions);
+        const searchChoicesSpy = jest.spyOn(utility, 'searchChoices').mockReturnValue(filteredUI5Versions);
         expect(ui5VersionQ.source({}, '1.0')).toEqual(filteredUI5Versions);
         expect(searchChoicesSpy).toHaveBeenCalledWith('1.0', ui5VersionsGrouped);
     });

--- a/packages/ui5-library-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-library-inquirer/test/unit/prompts/prompts.test.ts
@@ -50,7 +50,7 @@ describe('getPrompts', () => {
         expect(projectQuestions.length).toEqual(5);
 
         const prompts = projectQuestions.reduce(
-            (prompts, prompt) => Object.assign(prompts, { [prompt.name || 'unknown_prompt']: prompt }),
+            (prompts, prompt) => Object.assign(prompts, { [prompt.name ?? 'unknown_prompt']: prompt }),
             {}
         ) as any;
 
@@ -130,7 +130,7 @@ describe('getPrompts', () => {
         expect(projectQuestions.length).toEqual(5);
 
         const prompts = projectQuestions.reduce(
-            (prompts, prompt) => Object.assign(prompts, { [prompt.name || 'unknown_prompt']: prompt }),
+            (prompts, prompt) => Object.assign(prompts, { [prompt.name ?? 'unknown_prompt']: prompt }),
             {}
         ) as any;
 

--- a/packages/ui5-library-inquirer/test/unit/ui5-library-inquirer.test.ts
+++ b/packages/ui5-library-inquirer/test/unit/ui5-library-inquirer.test.ts
@@ -1,6 +1,6 @@
 import type { UI5Version } from '@sap-ux/ui5-info';
 import { getPrompts, prompt } from '../../src/index';
-import type { InquirerAdaptor, UI5LibraryAnswers } from '../../src/types';
+import type { InquirerAdapter, UI5LibraryAnswers } from '../../src/types';
 import * as ui5LibInqApi from '../../src/index';
 import * as ui5Info from '@sap-ux/ui5-info';
 import * as prompting from '../../src/prompts/prompts';
@@ -157,7 +157,7 @@ describe('API test', () => {
         expect(inquirerPromptSpy).toHaveBeenCalledWith(questions);
     });
 
-    it('prompt, with adaptor', async () => {
+    it('prompt, with adapter', async () => {
         const questions = [
             {
                 name: 'testPrompt',
@@ -176,8 +176,8 @@ describe('API test', () => {
         const inquirerRegisterPromptSpy = jest.spyOn(inquirer, 'registerPrompt').mockReturnValue();
         const inquirerPromptSpy = jest.spyOn(inquirer, 'prompt');
         const mockPromptsModule = createPromptModule();
-        const adaptorRegisterPromptSpy = jest.spyOn(mockPromptsModule, 'registerPrompt');
-        const mockAdaptor: InquirerAdaptor = {
+        const adapterRegisterPromptSpy = jest.spyOn(mockPromptsModule, 'registerPrompt');
+        const mockAdapter: InquirerAdapter = {
             prompt: jest.fn().mockResolvedValue(Object.assign({}, answers)),
             promptModule: mockPromptsModule
         };
@@ -187,7 +187,7 @@ describe('API test', () => {
             targetFolder: '/some/target/folder2',
             useAutocomplete: true
         };
-        const promptAnswers = await prompt(promptOptions, mockAdaptor);
+        const promptAnswers = await prompt(promptOptions, mockAdapter);
         // No options provided
         expect(promptAnswers).toMatchInlineSnapshot(`
             {
@@ -201,7 +201,7 @@ describe('API test', () => {
         expect(getPromptsSpy).toHaveBeenCalledWith(promptOptions);
         expect(inquirerRegisterPromptSpy).not.toHaveBeenCalledWith();
         expect(inquirerPromptSpy).not.toHaveBeenCalledWith();
-        expect(mockAdaptor.prompt).toHaveBeenCalledWith([{ 'message': 'Test Prompt', 'name': 'testPrompt' }]);
-        expect(adaptorRegisterPromptSpy).toHaveBeenCalledWith('autocomplete', expect.any(Function));
+        expect(mockAdapter.prompt).toHaveBeenCalledWith([{ 'message': 'Test Prompt', 'name': 'testPrompt' }]);
+        expect(adapterRegisterPromptSpy).toHaveBeenCalledWith('autocomplete', expect.any(Function));
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1459,8 +1459,8 @@ importers:
         version: 2.0.1(inquirer@8.2.6)
     devDependencies:
       '@types/inquirer':
-        specifier: 8.2.7
-        version: 8.2.7
+        specifier: 8.2.6
+        version: 8.2.6
       '@types/inquirer-autocomplete-prompt':
         specifier: 2.0.1
         version: 2.0.1
@@ -8029,11 +8029,18 @@ packages:
   /@types/inquirer-autocomplete-prompt@2.0.1:
     resolution: {integrity: sha512-y/IFCMwNnxliCUxc7q1fwYUDkekP0Q+niL1YR9dvD1jKnIq8irirfsPCRXKN1jem82fNGT/91IPOufQTEi8STQ==}
     dependencies:
-      '@types/inquirer': 8.2.7
+      '@types/inquirer': 8.2.6
     dev: true
 
   /@types/inquirer@8.2.1:
     resolution: {integrity: sha512-wKW3SKIUMmltbykg4I5JzCVzUhkuD9trD6efAmYgN2MrSntY0SMRQzEnD3mkyJ/rv9NLbTC7g3hKKE86YwEDLw==}
+    dependencies:
+      '@types/through': 0.0.30
+      rxjs: 7.8.1
+    dev: true
+
+  /@types/inquirer@8.2.6:
+    resolution: {integrity: sha512-3uT88kxg8lNzY8ay2ZjP44DKcRaTGztqeIvN2zHvhzIBH/uAPaL75aBtdNRKbA7xXoMbBt5kX0M00VKAnfOYlA==}
     dependencies:
       '@types/through': 0.0.30
       rxjs: 7.8.1


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1444

- Extends `prompt()` signature to allow caller to pass prompting module reference (`InquirerAdaptor`) thereby allowing the calling module to integrate the prompts more easily. Especially useful for calling Yeoman generators when running in a UI environment rather than CLI.

- Adds tests to cover