### PR TITLE
fix(project-access): load different cds versions

### DIFF
--- a/.changeset/quiet-jars-warn.md
+++ b/.changeset/quiet-jars-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix for "TypeError: Cannot read properties of undefined (reading 'odata-v4')" which can occur when dynamically loading different @sap/cds verrsions

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -332,6 +332,13 @@ export async function getCapEnvironment(capProjectPath: string): Promise<CdsEnvi
 }
 
 /**
+ * To fix issues when switching different cds versions dynamically, we need to set global.cds, see end of function loadCdsModuleFromProject()
+ */
+declare const global: {
+    cds: CdsFacade;
+};
+
+/**
  * Load CAP CDS module. First attempt loads @sap/cds for a project based on its root.
  * Second attempt loads @sap/cds from global installed @sap/cds-dk.
  * Throws error if module could not be loaded.
@@ -362,7 +369,12 @@ async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFaca
             `Could not load cds module. Attempt to load module @sap/cds from project threw error '${loadProjectError}', attempt to load module @sap/cds from @sap/cds-dk threw error '${loadError}'`
         );
     }
-    return 'default' in module ? module.default : module;
+    const cds = 'default' in module ? module.default : module;
+    // Fix when switching cds versions dynamically
+    if (global) {
+        global.cds = cds;
+    }
+    return cds;
 }
 
 /**

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -357,6 +357,32 @@ describe('Test getCapEnvironment()', () => {
         expect(forSpy).toHaveBeenCalledWith('cds', 'PROJECT_ROOT');
     });
 
+    test('Updating global.cds to fix issue with version switch', async () => {
+        // Mock setup
+        type GlobalCds = { cds?: object };
+        delete (global as GlobalCds)?.cds;
+        const cdsV1 = {
+            version: 1,
+            env: {
+                for: jest.fn()
+            }
+        };
+        const cdsV2 = {
+            version: 2,
+            env: {
+                for: jest.fn()
+            }
+        };
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject')
+            .mockResolvedValueOnce(cdsV1)
+            .mockResolvedValueOnce(cdsV2);
+
+        await getCapEnvironment('PROJECT');
+        expect((global as GlobalCds).cds).toBe(cdsV1);
+        await getCapEnvironment('PROJECT');
+        expect((global as GlobalCds).cds).toBe(cdsV2);
+    });
+
     test('failed to load cds from any location', async () => {
         // Mock setup
         childProcessMock.spawn.mockReturnValueOnce(getChildProcessMock('WRONG'));


### PR DESCRIPTION
## Issue

Error:
```
TypeError: Cannot read properties of undefined (reading 'odata-v4')
```

### Description
When loading different versions of `@sap/cds` dynamically, this error can occur. Affected are versions >= `@sap/cds@7.3`. It seems `global.cds`, which might remains in global node environment space, causes this issue. Assigning `global.cds` to newly loaded cds versions fixes the issue.
 