### PR TITLE
odata-vocabularies for CDS analytics: use IsFLags for collection of enums, remove empty lines

### DIFF
--- a/.changeset/young-insects-hug.md
+++ b/.changeset/young-insects-hug.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-vocabularies": patch
+---
+
+odata-vocabularies for CDS analytics: use IsFLags for collection of enums, remove empty lines

--- a/packages/odata-vocabularies/src/resources/com.sap.cds.vocabularies.AnalyticsDetails.ts
+++ b/packages/odata-vocabularies/src/resources/com.sap.cds.vocabularies.AnalyticsDetails.ts
@@ -32,7 +32,6 @@ export default {
                 '$Type': 'com.sap.cds.vocabularies.AnalyticsDetails.ExceptionAggregationBehaviorType',
                 '@Org.OData.Core.V1.Description': 'Description exception aggregation behavior (TODO)'
             },
-
             'exceptionAggregationElements': {
                 '$Collection': true,
                 '$Type': 'Edm.PropertyPath',
@@ -183,7 +182,6 @@ export default {
                 '$Type': 'com.sap.cds.vocabularies.AnalyticsDetails.RangeOptionType',
                 '@Org.OData.Core.V1.Description': 'Description range option (TODO)'
             },
-
             'low': {
                 '@Org.OData.Core.V1.Description': 'TODO description for range type low'
             },

--- a/packages/odata-vocabularies/src/resources/com.sap.cds.vocabularies.ObjectModel.ts
+++ b/packages/odata-vocabularies/src/resources/com.sap.cds.vocabularies.ObjectModel.ts
@@ -23,11 +23,11 @@ export default {
             '$Kind': 'Term',
             '$AppliesTo': ['EntityType'],
             '$Type': 'com.sap.cds.vocabularies.ObjectModel.SupportedCapabilitiesType',
-            '$Collection': true,
             '@Org.OData.Core.V1.Description': '(CDS annotation) Defines the supported capabilities (TODO)'
         },
         'SupportedCapabilitiesType': {
             '$Kind': 'EnumType',
+            '$IsFlags': true,
             'ANALYTICAL_DIMENSION': 0,
             'ANALYTICAL_DIMENSION@Org.OData.Core.V1.Description': 'Description for ANALYTICAL_DIMENSION (TODO)',
             'ANALYTICAL_PROVIDER': 1,


### PR DESCRIPTION
odata-vocabularies for CDS analytics: use `IsFLags` for collection of enums, remove empty lines