### PR TITLE
fix: update tesconfig to generate correct files order in dist

### DIFF
--- a/.changeset/short-pumpkins-switch.md
+++ b/.changeset/short-pumpkins-switch.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-vocabularies": patch
+---
+
+fix: update tesconfig to generate correct files order in dist

--- a/packages/odata-vocabularies/tsconfig.build.json
+++ b/packages/odata-vocabularies/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.json", "types"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.json", "types/csdl.d.ts"],
   "exclude": ["dist", "node_modules", "test", "reports"]
 }


### PR DESCRIPTION
changed the rootDir path to "src" instead of ".", to generate the correct files order in dist folder