### PR TITLE
fix: Allow to pass custom data-* attributes for UISections, UISection, UIToolbar and UIToolbarColumn components

### DIFF
--- a/.changeset/early-moles-jam.md
+++ b/.changeset/early-moles-jam.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+fix: Allow to pass custom `data-*` attributes for `UISections`, `UISection`, `UIToolbar` and `UIToolbarColumn` components.

--- a/packages/ui-components/src/components/UISection/UISection.tsx
+++ b/packages/ui-components/src/components/UISection/UISection.tsx
@@ -50,7 +50,11 @@ export class UISection extends React.Component<UISectionProps & Readonly<{ child
         if ('height' in this.props) {
             style.height = this.props.height;
         }
-        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
+            'onScroll',
+            'className',
+            'children'
+        ]);
         return (
             <div
                 {...divProps}

--- a/packages/ui-components/src/components/UISection/UISection.tsx
+++ b/packages/ui-components/src/components/UISection/UISection.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { divProperties, getNativeProps } from '@fluentui/react';
+
 import './UISection.scss';
 
 export enum UISectionLayout {
@@ -48,8 +50,10 @@ export class UISection extends React.Component<UISectionProps & Readonly<{ child
         if ('height' in this.props) {
             style.height = this.props.height;
         }
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
         return (
             <div
+                {...divProps}
                 className={`section${this.props.className ? ' ' + this.props.className : ''} section--${layout}${
                     scrollable ? ' section--scrollable' : ''
                 }${this.props.cleanPadding ? ' section--clean' : ''}${this.props.hidden ? ' section--hidden' : ''}`}

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { divProperties, getNativeProps } from '@fluentui/react';
 import { UISection } from './UISection';
 import type { UISectionProps } from './UISection';
 import { UISplitter, UISplitterType, UISplitterLayoutType } from './UISplitter';
@@ -789,6 +790,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
      * @returns {React.ReactElement}
      */
     render(): React.ReactElement {
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
         const sections = [];
         let visibleSections = 0;
         for (let i = 0; i < this.props.children.length; i++) {
@@ -806,6 +808,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
 
         return (
             <div
+                {...divProps}
                 ref={this.rootRef}
                 className={`sections ${this.getClassNames(visibleSections === 1)}`}
                 style={{

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -790,7 +790,10 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
      * @returns {React.ReactElement}
      */
     render(): React.ReactElement {
-        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
+            'className',
+            'children'
+        ]);
         const sections = [];
         let visibleSections = 0;
         for (let i = 0; i < this.props.children.length; i++) {

--- a/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { divProperties, getNativeProps } from '@fluentui/react';
+
 import './UIToolbar.scss';
 
 export interface UIToolbarProps {
@@ -111,8 +113,10 @@ export class UIToolbar extends React.Component<UIToolbarProps, UIToolbarState> {
      * @returns {React.ReactNode}
      */
     render(): React.ReactNode {
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
         return (
             <div
+                {...divProps}
                 tabIndex={-1}
                 ref={this.toolbarRef}
                 className={`ui-toolbar ${this.state.toolbarWidthClassName} ${

--- a/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
@@ -113,7 +113,10 @@ export class UIToolbar extends React.Component<UIToolbarProps, UIToolbarState> {
      * @returns {React.ReactNode}
      */
     render(): React.ReactNode {
-        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
+        const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
+            'className',
+            'children'
+        ]);
         return (
             <div
                 {...divProps}

--- a/packages/ui-components/src/components/UIToolbar/UIToolbarColumn.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbarColumn.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { divProperties, getNativeProps } from '@fluentui/react';
+
 import './UIToolbar.scss';
 
 export interface UIColumnProps {
@@ -7,8 +9,9 @@ export interface UIColumnProps {
 }
 
 export const UIToolbarColumn: React.FC<UIColumnProps> = (props: UIColumnProps) => {
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
     return (
-        <div className={'ui-toolbar__column ' + props.className}>
+        <div {...divProps} className={'ui-toolbar__column ' + props.className}>
             <div className="ui-toolbar__column__content">{props.children}</div>
         </div>
     );

--- a/packages/ui-components/src/components/UIToolbar/UIToolbarColumn.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbarColumn.tsx
@@ -9,7 +9,10 @@ export interface UIColumnProps {
 }
 
 export const UIToolbarColumn: React.FC<UIColumnProps> = (props: UIColumnProps) => {
-    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties, [
+        'className',
+        'children'
+    ]);
     return (
         <div {...divProps} className={'ui-toolbar__column ' + props.className}>
             <div className="ui-toolbar__column__content">{props.children}</div>

--- a/packages/ui-components/stories/UISections.story.tsx
+++ b/packages/ui-components/stories/UISections.story.tsx
@@ -16,6 +16,9 @@ const css = `
         min-width: 100px;
         margin-right: 10px;
     }
+    #storybook-root {
+        height: 100%;
+    }
 `;
 
 const text = `Lorem ipsum dolor sit amet, modo iriure prompta eos in, eos ex meis ponderum, veniam cetero imperdiet ex mel. Munere recteque nam ut, ipsum aeterno est ex. Duo porro nulla ea, ut iudicabit scriptorem sed. Eos senserit imperdiet consequuntur in.
@@ -191,7 +194,11 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
                         onClose={() => {
                             setRightSectionVisible(!rightSectionVisible);
                         }}>
-                        <UISections.Section height="100%" cleanPadding={true} hidden={!leftSectionVisible}>
+                        <UISections.Section
+                            height="100%"
+                            cleanPadding={true}
+                            hidden={!leftSectionVisible}
+                            data-test="test">
                             <div>
                                 {text}
                                 {text}

--- a/packages/ui-components/test/unit/components/UISection.test.tsx
+++ b/packages/ui-components/test/unit/components/UISection.test.tsx
@@ -59,7 +59,9 @@ describe('<Section />', () => {
     it('Test "onScroll" event', () => {
         const onScroll = jest.fn();
         wrapper.setProps({
-            onScroll
+            onScroll,
+            className: 'aaaa',
+            collapsible: true
         });
         expect(wrapper.find('.section__body').length).toEqual(1);
         wrapper.find('.section__body').simulate('scroll', {});
@@ -73,5 +75,17 @@ describe('<Section />', () => {
             hidden: true
         });
         expect(wrapper.find('.section--hidden').length).toEqual(1);
+    });
+
+    it('Test data property', () => {
+        const testValue = 'test value';
+        wrapper = Enzyme.mount(
+            <UISection data-test={testValue}>
+                <div>Dummy Content</div>
+            </UISection>
+        );
+        expect(wrapper.find('.section[data-test="test value"]').getDOMNode().getAttribute('data-test')).toEqual(
+            testValue
+        );
     });
 });

--- a/packages/ui-components/test/unit/components/UISections.test.tsx
+++ b/packages/ui-components/test/unit/components/UISections.test.tsx
@@ -446,4 +446,21 @@ describe('<Sections />', () => {
             });
         }
     });
+
+    it('Test data property', () => {
+        const testValue = 'test value';
+        wrapper = Enzyme.mount(
+            <UISections data-test={testValue}>
+                <UISections.Section>
+                    <div />
+                </UISections.Section>
+                <UISections.Section>
+                    <div />
+                </UISections.Section>
+            </UISections>
+        );
+        expect(wrapper.find('.sections[data-test="test value"]').getDOMNode().getAttribute('data-test')).toEqual(
+            testValue
+        );
+    });
 });

--- a/packages/ui-components/test/unit/components/UIToolbar.test.tsx
+++ b/packages/ui-components/test/unit/components/UIToolbar.test.tsx
@@ -1,14 +1,17 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import { UIToolbar, UIToolbarColumn } from '../../../src/components';
+import { mockResizeObserver } from '../../utils/utils';
+
+mockResizeObserver();
 
 describe('<UIToolbar />', () => {
     const selectors = {
-        toolbar: '.toolbar',
+        toolbar: '.ui-toolbar',
         column: '.ui-toolbar__column'
     };
     it('Render', () => {
-        const { container } = render(
+        render(
             <UIToolbar>
                 <UIToolbarColumn>
                     <div>Left</div>
@@ -19,13 +22,13 @@ describe('<UIToolbar />', () => {
             </UIToolbar>
         );
 
-        expect(container.querySelectorAll(selectors.toolbar).length).toEqual(1);
-        expect(container.querySelectorAll(selectors.column).length).toEqual(2);
+        expect(document.querySelectorAll(selectors.toolbar).length).toEqual(1);
+        expect(document.querySelectorAll(selectors.column).length).toEqual(2);
     });
 
     it('Render with custom attributes', () => {
         const testValue = 'test value';
-        const { container } = render(
+        render(
             <UIToolbar data-test={testValue}>
                 <UIToolbarColumn data-test2={testValue}>
                     <div>Left</div>
@@ -36,7 +39,7 @@ describe('<UIToolbar />', () => {
             </UIToolbar>
         );
 
-        expect(container.querySelector(`${selectors.toolbar} [data-test="test value"]`)).not.toEqual(null);
-        expect(container.querySelector(`${selectors.column} [data-test2="test value"]`)).not.toEqual(null);
+        expect(document.querySelector(`${selectors.toolbar}[data-test="test value"]`)).not.toEqual(null);
+        expect(document.querySelector(`${selectors.column}[data-test2="test value"]`)).not.toEqual(null);
     });
 });

--- a/packages/ui-components/test/unit/components/UIToolbar.test.tsx
+++ b/packages/ui-components/test/unit/components/UIToolbar.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { UIToolbar, UIToolbarColumn } from '../../../src/components';
+
+describe('<UIToolbar />', () => {
+    const selectors = {
+        toolbar: '.toolbar',
+        column: '.ui-toolbar__column'
+    };
+    it('Render', () => {
+        const { container } = render(
+            <UIToolbar>
+                <UIToolbarColumn>
+                    <div>Left</div>
+                </UIToolbarColumn>
+                <UIToolbarColumn>
+                    <div>Right</div>
+                </UIToolbarColumn>
+            </UIToolbar>
+        );
+
+        expect(container.querySelectorAll(selectors.toolbar).length).toEqual(1);
+        expect(container.querySelectorAll(selectors.column).length).toEqual(2);
+    });
+
+    it('Render with custom attributes', () => {
+        const testValue = 'test value';
+        const { container } = render(
+            <UIToolbar data-test={testValue}>
+                <UIToolbarColumn data-test2={testValue}>
+                    <div>Left</div>
+                </UIToolbarColumn>
+                <UIToolbarColumn>
+                    <div>Right</div>
+                </UIToolbarColumn>
+            </UIToolbar>
+        );
+
+        expect(container.querySelector(`${selectors.toolbar} [data-test="test value"]`)).not.toEqual(null);
+        expect(container.querySelector(`${selectors.column} [data-test2="test value"]`)).not.toEqual(null);
+    });
+});


### PR DESCRIPTION
issue #1629

Allow to pass custom `data-*` attributes for `UISections`, `UISection`, `UIToolbar` and `UIToolbarColumn` components, like:
```
<UISections.Section height="100%" cleanPadding={true} hidden={!leftSectionVisible} data-test="test-value">
         <div></div>
</UISections.Section>
```