### PR TITLE
fix(project-access): remove setting of cds.root

### DIFF
--- a/.changeset/silly-emus-melt.md
+++ b/.changeset/silly-emus-melt.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': minor
+---
+
+Remove setting of cds.root. Set the project in cds.load() instead.

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -143,10 +143,6 @@ export async function getCapModelAndServices(
     }
 
     const cds = await loadCdsModuleFromProject(_projectRoot);
-
-    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.home': ${cds.home}`);
-    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.version': ${cds.version}`);
-
     const capProjectPaths = await getCapCustomPaths(_projectRoot);
     const modelPaths = [
         join(_projectRoot, capProjectPaths.app),
@@ -154,6 +150,11 @@ export async function getCapModelAndServices(
         join(_projectRoot, capProjectPaths.db)
     ];
     const model = await cds.load(modelPaths, { root: _projectRoot });
+
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.home': ${cds.home}`);
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.version': ${cds.version}`);
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.root': ${cds.root}`);
+
     let services = cds.compile.to.serviceinfo(model, { root: _projectRoot }) ?? [];
     if (services.map) {
         services = services.map((value) => {

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -204,6 +204,7 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: projectRoot });
         expect(loggerSpy).toHaveBeenNthCalledWith(1, expect.stringContaining("'cds.home': /cds/home/path"));
         expect(loggerSpy).toHaveBeenNthCalledWith(2, expect.stringContaining("'cds.version': 7.4.2"));
+        expect(loggerSpy).toHaveBeenNthCalledWith(3, expect.stringContaining("'cds.root':"));
     });
 });
 

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -133,11 +133,10 @@ describe('Test getCapModelAndServices()', () => {
                 }
             ]
         });
-        expect(cdsMock.load).toBeCalledWith([
-            join('PROJECT_ROOT', 'APP'),
-            join('PROJECT_ROOT', 'SRV'),
-            join('PROJECT_ROOT', 'DB')
-        ]);
+        expect(cdsMock.load).toBeCalledWith(
+            [join('PROJECT_ROOT', 'APP'), join('PROJECT_ROOT', 'SRV'), join('PROJECT_ROOT', 'DB')],
+            { root: 'PROJECT_ROOT' }
+        );
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
     });
 
@@ -170,7 +169,7 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: 'ROOT_PATH' });
     });
 
-    test('Get model and service, project root sets `cds.root`', async () => {
+    test('Get model and service', async () => {
         // Mock setup
         const cdsMock = {
             env: {
@@ -205,7 +204,6 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: projectRoot });
         expect(loggerSpy).toHaveBeenNthCalledWith(1, expect.stringContaining("'cds.home': /cds/home/path"));
         expect(loggerSpy).toHaveBeenNthCalledWith(2, expect.stringContaining("'cds.version': 7.4.2"));
-        expect(loggerSpy).toHaveBeenNthCalledWith(3, expect.stringContaining("'cds.root': /some/test/path"));
     });
 });
 
@@ -565,7 +563,10 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual(['file1', 'file2']);
-        expect(cdsMock.load).toBeCalledWith([join('db/'), join('srv/'), join('app/'), 'schema', 'services']);
+        expect(cdsMock.load).toBeCalledWith(
+            [join('db/'), join('srv/'), join('app/'), 'schema', 'services'],
+            expect.any(Object)
+        );
     });
 
     test('Get CDS files from project, but no $sources', async () => {
@@ -637,7 +638,7 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual([`${sep}file1`]);
-        expect(cdsMock.load).toBeCalledWith('envroot');
+        expect(cdsMock.load).toBeCalledWith('envroot', expect.any(Object));
     });
 
     test('Get CDS files from project with envRoot and ignoreErrors true and model data in exception', async () => {
@@ -656,7 +657,7 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual([`${sep}file1`, `${sep}file2`]);
-        expect(cdsMock.load).toBeCalledWith('envroot');
+        expect(cdsMock.load).toBeCalledWith('envroot', expect.any(Object));
     });
 });
 


### PR DESCRIPTION
Removes the setting of `cds.root`, which was introduced in https://github.com/SAP/open-ux-tools/pull/1563. Setting of `cds.root` has unforeseen side effects when using `require.resolve`. Instead set the project root when calling `cds.load`.