### PR TITLE
fix: XML fragment is written to project before save button is pressed

### DIFF
--- a/packages/adp-tooling/src/index.ts
+++ b/packages/adp-tooling/src/index.ts
@@ -1,4 +1,4 @@
 export { AdpPreviewConfig, AdpWriterConfig } from './types';
-export * from './preview/adp-preview';
+export * from './preview';
 export { generate } from './writer';
 export { promptGeneratorInput, PromptDefaults } from './base/prompt';

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -137,7 +137,7 @@ export class AdpPreview {
      */
     addApis(router: Router): void {
         router.get(ApiRoutes.FRAGMENT, this.routesHandler.handleReadAllFragments as RequestHandler);
-        router.post(ApiRoutes.FRAGMENT, express.json(), this.routesHandler.handleWriteFragment as RequestHandler);
+        router.post(ApiRoutes.FRAGMENT, express.json(), this.routesHandler.handleCacheFragment as RequestHandler);
 
         router.get(ApiRoutes.CONTROLLER, this.routesHandler.handleReadAllControllers as RequestHandler);
         router.post(

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -147,5 +147,6 @@ export class AdpPreview {
         );
 
         router.get(ApiRoutes.CODE_EXT, this.routesHandler.handleGetControllerExtensionData as RequestHandler);
+        router.use(this.routesHandler.handleFragmentMemoryFs);
     }
 }

--- a/packages/adp-tooling/src/preview/index.ts
+++ b/packages/adp-tooling/src/preview/index.ts
@@ -1,0 +1,2 @@
+export * from './adp-preview';
+export * from './routes-handler';

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -315,18 +315,13 @@ export default class RoutesHandler {
     };
 
     public handleFragmentMemoryFs = async (req: Request, res: Response, next: NextFunction) => {
-        if (req.method !== 'GET') {
+        const url = req.url;
+        if (req.method !== 'GET' || !this.fragmentPaths.size || !url.includes('.fragment.')) {
             next();
             return;
         }
 
         try {
-            const url = req.url;
-            if (!this.fragmentPaths.size || !url.includes('.fragment.')) {
-                next();
-                return;
-            }
-
             const fragmentName = url.split('/').pop();
 
             const cachedFragmentPath = this.getFragmentPathFromCache(fragmentName);

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -124,12 +124,11 @@ export default class RoutesHandler {
      * @param res Response
      * @param next Next Function
      */
-    public handleWriteFragment = async (req: Request, res: Response, next: NextFunction) => {
-        let fragmentName = '';
+    public handleCacheFragment = async (req: Request, res: Response, next: NextFunction) => {
         try {
             const data = req.body as WriteFragmentBody;
 
-            fragmentName = sanitize(data.fragmentName);
+            const fragmentName = sanitize(data.fragmentName);
 
             const sourcePath = this.util.getProject().getSourcePath();
 
@@ -344,4 +343,29 @@ export default class RoutesHandler {
             next(e);
         }
     };
+}
+
+/**
+ * Writes an XML fragment to a specified location within the workspace.
+ *
+ * @param {string} webappPath - The absolute path to the webapp directory of the current project.
+ * @param {string} fragmentPath - The path where the fragment will be written under the 'changes' directory.
+ * @throws {Error} Throws an error if the directory creation or file copy operation fails.
+ * @returns {void}
+ */
+export function writeFragmentToWorkspace(webappPath: string, fragmentPath: string): void {
+    const changeFolderPath = path.join(webappPath, FolderNames.Changes);
+    const folderPath = path.join(changeFolderPath, FolderNames.Fragments);
+    const filePath = path.join(changeFolderPath, fragmentPath);
+
+    try {
+        if (!fs.existsSync(folderPath)) {
+            fs.mkdirSync(folderPath, { recursive: true });
+        }
+
+        const fragmentTemplatePath = path.join(__dirname, '../../templates/rta', TemplateFileName.Fragment);
+        fs.copyFileSync(fragmentTemplatePath, filePath);
+    } catch (e) {
+        throw new Error(`Could not write XML fragment to ${filePath}. Reason: ${e.message}`);
+    }
 }

--- a/packages/preview-middleware/src/base/flex.ts
+++ b/packages/preview-middleware/src/base/flex.ts
@@ -1,3 +1,4 @@
+import { writeFragmentToWorkspace } from '@sap-ux/adp-tooling';
 import type { Logger } from '@sap-ux/logger';
 import type { ReaderCollection } from '@ui5/fs';
 import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
@@ -76,13 +77,17 @@ export async function readChanges(project: ReaderCollection, logger: Logger): Pr
  * @returns object with success flag and optional message
  */
 export function writeChange(
-    data: object & { fileName?: string; fileType?: string },
+    data: FlexChange,
     webappPath: string,
     logger: Logger
 ): { success: boolean; message?: string } {
     const fileName = data.fileName;
     const fileType = data.fileType;
     if (fileName && fileType) {
+        if (data.changeType === 'addXML' && data.content?.fragmentPath) {
+            const fragmentPath = data.content?.fragmentPath;
+            writeFragmentToWorkspace(webappPath, fragmentPath);
+        }
         logger.debug(`Write change ${fileName}.${fileType}`);
         const path = join(webappPath, 'changes');
         if (!existsSync(path)) {


### PR DESCRIPTION
Fix for #1621.

- Adds caching for fragment paths, and serves them after the command for addXML is pushed and executed and the fragment is requested.