### PR TITLE
Preview middleware doesn't work on windows if the custom url is multiple folders deep

### DIFF
--- a/.changeset/late-phones-love.md
+++ b/.changeset/late-phones-love.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+FIX: preview path on windows

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -2,7 +2,7 @@ import type { ReaderCollection } from '@ui5/fs';
 import { render } from 'ejs';
 import type { Request, RequestHandler, Response, Router } from 'express';
 import { readFileSync } from 'fs';
-import { dirname, join, relative } from 'path';
+import { dirname, join, posix } from 'path';
 import type { App, Editor, FlpConfig, MiddlewareConfig, RtaConfig } from '../types';
 import { Router as createRouter, static as serveStatic, json } from 'express';
 import type { Logger, ToolsLogger } from '@sap-ux/logger';
@@ -182,7 +182,7 @@ export class FlpSandbox {
         const ui5Theme =
             this.config.theme ?? (supportedThemes.includes(DEFAULT_THEME) ? DEFAULT_THEME : supportedThemes[0]);
         this.templateConfig = {
-            basePath: relative(dirname(this.config.path), '/') ?? '.',
+            basePath: posix.relative(posix.dirname(this.config.path), '/') ?? '.',
             apps: {},
             ui5: {
                 libs: this.getUI5Libs(manifest),


### PR DESCRIPTION
Issue found by @heimwege while working on #1726.