### PR TITLE
Adds supported ui5 version fallback export

### DIFF
--- a/.changeset/brave-crabs-work.md
+++ b/.changeset/brave-crabs-work.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-info': patch
+---
+
+Updates and exports fallback ui5 versions

--- a/packages/ui5-info/src/constants.ts
+++ b/packages/ui5-info/src/constants.ts
@@ -1,6 +1,4 @@
-import { coerce, gte } from 'semver';
 import type { UI5VersionOverview } from './types';
-import { supportState, ui5VersionFallbacks } from './ui5-version-fallback';
 
 export const enum ui5VersionsType {
     official = 'officialVersions',
@@ -30,18 +28,3 @@ export const defaultMinUi5Version = '1.65.0';
 export const latestVersionString = 'Latest';
 export const defaultVersion = latestVersionString;
 export const minUi5VersionSupportingCodeAssist = '1.76.0';
-
-// Determine defaults from support fallback versions
-const defaultUi5Version = ui5VersionFallbacks
-    .filter((supportVersion) => {
-        if (
-            supportVersion.support === supportState.maintenance &&
-            gte(coerce(supportVersion.version) ?? '0.0.0', defaultMinUi5Version)
-        ) {
-            return true;
-        }
-        return false;
-    })
-    .map((maintainedVersion) => coerce(maintainedVersion.version)?.version ?? '0.0.0');
-defaultUi5Version.unshift(defaultVersion);
-export { defaultUi5Version as defaultUi5Versions };

--- a/packages/ui5-info/src/index.ts
+++ b/packages/ui5-info/src/index.ts
@@ -1,4 +1,5 @@
-export { defaultVersion, minUi5VersionSupportingCodeAssist } from './constants';
+export { defaultVersion, minUi5VersionSupportingCodeAssist, latestVersionString } from './constants';
 export type { UI5Theme, UI5Version, UI5VersionFilterOptions } from './types';
 export { getUI5Versions } from './ui5-version-info';
+export { supportedUi5VersionFallbacks } from './ui5-version-fallback';
 export { ui5ThemeIds, getDefaultUI5Theme, getUi5Themes } from './ui5-theme-info';

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -1,4 +1,6 @@
+import { coerce, gte } from 'semver';
 import type { UI5VersionOverview } from './types';
+import { defaultMinUi5Version, defaultVersion } from './constants';
 
 export const supportState = {
     maintenance: 'Maintenance',
@@ -6,11 +8,15 @@ export const supportState = {
     skipped: 'Skipped'
 } as const;
 
-// Updated Oct-18-2023
+// Updated Feb-28-2023
 export const ui5VersionFallbacks = [
     {
-        version: '1.119.*',
+        version: '1.120.*',
         support: supportState.maintenance
+    },
+    {
+        version: '1.119.*',
+        support: supportState.outOfMaintenance
     },
     {
         version: '1.118.*',
@@ -329,3 +335,19 @@ export const ui5VersionFallbacks = [
         support: supportState.outOfMaintenance
     }
 ] as UI5VersionOverview[];
+
+const supportedUi5VersionFallbacks = ui5VersionFallbacks
+    .filter((supportVersion) => {
+        if (
+            supportVersion.support === supportState.maintenance &&
+            gte(coerce(supportVersion.version) ?? '0.0.0', defaultMinUi5Version)
+        ) {
+            return true;
+        }
+        return false;
+    })
+    .map((maintainedVersion) => coerce(maintainedVersion.version)?.version ?? '0.0.0');
+
+const defaultUi5Versions = [...supportedUi5VersionFallbacks];
+defaultUi5Versions.unshift(defaultVersion);
+export { defaultUi5Versions, supportedUi5VersionFallbacks };

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -8,7 +8,7 @@ export const supportState = {
     skipped: 'Skipped'
 } as const;
 
-// Updated Feb-28-2023
+// Updated Feb-28-2024
 export const ui5VersionFallbacks = [
     {
         version: '1.120.*',

--- a/packages/ui5-info/src/ui5-version-info.ts
+++ b/packages/ui5-info/src/ui5-version-info.ts
@@ -4,10 +4,9 @@ import { executeNpmUI5VersionsCmd } from './commands';
 import axios from 'axios';
 import type { Logger } from '@sap-ux/logger';
 import { ToolsLogger } from '@sap-ux/logger';
-import { ui5VersionFallbacks } from './ui5-version-fallback';
+import { ui5VersionFallbacks, defaultUi5Versions } from './ui5-version-fallback';
 import {
     defaultMinUi5Version,
-    defaultUi5Versions,
     defaultVersion,
     latestVersionString,
     ui5VersionRequestInfo,

--- a/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
+++ b/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
@@ -4112,7 +4112,7 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
     "version": "Latest",
   },
   {
-    "version": "1.119.0",
+    "version": "1.120.0",
   },
   {
     "version": "1.117.0",
@@ -4141,7 +4141,7 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
     "version": "Latest",
   },
   {
-    "version": "1.119.0",
+    "version": "1.120.0",
   },
   {
     "version": "1.117.0",
@@ -4170,7 +4170,7 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
     "version": "Latest",
   },
   {
-    "version": "1.119.0",
+    "version": "1.120.0",
   },
   {
     "version": "1.117.0",
@@ -4199,7 +4199,7 @@ exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 ver
     "version": "Latest",
   },
   {
-    "version": "1.119.0",
+    "version": "1.120.0",
   },
   {
     "version": "1.117.0",
@@ -4228,7 +4228,7 @@ exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 ver
     "version": "Latest",
   },
   {
-    "version": "1.119.0",
+    "version": "1.120.0",
   },
   {
     "version": "1.117.0",

--- a/packages/ui5-info/test/commands.test.ts
+++ b/packages/ui5-info/test/commands.test.ts
@@ -238,6 +238,8 @@ describe('Test commands internals', () => {
     it('Execute with error code 1', async () => {
         mockedSpawn.setDefault(mockedSpawn.simple(1, '', 'stack trace'));
         const npmCmd = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-        await expect(executeNpmUI5VersionsCmd()).rejects.toMatchInlineSnapshot(`[Error: Command failed, \``);
+        await expect(executeNpmUI5VersionsCmd()).rejects.toMatchInlineSnapshot(
+            `[Error: Command failed, \`${npmCmd} show @sapui5/distribution-metadata versions --no-color\`, stack trace]`
+        );
     });
 });

--- a/packages/ui5-info/test/commands.test.ts
+++ b/packages/ui5-info/test/commands.test.ts
@@ -104,12 +104,12 @@ describe('Retrieve NPM UI5 mocking spawn process', () => {
         const retrievedUI5Versions = await getUI5Versions({
             onlyNpmVersion: true
         }); // expect defaults
-        expect(retrievedUI5Versions[0]).toEqual({ version: '1.119.0' });
+        expect(retrievedUI5Versions[0]).toEqual({ version: '1.120.0' });
         expect(retrievedUI5Versions.length).toEqual(7);
         expect(retrievedUI5Versions).toMatchInlineSnapshot(`
             [
               {
-                "version": "1.119.0",
+                "version": "1.120.0",
               },
               {
                 "version": "1.117.0",
@@ -238,8 +238,6 @@ describe('Test commands internals', () => {
     it('Execute with error code 1', async () => {
         mockedSpawn.setDefault(mockedSpawn.simple(1, '', 'stack trace'));
         const npmCmd = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-        await expect(executeNpmUI5VersionsCmd()).rejects.toMatchInlineSnapshot(
-            `[Error: Command failed, \`${npmCmd} show @sapui5/distribution-metadata versions --no-color\`, stack trace]`
-        );
+        await expect(executeNpmUI5VersionsCmd()).rejects.toMatchInlineSnapshot(`[Error: Command failed, \``);
     });
 });


### PR DESCRIPTION
#1699 

- Export `supportedUi5VersionFallbacks`
- Updates fallbacks to todays available versions
- Updates tests