### PR TITLE
fix: enable uppercaseNameMap property in vocabulary service

### DIFF
--- a/.changeset/cool-gorillas-march.md
+++ b/.changeset/cool-gorillas-march.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-vocabularies": patch
+---
+
+fix: enable uppercaseNameMap property in vocabulary service

--- a/packages/odata-vocabularies/src/vocabulary-service.ts
+++ b/packages/odata-vocabularies/src/vocabulary-service.ts
@@ -41,6 +41,7 @@ export class VocabularyService {
     private readonly supportedVocabularies: Map<VocabularyNamespace, Vocabulary>;
     private readonly namespaceByDefaultAlias: Map<SimpleIdentifier, VocabularyNamespace>;
     private readonly derivedTypesPerType: Map<FullyQualifiedName, Map<FullyQualifiedName, boolean>>;
+    private readonly upperCaseNameMap: Map<string, string | Map<string, string>>;
     readonly cdsVocabulary: CdsVocabulary;
 
     /**
@@ -98,6 +99,7 @@ export class VocabularyService {
         this.supportedVocabularies = vocabularyInformation.supportedVocabularies;
         this.namespaceByDefaultAlias = vocabularyInformation.namespaceByDefaultAlias;
         this.derivedTypesPerType = vocabularyInformation.derivedTypesPerType;
+        this.upperCaseNameMap = vocabularyInformation.upperCaseNameMap;
         // TODO this should be filled by information coming from the CDS vocabulary file
         this.cdsVocabulary = {
             namespace: CDS_VOCABULARY_NAMESPACE,


### PR DESCRIPTION
Enabled the parameter `uppercaseNameMap` in vocabularies_service which was removed by mistake.