### PR TITLE
Update Icons.tsx to fix typo 

### DIFF
--- a/.changeset/fast-chefs-speak.md
+++ b/.changeset/fast-chefs-speak.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/ui-components": patch
+---
+
+Update Icons.tsx to fix typo 

--- a/packages/ui-components/src/components/Icons.tsx
+++ b/packages/ui-components/src/components/Icons.tsx
@@ -55,7 +55,7 @@ export enum UiIcons {
     DataSource = 'DataSource',
     Edit = 'Edit',
     Error = 'Error',
-    ExpandGroup = 'ExandGroup',
+    ExpandGroup = 'ExpandGroup',
     ExpandNodes = 'ExpandNodes',
     Export = 'Export',
     Eye = 'Eye',


### PR DESCRIPTION
Fixed typo in variable definition of 'ExpandGroup'