### PR TITLE
fix(axios-ext): fix message order, remove showAddInfo flag

### DIFF
--- a/.changeset/sharp-cats-compare.md
+++ b/.changeset/sharp-cats-compare.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/axios-extension': minor
+'@sap-ux/deploy-tooling': minor
+---
+
+fix log info order, remove showAddInfo

--- a/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
+++ b/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
@@ -53,10 +53,6 @@ export interface DeployConfig {
      * if set then the SafeMode url parameter will be set. SafeMode is by default active, to deactivate provide false
      */
     safeMode?: boolean;
-    /**
-     * if set to true, then any additional info messages will be logged
-     */
-    showAddInfo?: boolean;
 }
 
 /**
@@ -178,16 +174,9 @@ export class Ui5AbapRepositoryService extends ODataService {
      * @param config.bsp BSP configuration
      * @param config.testMode if set to true, all requests will be sent, the service checks them, but no actual deployment will happen
      * @param config.safeMode if set then the SafeMode url parameter will be set. SafeMode is by default active, to activate provide false
-     * @param config.showAddInfo if set to true, then additional info message will be logged
      * @returns the Axios response object for further processing
      */
-    public async deploy({
-        archive,
-        bsp,
-        testMode = false,
-        safeMode,
-        showAddInfo = false
-    }: DeployConfig): Promise<AxiosResponse> {
+    public async deploy({ archive, bsp, testMode = false, safeMode }: DeployConfig): Promise<AxiosResponse> {
         const info: AppInfo = await this.getInfo(bsp.name);
         const payload = this.createPayload(
             archive,
@@ -215,11 +204,6 @@ export class Ui5AbapRepositoryService extends ODataService {
                 const query = this.defaults.params?.['sap-client']
                     ? '?sap-client=' + this.defaults.params['sap-client']
                     : '';
-                if (this.isDest && showAddInfo) {
-                    this.log.info(
-                        '(Note: As the destination is configured using an On-Premise SAP Cloud Connector, you will need to replace the host in the URL above with the internal host)'
-                    );
-                }
                 this.log.info(`App available at ${frontendUrl}${path}${query}`);
             } else {
                 // Test mode returns a HTTP response code of 403 so we dont want to show all error messages

--- a/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
+++ b/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
@@ -123,11 +123,10 @@ describe('Ui5AbapRepositoryService', () => {
                 .reply(200);
             const response = await destinationService.deploy({
                 archive,
-                bsp: { name: notExistingApp },
-                showAddInfo: true
+                bsp: { name: notExistingApp }
             });
             expect(response.data).toBeDefined();
-            expect(loggerMock.info).toHaveBeenCalledTimes(8); // Ensures the logFullURL method is called to support destinations
+            expect(loggerMock.info).toHaveBeenCalledTimes(7); // Ensures the logFullURL method is called to support destinations
             expect(loggerMock.warn).toHaveBeenCalledTimes(0);
             expect(loggerMock.error).toHaveBeenCalledTimes(0);
         });

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -295,8 +295,7 @@ async function tryDeploy(
                 archive,
                 bsp: config.app,
                 testMode: config.test,
-                safeMode: config.safe,
-                showAddInfo: await showAdditionalInfoForOnPrem(`${config.target.destination}`)
+                safeMode: config.safe
             });
         } else {
             await tryDeployToLrep(provider, config, logger, archive);
@@ -307,6 +306,11 @@ async function tryDeploy(
             );
         } else {
             logger.info('Deployment Successful.');
+            if (await showAdditionalInfoForOnPrem(`${config.target.destination}`)) {
+                logger.info(
+                    '(Note: As the destination is configured using an On-Premise SAP Cloud Connector, you will need to replace the host in the URL above with the internal host)'
+                );
+            }
         }
     } catch (error) {
         await handleError(tryDeploy, error, provider, config, logger, archive);

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -59,8 +59,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: undefined,
-                safeMode: undefined,
-                showAddInfo: false
+                safeMode: undefined
             });
             mockedUi5RepoService.deploy.mockClear();
 
