### PR TITLE
FIX: preview of adp projects with controller extensions written in typescript

### DIFF
--- a/.changeset/wet-ducks-cough.md
+++ b/.changeset/wet-ducks-cough.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': patch
+---
+
+FIX: preview of controller extensions in typescript

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -121,9 +121,11 @@ export class AdpPreview {
         } else if (req.path === '/Component-preload.js') {
             res.status(404).send();
         } else {
-            const files = await this.project.byGlob(req.path);
+            // check if the requested file exists in the file system (replace .js with .* for typescript)
+            const files = await this.project.byGlob(req.path.replace('.js', '.*'));
             if (files.length === 1) {
-                res.status(200).send(await files[0].getString());
+                // redirect to the exposed path so that other middlewares can handle it
+                res.redirect(302, req.path);
             } else {
                 next();
             }

--- a/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
+++ b/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
@@ -197,15 +197,14 @@ describe('AdaptationProject', () => {
         });
 
         test('/local.file', async () => {
-            const testFileContent = '~test';
+            const localPath = '/local.file';
             mockProject.byGlob.mockResolvedValueOnce([
                 {
-                    getPath: () => '/local.file',
-                    getString: () => testFileContent
+                    getPath: () => localPath
                 }
             ]);
-            const response = await server.get(`${mockMergedDescriptor.url}/local.file`).expect(200);
-            expect(response.text).toEqual(testFileContent);
+            const response = await server.get(`${mockMergedDescriptor.url}${localPath}`).expect(302);
+            expect(response.text).toEqual(`Found. Redirecting to ${localPath}`);
         });
 
         test('/original.file', async () => {

--- a/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
+++ b/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
@@ -196,15 +196,16 @@ describe('AdaptationProject', () => {
             await server.get('/my/adaptation/Component-preload.js').expect(404);
         });
 
-        test('/local.file', async () => {
-            const localPath = '/local.file';
+        test('/local-file.ts', async () => {
+            const localPath = '/local-file';
             mockProject.byGlob.mockResolvedValueOnce([
                 {
-                    getPath: () => localPath
+                    getPath: () => `${localPath}.ts`
                 }
             ]);
-            const response = await server.get(`${mockMergedDescriptor.url}${localPath}`).expect(302);
-            expect(response.text).toEqual(`Found. Redirecting to ${localPath}`);
+            const response = await server.get(`${mockMergedDescriptor.url}${localPath}.js`).expect(302);
+            expect(response.text).toEqual(`Found. Redirecting to ${localPath}.js`);
+            expect(mockProject.byGlob).toBeCalledWith(`${localPath}.*`);
         });
 
         test('/original.file', async () => {


### PR DESCRIPTION
Instead of trying to handle the loading of local files in the preview middleware, just redirect to root so that the other UI5 middleware can handle the loading.