### PR TITLE
Fix: show save button on UI5 versions lower than 1.110

### DIFF
--- a/.changeset/wise-snails-nail.md
+++ b/.changeset/wise-snails-nail.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/preview-middleware': patch
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+Save button for ui5 versions lower than 1.110 is shown

--- a/packages/preview-middleware/templates/flp/sandbox.html
+++ b/packages/preview-middleware/templates/flp/sandbox.html
@@ -61,7 +61,7 @@
     </script><% if (locals.flex && flex?.scenario === 'ADAPTATION_PROJECT') { %>
         <!-- Temporary fix until RTA provides api for enable/disable buttons in main RTA navigation menu -->
     <style>
-        .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_exit"],
+        .sapUiRtaToolbarActionsSection button[aria-label="Exit"],
         .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_feedback"], 
         .sapUiRtaToolbarActionsSection button[id$="fragment--sapUiRta_actionsToolbar-overflowButton"] {
         display:none;


### PR DESCRIPTION
Fix for: #1523 

- Save and Exit button is the same on UI5 versions lower than 1.110