### PR TITLE
fix: No Datetime is shown for Code Ext changes in saved changes panel

### DIFF
--- a/.changeset/grumpy-berries-do.md
+++ b/.changeset/grumpy-berries-do.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+No Datetime is shown for Code Ext changes in saved changes panel

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -37,7 +37,7 @@ import {
 import BaseDialog from './BaseDialog.controller';
 
 interface ControllerExtensionService {
-    add: (codeRef: string, viewId: string) => Promise<unknown>;
+    add: (codeRef: string, viewId: string) => Promise<{ creation: string }>;
 }
 
 interface ControllerInfo {
@@ -266,6 +266,7 @@ export default class ControllerExtension extends BaseDialog {
             const service = await this.rta.getService<ControllerExtensionService>('controllerExtension');
 
             const change = await service.add(controllerRef.codeRef, controllerRef.viewId);
+            change.creation = new Date().toISOString();
 
             await writeChange(change);
             MessageToast.show(`Controller extension with name '${controllerName}' was created.`);


### PR DESCRIPTION
Fix for #1528.

- Adds creation property to change object before writing it to the workspace.