### PR TITLE
fix(fpm-writer): adjust fpm writer tests to avoid test failure on windows

### DIFF
--- a/packages/fe-fpm-writer/test/common/index.ts
+++ b/packages/fe-fpm-writer/test/common/index.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { rmdirSync, existsSync } from 'fs';
 import type { Editor } from 'mem-fs-editor';
 
@@ -62,3 +63,20 @@ export const tabSizingTestCases = [
         }
     }
 ];
+
+/**
+ * Method returns length of end of lines symbols for passed line.
+ * In Windows it might be two symbols '\r\n'.
+ *
+ * @param line Index of line to calculate.
+ * @param content Existing content to check.
+ * @returns Length of end of line symbols.
+ */
+export function getEndOfLinesLength(line: number, content?: string) {
+    let size = line * os.EOL.length;
+    if (content) {
+        // Apply 2 symbols as end of line for Windows if it exists in original file '\n\n'
+        size = content.includes('\r\n') ? line * 2 : line;
+    }
+    return size;
+}

--- a/packages/fe-fpm-writer/test/unit/action.test.ts
+++ b/packages/fe-fpm-writer/test/unit/action.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
@@ -9,7 +8,7 @@ import { TargetControl } from '../../src/action/types';
 import type { EventHandlerConfiguration, FileContentPosition, Manifest } from '../../src/common/types';
 import { Placement } from '../../src/common/types';
 import { detectTabSpacing } from '../../src/common/file';
