### PR TITLE
Fix: White spaces behind the ConExt/Fragment name are not validated/trimmed

### DIFF
--- a/.changeset/big-ducks-boil.md
+++ b/.changeset/big-ducks-boil.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
 ---
 
 Controller Extension and Fragment name now show error if there is a whitespace after their name

--- a/.changeset/big-ducks-boil.md
+++ b/.changeset/big-ducks-boil.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+Controller Extension and Fragment name now show error if there is a whitespace after their name

--- a/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
@@ -52,7 +52,7 @@ export default abstract class BaseDialog extends Controller {
         const input = event.getSource<Input>();
         const beginBtn = this.dialog.getBeginButton();
 
-        const fragmentName: string = input.getValue().trim();
+        const fragmentName: string = input.getValue();
         const fragmentList: { fragmentName: string }[] = this.model.getProperty('/fragmentList');
 
         const updateDialogState = (valueState: ValueState, valueStateText = '') => {

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -80,7 +80,7 @@ export default class ControllerExtension extends BaseDialog {
         const input = event.getSource<Input>();
         const beginBtn = this.dialog.getBeginButton();
 
-        const controllerName: string = input.getValue().trim();
+        const controllerName: string = input.getValue();
         const controllerList: { controllerName: string }[] = this.model.getProperty('/controllersList');
 
         const updateDialogState = (valueState: ValueState, valueStateText = '') => {

--- a/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
@@ -265,7 +265,7 @@ describe('AddFragment', () => {
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.None);
         });
 
-        test('sets error when the fragment name is has special characters', () => {
+        test('sets error when the fragment name has special characters', () => {
             const addFragment = new AddFragment(
                 'adp.extension.controllers.AddFragment',
                 {} as unknown as UI5Element,
@@ -290,6 +290,32 @@ describe('AddFragment', () => {
 
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
         });
+
+        test('sets error when the fragment name contains a whitespace at the end', () => {
+            const addFragment = new AddFragment(
+                'adp.extension.controllers.AddFragment',
+                {} as unknown as UI5Element,
+                {} as unknown as RuntimeAuthoring
+            );
+
+            const valueStateSpy = jest.fn().mockReturnValue({ setValueStateText: jest.fn() });
+            const event = {
+                getSource: jest.fn().mockReturnValue({
+                    getValue: jest.fn().mockReturnValue('samplename '),
+                    setValueState: valueStateSpy
+                })
+            };
+
+            addFragment.model = testModel;
+            
+            addFragment.dialog = {
+                getBeginButton: jest.fn().mockReturnValue({ setEnabled: jest.fn() })
+            } as unknown as Dialog;
+
+            addFragment.onFragmentNameInputChange(event as unknown as Event);
+
+            expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
+        })
 
         test('sets error when the fragment name exceeds 64 characters', () => {
             const addFragment = new AddFragment(

--- a/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
@@ -287,7 +287,7 @@ describe('ControllerExtension', () => {
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.None);
         });
 
-        test('sets error when the controller name is has special characters', () => {
+        test('sets error when the controller name has special characters', () => {
             const controllerExt = new ControllerExtension(
                 'adp.extension.controllers.ControllerExtension',
                 {} as unknown as UI5Element,
@@ -312,6 +312,32 @@ describe('ControllerExtension', () => {
 
             expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error);
         });
+
+        test('sets error when the controller name contains a whitespace at the end', () => {
+            const controllerExt = new ControllerExtension(
+            'adp.extension.controllers.ControllerExtension',
+            {} as unknown as UI5Element,
+            {} as unknown as RuntimeAuthoring
+            );
+            
+            const valueStateSpy = jest.fn().mockReturnValue({ setValueStateText: jest.fn() });
+            const event = {
+                getSource: jest.fn().mockReturnValue({
+                    getValue: jest.fn().mockReturnValue('samplename '),
+                    setValueState: valueStateSpy,
+                })
+            };
+
+            controllerExt.model = testModel;
+            
+            controllerExt.dialog = {
+                getBeginButton: jest.fn().mockReturnValue({ setEnabled: jest.fn() })
+            } as unknown as Dialog;
+
+            controllerExt.onControllerNameInputChange(event as unknown as Event)
+            
+            expect(valueStateSpy).toHaveBeenCalledWith(ValueState.Error)
+        })
 
         test('sets error when the controller name exceeds 64 characters', () => {
             const controllerExt = new ControllerExtension(


### PR DESCRIPTION
Bug fix for #1520 

- Removed trim for name inputs for Controller extension and Fragment so as to have validation by regexf