### PR TITLE
fix: getI18nBundles and add JSDoc

### DIFF
--- a/.changeset/slow-shoes-exercise.md
+++ b/.changeset/slow-shoes-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+fix: enhance `getI18nBundles` to be more tolerant

--- a/.eslintrc
+++ b/.eslintrc
@@ -124,7 +124,8 @@
                     "ClassDeclaration": true,
                     "MethodDefinition": true
                 },
-                "exemptEmptyFunctions": true
+                "exemptEmptyFunctions": true,
+                "contexts": ["TSMethodSignature"]
             }
         ],
         "jsdoc/valid-types": "error",

--- a/packages/axios-extension/src/abap/adt-catalog/services/adt-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/adt-service.ts
@@ -3,6 +3,11 @@ import type { AdtCategory, AdtCollection } from 'abap/types';
 import { Axios } from 'axios';
 
 interface AdtServiceExtension {
+    /**
+     * Attaches an ADT schema to the service.
+     *
+     * @param serviceSchema - The ADT collection to attach.
+     */
     attachAdtSchema(serviceSchema: AdtCollection): void;
 }
 

--- a/packages/axios-extension/src/auth/reentrance-ticket/redirect.ts
+++ b/packages/axios-extension/src/auth/reentrance-ticket/redirect.ts
@@ -7,6 +7,12 @@ import type { ABAPSystem } from './abap-system';
 
 interface Redirect {
     server: http.Server;
+    /**
+     * Redirect URL.
+     *
+     * @param port Port number.
+     * @returns Redirect URL.
+     */
     redirectUrl(port: number): string;
 }
 

--- a/packages/axios-extension/src/base/odata-service.ts
+++ b/packages/axios-extension/src/base/odata-service.ts
@@ -15,7 +15,17 @@ export interface ServiceDocument {
 }
 
 export interface ODataServiceExtension {
+    /**
+     * Retrieves the service document.
+     *
+     * @returns A Promise that resolves to a ServiceDocument
+     */
     document(): Promise<ServiceDocument>;
+    /**
+     * Retrieves the metadata of the service.
+     *
+     * @returns A Promise that resolves to a string containing the metadata
+     */
     metadata(): Promise<string>;
 }
 
@@ -47,6 +57,9 @@ function parseODataResponse<T>(): T {
 }
 
 export interface ODataResponse<T> extends AxiosResponse {
+    /**
+     *
+     */
     odata(): T;
 }
 

--- a/packages/axios-extension/src/base/service-provider.ts
+++ b/packages/axios-extension/src/base/service-provider.ts
@@ -20,6 +20,12 @@ export interface ProviderConfiguration {
 }
 
 export interface ServiceProviderExtension {
+    /**
+     * Retrieves the service based on the provided path.
+     *
+     * @param path - The path of the service.
+     * @returns service.
+     */
     service(path: string): Service;
 }
 

--- a/packages/control-property-editor/src/panels/properties/PropertyDocumentation.tsx
+++ b/packages/control-property-editor/src/panels/properties/PropertyDocumentation.tsx
@@ -18,6 +18,12 @@ export interface PropertyDocumentationProps {
     description: string;
     propertyName: string;
     propertyType: string | undefined;
+    /**
+     * Optional callback function for delete event.
+     *
+     * @param controlId - The ID of the control.
+     * @param propertyName - The name of the property.
+     */
     onDelete?(controlId: string, propertyName: string): void;
 }
 /**

--- a/packages/environment-check/src/types.ts
+++ b/packages/environment-check/src/types.ts
@@ -170,7 +170,17 @@ export enum DirName {
 }
 
 export interface ILogger extends Logger {
+    /**
+     * Pushes new messages to the logger.
+     *
+     * @param newMessages - An array of ResultMessage objects representing the new messages to be added.
+     */
     push(...newMessages: ResultMessage[]): void;
