### PR TITLE
feat(adp): provide possibility to enter credentials via yaml config or .env

### DIFF
--- a/.changeset/thin-rats-bake.md
+++ b/.changeset/thin-rats-bake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': patch
+---
+
+Provide possibilty to enter credentials via yaml config or .env

--- a/packages/adp-tooling/package.json
+++ b/packages/adp-tooling/package.json
@@ -39,12 +39,13 @@
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/system-access": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
-        "sanitize-filename": "1.6.3",
+        "adm-zip": "0.5.10",
+        "dotenv": "16.3.1",
         "ejs": "3.1.9",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
         "prompts": "2.4.2",
-        "adm-zip": "0.5.10"
+        "sanitize-filename": "1.6.3"
     },
     "devDependencies": {
         "@sap-ux/project-access": "workspace:*",

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -84,6 +84,9 @@ export class AdpPreview {
                 username: process.env.FIORI_TOOLS_USER,
                 password: process.env.FIORI_TOOLS_PASSWORD
             };
+        } else if (config.auth && !process.env.FIORI_TOOLS_USER && !process.env.FIORI_TOOLS_PASSWORD) {
+            process.env.FIORI_TOOLS_USER = config.auth.username;
+            process.env.FIORI_TOOLS_PASSWORD = config.auth.password;
         }
     }
 

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv';
 import express from 'express';
 import ZipFile from 'adm-zip';
 import type { ReaderCollection } from '@ui5/fs';
@@ -75,7 +76,15 @@ export class AdpPreview {
         private readonly util: MiddlewareUtils,
         private readonly logger: ToolsLogger
     ) {
+        dotenv.config();
         this.routesHandler = new RoutesHandler(project, util, logger);
+
+        if (!config.auth && process.env.FIORI_TOOLS_USER && process.env.FIORI_TOOLS_PASSWORD) {
+            config.auth = {
+                username: process.env.FIORI_TOOLS_USER,
+                password: process.env.FIORI_TOOLS_PASSWORD
+            };
+        }
     }
 
     /**
@@ -87,7 +96,7 @@ export class AdpPreview {
     async init(descriptorVariant: DescriptorVariant): Promise<UI5FlexLayer> {
         const provider = await createAbapServiceProvider(
             this.config.target,
-            { ignoreCertErrors: this.config.ignoreCertErrors },
+            { ignoreCertErrors: this.config.ignoreCertErrors, auth: this.config.auth },
             true,
             this.logger
         );

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -21,7 +21,7 @@ export interface AdpPreviewConfig {
      * If set to true then certification validation errors are ignored.
      */
     ignoreCertErrors?: boolean;
-    auth: {
+    auth?: {
         username: string;
         password: string;
     };

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -21,6 +21,10 @@ export interface AdpPreviewConfig {
      * If set to true then certification validation errors are ignored.
      */
     ignoreCertErrors?: boolean;
+    auth: {
+        username: string;
+        password: string;
+    };
 }
 
 export interface AdpWriterConfig {

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -16,6 +16,7 @@ It hosts a local Fiori launchpad based on your configuration as well as offers a
 | `flp.theme`             | `string` | `undefined`      | Optional flag for setting the UI5 Theme. |
 | `adp.target`           |           |                  | Required configuration for adaptation projects defining the connected backend                                                       |
 | `adp.ignoreCertErrors` | `boolean` | `false`          | Optional setting to ignore certification validation errors when working with e.g. development systems with self signed certificates |
+| `adp.auth` | `object` | `undefined`          | Optional setting for providing credentials for basic authentication |
 | `rta`                  |           |                  | Optional configuration allowing to add mount points for runtime adaptation                                                          |
 | `rta.layer`            | `string`  | `(calculated)`   | Optional property for defining the runtime adaptation layer for changes (default is `CUSTOMER_BASE` or read from the project for adaptation projects) |
 | `rta.editors`          | `array`   | `undefined`      | Optional list of mount points for editing                                                                                           |
@@ -38,6 +39,12 @@ Array of additional application configurations:
 | `destination` | `string` mandatory (if no url) | Required if the backend system is available as destination in SAP Business Application Studio.                                                  |
 | `client`      | `string` optional              | sap-client parameter                                                                                                                            |
 | `scp`         | `boolean` optional             | If set to true the proxy will execute the required OAuth routine for the ABAP environment on SAP BTP                                            |
+
+### `adp.auth`
+| Option        | Type                           | Description                                                                                                                                     |
+| ------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `username`         | `string` mandatory    | Username to use for basic authentication |
+| `password` | `string` mandatory | Password to use for basic authentication                                                  |
 
 ### `rta.editors`
 | Option          | Type               | Description                                                                                    |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       adm-zip:
         specifier: 0.5.10
         version: 0.5.10
+      dotenv:
+        specifier: 16.3.1
+        version: 16.3.1
       ejs:
         specifier: 3.1.9
         version: 3.1.9
@@ -208,9 +211,6 @@ importers:
       '@types/supertest':
         specifier: 2.0.12
         version: 2.0.12
-      dotenv:
-        specifier: 16.3.1
-        version: 16.3.1
       nock:
         specifier: 13.2.1
         version: 13.2.1


### PR DESCRIPTION
This PR enables the user to provide credentials via `yaml` config or `.env` file when previewing and editing adaptation projects.