### PR TITLE
fix: CPE Icons on Changes Panel not easily visible in Light Theme (#2…

### DIFF
--- a/packages/control-property-editor/src/Workarounds.scss
+++ b/packages/control-property-editor/src/Workarounds.scss
@@ -48,6 +48,22 @@
     }
 }
 
+// CPE-UIIcon-Changes
+.ui-cpe-icon-light-theme {
+    margin-right: 5px;
+    background-color: var(--vscode-terminal-ansiBlue);
+    border-radius: 50%;
+    height: 16px;
+    width: 16px;
+    vertical-align: bottom;
+    svg {
+        path,
+        rect {
+            fill: var(--vscode-button-foreground);
+        }
+    }
+}
+
 // Tree
 .app-panel-selected-bg {
     .ms-GroupHeader-expand:hover {

--- a/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/PropertyChange.tsx
@@ -59,20 +59,7 @@ export function PropertyChange(propertyChangeProps: Readonly<ChangeProps>): Reac
                         <Stack.Item>
                             <Text className={styles.text}>{convertCamelCaseToPascalCase(propertyName)}</Text>
                             <UIIcon iconName={IconName.arrow} className={styles.text} />
-                            {valueIcon && (
-                                <UIIcon
-                                    className={styles.valueIcon}
-                                    iconName={valueIcon}
-                                    style={{
-                                        marginRight: 5,
-                                        background: 'var(--vscode-terminal-ansiBlue)',
-                                        borderRadius: '50%',
-                                        height: 16,
-                                        width: 16,
-                                        verticalAlign: 'bottom'
-                                    }}
-                                />
-                            )}
+                            {valueIcon && <UIIcon className={'ui-cpe-icon-light-theme'} iconName={valueIcon} />}
                             <Text className={styles.text}>{value}</Text>
                         </Stack.Item>
                         {fileName && (


### PR DESCRIPTION
This fix addresses the issue related to the visibility of CPE icons in the light theme. 

Navigate to the CPE. Subsequently switch the theme to Light Mode. It is observed that CPE Icons are not easily visible on light mode. 

![1](https://github.com/SAP/open-ux-tools/assets/38275501/c67462a9-eb64-4258-a032-b321d19bbd36)


CPE icons are now visible on light theme also, furthermore removed the inline styling from the UIIcon component and moved to the CSS class.

![Screenshot 2024-01-23 at 19 13 13](https://github.com/SAP/open-ux-tools/assets/38275501/a51df8e3-569a-41f0-8538-2c936dbc29d2)
