### PR TITLE
feat(reload-middleware): expose the livereload port as env variable

### DIFF
--- a/.changeset/heavy-bottles-warn.md
+++ b/.changeset/heavy-bottles-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/reload-middleware': patch
+---
+
+Expose the livereload port as env variable

--- a/packages/reload-middleware/src/base/livereload.ts
+++ b/packages/reload-middleware/src/base/livereload.ts
@@ -31,6 +31,8 @@ export const getLivereloadServer = async (
     }
 
     const livereload = createServer({ ...defaultLiveReloadOpts, ...options });
+    // Set the livereload port as an environment variable to be used by the preview middleware
+    process.env.FIORI_TOOLS_LIVERELOAD_PORT = livereload.config.port?.toString();
 
     return livereload;
 };

--- a/packages/reload-middleware/test/unit/base/livereload.test.ts
+++ b/packages/reload-middleware/test/unit/base/livereload.test.ts
@@ -12,7 +12,12 @@ jest.mock('connect-livereload', () => ({
 }));
 
 describe('Livereload', () => {
-    const livereloadSpy = jest.spyOn(livereload, 'createServer').mockImplementation(jest.fn());
+    const livereloadSpy = jest.spyOn(livereload, 'createServer').mockImplementation((): any => {
+        return {
+            watch: jest.fn(),
+            config: { port: 35729 }
+        };
+    });
     jest.spyOn(portfinder, 'getPort').mockImplementation((options, callback) => {
         //@ts-expect-error - ignore for testing purposes
         callback(null, options.port);
@@ -35,6 +40,8 @@ describe('Livereload', () => {
         await getLivereloadServer(options);
         expect(livereloadSpy).toHaveBeenCalledTimes(1);
         expect(livereloadSpy).toHaveBeenCalledWith({ port: 35729, ...defaultLiveReloadOpts });
+        expect(process.env.FIORI_TOOLS_LIVERELOAD_PORT).toBeDefined();
+        expect(process.env.FIORI_TOOLS_LIVERELOAD_PORT).toBe('35729');
     });
 
     test('livereload server with custom port', async () => {


### PR DESCRIPTION
Sets the livereload port as env variable after the livereload server is started