### PR TITLE
fix(fpm-writer): use correct namespace when generating typescript controllers of controller extension and custom page controllers

### DIFF
--- a/.changeset/brown-nails-wonder.md
+++ b/.changeset/brown-nails-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+fix: use correct namespace when generating typescript controllers of controller extension and custom page controllers

--- a/packages/fe-fpm-writer/templates/controller-extension/Controller.ts
+++ b/packages/fe-fpm-writer/templates/controller-extension/Controller.ts
@@ -2,7 +2,7 @@ import ControllerExtension from 'sap/ui/core/mvc/ControllerExtension';
 import ExtensionAPI from 'sap/fe/<%- typeof extension === "object" ? `templates/${extension.pageType}` : "core" -%>/ExtensionAPI';
 
 /**
- * @namespace <%- ns %>.<%- name %>
+ * @namespace <%- ns %>
  * @controller
  */
 export default class <%- name %> extends ControllerExtension<ExtensionAPI> {

--- a/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.ts
+++ b/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.ts
@@ -1,7 +1,7 @@
 import Controller from 'sap/ui/core/mvc/Controller'; /** If UI5 version 1.94 or newer can be used, the change the base controller to sap/fe/core/PageController to get full FEv4 FPM support */
 
 /**
- * @namespace <%- ns %>.<%- name %>.controller
+ * @namespace <%- ns %>
  */
 export default class <%- name %> extends Controller {
 

--- a/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.ts
+++ b/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.ts
@@ -1,7 +1,7 @@
 import Controller from "sap/fe/core/PageController";
 
 /**
- * @namespace <%- ns %>.<%- name %>.controller
+ * @namespace <%- ns %>
  */
 export default class <%- name %> extends Controller {
 

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/controller-extension.test.ts.snap
@@ -687,7 +687,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -744,7 +744,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ObjectPage/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -801,7 +801,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -858,7 +858,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/core/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -915,7 +915,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -972,7 +972,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ListReport/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {
@@ -1029,7 +1029,7 @@ exports[`ControllerExtension generateControllerExtension Typescript controller N
 import ExtensionAPI from 'sap/fe/templates/ObjectPage/ExtensionAPI';
 
 /**
- * @namespace my.test.App.ext.controller.NewExtension
+ * @namespace my.test.App.ext.controller
  * @controller
  */
 export default class NewExtension extends ControllerExtension<ExtensionAPI> {

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
@@ -60,7 +60,7 @@ export default class CustomPage extends Controller {
 }"
 `;
 
-exports[`CustomPage Typescript controller lower UI5 version 1`] = `
+exports[`CustomPage Typescript controller lower UI5 version(1.84) 1`] = `
 "import Controller from 'sap/ui/core/mvc/Controller'; /** If UI5 version 1.94 or newer can be used, the change the base controller to sap/fe/core/PageController to get full FEv4 FPM support */
 
 /**

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
@@ -15,6 +15,96 @@ exports[`CustomPage Test property custom "tabSizing" 6 spaces 1`] = `
 CustomPageTitle=CustomPage"
 `;
 
+exports[`CustomPage Typescript controller latest version with minimal input 1`] = `
+"import Controller from \\"sap/fe/core/PageController\\";
+
+/**
+ * @namespace my.test.App.ext.customPage
+ */
+export default class CustomPage extends Controller {
+
+    /**
+     * Called when a controller is instantiated and its View controls (if available) are already created.
+     * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public onInit(): void {
+    //
+    //}
+
+    /**
+     * Similar to onAfterRendering, but this hook is invoked before the controller's View is re-rendered
+     * (NOT before the first rendering! onInit() is used for that one!).
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public  onBeforeRendering(): void {
+    //
+    //  }
+
+    /**
+     * Called when the View has been rendered (so its HTML is part of the document). Post-rendering manipulations of the HTML could be done here.
+     * This hook is the same one that SAPUI5 controls get after being rendered.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public  onAfterRendering(): void {
+    //
+    //  }
+
+    /**
+     * Called when the Controller is destroyed. Use this one to free resources and finalize activities.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public onExit(): void {
+    //
+    //  }
+}"
+`;
+
+exports[`CustomPage Typescript controller lower UI5 version 1`] = `
+"import Controller from 'sap/ui/core/mvc/Controller'; /** If UI5 version 1.94 or newer can be used, the change the base controller to sap/fe/core/PageController to get full FEv4 FPM support */
+
+/**
+ * @namespace my.test.App.ext.customPage
+ */
+export default class CustomPage extends Controller {
+
+    /**
+     * Called when a controller is instantiated and its View controls (if available) are already created.
+     * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public onInit(): void {
+    //
+    //}
+
+    /**
+     * Similar to onAfterRendering, but this hook is invoked before the controller's View is re-rendered
+     * (NOT before the first rendering! onInit() is used for that one!).
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public  onBeforeRendering(): void {
+    //
+    //  }
+
+    /**
+     * Called when the View has been rendered (so its HTML is part of the document). Post-rendering manipulations of the HTML could be done here.
+     * This hook is the same one that SAPUI5 controls get after being rendered.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public  onAfterRendering(): void {
+    //
+    //  }
+
+    /**
+     * Called when the Controller is destroyed. Use this one to free resources and finalize activities.
+     * @memberOf my.test.App.ext.customPage.CustomPage
+     */
+    // public onExit(): void {
+    //
+    //  }
+}"
+`;
+
 exports[`CustomPage generateCustomPage: different navigations inbound navigation defined as array (for FCL) 1`] = `
 Object {
   "config": Object {

--- a/packages/fe-fpm-writer/test/unit/page/custom.test.ts
+++ b/packages/fe-fpm-writer/test/unit/page/custom.test.ts
@@ -272,4 +272,30 @@ describe('CustomPage', () => {
             expect(result).toEqual(expectedAfterSave);
         });
     });
+
+    describe('Typescript controller', () => {
+        const minimalInput: CustomPage = {
+            name: 'CustomPage',
+            entity: 'RootEntity',
+            typescript: true
+        };
+        test('latest version with minimal input', () => {
+            const target = join(testDir, 'minimal-input');
+            fs.write(join(target, 'webapp/manifest.json'), testAppManifest);
+            //act
+            generateCustomPage(target, minimalInput, fs);
+            //check
+            expect(fs.read(join(target, 'webapp/ext/customPage/CustomPage.controller.ts'))).toMatchSnapshot();
+        });
+
+        test('lower UI5 version(1.84)', () => {
+            const target = join(testDir, 'minimal-input');
+            fs.write(join(target, 'webapp/manifest.json'), testAppManifest);
+            const testInput = { ...minimalInput, minUI5Version: '1.84.62' };
+            //act
+            generateCustomPage(target, testInput, fs);
+            //check
+            expect(fs.read(join(target, 'webapp/ext/customPage/CustomPage.controller.ts'))).toMatchSnapshot();
+        });
+    });
 });

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3965,7 +3965,7 @@ export default class Component extends BaseComponent {
     "contents": "import Controller from \\"sap/fe/core/PageController\\";
 
 /**
- * @namespace fefpmts.ext.main.Main.controller
+ * @namespace fefpmts.ext.main
  */
 export default class Main extends Controller {
 


### PR DESCRIPTION
Issue #1552

# Issue
Wrong namespace was created for new controller extension in typescript project:
```
/**
 * @namespace project1.ext.controller.Test
 * @controller
 */
export default class Test extends ControllerExtension<ExtensionAPI> {
```
is compiled as:
```
var Test = ControllerExtension.extend("project1.ext.controller.Test.Test", {
```

Both proposed solutions from Christian works:
```
Solution
The fpm writer should either define
@namespace <%- ns %>
or
@name <%- ns %>.<%- name %>
```

Additionally - I noticed that custom page's controller does not look optimal as well:
```
/**
 * @namespace project1.ext.view.Aaaaaaaa.controller
 */
export default class Aaaaaaaa extends Controller {
```
compiles as:
```
var Aaaaaaaa = Controller.extend("project1.ext.view.Aaaaaaaa.controller.Aaaaaaaa", {
```

If we use generator for js controller, then js version is generated following:
```
 return PageController.extend('project1.ext.view.Aaaaaaaa', {
```

## Result/Solution

In result, applying same solution with `@namespace` approach for both:
1. controller extensions
2. custom page's controllers

____
1. controller extension:
```
/**
 * @namespace project3.ext.controller
 * @controller
 */
export default class Test extends ControllerExtension<ExtensionAPI> {
```
compiled as:
```
var Test = ControllerExtension.extend("project3.ext.controller.Test", {
```
2. custom page's controller:
```
/**
 * @namespace project3.ext.view
 */
export default class Test extends Controller {
```
compiled as:
```
var Test = Controller.extend("project3.ext.view.Test", {
```

As tested with app - both works for me