### PR TITLE
tbi(telemetry): update init settings, bump azure applicationinsights and stablise tests

### DIFF
--- a/.changeset/four-kids-bathe.md
+++ b/.changeset/four-kids-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/telemetry': minor
+---
+
+update init settings, bump azure applicationinsights and stablise tests

--- a/.changeset/seven-months-type.md
+++ b/.changeset/seven-months-type.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/telemetry': patch
+---
+
+fix tests and bump applicationinsights

--- a/.changeset/seven-months-type.md
+++ b/.changeset/seven-months-type.md
@@ -1,5 +1,0 @@
----
-'@sap-ux/telemetry': patch
----
-
-fix tests and bump applicationinsights

--- a/packages/telemetry/example/index.ts
+++ b/packages/telemetry/example/index.ts
@@ -44,7 +44,8 @@ initTelemetrySettings({
     consumerModule: {
         name: 'OpenUxTools',
         version: '0.1.0'
-    }
+    },
+    watchTelemetrySettingStore: false
 })
     .then(sendTelemetryEvent)
     .catch((error) => {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -33,7 +33,7 @@
         "@sap/ux-specification": "1.108.18",
         "@sap-ux/ui5-config": "workspace:*",
         "@sap-ux/logger": "workspace:*",
-        "applicationinsights": "2.9.0",
+        "applicationinsights": "2.9.2",
         "axios": "1.6.0",
         "performance-now": "2.1.0",
         "yaml": "2.3.3"

--- a/packages/telemetry/src/tooling-telemetry/telemetry-settings.ts
+++ b/packages/telemetry/src/tooling-telemetry/telemetry-settings.ts
@@ -120,7 +120,10 @@ export const initTelemetrySettings = async (options: ToolsSuiteTelemetryInitSett
         });
 
         await readEnableTelemetry(storeService);
-        watchTelemetrySettingStore(storeService);
+
+        if (options.watchTelemetrySettingStore) {
+            watchTelemetrySettingStore(storeService);
+        }
     } catch (err) {
         reportRuntimeError(err);
     }

