### PR TITLE
fix: correct  playwright config to avoid timeout on failure

### DIFF
--- a/packages/preview-middleware/playwright.config.ts
+++ b/packages/preview-middleware/playwright.config.ts
@@ -17,7 +17,7 @@ const config: PlaywrightTestConfig = {
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
-    retries: process.env.CI ? 2 : 0,
+    retries: process.env.CI ? 1 : 0,
     /* Opt out of parallel tests on CI. */
     workers: 1,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -25,7 +25,7 @@ const config: PlaywrightTestConfig = {
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+        trace: 'on-first-retry',
         screenshot: 'only-on-failure'
     },
     /* Configure projects for major browsers */
@@ -36,7 +36,6 @@ const config: PlaywrightTestConfig = {
         }
     ],
     /* 5 min for npm i + 30000 ms default timeout */
-    timeout,
-    expect: { timeout }
+    timeout
 };
 export default defineConfig(config);


### PR DESCRIPTION
This PR fix:
* The job running on runner GitHub Actions 2 has exceeded the maximum execution time of 15 minutes.

**Explanation** 
Long `expect` timeout plus number of retries can cause exceed of maximum execution 