### PR TITLE
fix(create): unit test for trace changes

### DIFF
--- a/packages/create/test/unit/tracing/trace.test.ts
+++ b/packages/create/test/unit/tracing/trace.test.ts
@@ -89,15 +89,17 @@ describe('Test traceChanges()', () => {
 
     test('Modified yaml file', async () => {
         // Mock setup
-        const ls = process.platform === 'win32' ? '\r' : '';
         const modifiedFile = join(rootPath, 'file.yaml');
+        // Read/write file to avoid os-specific errors due to line endings
+        const fileContent = await promises.readFile(modifiedFile, { encoding: 'utf8' });
+        await promises.writeFile(modifiedFile, fileContent);
         const fsMock = {
             dump: () => ({
                 [modifiedFile]: {
-                    contents: `rootProperty: 'changed prop on root'${ls}
-nested:${ls}
-    - item: one${ls}
-    - item: three${ls}
+                    contents: `rootProperty: 'changed prop on root'
+nested:
+    - item: one
+    - item: three
 `,
                     state: 'modified'
                 }
@@ -109,10 +111,16 @@ nested:${ls}
 
         // Result check
         expect(loggerMock.info).toBeCalledWith(expect.stringContaining(`'${modifiedFile}' modified`));
-        expect(loggerMock.debug).toBeCalledWith(expect.stringContaining(`[31mrootProperty: 'prop on root'[39m${ls}`));
-        expect(loggerMock.debug).toBeCalledWith(expect.stringContaining(`[31m[39m[32mrootProperty: 'changed prop on root'[39m${ls}`));
-        expect(loggerMock.debug).toBeCalledWith(expect.stringContaining(`[90m[39m[31m- item: two[39m${ls}`));
-        expect(loggerMock.debug).toBeCalledWith(expect.stringContaining(`[31m[39m[32m- item: three[39m${ls}`));
+        expect(loggerMock.debug).toBeCalledWith(
+            `File changes:
+[31mrootProperty: 'prop on root'[39m
+[31m[39m[32mrootProperty: 'changed prop on root'[39m
+[32m[39m[90mnested:[39m
+[90m- item: one[39m
+[90m[39m[31m- item: two[39m
+[31m[39m[32m- item: three[39m
+[32m[39m`
+        );
     });
 
     test('Modified file without type', async () => {

--- a/packages/create/test/unit/tracing/trace.test.ts
+++ b/packages/create/test/unit/tracing/trace.test.ts
@@ -90,9 +90,6 @@ describe('Test traceChanges()', () => {
     test('Modified yaml file', async () => {
         // Mock setup
         const modifiedFile = join(rootPath, 'file.yaml');
-        // Read/write file to avoid os-specific errors due to line endings
-        const fileContent = await promises.readFile(modifiedFile, { encoding: 'utf8' });
-        await promises.writeFile(modifiedFile, fileContent);
         const fsMock = {
             dump: () => ({
                 [modifiedFile]: {


### PR DESCRIPTION
Even after https://github.com/SAP/open-ux-tools/pull/977 we get unit test failures on windows, e.g. https://github.com/SAP/open-ux-tools/actions/runs/7473778321/job/20340697749?pr=1578

<img width="437" alt="image" src="https://github.com/SAP/open-ux-tools/assets/66327622/6c10e45e-992c-4ea9-a8af-2661623aa743">

I was able to reproduce the issue on Windows, after removing the line ending `${lr}` which it `\r` the expect:
```typescript
expect(loggerMock.debug).toBeCalledWith(expect.stringContaining(`[31mrootProperty: 'prop on root'[39m${ls}`));
```

Went through, failed at another point though. By now I'm pretty confident, that the issue is related to different line endings on Windows and MacOS/Linux. 

### Update
Probably found the issue, with https://github.com/SAP/open-ux-tools/pull/1554 file `.gitattributes` was introduce unifying the line endings. **-> Adjusted the test case.**


