### PR TITLE
Fix: Show save button

### DIFF
--- a/.changeset/big-ducks-boil.md
+++ b/.changeset/big-ducks-boil.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+Controller Extension and Fragment name now show error if there is a whitespace after their name

--- a/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/BaseDialog.controller.ts
@@ -52,7 +52,7 @@ export default abstract class BaseDialog extends Controller {
         const input = event.getSource<Input>();
         const beginBtn = this.dialog.getBeginButton();
 
-        const fragmentName: string = input.getValue().trim();
+        const fragmentName: string = input.getValue();
         const fragmentList: { fragmentName: string }[] = this.model.getProperty('/fragmentList');
 
         const updateDialogState = (valueState: ValueState, valueStateText = '') => {

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -80,7 +80,7 @@ export default class ControllerExtension extends BaseDialog {
         const input = event.getSource<Input>();
         const beginBtn = this.dialog.getBeginButton();
 
-        const controllerName: string = input.getValue().trim();
+        const controllerName: string = input.getValue();
         const controllerList: { controllerName: string }[] = this.model.getProperty('/controllersList');
 
         const updateDialogState = (valueState: ValueState, valueStateText = '') => {

--- a/packages/preview-middleware/templates/flp/sandbox.html
+++ b/packages/preview-middleware/templates/flp/sandbox.html
@@ -61,7 +61,7 @@
     </script><% if (locals.flex && flex?.scenario === 'ADAPTATION_PROJECT') { %>
         <!-- Temporary fix until RTA provides api for enable/disable buttons in main RTA navigation menu -->
     <style>
-        .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_exit"],
+        .sapUiRtaToolbarActionsSection button[aria-label="Exit"],
         .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_feedback"], 
         .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_actionsToolbar-overflowButton"] {
         display:none;


### PR DESCRIPTION
Fix for: #1523 

- Save and exit button is the same in UI5 versions lower than 1.110