+    /**
+     * Retrieves all the messages stored in the logger.
+     *
+     * @returns An array of ResultMessage objects representing the stored messages.
+     */
     getMessages(): ResultMessage[];
 }
 

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -138,7 +138,7 @@ class ApplicationAccessImp implements ApplicationAccess {
     /**
      * For a given app in project, retrieves i18n bundles for 'sap.app' namespace,`models` of `sap.ui5` namespace and service for cap services.
      *
-     * @returns i18n bundles or exception for respective bundle
+     * @returns i18n bundles or exception captured in optional errors object
      */
     getI18nBundles(): Promise<I18nBundles> {
         return getI18nBundles(this.project.root, this.app.i18n, this.project.projectType, this.fs);

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -138,7 +138,7 @@ class ApplicationAccessImp implements ApplicationAccess {
     /**
      * For a given app in project, retrieves i18n bundles for 'sap.app' namespace,`models` of `sap.ui5` namespace and service for cap services.
      *
-     * @returns i18n bundles or exception
+     * @returns i18n bundles or exception for respective bundle
      */
     getI18nBundles(): Promise<I18nBundles> {
         return getI18nBundles(this.project.root, this.app.i18n, this.project.projectType, this.fs);

--- a/packages/project-access/src/project/i18n/read.ts
+++ b/packages/project-access/src/project/i18n/read.ts
@@ -5,7 +5,7 @@ import type { Editor } from 'mem-fs-editor';
 
 /**
  * Add error to optional errors object.
- * 
+ *
  * @param result i18n bundles
  * @param key key to associate with the error
  * @param error error to add
@@ -49,7 +49,7 @@ export async function getI18nBundles(
         try {
             result.models[key] = await getPropertiesI18nBundle(i18nPropertiesPaths.models[key].path, fs);
         } catch (error) {
-            // add models key with empty model 
+            // add models key with empty model
             result.models[key] = {};
 
             addToErrors(result, `models.${key}`, error);
@@ -62,7 +62,7 @@ export async function getI18nBundles(
             const cdsFiles = await getCdsFiles(root, true);
             result.service = await getCapI18nBundle(root, env, cdsFiles, fs);
         } catch (error) {
-            addToErrors(result, 'service', error)
+            addToErrors(result, 'service', error);
         }
     }
 

--- a/packages/project-access/src/project/i18n/read.ts
+++ b/packages/project-access/src/project/i18n/read.ts
@@ -47,7 +47,7 @@ async function tryGetCapI18nBundle(root: string, fs?: Editor): Promise<I18nBundl
  * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node.
  * In case of CAP project, some CDS APIs are used internally which depends on `fs` of node and not `mem-fs-editor`.
  * When calling this function, adding or removing a CDS file in memory or changing CDS configuration will not be considered until present on real file system.
- * @returns i18n bundles or exception
+ * @returns i18n bundles or exception for respective bundle
  */
 export async function getI18nBundles(
     root: string,

--- a/packages/project-access/src/types/access/index.ts
+++ b/packages/project-access/src/types/access/index.ts
@@ -10,13 +10,89 @@ interface BaseAccess {
 
 export interface ApplicationAccess extends BaseAccess {
     readonly app: ApplicationStructure;
+    /**
+     * Maintains new translation entries in an existing i18n file or in a new i18n properties file if it does not exist.
+     *
+     * @param newEntries - translation entries to write in the `.properties` file
+     * @returns - boolean or exception
+     * @description It also update `manifest.json` file if `@i18n` entry is missing from `"sap.ui5":{"models": {}}`
+     * as
+     * ```JSON
+     * {
+     *      "sap.ui5": {
+     *          "models": {
+     *              "@i18n": {
+     *                  "type": "sap.ui.model.resource.ResourceModel",
+     *                  "uri": "i18n/i18n.properties"
+     *              }
+     *          }
+     *      }
+     * }
+     * ```
+     */
     createAnnotationI18nEntries(newEntries: NewI18nEntry[]): Promise<boolean>;
+    /**
+     * Maintains new translation entries in an existing i18n file or in a new i18n properties file if it does not exist.
+     *
+     * @param newEntries - translation entries to write in the `.properties` file
+     * @param modelKey - i18n model key. Default key is `i18n`
+     * @returns boolean or exception
+     * @description It also update `manifest.json` file if `<modelKey>` entry is missing from `"sap.ui5":{"models": {}}`
+     * as
+     * ```JSON
+     * {
+     *      "sap.ui5": {
+     *          "models": {
+     *              "<modelKey>": {
+     *                  "type": "sap.ui.model.resource.ResourceModel",
+     *                  "uri": "i18n/i18n.properties"
+     *              }
+     *          }
+     *      }
+     * }
+     * ```
+     */
     createUI5I18nEntries(newEntries: NewI18nEntry[], modelKey?: string): Promise<boolean>;
+    /**
+     * Maintains new translation entries in an existing i18n file or in a new i18n properties file if it does not exist.
+     *
+     * @param newEntries translation entries to write in the `.properties` file
+     * @returns boolean or exception
+     * @description If `i18n` entry is missing from `"sap.app":{}`, default `i18n/i18n.properties` is used. Update of `manifest.json` file is not needed.
+     */
     createManifestI18nEntries(newEntries: NewI18nEntry[]): Promise<boolean>;
+    /**
+     * Maintains new translation entries in CAP i18n files.
+     *
+     * @param filePath file in which the translation entry will be used.
+     * @param newI18nEntries translation entries to write in the i18n file.
+     * @returns boolean or exception
+     */
     createCapI18nEntries(filePath: string, newI18nEntries: NewI18nEntry[]): Promise<boolean>;
+    /**
+     * Return the application id of this app, which is the relative path from the project root
+     * to the app root.
+     *
+     * @returns - Application root path
+     */
     getAppId(): string;
+    /**
+     * Return the absolute application root path.
+     *
+     * @returns - Application root path
+     */
     getAppRoot(): string;
+    /**
+     * For a given app in project, retrieves i18n bundles for 'sap.app' namespace,`models` of `sap.ui5` namespace and service for cap services.
+     *
+     * @returns i18n bundles or exception
+     */
     getI18nBundles(): Promise<I18nBundles>;
+    /**
+     * Return absolute paths to i18n.properties files from manifest.
+     *
+     * @returns absolute paths to i18n.properties
+     */
     getI18nPropertiesPaths(): Promise<I18nPropertiesPaths>;
 }
 

--- a/packages/project-access/src/types/cap/index.ts
+++ b/packages/project-access/src/types/cap/index.ts
@@ -116,6 +116,12 @@ interface Entity extends Struct {
 }
 
 interface LinkedDefinition {
+    /**
+     * Checks if the definition is of the specified kind or has the 'Association' or 'Composition' kind.
+     *
+     * @param {kind | 'Association' | 'Composition'} kind - The kind to check for.
+     * @returns {boolean} - True if the definition is of the specified kind or has the 'Association' or 'Composition' kind, false otherwise.
+     */
     is(kind: kind | 'Association' | 'Composition'): boolean;
     name: string;
 }

--- a/packages/project-access/src/types/i18n/index.ts
+++ b/packages/project-access/src/types/i18n/index.ts
@@ -4,15 +4,15 @@ export interface I18nBundles {
     /**
      * i18n bundle for `i18n` of `"sap.app"` namespace in `manifest.json` file
      */
-    'sap.app': I18nBundle;
+    'sap.app': I18nBundle | Error;
     /**
      * i18n bundle for `models` entry of `sap.ui5` namespace in `manifest.json` file with type `sap.ui.model.resource.ResourceModel`
      */
     models: {
-        [modelKey: string]: I18nBundle;
+        [modelKey: string]: I18nBundle | Error;
     };
     /**
      * i18n bundle for cap services
      */
-    service: I18nBundle;
+    service: I18nBundle | Error;
 }

--- a/packages/project-access/src/types/i18n/index.ts
+++ b/packages/project-access/src/types/i18n/index.ts
@@ -4,15 +4,19 @@ export interface I18nBundles {
     /**
      * i18n bundle for `i18n` of `"sap.app"` namespace in `manifest.json` file
      */
-    'sap.app': I18nBundle | Error;
+    'sap.app': I18nBundle;
     /**
      * i18n bundle for `models` entry of `sap.ui5` namespace in `manifest.json` file with type `sap.ui.model.resource.ResourceModel`
      */
     models: {
-        [modelKey: string]: I18nBundle | Error;
+        [modelKey: string]: I18nBundle;
     };
     /**
      * i18n bundle for cap services
      */
-    service: I18nBundle | Error;
+    service: I18nBundle;
+    /**
+     * Optional errors object containing error records of i18n bundles
+     */
+    errors?: Record<string, Error>;
 }

--- a/packages/project-access/test/project/access.test.ts
+++ b/packages/project-access/test/project/access.test.ts
@@ -3,6 +3,7 @@ import { createApplicationAccess, createProjectAccess } from '../../src';
 import * as i18nMock from '../../src/project/i18n/write';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
+import type { I18nBundle } from '@sap-ux/i18n';
 
 describe('Test function createApplicationAccess()', () => {
     const memFs = create(createStorage());
@@ -39,9 +40,10 @@ describe('Test function createApplicationAccess()', () => {
         const appAccess = await createApplicationAccess(appRoot);
         const i18nBundles = await appAccess.getI18nBundles();
         const i18nPropertiesPaths = await appAccess.getI18nPropertiesPaths();
-        expect(i18nBundles['sap.app'].testTextKey[0].key.value).toBe('testTextKey');
-        expect(i18nBundles['sap.app'].testTextKey[0].value.value).toBe('Test Text Value');
-        expect(i18nBundles['sap.app'].testTextKey[0].annotation?.textType.value).toBe(' Test comment');
+        const app = i18nBundles['sap.app'] as I18nBundle;
+        expect(app.testTextKey[0].key.value).toBe('testTextKey');
+        expect(app.testTextKey[0].value.value).toBe('Test Text Value');
+        expect(app.testTextKey[0].annotation?.textType.value).toBe(' Test comment');
         expect(i18nPropertiesPaths).toEqual({
             'sap.app': join(appRoot, 'webapp/i18n/i18n.properties'),
             'models': {
@@ -59,9 +61,10 @@ describe('Test function createApplicationAccess()', () => {
         const appAccess = await createApplicationAccess(appRoot, memFs);
         const i18nBundles = await appAccess.getI18nBundles();
         const i18nPropertiesPaths = await appAccess.getI18nPropertiesPaths();
-        expect(i18nBundles['sap.app'].testTextKey[0].key.value).toBe('testTextKey');
-        expect(i18nBundles['sap.app'].testTextKey[0].value.value).toBe('Test Text Value');
-        expect(i18nBundles['sap.app'].testTextKey[0].annotation?.textType.value).toBe(' Test comment');
+        const app = i18nBundles['sap.app'] as I18nBundle;
+        expect(app.testTextKey[0].key.value).toBe('testTextKey');
+        expect(app.testTextKey[0].value.value).toBe('Test Text Value');
+        expect(app.testTextKey[0].annotation?.textType.value).toBe(' Test comment');
         expect(i18nPropertiesPaths).toEqual({
             'sap.app': join(appRoot, 'webapp/i18n/i18n.properties'),
             'models': {

--- a/packages/project-access/test/project/access.test.ts
+++ b/packages/project-access/test/project/access.test.ts
@@ -3,7 +3,6 @@ import { createApplicationAccess, createProjectAccess } from '../../src';
 import * as i18nMock from '../../src/project/i18n/write';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
-import type { I18nBundle } from '@sap-ux/i18n';
 
 describe('Test function createApplicationAccess()', () => {
     const memFs = create(createStorage());
@@ -40,7 +39,7 @@ describe('Test function createApplicationAccess()', () => {
         const appAccess = await createApplicationAccess(appRoot);
         const i18nBundles = await appAccess.getI18nBundles();
         const i18nPropertiesPaths = await appAccess.getI18nPropertiesPaths();
-        const app = i18nBundles['sap.app'] as I18nBundle;
+        const app = i18nBundles['sap.app'];
         expect(app.testTextKey[0].key.value).toBe('testTextKey');
         expect(app.testTextKey[0].value.value).toBe('Test Text Value');
         expect(app.testTextKey[0].annotation?.textType.value).toBe(' Test comment');
@@ -61,7 +60,7 @@ describe('Test function createApplicationAccess()', () => {
         const appAccess = await createApplicationAccess(appRoot, memFs);
         const i18nBundles = await appAccess.getI18nBundles();
         const i18nPropertiesPaths = await appAccess.getI18nPropertiesPaths();
-        const app = i18nBundles['sap.app'] as I18nBundle;
+        const app = i18nBundles['sap.app'];
         expect(app.testTextKey[0].key.value).toBe('testTextKey');
         expect(app.testTextKey[0].value.value).toBe('Test Text Value');
         expect(app.testTextKey[0].annotation?.textType.value).toBe(' Test comment');

--- a/packages/project-access/test/project/i18n/read.test.ts
+++ b/packages/project-access/test/project/i18n/read.test.ts
@@ -127,7 +127,12 @@ describe('read', () => {
                     },
                     'CAPNodejs'
                 );
-                expect(result).toEqual({ 'sap.app': data, models: {}, service: 'error-raised' });
+                expect(result).toEqual({
+                    'sap.app': data,
+                    models: {},
+                    service: {},
+                    errors: { service: 'error-raised' }
+                });
                 expect(getPropertiesI18nBundleSpy).toHaveBeenNthCalledWith(1, absolutePath, undefined);
                 expect(getCapEnvironmentSoy).toHaveBeenNthCalledWith(1, root);
                 expect(getCdsFilesSpy).toHaveBeenNthCalledWith(1, root, true);
@@ -149,14 +154,18 @@ describe('read', () => {
                 const result = await getI18nBundles(root, {
                     'sap.app': absolutePath,
                     models: {
-                        'i18n': { path: absolutePathI18n },
+                        i18n: { path: absolutePathI18n },
                         '@i18n': { path: absolutePathAtI18n }
                     }
                 });
                 expect(result).toEqual({
-                    'sap.app': 'error-raised-app',
-                    models: { i18n: 'error-raised-model-i18n', '@i18n': data },
-                    service: {}
+                    'sap.app': {},
+                    models: { i18n: {}, '@i18n': data },
+                    service: {},
+                    errors: {
+                        'sap.app': 'error-raised-app',
+                        'models.i18n': 'error-raised-model-i18n'
+                    }
                 });
                 expect(getPropertiesI18nBundleSpy).toHaveBeenNthCalledWith(1, absolutePath, undefined);
                 expect(getPropertiesI18nBundleSpy).toHaveBeenNthCalledWith(2, absolutePathI18n, undefined);

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -34,7 +34,15 @@ export interface UIComboBoxProps extends IComboBoxProps, UIMessagesExtendedProps
     useComboBoxAsMenuMinWidth?: boolean;
     // Default value for "openMenuOnClick" is "true"
     openMenuOnClick?: boolean;
+    /**
+     * An optional callback function for refresh event.
+     */
     onRefresh?(): void;
+    /**
+     * An optional callback function to handle change.
+     *
+     * @param value - The new value of the combo box.
+     */
     onHandleChange?(value: string | number): void;
     tooltipRefreshButton?: string;
     isLoading?: boolean;

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -20,8 +20,23 @@ export { IDropdownOption as UIDropdownOption };
 export { DropdownMenuItemType as UIDropdownMenuItemType };
 
 export interface UIDropdownProps extends IDropdownProps, UIMessagesExtendedProps {
+    /**
+     * An optional callback function to handle change.
+     *
+     * @param option - The selected option.
+     * @param index - The index of the selected option.
+     */
     onHandleChange?(option: IDropdownOption, index: number): void;
+    /**
+     * An optional callback function to handle open event.
+     */
     onHandleOpen?(): void;
+    /**
+     * An optional callback function to render the title of the dropdown.
+     *
+     * @param items - The options of the dropdown.
+     * @returns The JSX element representing the title.
+     */
     onHandleRenderTitle?(items: IDropdownOption[] | undefined): JSX.Element;
     useDropdownAsMenuMinWidth?: boolean;
     readOnly?: boolean;

--- a/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbar.tsx
@@ -9,6 +9,12 @@ export interface UIToolbarProps {
     breakPointLarge?: number;
     breakPointMedium?: number;
     breakPointSmall?: number;
+    /**
+     * An optional callback function triggered when the toolbar is resized.
+     *
+     * @param {number} width - The new width of the toolbar.
+     * @param {string} widthName - The name of the width.
+     */
     onResize?(width: number, widthName: string): void;
 }
 

--- a/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
+++ b/packages/ui-components/src/components/UITreeDropdown/UITreeDropdown.tsx
@@ -39,6 +39,11 @@ export interface UITreeDropdownProps extends UIMessagesExtendedProps {
     required?: boolean;
     value?: string;
     items: ItemsProps[];
+    /**
+     * Callback function to handle parameter value changes.
+     *
+     * @param value - The new value of the parameter.
+     */
     onParameterValueChange(value: string): void;
     placeholderText: string;
     valueSeparator?: string;


### PR DESCRIPTION
This PR address:
* improvement in `getI18nBundles` 
Currently `getI18nBundles` throw exception if it fails for any bundle it tries to retrieve. This PR enhances to be more tolerant and tries all bundles. If there is any exception, it is captured in optional errors object.
* enhance eslint for JSDoc
Report on  missing  of JSDoc for `TSMethodSignature`