### PR TITLE
feat(project-access): make `findFileUp` consumable

### DIFF
--- a/.changeset/eight-bikes-enjoy.md
+++ b/.changeset/eight-bikes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+makes function `findFileUp` publicly available

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -24,5 +24,5 @@ export {
     readCapServiceMetadataEdmx,
     readUi5Yaml
 } from './project';
-export { getFilePaths } from './file';
+export { getFilePaths, findFileUp } from './file';
 export * from './types';

--- a/packages/project-access/test/file/file-search.test.ts
+++ b/packages/project-access/test/file/file-search.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
-import { getFilePaths } from '../../src';
-import { findFiles, findFilesByExtension, findFileUp } from '../../src/file';
+import { findFileUp, getFilePaths } from '../../src';
+import { findFiles, findFilesByExtension } from '../../src/file';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
 


### PR DESCRIPTION
- Adds `findFileUp` to general `@sap-ux/project-access` export to be able to be consumed