### PR TITLE
fix: change access type of uppercaseNameMap prop

### DIFF
--- a/.changeset/thin-sheep-tie.md
+++ b/.changeset/thin-sheep-tie.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-vocabularies": patch
+---
+
+fix: change access type of uppercaseNameMap prop

--- a/packages/odata-vocabularies/src/vocabulary-service.ts
+++ b/packages/odata-vocabularies/src/vocabulary-service.ts
@@ -41,7 +41,7 @@ export class VocabularyService {
     private readonly supportedVocabularies: Map<VocabularyNamespace, Vocabulary>;
     private readonly namespaceByDefaultAlias: Map<SimpleIdentifier, VocabularyNamespace>;
     private readonly derivedTypesPerType: Map<FullyQualifiedName, Map<FullyQualifiedName, boolean>>;
-    private readonly upperCaseNameMap: Map<string, string | Map<string, string>>;
+    public readonly upperCaseNameMap: Map<string, string | Map<string, string>>;
     readonly cdsVocabulary: CdsVocabulary;
 
     /**


### PR DESCRIPTION
Change the access type of "upperCaseNameMap" property from Private to public, 