### PR TITLE
tbi(axios-ext): log error msg for transport check xml response

### DIFF
--- a/.changeset/fair-vans-complain.md
+++ b/.changeset/fair-vans-complain.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+adds more concise logging of error from xml response

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -102,7 +102,7 @@ export class TransportChecksService extends AdtService {
 
         for (const msg of Array.from(messages)) {
             if (msg.getElementsByTagName('SEVERITY')[0]?.textContent === 'E') {
-                const text = msg.getElementsByTagName('TEXT')[0].textContent;
+                const text = msg.getElementsByTagName('TEXT')[0]?.textContent;
                 this.log.error(text);
             }
         }

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -100,9 +100,9 @@ export class TransportChecksService extends AdtService {
     private logErrorMsgs(doc: Document) {
         const messages = doc.getElementsByTagName('CTS_MESSAGE');
 
-        for (let i = 0; i < messages.length; i++) {
-            if (messages[i].getElementsByTagName('SEVERITY')[0].textContent === 'E') {
-                const text = messages[i].getElementsByTagName('TEXT')[0].textContent;
+        for (const msg of messages) {
+            if (msg.getElementsByTagName('SEVERITY')[0].textContent === 'E') {
+                const text = msg.getElementsByTagName('TEXT')[0].textContent;
                 this.log.error(text);
             }
         }

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -100,7 +100,7 @@ export class TransportChecksService extends AdtService {
     private logErrorMsgs(doc: Document) {
         const messages = doc.getElementsByTagName('CTS_MESSAGE');
 
-        for (const msg of messages) {
+        for (const msg of Array.from(messages)) {
             if (msg.getElementsByTagName('SEVERITY')[0].textContent === 'E') {
                 const text = msg.getElementsByTagName('TEXT')[0].textContent;
                 this.log.error(text);

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -101,7 +101,7 @@ export class TransportChecksService extends AdtService {
         const messages = doc.getElementsByTagName('CTS_MESSAGE');
 
         for (const msg of Array.from(messages)) {
-            if (msg.getElementsByTagName('SEVERITY')[0].textContent === 'E') {
+            if (msg.getElementsByTagName('SEVERITY')[0]?.textContent === 'E') {
                 const text = msg.getElementsByTagName('TEXT')[0].textContent;
                 this.log.error(text);
             }

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -84,9 +84,27 @@ export class TransportChecksService extends AdtService {
             case 'S':
                 return this.getTransportList(doc);
             case 'E':
-            default:
-                this.log.warn(`Error or unkown response content: ${xml}`);
+                this.logErrorMsgs(doc);
                 return [];
+            default:
+                this.log.warn(`Unknown response content: ${xml}`);
+                return [];
+        }
+    }
+
+    /**
+     * Parses the document to find and log the <CTS_MESSAGE> with severity 'E' in <MESSAGES>.
+     *
+     * @param doc document
+     */
+    private logErrorMsgs(doc: Document) {
+        const messages = doc.getElementsByTagName('CTS_MESSAGE');
+
+        for (let i = 0; i < messages.length; i++) {
+            if (messages[i].getElementsByTagName('SEVERITY')[0].textContent === 'E') {
+                const text = messages[i].getElementsByTagName('TEXT')[0].textContent;
+                this.log.error(text);
+            }
         }
     }
 

--- a/packages/axios-extension/test/abap/mockResponses/transportChecks-6.xml
+++ b/packages/axios-extension/test/abap/mockResponses/transportChecks-6.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+   <asx:values>
+      <DATA>
+         <PGMID>R3TR</PGMID>
+         <OBJECT>WAPA</OBJECT>
+         <OBJECTNAME>PROJ090123</OBJECTNAME>
+         <OPERATION>I</OPERATION>
+         <DEVCLASS>PACKAGE</DEVCLASS>
+         <KORRFLAG>X</KORRFLAG>
+         <AS4USER />
+         <PDEVCLASS />
+         <DLVUNIT>ZLOCAL</DLVUNIT>
+         <NAMESPACE>/0CUST/</NAMESPACE>
+         <SUPER_PACKAGE />
+         <RESULT>E</RESULT>
+         <RECORDING />
+         <EXISTING_REQ_ONLY />
+         <MESSAGES>
+            <CTS_MESSAGE>
+               <SEVERITY>E</SEVERITY>
+               <SPRSL>E</SPRSL>
+               <ARBGB>TO</ARBGB>
+               <MSGNR>142</MSGNR>
+               <VARIABLES>
+                  <CTS_VARIABLE>
+                     <VARIABLE>WAPA</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE>PROJCM090124</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE>PACKAGE</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE />
+                  </CTS_VARIABLE>
+               </VARIABLES>
+               <TEXT>This is the first error message</TEXT>
+            </CTS_MESSAGE>
+            <CTS_MESSAGE>
+               <SEVERITY>E</SEVERITY>
+               <SPRSL>E</SPRSL>
+               <ARBGB>TO</ARBGB>
+               <MSGNR>142</MSGNR>
+               <VARIABLES>
+                  <CTS_VARIABLE>
+                     <VARIABLE>WAPA</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE>PROJ090123</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE>PACKAGE</VARIABLE>
+                  </CTS_VARIABLE>
+                  <CTS_VARIABLE>
+                     <VARIABLE />
+                  </CTS_VARIABLE>
+               </VARIABLES>
+               <TEXT>This is the second error message</TEXT>
+            </CTS_MESSAGE>
+         </MESSAGES>
+         <REQUESTS />
+         <LOCKS />
+         <TADIRDEVC>PACKAGE</TADIRDEVC>
+         <URI>/sap/bc/adt/filestore/ui5-bsp/objects/PROJ090123/$create</URI>
+         <CTS_PROJECTS />
+      </DATA>
+   </asx:values>
+</asx:abap>


### PR DESCRIPTION
#1671

Rather than showing the raw XML in the case of errors, parse the XML and extract the messages to be displayed clearly as errors