-import { tabSizingTestCases } from '../common';
+import { getEndOfLinesLength, tabSizingTestCases } from '../common';
 
 describe('CustomAction', () => {
     describe('getTargetElementReference', () => {
@@ -305,12 +304,13 @@ describe('CustomAction', () => {
                     {
                         line: 8,
                         character: 9
-                    }
+                    },
+                    undefined
                 ],
-                ['absolute position', 196 + 8 * os.EOL.length]
+                ['absolute position', 196, 8]
             ])(
                 '"eventHandler" is object. Append new function to existing js file with %s',
-                (_desc: string, position: number | FileContentPosition) => {
+                (_desc: string, position: number | FileContentPosition, appendLines?: number) => {
                     const fileName = 'MyExistingAction';
                     // Create existing file with existing actions
                     const folder = join('ext', 'fragments');
@@ -319,6 +319,10 @@ describe('CustomAction', () => {
                     fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
                         eventHandlerFnName: 'onPress'
                     });
+                    if (typeof position === 'number' && appendLines !== undefined) {
+                        const content = fs.read(existingPath);
+                        position += getEndOfLinesLength(appendLines, content);
+                    }
                     // Create third action - append existing js file
                     const actionName = 'CustomAction2';
                     const fnName = 'onHandleSecondAction';

--- a/packages/fe-fpm-writer/test/unit/column.test.ts
+++ b/packages/fe-fpm-writer/test/unit/column.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
@@ -11,7 +10,7 @@ import * as manifest from './sample/column/webapp/manifest.json';
 import type { EventHandlerConfiguration, FileContentPosition, Manifest } from '../../src/common/types';
 import { Placement } from '../../src/common/types';
 import { detectTabSpacing } from '../../src/common/file';
-import { tabSizingTestCases } from '../common';
+import { getEndOfLinesLength, tabSizingTestCases } from '../common';
 
 const testDir = join(__dirname, 'sample/column');
 
@@ -277,12 +276,13 @@ describe('CustomAction', () => {
                     {
                         line: 8,
                         character: 9
-                    }
+                    },
+                    undefined
                 ],
-                ['absolute position', 196 + 8 * os.EOL.length]
+                ['absolute position', 196, 8]
             ])(
                 '"eventHandler" is object. Append new function to existing js file with %s',
-                (_desc: string, position: number | FileContentPosition) => {
+                (_desc: string, position: number | FileContentPosition, appendLines?: number) => {
                     const fileName = 'MyExistingAction';
                     // Create existing file with existing actions
                     const folder = join('extensions', 'custom');
@@ -291,6 +291,10 @@ describe('CustomAction', () => {
                     fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
                         eventHandlerFnName: 'onPress'
                     });
+                    if (typeof position === 'number' && appendLines !== undefined) {
+                        const content = fs.read(existingPath);
+                        position += getEndOfLinesLength(appendLines, content);
+                    }
                     const fnName = 'onHandleSecondAction';
 
                     const extension = {

--- a/packages/fe-fpm-writer/test/unit/filter.test.ts
+++ b/packages/fe-fpm-writer/test/unit/filter.test.ts
@@ -6,7 +6,7 @@ import type { CustomFilter } from '../../src/filter/types';
 import { generateCustomFilter } from '../../src/filter';
 import type { EventHandlerConfiguration, FileContentPosition } from '../../src/common/types';
 import { Placement } from '../../src/common/types';
-import os from 'os';
+import { getEndOfLinesLength } from '../common';
 
 describe('CustomFilter', () => {
     describe('generateCustomFilter', () => {
@@ -187,12 +187,13 @@ describe('CustomFilter', () => {
                     {
                         line: 18,
                         character: 9
-                    }
+                    },
+                    undefined
                 ],
-                ['absolute position', 870 + 18 * os.EOL.length]
+                ['absolute position', 870, 18]
             ])(
                 '"eventHandler" is object. Append new function to existing js file with %s',
-                (_desc: string, position: number | FileContentPosition) => {
+                (_desc: string, position: number | FileContentPosition, appendLines?: number) => {
                     const fileName = 'MyExistingFilter';
                     // Create existing file with existing filters
                     const folder = join('ext', 'fragments');
@@ -202,6 +203,10 @@ describe('CustomFilter', () => {
                         ...filter,
                         eventHandlerFnName: 'filterItems'
                     });
+                    if (typeof position === 'number' && appendLines !== undefined) {
+                        const content = fs.read(existingPath);
+                        position += getEndOfLinesLength(appendLines, content);
+                    }
                     // Create third action - append existing js file
                     const filterName = 'CustomFilter2';
                     const fnName = 'onHandleSecondAction';

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -347,14 +347,6 @@ describe('CustomSection', () => {
             test.each(positions)(
                 '"eventHandler" is object. Append new function to existing js file with $name',
                 ({ position, endOfLines }) => {
-                    const extension = {
-                        fnName,
-                        fileName,
-                        insertScript: {
-                            fragment: `,\n        ${fnName}: function() {\n            MessageToast.show("Custom handler invoked.");\n        }`,
-                            position
-                        }
-                    };
                     // Generate handler with single method - content should be updated during generating of custom section
                     fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
                         eventHandlerFnName: 'onPress'
@@ -363,6 +355,14 @@ describe('CustomSection', () => {
                         const content = fs.read(existingPath);
                         position += getEndOfLinesLength(endOfLines, content);
                     }
+                    const extension = {
+                        fnName,
+                        fileName,
+                        insertScript: {
+                            fragment: `,\n        ${fnName}: function() {\n            MessageToast.show("Custom handler invoked.");\n        }`,
+                            position
+                        }
+                    };
 
                     generateCustomSectionWithEventHandler(id, extension, folder);
                     const xmlPath = join(testDir, 'webapp', folder, `${id}.fragment.xml`);

--- a/packages/fe-fpm-writer/test/unit/section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/section.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';
@@ -9,7 +8,7 @@ import type { EventHandlerConfiguration, Manifest } from '../../src/common/types
 import { Placement } from '../../src/common/types';
 import * as manifest from './sample/section/webapp/manifest.json';
 import { detectTabSpacing } from '../../src/common/file';
-import { tabSizingTestCases } from '../common';
+import { getEndOfLinesLength, tabSizingTestCases } from '../common';
 
 const testDir = join(__dirname, 'sample/section');
 
@@ -341,12 +340,13 @@ describe('CustomSection', () => {
                 },
                 {
                     name: 'absolute position',
-                    position: 196 + 8 * os.EOL.length
+                    position: 196,
+                    endOfLines: 8
                 }
             ];
             test.each(positions)(
                 '"eventHandler" is object. Append new function to existing js file with $name',
-                ({ position }) => {
+                ({ position, endOfLines }) => {
                     const extension = {
                         fnName,
                         fileName,
@@ -359,6 +359,10 @@ describe('CustomSection', () => {
                     fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
                         eventHandlerFnName: 'onPress'
                     });
+                    if (typeof position === 'number' && endOfLines !== undefined) {
+                        const content = fs.read(existingPath);
+                        position += getEndOfLinesLength(endOfLines, content);
+                    }
 
                     generateCustomSectionWithEventHandler(id, extension, folder);
                     const xmlPath = join(testDir, 'webapp', folder, `${id}.fragment.xml`);

--- a/packages/fe-fpm-writer/test/unit/view.test.ts
+++ b/packages/fe-fpm-writer/test/unit/view.test.ts
@@ -285,7 +285,7 @@ describe('CustomView', () => {
             },
             {
                 name: 'absolute position',
-                position: 196 + 8 * os.EOL.length,
+                position: 196,
                 endOfLines: 8
             }
         ];

--- a/packages/fe-fpm-writer/test/unit/view.test.ts
+++ b/packages/fe-fpm-writer/test/unit/view.test.ts
@@ -9,7 +9,7 @@ import * as manifest from './sample/view/webapp/manifest.json';
 import type { Views, EventHandlerConfiguration } from '../../src/common/types';
 import type { Manifest } from '@sap-ux/project-access';
 import { detectTabSpacing } from '../../src/common/file';
-import { tabSizingTestCases } from '../common';
+import { getEndOfLinesLength, tabSizingTestCases } from '../common';
 
 const testDir = join(__dirname, 'sample/view');
 
@@ -285,12 +285,13 @@ describe('CustomView', () => {
             },
             {
                 name: 'absolute position',
-                position: 196 + 8 * os.EOL.length
+                position: 196 + 8 * os.EOL.length,
+                endOfLines: 8
             }
         ];
         test.each(positions)(
             '"eventHandler" is object. Append new function to existing js file with $name',
-            ({ position }) => {
+            ({ position, endOfLines }) => {
                 const fileName = 'MyExistingAction';
                 // Create existing file with existing actions
                 const folder = join('extensions', 'custom');
@@ -299,6 +300,10 @@ describe('CustomView', () => {
                 fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
                     eventHandlerFnName: 'onPress'
                 });
+                if (typeof position === 'number' && endOfLines !== undefined) {
+                    const content = fs.read(existingPath);
+                    position += getEndOfLinesLength(endOfLines, content);
+                }
                 const fnName = 'onHandleSecondAction';
 
                 const extension = {

--- a/packages/fe-fpm-writer/test/unit/view.test.ts
+++ b/packages/fe-fpm-writer/test/unit/view.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
 import { create as createStorage } from 'mem-fs';


### PR DESCRIPTION
I noticed following difference running on Windows:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/f9aa62d5-b759-4220-a8b2-e7c4b5874221)
vs
![image](https://github.com/SAP/open-ux-tools/assets/90789422/cfc83a50-46f7-4cbf-b0b6-196666ac3b25)

Run was on fresh clone vs old clope of `fpm-writer`.

Adjusting tests by handling both cases - detecting if new line in existing file is `\n`(1 symbol) or `\r\n`(2 symbols). Method -> `getEndOfLinesLength`
