### PR TITLE
fix(ui-components): Support VSCode theme color styling for UIIconButton property 'checked'

### DIFF
--- a/.changeset/weak-ladybugs-sparkle.md
+++ b/.changeset/weak-ladybugs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIIconButton. Apply vscode theme variables for UIIconButton when 'checked' property is set as 'true'

--- a/packages/ui-components/src/components/UIButton/UIIconButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIIconButton.tsx
@@ -96,6 +96,30 @@ export class UIIconButton extends React.Component<ButtonProps, {}> {
             },
             menuIcon: {
                 display: 'none'
+            },
+            rootChecked: {
+                backgroundColor: 'var(--vscode-button-background)',
+                color: 'var(--vscode-button-foreground)',
+                outline: '1px solid var(--vscode-contrastActiveBorder)',
+                selectors: {
+                    // Move focus border otside of root box, because selection background covers inner border
+                    '.ms-Fabric--isFocusVisible &:focus:after': {
+                        inset: '-1px'
+                    }
+                }
+            },
+            rootCheckedHovered: {
+                backgroundColor: 'var(--vscode-button-hoverBackground)',
+                outline: '1px dashed var(--vscode-contrastActiveBorder)'
+            },
+            iconChecked: {
+                color: 'var(--vscode-button-foreground)',
+                selectors: {
+                    // Inherit color from icon
+                    '> svg *': {
+                        fill: 'currentColor'
+                    }
+                }
             }
         };
     };

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -27,7 +27,6 @@ export const defaultUsage = (): JSX.Element => {
         btn2: true,
         btn3: true
     });
-    console.log(checked);
 
     const onCallback = (key?: string) => {
         setSelection(key);

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -22,9 +22,23 @@ const stackTokens: IStackTokens = { childrenGap: 40 };
 
 export const defaultUsage = (): JSX.Element => {
     const [selection, setSelection] = useState<string>('');
+    const [checked, setChecked] = useState<{ [key: string]: boolean }>({
+        btn1: true,
+        btn2: true,
+        btn3: true
+    });
+    console.log(checked);
 
     const onCallback = (key?: string) => {
         setSelection(key);
+    };
+
+    const onToggleChecked = (id: string) => {
+        const newChecked = {
+            ...checked,
+            [id]: !checked[id]
+        };
+        setChecked(newChecked);
     };
 
     const getMenuItem = (key: string, text: string, icon?: UiIcons): UIContextualMenuItem => {
@@ -166,6 +180,32 @@ export const defaultUsage = (): JSX.Element => {
                         iconProps={{ iconName: UiIcons.Source }}
                         disabled={true}
                         title="Undo"></UIIconButton>
+                </Stack>
+            </Stack>
+            <Stack tokens={stackTokens}>
+                <Text variant={'large'} className="textColor" block>
+                    Icon Button - Checked
+                </Text>
+                <Stack horizontal tokens={stackTokens}>
+                    <UIIconButton
+                        id="btn1"
+                        iconProps={{ iconName: UiIcons.Undo }}
+                        checked={checked.btn1}
+                        onClick={onToggleChecked.bind(window, 'btn1')}
+                        title="Undo"></UIIconButton>
+                    <UIIconButton
+                        id="btn2"
+                        checked={checked.btn2}
+                        iconProps={{ iconName: UiIcons.Add }}
+                        onClick={onToggleChecked.bind(window, 'btn2')}
+                        title="Undo"></UIIconButton>
+                    <UIIconButton
+                        id="btn3"
+                        sizeType={UIIconButtonSizes.Wide}
+                        checked={checked.btn3}
+                        iconProps={{ iconName: UiIcons.QuestionMarkWithChevron }}
+                        onClick={onToggleChecked.bind(window, 'btn3')}
+                        title="QuestionMarkWithChevron"></UIIconButton>
                 </Stack>
             </Stack>
             <Stack tokens={stackTokens}>

--- a/packages/ui-components/test/unit/components/UIIconButton.test.tsx
+++ b/packages/ui-components/test/unit/components/UIIconButton.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { UiIcons, initIcons, UIIconButton } from '../../../src/components';
+
+describe('<UIIconButton />', () => {
+    initIcons();
+
+    it('Render button - default', () => {
+        const { container } = render(
+            <UIIconButton
+                iconProps={{
+                    iconName: UiIcons.CopyToClipboard
+                }}
+                text="Copy"></UIIconButton>
+        );
+
+        expect(container.firstElementChild?.classList.contains('is-checked')).toBeFalsy();
+    });
+
+    it('Render button - checked', () => {
+        const { container } = render(
+            <UIIconButton
+                iconProps={{
+                    iconName: UiIcons.CopyToClipboard
+                }}
+                text="Copy"
+                checked={true}></UIIconButton>
+        );
+
+        expect(container.firstElementChild?.classList.contains('is-checked')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Issue - #1703

When we use `UIIconButton` with `checked=true`, like:
```
                    <UIIconButton
                        id="btn1"
                        iconProps={{ iconName: UiIcons.Undo }}
                        checked={true}
                        title="Undo" />
```
 2. It looks following:
 
![image](https://github.com/SAP/open-ux-tools/assets/90789422/b491c758-a0f5-43c5-96b5-725585676146)

Problem is that colors are hardcoded from fluent-ui and does not support vscode themming.

After fix:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/d87fbea0-d196-41ac-90db-1d42f03d4c53)