### PR TITLE
fix: expose getI18nPropertiesPaths and include web.js

### DIFF
--- a/.changeset/slow-ads-sleep.md
+++ b/.changeset/slow-ads-sleep.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/project-access': patch
+'@sap-ux/i18n': patch
+---
+
+fix: expose getI18nPropertiesPaths and include web.js in @sap-ux/i18n

--- a/.changeset/slow-ads-sleep.md
+++ b/.changeset/slow-ads-sleep.md
@@ -3,4 +3,4 @@
 '@sap-ux/i18n': patch
 ---
 
-fix: expose getI18nPropertiesPaths and include web.js in @sap-ux/i18n
+fix: expose getI18nPropertiesPaths and export types for browser in @sap-ux/i18n

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,6 +1,6 @@
 # `@sap-ux/i18n`
 
-Package containing low level APIs and utility functions for working with i18n of a project. For more convenient high level APIs on i18n, check [`@sap-ux/project-access`](../project-access/src/i18n/index.ts)
+Package containing low level APIs and utility functions for working with i18n of a project. For more convenient high level APIs on i18n, check [`@sap-ux/project-access`](../project-access)
 
 
 ## Installation

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -13,6 +13,13 @@
     "license": "Apache-2.0",
     "private": false,
     "main": "dist/index.js",
+    "exports": {
+        ".": {
+            "browser": "./dist/web/index.js",
+            "import": "./dist/index.js",
+            "default": "./dist/index.js"
+        }
+    },
     "scripts": {
         "build": "tsc --build",
         "watch": "tsc --watch",
@@ -44,9 +51,7 @@
         "dist",
         "LICENSE",
         "!dist/*.map",
-        "!dist/**/*.map",
-        "web.js",
-        "web.d.ts"
+        "!dist/**/*.map"
     ],
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -44,7 +44,9 @@
         "dist",
         "LICENSE",
         "!dist/*.map",
-        "!dist/**/*.map"
+        "!dist/**/*.map",
+        "web.js",
+        "web.d.ts"
     ],
     "engines": {
         "pnpm": ">=6.26.1 < 7.0.0 || >=7.1.0",

--- a/packages/i18n/web.d.ts
+++ b/packages/i18n/web.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/web';

--- a/packages/i18n/web.js
+++ b/packages/i18n/web.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./dist/web');

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -18,6 +18,7 @@ export {
     getCdsRoots,
     getCdsServices,
     getCapI18nFolderNames,
+    getI18nPropertiesPaths,
     getMtaPath,
     getNodeModulesPath,
     getProject,

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -1,11 +1,11 @@
 import { relative } from 'path';
+import type { NewI18nEntry } from '@sap-ux/i18n';
 import type {
     ApplicationAccess,
     ProjectAccess,
     Project,
     I18nBundles,
     I18nPropertiesPaths,
-    NewI18nEntry,
     ProjectType,
     ApplicationStructure
 } from '../types';

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -11,7 +11,7 @@ export {
     readCapServiceMetadataEdmx
 } from './cap';
 export { getNodeModulesPath } from './dependencies';
-export { getCapI18nFolderNames } from './i18n';
+export { getCapI18nFolderNames, getI18nPropertiesPaths } from './i18n';
 export { getAppProgrammingLanguage, getAppType, getProject, getProjectType } from './info';
 export { loadModuleFromProject } from './module-loader';
 export { findAllApps, findCapProjects, findFioriArtifacts, findProjectRoot, getAppRootFromWebappPath } from './search';

--- a/packages/project-access/src/types/access/index.ts
+++ b/packages/project-access/src/types/access/index.ts
@@ -1,4 +1,5 @@
-import type { I18nBundles, NewI18nEntry } from '../i18n';
+import type { I18nBundles } from '../i18n';
+import type { NewI18nEntry } from '@sap-ux/i18n';
 import type { ApplicationStructure, I18nPropertiesPaths, Project, ProjectType } from '../info';
 
 interface BaseAccess {

--- a/packages/project-access/src/types/i18n/index.ts
+++ b/packages/project-access/src/types/i18n/index.ts
@@ -1,18 +1,5 @@
 import type { I18nBundle } from '@sap-ux/i18n';
 
-export type {
-    CdsI18nConfiguration,
-    CdsI18nEnv,
-    I18nAnnotation,
-    I18nBundle,
-    I18nEntry,
-    NewI18nEntry,
-    SapTextType,
-    ValueNode
-} from '@sap-ux/i18n';
-
-export { SapShortTextType, SapLongTextType } from '@sap-ux/i18n';
-
 export interface I18nBundles {
     /**
      * i18n bundle for `i18n` of `"sap.app"` namespace in `manifest.json` file


### PR DESCRIPTION
This PR contains:
* expose getI18nPropertiesPaths
 * remove of reexport type from `@sap-ux/i18n`
 * include `exports` in `package.json` file of `@sap-ux/i18n`
