### PR TITLE
fix(ui-components): UIIconButton. Some button icons(which are not 16x16) are not vertically centered.

### DIFF
--- a/.changeset/ninety-kids-stare.md
+++ b/.changeset/ninety-kids-stare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIIconButton. Some icons(which are not 16x16) are not centered within UIIconButton

--- a/packages/ui-components/src/components/UIButton/UIIconButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIIconButton.tsx
@@ -86,7 +86,10 @@ export class UIIconButton extends React.Component<ButtonProps, {}> {
             icon: {
                 height: 16,
                 width: width,
-                lineHeight: 16
+                lineHeight: 16,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
             },
             iconHovered: {
                 backgroundColor: 'transparent'

--- a/packages/ui-components/stories/UIButton.story.tsx
+++ b/packages/ui-components/stories/UIButton.story.tsx
@@ -195,16 +195,16 @@ export const defaultUsage = (): JSX.Element => {
                     <UIIconButton
                         id="btn2"
                         checked={checked.btn2}
-                        iconProps={{ iconName: UiIcons.Add }}
+                        iconProps={{ iconName: UiIcons.LayoutLeft }}
                         onClick={onToggleChecked.bind(window, 'btn2')}
-                        title="Undo"></UIIconButton>
+                        title="LayoutLeft"></UIIconButton>
                     <UIIconButton
                         id="btn3"
                         sizeType={UIIconButtonSizes.Wide}
                         checked={checked.btn3}
                         iconProps={{ iconName: UiIcons.QuestionMarkWithChevron }}
                         onClick={onToggleChecked.bind(window, 'btn3')}
-                        title="QuestionMarkWithChevron"></UIIconButton>
+                        title="Wide"></UIIconButton>
                 </Stack>
             </Stack>
             <Stack tokens={stackTokens}>

--- a/packages/ui-components/test/unit/components/UIIconButton.test.tsx
+++ b/packages/ui-components/test/unit/components/UIIconButton.test.tsx
@@ -5,6 +5,10 @@ import { UiIcons, initIcons, UIIconButton } from '../../../src/components';
 describe('<UIIconButton />', () => {
     initIcons();
 
+    const getStyle = (element: Element): CSSStyleDeclaration => {
+        return window.getComputedStyle(element);
+    };
+
     it('Render button - default', () => {
         const { container } = render(
             <UIIconButton
@@ -15,6 +19,8 @@ describe('<UIIconButton />', () => {
         );
 
         expect(container.firstElementChild?.classList.contains('is-checked')).toBeFalsy();
+        const icon = container.querySelector('i') as Element;
+        expect(getStyle(icon).alignItems).toEqual('center');
     });
 
     it('Render button - checked', () => {


### PR DESCRIPTION
Use example as:
1. Use `UIIconButton`, like:
```
<UIIconButton
                        iconProps={{ iconName: UiIcons.LayoutLeft }}
                        checked={true}></UIIconButton>
```

Previously it looked following:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/9046c1be-c3fb-44df-aa5f-0b0b2877df13)

After correction:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/f9032a1b-886d-4043-807d-f2e5b74685ca)