### PR TITLE
fix(backend-proxy): remove Partitioned from the cookies

### DIFF
--- a/.changeset/nasty-trainers-sort.md
+++ b/.changeset/nasty-trainers-sort.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/backend-proxy-middleware': patch
+---
+
+Remove 'Partitioned' from cookies

--- a/packages/backend-proxy-middleware/src/base/proxy.ts
+++ b/packages/backend-proxy-middleware/src/base/proxy.ts
@@ -55,7 +55,10 @@ export const ProxyEventHandlers = {
         const header = proxyRes?.headers?.['set-cookie'];
         if (header?.length) {
             for (let i = header.length - 1; i >= 0; i--) {
-                const cookie = header[i].replace(/\s?Domain=[^\s]*\s?|\s?SameSite=[^\s]*\s?|\s?Secure[^\s]*\s?/gi, '');
+                const cookie = header[i].replace(
+                    /\s?Domain=[^\s]*\s?|\s?SameSite=[^\s]*\s?|\s?Secure[^\s]*\s?|\s?Partitioned[^\s]*\s?/gi,
+                    ''
+                );
                 header[i] = cookie;
             }
         }

--- a/packages/backend-proxy-middleware/test/base/proxy.test.ts
+++ b/packages/backend-proxy-middleware/test/base/proxy.test.ts
@@ -136,13 +136,13 @@ describe('proxy', () => {
             onProxyRes(response);
             expect(response).toEqual({ headers: { 'set-cookie': [] } });
 
-            // cookies are modified i.e. SameSite, Domain, Secure are removed
+            // cookies are modified i.e. SameSite, Domain, Secure, Partitioned are removed
             response.headers['set-cookie'] = [
-                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; SameSite=None; secure; Domain=example.com',
-                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; SameSite=None; Domain=example.com; secure',
-                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; secure; Domain=example.com; SameSite=None',
-                'SameSite=None; MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; secure; Domain=example.com',
-                'Domain=example.com MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; SameSite=None; secure'
+                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; SameSite=None; secure; Domain=example.com Partitioned',
+                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; SameSite=None; Domain=example.com; Partitioned; secure',
+                'MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; secure; Domain=example.com; Partitioned; SameSite=None',
+                'SameSite=None; MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; Partitioned; secure; Domain=example.com',
+                'Domain=example.com MYCOOKIE=123456789qwertzuiop; path=/; HttpOnly; Partitioned; SameSite=None; secure'
             ];
             onProxyRes(response);
             expect(response.headers['set-cookie']).toEqual([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16421,27 +16421,6 @@ packages:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
 
-  /mem-fs-editor@9.4.0:
-    resolution: {integrity: sha512-HSSOLSVRrsDdui9I6i96dDtG+oAez/4EB2g4cjSrNhgNQ3M+L57/+22NuPdORSoxvOHjIg/xeOE+C0wwF91D2g==}
-    engines: {node: '>=12.10.0'}
-    peerDependencies:
-      mem-fs: ^2.1.0
-    peerDependenciesMeta:
-      mem-fs:
-        optional: true
-    dependencies:
-      binaryextensions: 4.18.0
-      commondir: 1.0.1
-      deep-extend: 0.6.0
-      ejs: 3.1.9
-      globby: 11.1.0
-      isbinaryfile: 4.0.10
-      minimatch: 3.0.5
-      multimatch: 5.0.0
-      normalize-path: 3.0.0
-      textextensions: 5.14.0
-    dev: false
-
   /mem-fs-editor@9.4.0(mem-fs@2.1.0):
     resolution: {integrity: sha512-HSSOLSVRrsDdui9I6i96dDtG+oAez/4EB2g4cjSrNhgNQ3M+L57/+22NuPdORSoxvOHjIg/xeOE+C0wwF91D2g==}
     engines: {node: '>=12.10.0'}
@@ -21707,7 +21686,7 @@ packages:
       execa: 5.1.1
       github-username: 6.0.0
       lodash: 4.17.21
-      mem-fs-editor: 9.4.0
+      mem-fs-editor: 9.4.0(mem-fs@2.1.0)
       minimist: 1.2.6
       pacote: 15.2.0
       read-pkg-up: 7.0.1


### PR DESCRIPTION
This PR removes the `Partitioned` property if it is present in a cookie. `Partitioned` needs to be used together with `Secure`. If `Secure` is missing then the cookie is considered invalid and it is not set.