### PR TITLE
fix(project-access): detecting apps that are part of CAP

### DIFF
--- a/.changeset/seven-emus-dress.md
+++ b/.changeset/seven-emus-dress.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix for detecting apps that are part of CAP

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -187,22 +187,22 @@ async function findRootsForPath(path: string): Promise<{ appRoot: string; projec
             // in root -> not supported
             return null;
         }
-        // Now we have the app root folder. Check for freestyle non CAP
-        if (
+        // Check if app is included in CAP project
+        const projectRoot = await findCapProjectRoot(appRoot);
+        if (projectRoot) {
+            // App included in CAP
+            return {
+                appRoot,
+                projectRoot
+            };
+        } else if (
+            // Check for freestyle non CAP
             (await fileExists(join(appRoot, FileName.Ui5LocalYaml))) &&
             hasDependency(appPckJson, '@sap/ux-ui5-tooling')
         ) {
             return {
                 appRoot,
                 projectRoot: appRoot
-            };
-        }
-        // Project must be CAP, find project root
-        const projectRoot = await findCapProjectRoot(appRoot);
-        if (projectRoot) {
-            return {
-                appRoot,
-                projectRoot
             };
         }
     } catch {

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -39,6 +39,7 @@ describe('Test findAllApps()', () => {
             'single_apps-custom_webapp_fiori_elements',
             'single_apps-custom_webapp_freestyle',
             'CAPJava_fiori_elements-fiori_elements_no_package_json',
+            'CAPJava_mix-fiori_elements_with_ui5tooling_and_localyaml',
             'CAPJava_fiori_elements-fiori_elements',
             'CAPJava_freestyle-freestyle',
             'CAPJava_mix-fiori_elements',

--- a/packages/project-access/test/test-data/project/find-all-apps/CAP/CAPJava_mix/app/fiori_elements_with_ui5tooling_and_localyaml/package.json
+++ b/packages/project-access/test/test-data/project/find-all-apps/CAP/CAPJava_mix/app/fiori_elements_with_ui5tooling_and_localyaml/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "@sap/ux-ui5-tooling": "latest"
+    }
+}

--- a/packages/project-access/test/test-data/project/find-all-apps/CAP/CAPJava_mix/app/fiori_elements_with_ui5tooling_and_localyaml/webapp/manifest.json
+++ b/packages/project-access/test/test-data/project/find-all-apps/CAP/CAPJava_mix/app/fiori_elements_with_ui5tooling_and_localyaml/webapp/manifest.json
@@ -1,0 +1,6 @@
+{
+    "sap.app": {
+        "id": "CAPJava_mix-fiori_elements_with_ui5tooling_and_localyaml",
+        "type": "application"
+    }
+}


### PR DESCRIPTION
Function `findFioriArtifacts()` from `@sap-ux/project-access` does not detect an app correctly, if 
- embedded into CAP
- has entry `@sap/ux-ui5-tooling` in `devDependencies` of package.json and file `ui5-local.yaml`

The project root path was pointing to the application root instead of the CAP project root.