### PR TITLE
feat: Controller prefix for event handler

### DIFF
--- a/.changeset/beige-timers-buy.md
+++ b/.changeset/beige-timers-buy.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Added optional `controllerPrefix` property to custom action event handler

--- a/packages/fe-fpm-writer/src/common/event-handler.ts
+++ b/packages/fe-fpm-writer/src/common/event-handler.ts
@@ -72,6 +72,7 @@ export function applyEventHandlerConfiguration(
         return eventHandler;
     }
     let insertScript: TextFragmentInsertion | undefined;
+    let controllerPrefix = '';
     // By default - use config name for created file name
     let fileName = config.name;
     if (typeof eventHandler === 'object') {
@@ -82,6 +83,9 @@ export function applyEventHandlerConfiguration(
         if (eventHandler.fileName) {
             // Use passed file name
             fileName = eventHandler.fileName;
+        }
+        if (eventHandler.controllerPrefix) {
+            controllerPrefix = eventHandler.controllerPrefix;
         }
     }
 
@@ -105,5 +109,6 @@ export function applyEventHandlerConfiguration(
         fs.write(controllerPath, content);
     }
     // Return full namespace path to method
-    return `${config.ns}.${fileName}.${eventHandlerFnName}`;
+    const fullNamespace = `${config.ns}.${fileName}.${eventHandlerFnName}`;
+    return controllerPrefix ? `${controllerPrefix}.${fullNamespace}` : `${fullNamespace}`;
 }

--- a/packages/fe-fpm-writer/src/common/event-handler.ts
+++ b/packages/fe-fpm-writer/src/common/event-handler.ts
@@ -72,7 +72,7 @@ export function applyEventHandlerConfiguration(
         return eventHandler;
     }
     let insertScript: TextFragmentInsertion | undefined;
-    let controllerPrefix = '';
+    let controllerPrefix: string | undefined = '';
     // By default - use config name for created file name
     let fileName = config.name;
     if (typeof eventHandler === 'object') {
@@ -84,9 +84,7 @@ export function applyEventHandlerConfiguration(
             // Use passed file name
             fileName = eventHandler.fileName;
         }
-        if (eventHandler.controllerPrefix) {
-            controllerPrefix = eventHandler.controllerPrefix;
-        }
+        controllerPrefix = eventHandler.controllerPrefix;
     }
 
     const ext = typescript ? 'ts' : 'js';

--- a/packages/fe-fpm-writer/src/common/types.ts
+++ b/packages/fe-fpm-writer/src/common/types.ts
@@ -155,6 +155,10 @@ export interface EventHandlerConfiguration {
      * If file exists, then existing file should be appended with passed script fragment.
      */
     insertScript?: TextFragmentInsertion;
+    /**
+     * Controller extension prefix.
+     */
+    controllerPrefix?: '.extension';
 }
 
 export interface EventHandler {

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/action.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/action.test.ts.snap
@@ -151,6 +151,24 @@ exports[`CustomAction generateCustomAction Test property "eventHandler" "eventHa
 "
 `;
 
+exports[`CustomAction generateCustomAction Test property "eventHandler" "eventHandler" is "object", append new function to controller extension 1`] = `
+"sap.ui.define([
+    \\"sap/m/MessageToast\\"
+], function(MessageToast) {
+    'use strict';
+
+    return {
+        onPress: function(oEvent) {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        },
+        onHandleSecondAction: function() {
+            MessageToast.show(\\"Custom handler invoked.\\");
+        }
+    };
+});
+"
+`;
+
 exports[`CustomAction generateCustomAction Test property "eventHandler" "eventHandler" is empty "object" - create new file with default function name 1`] = `
 "sap.ui.define([
     \\"sap/m/MessageToast\\"

--- a/packages/fe-fpm-writer/test/unit/action.test.ts
+++ b/packages/fe-fpm-writer/test/unit/action.test.ts
@@ -347,6 +347,45 @@ describe('CustomAction', () => {
                     expect(fs.read(existingPath)).toMatchSnapshot();
                 }
             );
+
+            test('"eventHandler" is "object", append new function to controller extension', () => {
+                const fileName = 'MyExistingAction';
+                // Create existing file with existing actions
+                const folder = join('ext', 'fragments');
+                const existingPath = join(testDir, 'webapp', folder, `${fileName}.js`);
+                // Generate handler with single method - content should be updated during generating of custom action
+                fs.copyTpl(join(__dirname, '../../templates', 'common/EventHandler.js'), existingPath, {
+                    eventHandlerFnName: 'onPress'
+                });
+                // Create third action - append existing js file
+                const actionName = 'CustomAction2';
+                const fnName = 'onHandleSecondAction';
+                const controllerPrefix = '.extension';
+                // use controller prefix to make sure it is controller extension
+                generateCustomActionWithEventHandler(
+                    actionName,
+                    {
+                        fnName,
+                        fileName,
+                        controllerPrefix,
+                        insertScript: {
+                            fragment:
+                                ',\n        onHandleSecondAction: function() {\n            MessageToast.show("Custom handler invoked.");\n        }',
+                            position: {
+                                line: 8,
+                                character: 9
+                            }
+                        }
+                    },
+                    folder
+                );
+                const manifest = fs.readJSON(join(testDir, 'webapp', 'manifest.json')) as Manifest;
+                const action = getActionByName(manifest, actionName);
+                // Check if action press has controller prefix added
+                expect(action['press']).toEqual(`${controllerPrefix}.my.test.App.ext.fragments.${fileName}.${fnName}`);
+                // Check update js file content
+                expect(fs.read(existingPath)).toMatchSnapshot();
+            });
         });
 
         describe('Test property custom "tabSizing"', () => {


### PR DESCRIPTION
Added `controllerPrefix` property to custom action event handlers. Use it when resolving event handler namespace.