### PR TITLE
Feat: hide feedback and close button in the main RTA navigation menu for Adaptation Projects

### DIFF
--- a/packages/preview-middleware/templates/flp/sandbox.html
+++ b/packages/preview-middleware/templates/flp/sandbox.html
@@ -58,7 +58,13 @@
         data-sap-ui-oninit="module:open/ux/preview/client/flp/init"<% if (locals.flex) { %>
         data-open-ux-preview-flex-settings='<%- JSON.stringify(flex) %>'<% } if (locals.locateReuseLibsScript) { %>
         data-open-ux-preview-libs-manifests='<%- JSON.stringify(Object.values(apps).map(app => app.url)) %>'<% } %>>
-    </script>
+    </script><% if (locals.flex && flex?.scenario === 'ADAPTATION_PROJECT') { %>
+        <!-- Temporary fix until RTA provide api for enable/disable buttons in main RTA navigation menu in UIADAPTATION Mode -->
+    <style>
+        #__fiori0_fragment--sapUiRta_exit, #__fiori0_fragment--sapUiRta_feedback, #__fiori0_fragment--sapUiRta_actionsToolbar-overflowButton {
+        display:none;
+        }
+    </style><% } %>
 </head>
 
 <!-- UI Content -->


### PR DESCRIPTION
feature for #1511 

- hide feedback and close buttons in the main RTA navigation menu for Adaptation Projects