### PR TITLE
Fix/27762/cpe icons visibility on light theme

### DIFF
--- a/packages/control-property-editor/src/Workarounds.scss
+++ b/packages/control-property-editor/src/Workarounds.scss
@@ -47,7 +47,20 @@
         }
     }
 }
-
+.uicpe-icon-light-theme {
+    background-color: var(--vscode-terminal-ansiBlue);
+    margin-right: 5px;
+    border-radius: 50%;
+    height: 16px;
+    width: 16px;
+    vertical-align: bottom;
+    svg {
+        path,
+        rect {
+            fill: var(--vscode-button-foreground);
+        }
+    }
+}
 // Tree
 .app-panel-selected-bg {
     .ms-GroupHeader-expand:hover {

--- a/packages/control-property-editor/src/index.css
+++ b/packages/control-property-editor/src/index.css
@@ -468,7 +468,7 @@ html[data-theme='light'] {
     --vscode-foreground: #616161;
     --vscode-errorForeground: #a1260d;
     --vscode-descriptionForeground: #717171;
-    --vscode-icon-foreground: #424242;
+    --vscode-icon-foreground: #ffffff;
     --vscode-focusBorder: #0090f1;
     --vscode-textSeparator-foreground: rgba(0, 0, 0, 0.18);
     --vscode-textLink-foreground: #006ab1;

--- a/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
@@ -61,16 +61,8 @@ export function PropertyChange(propertyChangeProps: Readonly<ChangeProps>): Reac
                             <UIIcon iconName={IconName.arrow} className={styles.text} />
                             {valueIcon && (
                                 <UIIcon
-                                    className={styles.valueIcon}
+                                    className={'uicpe-icon-light-theme'}
                                     iconName={valueIcon}
-                                    style={{
-                                        marginRight: 5,
-                                        background: 'var(--vscode-terminal-ansiBlue)',
-                                        borderRadius: '50%',
-                                        height: 16,
-                                        width: 16,
-                                        verticalAlign: 'bottom'
-                                    }}
                                 />
                             )}
                             <Text className={styles.text}>{value}</Text>

--- a/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
@@ -59,12 +59,7 @@ export function PropertyChange(propertyChangeProps: Readonly<ChangeProps>): Reac
                         <Stack.Item>
                             <Text className={styles.text}>{convertCamelCaseToPascalCase(propertyName)}</Text>
                             <UIIcon iconName={IconName.arrow} className={styles.text} />
-                            {valueIcon && (
-                                <UIIcon
-                                    className={'uicpe-icon-light-theme'}
-                                    iconName={valueIcon}
-                                />
-                            )}
+                            {valueIcon && <UIIcon className={'uicpe-icon-light-theme'} iconName={valueIcon} />}
                             <Text className={styles.text}>{value}</Text>
                         </Stack.Item>
                         {fileName && (


### PR DESCRIPTION
This fix is related to this Bug: https://github.wdf.sap.corp/ux-engineering/tools-suite/issues/27762

CPE icons are now visible on light theme also, furthermore removed the inline styling from the UIIcon component and moved to the CSS class 