### PR TITLE
fix: text input focus out do not trigger empty change

### DIFF
--- a/.changeset/fair-fireants-arrive.md
+++ b/.changeset/fair-fireants-arrive.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/control-property-editor': patch
+'@sap-ux/preview-middleware': patch
+---
+
+do not trigger empty change on focus out

--- a/packages/control-property-editor/src/panels/properties/StringEditor.tsx
+++ b/packages/control-property-editor/src/panels/properties/StringEditor.tsx
@@ -51,7 +51,7 @@ export function StringEditor(propertyInputProps: PropertyInputProps): ReactEleme
     const dispatch = useDispatch();
 
     const handlеChange = (e: React.FocusEvent | React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        if (value.toString() === e.target.value) {
+        if (value?.toString() === e.target.value) {
             return;
         }
         reportTelemetry({ category: 'Property Change', propertyName: name }).catch((error) => {

--- a/packages/control-property-editor/src/panels/properties/StringEditor.tsx
+++ b/packages/control-property-editor/src/panels/properties/StringEditor.tsx
@@ -51,7 +51,7 @@ export function StringEditor(propertyInputProps: PropertyInputProps): ReactEleme
     const dispatch = useDispatch();
 
     const handlеChange = (e: React.FocusEvent | React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        if (value && value.toString() === e.target.value) {
+        if (value.toString() === e.target.value) {
             return;
         }
         reportTelemetry({ category: 'Property Change', propertyName: name }).catch((error) => {


### PR DESCRIPTION
text input focus out do not trigger empty change