@@ -69,8 +68,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: true,
-                safeMode: false,
-                showAddInfo: false
+                safeMode: false
             });
             mockedUi5RepoService.deploy.mockClear();
             mockCreateForAbap.mockClear();
@@ -85,8 +83,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: true,
-                safeMode: false,
-                showAddInfo: false
+                safeMode: false
             });
             expect(mockCreateForAbap).toBeCalledWith(expect.objectContaining({ params }));
         });
@@ -104,8 +101,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: undefined,
-                safeMode: undefined,
-                showAddInfo: false
+                safeMode: undefined
             });
             mockedUi5RepoService.deploy.mockClear();
 
@@ -114,8 +110,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: true,
-                safeMode: false,
-                showAddInfo: false
+                safeMode: false
             });
             mockedUi5RepoService.deploy.mockClear();
             mockCreateForAbap.mockClear();
@@ -130,8 +125,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: true,
-                safeMode: false,
-                showAddInfo: false
+                safeMode: false
             });
             expect(mockCreateForAbap).toBeCalledWith(expect.objectContaining({ params }));
             expect(formatSummaryMock).toHaveBeenCalled();
@@ -187,8 +181,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: app,
                 testMode: undefined,
-                safeMode: undefined,
-                showAddInfo: false
+                safeMode: undefined
             });
         });
 
@@ -235,8 +228,7 @@ describe('base/deploy', () => {
                 archive,
                 bsp: { ...app, transport: '~transport123' },
                 testMode: true,
-                safeMode: false,
-                showAddInfo: false
+                safeMode: false
             });
             expect(config.createTransport).toBe(false);
             expect(mockedAdtService.createTransportRequest).toBeCalledTimes(1);

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -12,19 +12,10 @@ import {
 import type { AbapTarget } from '@sap-ux/system-access';
 import AdmZip from 'adm-zip';
 import { join } from 'path';
-import * as Logger from '@sap-ux/logger';
 
 import * as validate from '../../../src/base/validate';
 import { SummaryStatus } from '../../../src/base/validate';
 
-const loggerMock: ToolsLogger = {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn()
-} as Partial<ToolsLogger> as ToolsLogger;
-
-jest.spyOn(Logger, 'ToolsLogger').mockImplementation(() => loggerMock);
 const validateBeforeDeployMock = jest.spyOn(validate, 'validateBeforeDeploy');
 const formatSummaryMock = jest.spyOn(validate, 'formatSummary');
 const showAdditionalInfoForOnPremMock = jest.spyOn(validate, 'showAdditionalInfoForOnPrem');
@@ -58,7 +49,6 @@ describe('base/deploy', () => {
             mockedAdtService.createTransportRequest.mockReset();
             validateBeforeDeployMock.mockReset();
             formatSummaryMock.mockReset();
-            jest.clearAllMocks();
         });
 
         test('No errors locally with url', async () => {
@@ -279,13 +269,10 @@ describe('base/deploy', () => {
             expect(mockedAdtService.createTransportRequest).toBeCalledTimes(1);
         });
         test('additional info logged', async () => {
+            jest.spyOn(nullLogger, 'info');
             showAdditionalInfoForOnPremMock.mockResolvedValue(true);
             await deploy(archive, { app, target }, nullLogger);
-            expect(loggerMock.info).toHaveBeenCalledWith(
-                expect.stringContaining(
-                    '(Note: As the destination is configured using an On-Premise SAP Cloud Connector, you will need to replace the host in the URL above with the internal host)'
-                )
-            );
+            expect(nullLogger.info).toHaveBeenCalledTimes(3);
         });
 
         describe('adaptation projects', () => {


### PR DESCRIPTION
#1615

Removed `showAddInfo` and the order of messages displayed as: 

```
info abap-deploy-task YY1_TESTIAN334 App available at https://my301102.s4hana.ondemand.com/sap/bc/ui5_ui5/sap/yy1_testian334
info abap-deploy-task YY1_TESTIAN334 Deployment Successful
info abap-deploy-task YY1_TESTIAN334 (Note: As the destination is configured using an On-Premise SAP Cloud Connector, you will need to replace the host in the URL above with the internal host)
```