### PR TITLE
fix: CPE Icons on Changes Panel not easily visible in Light Theme (#27762)

### DIFF
--- a/packages/control-property-editor/src/Workarounds.scss
+++ b/packages/control-property-editor/src/Workarounds.scss
@@ -48,6 +48,22 @@
     }
 }
 
+// CPE-UIIcon-Changes
+.ui-cpe-icon-light-theme {
+    margin-right: 5px;
+    background-color: var(--vscode-terminal-ansiBlue);
+    border-radius: 50%;
+    height: 16px;
+    width: 16px;
+    vertical-align: bottom;
+    svg {
+        path,
+        rect {
+            fill: var(--vscode-button-foreground);
+        }
+    }
+}
+
 // Tree
 .app-panel-selected-bg {
     .ms-GroupHeader-expand:hover {

--- a/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
@@ -61,16 +61,8 @@ export function PropertyChange(propertyChangeProps: Readonly<ChangeProps>): Reac
                             <UIIcon iconName={IconName.arrow} className={styles.text} />
                             {valueIcon && (
                                 <UIIcon
-                                    className={styles.valueIcon}
+                                    className={'ui-cpe-icon-light-theme'}
                                     iconName={valueIcon}
-                                    style={{
-                                        marginRight: 5,
-                                        background: 'var(--vscode-terminal-ansiBlue)',
-                                        borderRadius: '50%',
-                                        height: 16,
-                                        width: 16,
-                                        verticalAlign: 'bottom'
-                                    }}
                                 />
                             )}
                             <Text className={styles.text}>{value}</Text>

--- a/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
@@ -59,12 +59,7 @@ export function PropertyChange(propertyChangeProps: Readonly<ChangeProps>): Reac
                         <Stack.Item>
                             <Text className={styles.text}>{convertCamelCaseToPascalCase(propertyName)}</Text>
                             <UIIcon iconName={IconName.arrow} className={styles.text} />
-                            {valueIcon && (
-                                <UIIcon
-                                    className={'ui-cpe-icon-light-theme'}
-                                    iconName={valueIcon}
-                                />
-                            )}
+                            {valueIcon && <UIIcon className={'ui-cpe-icon-light-theme'} iconName={valueIcon} />}
                             <Text className={styles.text}>{value}</Text>
                         </Stack.Item>
                         {fileName && (


### PR DESCRIPTION
This fix is related to this Bug

CPE icons are now visible on light theme also, furthermore removed the inline styling from the UIIcon component and moved to the CSS class