### PR TITLE
fix(jest-matchers): export types from jest matchers

### DIFF
--- a/.changeset/six-candles-dream.md
+++ b/.changeset/six-candles-dream.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/jest-file-matchers': patch
+---
+
+export types

--- a/packages/jest-file-matchers/src/index.ts
+++ b/packages/jest-file-matchers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './matchers';
+export * from './matchers/types';


### PR DESCRIPTION
#1664 

Export types from jest matchers to avoid importing as deeply nested dist references