### PR TITLE
tbi(axios-ext): handle security sessions for deployment

### DIFF
--- a/.changeset/gentle-eyes-check.md
+++ b/.changeset/gentle-eyes-check.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': minor
+---
+
+handles security sessions for abap cloud for 2402 release

--- a/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
+++ b/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
@@ -50,7 +50,7 @@ describe('Ui5AbapRepositoryService', () => {
         // mock an existing and not existing app
         nock(server)
             .get((url) => url.startsWith(`${Ui5AbapRepositoryService.PATH}/Repositories('${validApp}')`))
-            .reply(200, { d: validAppInfo })
+            .reply(200, { d: validAppInfo }, { 'Set-Cookie': 'SAP_SESSIONID=34131;' })
             .persist();
         nock(`https://${destination.Name}.dest`)
             .get(`${Ui5AbapRepositoryService.PATH}/Repositories('NOT_EXISTING_APP')?saml2=disabled&$format=json`)
@@ -176,7 +176,9 @@ describe('Ui5AbapRepositoryService', () => {
                 .reply(200);
 
             const response = await service.deploy({ archive, bsp: { name: notExistingApp } });
+
             expect(response.data).toBeDefined();
+            expect(response.request.headers.cookie).toBe('SAP_SESSIONID=34131');
         });
 
         test('deploy new app with additional parameter and info message', async () => {
@@ -297,6 +299,7 @@ describe('Ui5AbapRepositoryService', () => {
                 .reply(200);
             const response = await service.undeploy({ bsp: { name: validApp } });
             expect(response?.status).toBe(200);
+            expect(response?.request.headers.cookie).toBe('SAP_SESSIONID=34131');
         });
 
         test('successful removal - app name with namespace', async () => {


### PR DESCRIPTION
#1581

Adds `x-sap-security-session` with value `create`, when performing the first request to the backend to check for existing app
Adds `x-sap-security-session` with value `delete`, when performing the last request i.e deployment / undeployment