### PR TITLE
fix(store): export getSecureStore

### DIFF
--- a/.changeset/soft-students-help.md
+++ b/.changeset/soft-students-help.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/store': patch
+---
+
+Export getSecureStore()

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -40,7 +40,7 @@ export * from './services';
 export * from './entities/backend-system';
 export * from './entities/telemetry-setting';
 export * from './entities/api-hub';
-
+export { getSecureStore } from './secure-store';
 // @todo: change notification needs to be more generic and not tied to filesystems
 // Support any filesystem watchers
 export { getFilesystemWatcherFor } from './data-access';


### PR DESCRIPTION
To consume store for all Fiori tools we need `getSecureStore()` to be exported on root level