### PR TITLE
fix(telemetry): assigning resource id in telemetry settings

### DIFF
--- a/.changeset/funny-dodos-deny.md
+++ b/.changeset/funny-dodos-deny.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/telemetry': patch
+---
+
+fix for assigning resource id in telemetry settings

--- a/packages/telemetry/src/tooling-telemetry/telemetry-settings.ts
+++ b/packages/telemetry/src/tooling-telemetry/telemetry-settings.ts
@@ -112,7 +112,9 @@ export const initTelemetrySettings = async (options: ToolsSuiteTelemetryInitSett
         TelemetrySettings.consumerModuleName = options.consumerModule.name;
         TelemetrySettings.consumerModuleVersion = options.consumerModule.version;
         ToolingTelemetrySettings.internalFeature = options.internalFeature ?? false;
-        TelemetrySettings.azureInstrumentationKey = options.resourceId ?? '';
+        if (options.resourceId) {
+            TelemetrySettings.azureInstrumentationKey = options.resourceId;
+        }
         const storeService = await getService<TelemetrySetting, TelemetrySettingKey>({
             entityName: 'telemetrySetting'
         });

--- a/packages/telemetry/test/telemetrySettings/init-settings.test.ts
+++ b/packages/telemetry/test/telemetrySettings/init-settings.test.ts
@@ -82,7 +82,7 @@ describe('toolsSuiteTelemetrySettings', () => {
         );
 
         await initTelemetrySettings({
-            resourceId: '',
+            resourceId: undefined,
             consumerModule: packageJson,
             internalFeature: false
         });
@@ -91,6 +91,7 @@ describe('toolsSuiteTelemetrySettings', () => {
         expect(TelemetrySettings.telemetryEnabled).toBe(false);
         expect(TelemetrySettings.consumerModuleName).toBe('testProject');
         expect(TelemetrySettings.consumerModuleVersion).toBe('0.0.1');
+        expect(TelemetrySettings.azureInstrumentationKey).toBe('');
     });
 
     /**
@@ -108,7 +109,7 @@ describe('toolsSuiteTelemetrySettings', () => {
         readFileMock.mockReturnValueOnce(Promise.resolve(JSON.stringify(mockSettingFileContent)));
 
         await initTelemetrySettings({
-            resourceId: '',
+            resourceId: 'abc-123',
             consumerModule: packageJson,
             internalFeature: false
         });
@@ -118,6 +119,7 @@ describe('toolsSuiteTelemetrySettings', () => {
         expect(TelemetrySettings.telemetryEnabled).toBe(false);
         expect(TelemetrySettings.consumerModuleName).toBe('testProject');
         expect(TelemetrySettings.consumerModuleVersion).toBe('0.0.1');
+        expect(TelemetrySettings.azureInstrumentationKey).toBe('abc-123');
     });
 
     /**


### PR DESCRIPTION
Fix for assigning resource id in telemetry settings , introduced with https://github.com/SAP/open-ux-tools/pull/1698