--- a/packages/telemetry/src/tooling-telemetry/types.ts
+++ b/packages/telemetry/src/tooling-telemetry/types.ts
@@ -11,12 +11,14 @@ export type TelemetryHelperProperties = {
  *
  * - consumerModule: name and version of module that uses telemetry library
  * - internalFeature: if UX tooling InternalFeature is enabled
+ * - watchTelemetrySettingStore: watch changes to telemetry setting in the store and update runtime settings accordingly (recommended for extensions)
  * - resourceId: Id of cloud telemetry resource (e.g. Azure application insights resource is supported).
  *
  */
 export type ToolsSuiteTelemetryInitSettings = {
     consumerModule: ProjectInfo;
     internalFeature: boolean;
+    watchTelemetrySettingStore: boolean;
     resourceId?: string;
 };
 

--- a/packages/telemetry/test/telemetrySettings/init-settings.test.ts
+++ b/packages/telemetry/test/telemetrySettings/init-settings.test.ts
@@ -56,6 +56,7 @@ describe('toolsSuiteTelemetrySettings', () => {
      * Has existing central telemetry setting
      */
     it('Telemetry setting exists in store, enabled: true', async () => {
+        const getFilesystemWatcherForSpy = jest.spyOn(storeMock, 'getFilesystemWatcherFor');
         jest.spyOn(storeMock, 'getService').mockImplementation(() =>
             Promise.resolve({
                 read: () => Promise.resolve({ enableTelemetry: true })
@@ -65,10 +66,12 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: true
         });
 
         expect(readFileMock).toBeCalledTimes(0);
+        expect(getFilesystemWatcherForSpy).toBeCalledTimes(1);
         expect(TelemetrySettings.consumerModuleName).toBe('testProject');
         expect(TelemetrySettings.consumerModuleVersion).toBe('0.0.1');
         expect(TelemetrySettings.telemetryEnabled).toBe(true);
@@ -84,7 +87,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: undefined,
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
 
         expect(readFileMock).toBeCalledTimes(0);
@@ -99,6 +103,7 @@ describe('toolsSuiteTelemetrySettings', () => {
      * Set enableTelemetry to fase if any of the vscode extension setting is false.
      */
     it('Telemetry setting does not exist in store, at least one of legacy telemetry setting is disabled', async () => {
+        const getFilesystemWatcherForSpy = jest.spyOn(storeMock, 'getFilesystemWatcherFor');
         mockSettingFileContent['sap.ux.help.enableTelemetry'] = false;
         jest.spyOn(storeMock, 'getService').mockImplementation(() =>
             Promise.resolve({
@@ -111,11 +116,13 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: 'abc-123',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
 
         expect(readFileMock).toBeCalledTimes(1);
         expect(readFileMock).toBeCalledWith(expect.stringContaining('settings.json'), 'utf-8');
+        expect(getFilesystemWatcherForSpy).toBeCalledTimes(0);
         expect(TelemetrySettings.telemetryEnabled).toBe(false);
         expect(TelemetrySettings.consumerModuleName).toBe('testProject');
         expect(TelemetrySettings.consumerModuleVersion).toBe('0.0.1');
@@ -138,7 +145,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
 
         expect(readFileMock).toBeCalledTimes(1);
@@ -163,7 +171,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
         expect(readFileMock).toBeCalledTimes(1);
         expect(readFileMock).toBeCalledWith(expect.stringContaining('settings.json'), 'utf-8');
@@ -188,7 +197,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
         expect(readFileMock).toBeCalledTimes(1);
         expect(readFileMock).toBeCalledWith(expect.stringContaining('settings.json'), 'utf-8');
@@ -212,7 +222,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
         expect(readFileMock).toBeCalledTimes(1);
         expect(readFileMock).toBeCalledWith(expect.stringContaining('settings.json'), 'utf-8');
@@ -242,7 +253,8 @@ describe('toolsSuiteTelemetrySettings', () => {
         await initTelemetrySettings({
             resourceId: '',
             consumerModule: packageJson,
-            internalFeature: false
+            internalFeature: false,
+            watchTelemetrySettingStore: false
         });
         expect(readFileMock).toBeCalledTimes(0);
         expect(TelemetrySettings.telemetryEnabled).toBe(true);

--- a/packages/telemetry/test/tools-suite-telemetry/index.test.ts
+++ b/packages/telemetry/test/tools-suite-telemetry/index.test.ts
@@ -3,6 +3,7 @@ import * as memfs from 'memfs';
 import { processToolsSuiteTelemetry } from '../../src/tooling-telemetry';
 import { ToolingTelemetrySettings } from '../../src/tooling-telemetry/config-state';
 import fs from 'fs';
+import { join } from 'path';
 
 jest.mock('fs', () => {
     const fs1 = jest.requireActual('fs');
@@ -30,6 +31,8 @@ jest.mock('axios', () => {
 });
 
 describe('Tools Suite Telemetry Tests', () => {
+    jest.setTimeout(10000);
+
     beforeEach(() => {
         memfs.vol.reset();
     });
@@ -136,15 +139,15 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['/project1/README.md']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/README_LROPv4.md',
+                    join(__dirname, 'fixtures/fiori_elements/README_LROPv4.md'),
                     'utf-8'
                 ),
                 ['/project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/package.json',
+                    join(__dirname, 'fixtures/fiori_elements/package.json'),
                     'utf-8'
                 ),
                 ['/project1/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/manifest.json',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -177,15 +180,15 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['/project1/README.md']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/README_Form.md',
+                    join(__dirname, '/fixtures/fiori_elements/README_Form.md'),
                     'utf-8'
                 ),
                 ['/project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/package.json',
+                    join(__dirname, 'fixtures/fiori_elements/package.json'),
                     'utf-8'
                 ),
                 ['/project1/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/manifest.json',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -218,23 +221,23 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['/project1/ui5-deploy.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/ui5-deploy.cf.yaml',
+                    join(__dirname, 'fixtures/fiori_elements/ui5-deploy.cf.yaml'),
                     'utf-8'
                 ),
                 ['/project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/package.json',
+                    join(__dirname, 'fixtures/fiori_elements/package.json'),
                     'utf-8'
                 ),
                 ['/project1/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/manifest.json',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/manifest.json'),
                     'utf-8'
                 ),
                 ['/project1/webapp/Component.ts']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/Component.ts',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/Component.ts'),
                     'utf-8'
                 ),
                 ['/project1/tsconfig.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/tsconfig.json',
+                    join(__dirname, 'fixtures/fiori_elements/tsconfig.json'),
                     'utf-8'
                 )
             },
@@ -267,19 +270,19 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['./project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/package.json',
+                    join(__dirname, 'fixtures/fiori_elements/package.json'),
                     'utf-8'
                 ),
                 ['./project1/webapp/Component.js']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/Component.js',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/Component.js'),
                     'utf-8'
                 ),
                 ['./project1/ui5-deploy.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/ui5-deploy.abap.yaml',
+                    join(__dirname, 'fixtures/fiori_elements/ui5-deploy.abap.yaml'),
                     'utf-8'
                 ),
                 ['/project1/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/fiori_elements/webapp/manifest.json',
+                    join(__dirname, 'fixtures/fiori_elements/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -312,19 +315,19 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['./project1/srv/src/main/resources/application.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/srv/src/main/resources/application.yaml',
+                    join(__dirname, 'fixtures/cap-java-freestyle/srv/src/main/resources/application.yaml'),
                     'utf-8'
                 ),
                 ['./project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/package.json',
+                    join(__dirname, 'fixtures/cap-java-freestyle/package.json'),
                     'utf-8'
                 ),
                 ['./project1/app/freestyle/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/app/freestyle/package.json',
+                    join(__dirname, 'fixtures/cap-java-freestyle/app/freestyle/package.json'),
                     'utf-8'
                 ),
                 ['./project1/app/freestyle/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/app/freestyle/webapp/manifest.json',
+                    join(__dirname, 'fixtures/cap-java-freestyle/app/freestyle/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -357,15 +360,15 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['./project1/srv/src/main/resources/application.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/srv/src/main/resources/application.yaml',
+                    join(__dirname, 'fixtures/cap-java-freestyle/srv/src/main/resources/application.yaml'),
                     'utf-8'
                 ),
                 ['./project1/app/freestyle/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/app/freestyle/package.json',
+                    join(__dirname, 'fixtures/cap-java-freestyle/app/freestyle/package.json'),
                     'utf-8'
                 ),
                 ['./project1/app/freestyle/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-java-freestyle/app/freestyle/webapp/manifest.json',
+                    join(__dirname, 'fixtures/cap-java-freestyle/app/freestyle/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -398,19 +401,19 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['/project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-node-freestyle/package.json',
+                    join(__dirname, 'fixtures/cap-node-freestyle/package.json'),
                     'utf-8'
                 ),
                 ['/project1/srv/keep']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-node-freestyle/srv/keep',
+                    join(__dirname, 'fixtures/cap-node-freestyle/srv/keep'),
                     'utf-8'
                 ),
                 ['/project1/app/freestyle/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-node-freestyle/app/freestyle/package.json',
+                    join(__dirname, 'fixtures/cap-node-freestyle/app/freestyle/package.json'),
                     'utf-8'
                 ),
                 ['/project1/app/freestyle/webapp/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/cap-node-freestyle/app/freestyle/webapp/manifest.json',
+                    join(__dirname, 'fixtures/cap-node-freestyle/app/freestyle/webapp/manifest.json'),
                     'utf-8'
                 )
             },
@@ -442,20 +445,17 @@ describe('Tools Suite Telemetry Tests', () => {
     it('common telemetry property: reuse library', async () => {
         memfs.vol.fromNestedJSON(
             {
-                ['./project1/ui5.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-library/ui5.yaml',
-                    'utf-8'
-                ),
+                ['./project1/ui5.yaml']: fs.readFileSync(join(__dirname, 'fixtures/valid-library/ui5.yaml'), 'utf-8'),
                 ['./project1/src/manifest.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-library/src/manifest.json',
+                    join(__dirname, 'fixtures/valid-library/src/manifest.json'),
                     'utf-8'
                 ),
                 ['./project1/ui5-deploy.yaml']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-library/ui5-deploy.yaml',
+                    join(__dirname, 'fixtures/valid-library/ui5-deploy.yaml'),
                     'utf-8'
                 ),
                 ['./project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-library/package.json',
+                    join(__dirname, 'fixtures/valid-library/package.json'),
                     'utf-8'
                 )
             },
@@ -488,15 +488,15 @@ describe('Tools Suite Telemetry Tests', () => {
         memfs.vol.fromNestedJSON(
             {
                 ['/project1/.adp/config.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-adaptation/.adp/config.json',
+                    join(__dirname, 'fixtures/valid-adaptation/.adp/config.json'),
                     'utf-8'
                 ),
                 ['/project1/webapp/manifest.appdescr_variant']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-adaptation/webapp/manifest.appdescr_variant',
+                    join(__dirname, 'fixtures/valid-adaptation/webapp/manifest.appdescr_variant'),
                     'utf-8'
                 ),
                 ['/project1/package.json']: fs.readFileSync(
-                    './test/tools-suite-telemetry/fixtures/valid-adaptation/package.json',
+                    join(__dirname, 'fixtures/valid-adaptation/package.json'),
                     'utf-8'
                 )
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1526,8 +1526,8 @@ importers:
         specifier: 1.108.18
         version: 1.108.18
       applicationinsights:
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 2.9.2
+        version: 2.9.2
       axios:
         specifier: 1.6.0
         version: 1.6.0
@@ -10006,8 +10006,8 @@ packages:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
     dev: true
 
-  /applicationinsights@2.9.0:
-    resolution: {integrity: sha512-W90WNjtvZ10GUInpkyNM0xBGe2qRYChHhdb44SE5KU7hXtCZLxs3IZjWw1gJINQem0qGAgtZlxrVvKPj5SlTbQ==}
+  /applicationinsights@2.9.2:
+    resolution: {integrity: sha512-wlDiD7v0BQNM8oNzsf9C836R5ze25u+CuCEZsbA5xMIXYYBxkqkWE/mo9GFJM7rsKaiGqpxEwWmePHKD2Lwy2w==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
       applicationinsights-native-metrics: '*'
@@ -10027,7 +10027,7 @@ packages:
       cls-hooked: 4.2.2
       continuation-local-storage: 3.2.1
       diagnostic-channel: 1.1.1
-      diagnostic-channel-publishers: 1.0.7(diagnostic-channel@1.1.1)
+      diagnostic-channel-publishers: 1.0.8(diagnostic-channel@1.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -11936,8 +11936,8 @@ packages:
       wrappy: 1.0.2
     dev: true
 
-  /diagnostic-channel-publishers@1.0.7(diagnostic-channel@1.1.1):
-    resolution: {integrity: sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==}
+  /diagnostic-channel-publishers@1.0.8(diagnostic-channel@1.1.1):
+    resolution: {integrity: sha512-HmSm9hXxSPxA9BaLGY98QU1zsdjeCk113KjAYGPCen1ZP6mhVaTPzHd6UYv5r21DnWANi+f+NyPOHruGT9jpqQ==}
     peerDependencies:
       diagnostic-channel: '*'
     dependencies:


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1417

- Adds `watchTelemetrySettingStore` as a required option to ToolsSuiteTelemetryInitSettings. Using a watch on the store is not always desirable

- Bump `applicationinsights` to `2.9.2` to incorporate fix https://github.com/microsoft/ApplicationInsights-node.js/pull/1241 displaying `ApplicationInsights:Invalid JSON config file when using APPLICATIONINSIGHTS_CONNECTION_STRING` error 

- Increasing timeout for tests due to instabilities. Also making paths dynamic so they can be ran with tools like jest-runner
