### PR TITLE
Fix Missing Keyboard support for theme callout reported by Sonar

### DIFF
--- a/.changeset/weak-parrots-dress.md
+++ b/.changeset/weak-parrots-dress.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/control-property-editor': patch
+---
+
+keyboard support for theme selector callout

--- a/packages/control-property-editor/src/components/ThemeSelectorCallout.scss
+++ b/packages/control-property-editor/src/components/ThemeSelectorCallout.scss
@@ -26,8 +26,21 @@
     height: 20px;
     margin: 10px 0 10px 10px;
     border-radius: 1px;
+    position: relative;
+    outline: none;
 }
-
+.ms-Fabric--isFocusVisible {
+    .theme-child:focus::after {
+        content: "";
+        position: absolute;
+        border: 1px solid transparent;
+        outline-style: solid;
+        outline-width: 1px;
+        z-index: 1;
+        outline-color: var(--vscode-focusBorder);
+        inset: -3px;
+    }
+}
 .selected {
     border-radius: 1px;
     background-color: var(--vscode-progressBar-background);

--- a/packages/control-property-editor/src/components/ThemeSelectorCallout.tsx
+++ b/packages/control-property-editor/src/components/ThemeSelectorCallout.tsx
@@ -1,6 +1,6 @@
-import { UIIconButton, UiIcons, UICallout } from '@sap-ux/ui-components';
+import { UIIconButton, UiIcons, UICallout, UIFocusZone } from '@sap-ux/ui-components';
 import type { ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useId } from '@fluentui/react-hooks';
 import { useTranslation } from 'react-i18next';
 
@@ -19,6 +19,7 @@ export function ThemeSelectorCallout(): ReactElement {
     const theme = localStorage.getItem('theme') ?? 'dark';
     const [currentTheme, setTheme] = useState(theme);
     const buttonId = useId('callout-button');
+    const initialFocusRoot = useRef<HTMLElement | null>(null);
 
     /**
      *
@@ -60,6 +61,7 @@ export function ThemeSelectorCallout(): ReactElement {
         const isCurrentTheme = currentTheme === name;
         return (
             <div
+                data-is-focusable={true}
                 id={`theme-${nameSlug}-rect`}
                 key={name}
                 title={t(tooltip)}
@@ -93,6 +95,7 @@ export function ThemeSelectorCallout(): ReactElement {
             {isCalloutVisible && (
                 <UICallout
                     id={'themes-selector'}
+                    data-testid={'theme-selector-callout'}
                     role="alertdialog"
                     alignTargetEdge
                     target={`#${buttonId}`}
@@ -105,10 +108,24 @@ export function ThemeSelectorCallout(): ReactElement {
                             minWidth: 100
                         }
                     }}
+                    setInitialFocus={true}
+                    focusTargetSiblingOnTabPress={true}
                     onDismiss={(): void => {
                         setValue(false);
                     }}>
-                    {...themes.map(createThemeButton)}
+                    <UIFocusZone
+                        defaultTabbableElement={(root: HTMLElement) => {
+                            initialFocusRoot.current = root.querySelector('.theme-child.selected');
+                            return initialFocusRoot.current ?? root;
+                        }}
+                        onActiveElementChanged={() => {
+                            if (initialFocusRoot.current) {
+                                initialFocusRoot.current.focus();
+                                initialFocusRoot.current = null;
+                            }
+                        }}>
+                        {...themes.map(createThemeButton)}
+                    </UIFocusZone>
                 </UICallout>
             )}
         </>

--- a/packages/control-property-editor/test/unit/components/ThemeSelector.test.tsx
+++ b/packages/control-property-editor/test/unit/components/ThemeSelector.test.tsx
@@ -55,9 +55,7 @@ test('change theme to light and navigate via keyboard for dark to have focus', a
     // Use 'isVisible' property to make virtual nodes visible - 'isVisible' is used by fluent for testing purposes
     Object.defineProperty(HTMLElement.prototype, 'isVisible', {
         configurable: true,
-        get: function (this: HTMLElement) {
-            return true;
-        }
+        get: () => true
     });
     render(<ThemeSelectorCallout />);
     // Open callout

--- a/packages/control-property-editor/test/unit/components/ThemeSelector.test.tsx
+++ b/packages/control-property-editor/test/unit/components/ThemeSelector.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-
+import { screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { render } from '../utils';
 import { initI18n } from '../../../src/i18n';
 
@@ -38,4 +38,31 @@ test('change theme to light', () => {
     const pressedButton = themeCalloutContent.find((button) => button.getAttribute('aria-pressed') === 'true');
     expect(pressedButton?.getAttribute('id')).toStrictEqual('theme-light-rect');
     expect(localStorage.getItem('theme')).toStrictEqual('light');
+});
+
+test.only('change theme to light and navigate via keyboard for dark to have focus', async () => {
+    localStorage.setItem('theme', 'light');
+    const rect = {
+        top: 0,
+        height: 10,
+        width: 10,
+        left: 0
+    } as DOMRect;
+    render(<ThemeSelectorCallout />);
+    const button = screen.getByRole('button');
+    button.click();
+    jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => rect);
+    const callout = screen.getByTestId('theme-selector-callout');
+    callout.focus();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    callout.dispatchEvent(
+        new KeyboardEvent('keydown', {
+            key: 'ArrowRight',
+            code: 'ArrowRight',
+            charCode: 39,
+            which: 39
+        })
+    );
+    const darkButton = screen.getByTitle('Dark');
+    expect(document.activeElement).toBe(darkButton);
 });


### PR DESCRIPTION
This PR consumes the fix from first part mentioned below which was originally reported by [Sonar](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&id=SAP_open-ux-tools&open=AYtswOQV4zj9YHX0JpwV) for no support for keyboard events for ThemeSelector Callout. 

First part of the [fix](https://github.com/SAP/open-ux-tools/pull/1474) is merged on ui-components Thanks @815are 
