### PR TITLE
fix(ui5-application-inquirer): Wrong arg order

### DIFF
--- a/.changeset/plenty-hairs-smell.md
+++ b/.changeset/plenty-hairs-smell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+---
+
+Fix for wrong behaviour when calling prompt with CapCdsInfo

--- a/packages/ui5-application-inquirer/src/index.ts
+++ b/packages/ui5-application-inquirer/src/index.ts
@@ -2,7 +2,6 @@ import { type CdsUi5PluginInfo } from '@sap-ux/cap-config-writer';
 import type { InquirerAdapter } from '@sap-ux/inquirer-common';
 import { getDefaultUI5Theme, getUI5Versions, type UI5VersionFilterOptions } from '@sap-ux/ui5-info';
 import autocomplete from 'inquirer-autocomplete-prompt';
-import cloneDeep from 'lodash/cloneDeep';
 import isNil from 'lodash/isNil';
 import { getQuestions } from './prompts';
 import type {
@@ -33,9 +32,7 @@ async function getPrompts(
     };
     const ui5Versions = await getUI5Versions(filterOptions);
 
-    const promptOptionsClean = cloneDeep(promptOptions);
-
-    return getQuestions(ui5Versions, promptOptionsClean, capCdsInfo, isYUI);
+    return getQuestions(ui5Versions, promptOptions, capCdsInfo, isYUI);
 }
 
 /**
@@ -53,7 +50,7 @@ async function prompt(
     capCdsInfo?: CdsUi5PluginInfo,
     isYUI = false
 ): Promise<UI5ApplicationAnswers> {
-    const ui5AppPrompts = await exports.getPrompts(promptOptions, capCdsInfo, isYUI);
+    const ui5AppPrompts = await getPrompts(promptOptions, capCdsInfo, isYUI);
 
     if (adapter?.promptModule && promptOptions?.ui5Version?.useAutocomplete) {
         const pm = adapter.promptModule;

--- a/packages/ui5-application-inquirer/src/index.ts
+++ b/packages/ui5-application-inquirer/src/index.ts
@@ -43,17 +43,17 @@ async function getPrompts(
  *
  * @param adapter - optionally provide references to a calling inquirer instance, this supports integration to Yeoman generators, for example
  * @param promptOptions - options that can control some of the prompt behavior. See {@link UI5ApplicationPromptOptions} for details
- * @param isCli - since CLI prompting is done serially but UI prompting occurs in parallel this impacts on how some validation is run
- * @param capCdsInfo - the CAP CDS info for the project, if this prompting will add a UI% app to an existing CAP project
+ * @param [capCdsInfo] - the CAP CDS info for the project, if this prompting will add a UI% app to an existing CAP project
+ * @param [isYUI] - optional, default is `false`. Changes the behaviour of some validation since YUI does not re-validate prompts that may be inter-dependant.
  * @returns the prompt answers
  */
 async function prompt(
     adapter: InquirerAdapter,
     promptOptions?: UI5ApplicationPromptOptions,
-    isCli = true,
-    capCdsInfo?: CdsUi5PluginInfo
+    capCdsInfo?: CdsUi5PluginInfo,
+    isYUI = false
 ): Promise<UI5ApplicationAnswers> {
-    const ui5AppPrompts = await exports.getPrompts(promptOptions, isCli, capCdsInfo);
+    const ui5AppPrompts = await exports.getPrompts(promptOptions, capCdsInfo, isYUI);
 
     if (adapter?.promptModule && promptOptions?.ui5Version?.useAutocomplete) {
         const pm = adapter.promptModule;

--- a/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
@@ -5,6 +5,7 @@ import { createPromptModule } from 'inquirer';
 import AutocompletePrompt from 'inquirer-autocomplete-prompt';
 import type { InquirerAdapter, UI5ApplicationAnswers, UI5ApplicationPromptOptions } from '../../src';
 import { getPrompts, prompt, promptNames } from '../../src';
+import * as ui5AppInquirer from '../../src/index';
 import * as ui5AppPrompts from '../../src/prompts';
 
 /**
@@ -187,5 +188,29 @@ describe('ui5-application-inquirer API', () => {
               "ui5Version": "1.64.0",
             }
         `);
+    });
+
+    test('prompt, prompt args are passed correctly applied', async () => {
+        const getPromptsSpy = jest.spyOn(ui5AppInquirer, 'getPrompts');
+        const promptOpts: UI5ApplicationPromptOptions = {
+            [promptNames.name]: {
+                default: 'someName'
+            }
+        };
+
+        const mockPromptsModule = createPromptModule();
+        const mockInquirerAdapter: InquirerAdapter = {
+            prompt: jest.fn().mockResolvedValue({ [promptNames.name]: 'a prompt answer' }),
+            promptModule: mockPromptsModule
+        };
+        const mockCdsInfo = {
+            hasCdsUi5Plugin: true,
+            hasMinCdsVersion: true,
+            isCdsUi5PluginEnabled: true,
+            isWorkspaceEnabled: false
+        };
+        await prompt(mockInquirerAdapter, promptOpts, mockCdsInfo, true);
+
+        expect(getPromptsSpy).toHaveBeenCalledWith(promptOpts, mockCdsInfo, true);
     });
 });

--- a/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
@@ -5,7 +5,6 @@ import { createPromptModule } from 'inquirer';
 import AutocompletePrompt from 'inquirer-autocomplete-prompt';
 import type { InquirerAdapter, UI5ApplicationAnswers, UI5ApplicationPromptOptions } from '../../src';
 import { getPrompts, prompt, promptNames } from '../../src';
-import * as ui5AppInquirer from '../../src/index';
 import * as ui5AppPrompts from '../../src/prompts';
 
 /**
@@ -191,7 +190,7 @@ describe('ui5-application-inquirer API', () => {
     });
 
     test('prompt, prompt args are passed correctly applied', async () => {
-        const getPromptsSpy = jest.spyOn(ui5AppInquirer, 'getPrompts');
+        const getQuestionsSpy = jest.spyOn(ui5AppPrompts, 'getQuestions');
         const promptOpts: UI5ApplicationPromptOptions = {
             [promptNames.name]: {
                 default: 'someName'
@@ -211,6 +210,6 @@ describe('ui5-application-inquirer API', () => {
         };
         await prompt(mockInquirerAdapter, promptOpts, mockCdsInfo, true);
 
-        expect(getPromptsSpy).toHaveBeenCalledWith(promptOpts, mockCdsInfo, true);
+        expect(getQuestionsSpy).toHaveBeenCalledWith(ui5Vers, promptOpts, mockCdsInfo, true);
     });
 });


### PR DESCRIPTION
#1724

- Fixes wrong arg ordering when internally calling `getPrompts(...)`
- Removes in-line `exports` which was only added to support test mocking
- Removes unnecessary clone, remnant of previous implementation when prompt options were cleaned
- Add test to cover