### PR TITLE
fix(deploy-tooling): change logging in validation for deploy-test

### DIFF
--- a/.changeset/new-squids-remember.md
+++ b/.changeset/new-squids-remember.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+Adjust logging in validation for deploy-test to not log full stack trace, but only the message.

--- a/packages/deploy-tooling/src/base/validate.ts
+++ b/packages/deploy-tooling/src/base/validate.ts
@@ -238,6 +238,7 @@ async function getSystemPrefix(
         return atoSettings?.developmentPrefix;
     } catch (e) {
         logger.error(e.message);
+        logger.debug(e);
         output.summary.push({
             message: summaryMessage.atoAdtAccessError,
             status: SummaryStatus.Unknown

--- a/packages/deploy-tooling/src/base/validate.ts
+++ b/packages/deploy-tooling/src/base/validate.ts
@@ -237,7 +237,7 @@ async function getSystemPrefix(
         const atoSettings = await adtService.getAtoInfo();
         return atoSettings?.developmentPrefix;
     } catch (e) {
-        logger.error(e);
+        logger.error(e.message);
         output.summary.push({
             message: summaryMessage.atoAdtAccessError,
             status: SummaryStatus.Unknown

--- a/packages/deploy-tooling/test/unit/base/validate.test.ts
+++ b/packages/deploy-tooling/test/unit/base/validate.test.ts
@@ -8,6 +8,7 @@ import {
 import { mockedProvider, mockedAdtService } from '../../__mocks__';
 import { green, red, yellow } from 'chalk';
 import { TransportChecksService } from '@sap-ux/axios-extension';
+import type { AxiosError } from '@sap-ux/axios-extension';
 import { t } from '@sap-ux/project-input-validator/src/i18n';
 import { isAppStudio, isOnPremiseDestination, listDestinations } from '@sap-ux/btp-utils';
 
@@ -478,5 +479,34 @@ describe('deploy-test validation', () => {
                 expect(result).toBe(expectedResult);
             }
         );
+    });
+    describe('Validate error does not show full stack trace', () => {
+        jest.resetAllMocks();
+        const mockLogger = {
+            error: jest.fn()
+        };
+        jest.mock('@sap-ux/logger', () => {
+            const sapUxLogger = jest.requireActual('@sap-ux/logger');
+            return {
+                ...sapUxLogger,
+                ToolsLogger: jest.fn(() => mockLogger)
+            };
+        });
+        test('Only error message shown when error is thrown', async () => {
+            const logMock = jest.spyOn(mockLogger, 'error');
+            const mockAxiosError401 = {
+                response: {
+                    status: 401,
+                    statusText: 'Unauthorized'
+                },
+                message: 'Request failed with status code 401'
+            } as AxiosError;
+            mockedProvider.getAdtService.mockRejectedValueOnce(mockAxiosError401);
+
+            const output = await validateBeforeDeploy(testConfig, mockedProvider as any, mockLogger as any);
+
+            expect(output.result).toBe(false);
+            expect(logMock).toHaveBeenCalledWith(mockAxiosError401.message);
+        });
     });
 });

--- a/packages/deploy-tooling/test/unit/base/validate.test.ts
+++ b/packages/deploy-tooling/test/unit/base/validate.test.ts
@@ -483,7 +483,8 @@ describe('deploy-test validation', () => {
     describe('Validate error does not show full stack trace', () => {
         jest.resetAllMocks();
         const mockLogger = {
-            error: jest.fn()
+            error: jest.fn(),
+            debug: jest.fn()
         };
         jest.mock('@sap-ux/logger', () => {
             const sapUxLogger = jest.requireActual('@sap-ux/logger');


### PR DESCRIPTION
Fixes BUG - deploy-test displays stack trace if authentication is required #1758

Change to what is logged in console when `getSystemPrefix` throws an error.

Fix confirmed locally, full stack trace is no longer shown:

```
npm run deploy-test

> sampleproj1@0.0.1 deploy-test
> npm run build && fiori deploy --config ui5-deploy.yaml --testMode true


> sampleproj1@0.0.1 build
> ui5 build --config=ui5.yaml --clean-dest --dest dist

info ProjectBuilder Preparing build for project sampleproj1
info ProjectBuilder   Target directory: dist
info ProjectBuilder Cleaning target directory...
info Project 1 of 1: ❯ Building application project sampleproj1...
info sampleproj1 › Running task escapeNonAsciiCharacters...
info sampleproj1 › Running task replaceCopyright...
info sampleproj1 › Running task replaceVersion...
info sampleproj1 › Running task minify...
info sampleproj1 › Running task generateFlexChangesBundle...
info sampleproj1 › Running task generateComponentPreload...
info ProjectBuilder Build succeeded in 469 ms
info ProjectBuilder Executing cleanup tasks...

Confirmation is required to deploy the app in test mode:

    Application Name: SAMPLEVM1210
    Package: $tmp
    Transport Request: 
    Target: http://sampletarget:123456
    Client: 
    SCP: false
    
    
✔ Start deployment in test mode (Y/n)?

 … yes
info abap-deploy-task SAMPLEVM1210 Creating archive with UI5 build result.
info abap-deploy-task SAMPLEVM1210 Archive created.
2024-03-20 11:52:20 warn    main: dlopen(/Users/i123456Documents/ec1 deploy/sampleproj1/node_modules/keytar/build/Release/keytar.node, 0x0001): tried: '/Users/i123456/Documents/ec1 deploy/sampleproj1/node_modules/keytar/build/Release/keytar.node' (not a mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/Users/i123456/Documents/ec1 deploy/sampleproj1/node_modules/keytar/build/Release/keytar.node' (no such file), '/Users/i123456/Documents/ec1 deploy/sampleproj1/node_modules/keytar/build/Release/keytar.node' (not a mach-o file) 
2024-03-20 11:52:20 warn    main: Could not "require('keytar')". Trying VSCode's copy 
2024-03-20 11:52:20 warn    main: Cannot find module 'vscode'
Require stack:
- /Users/i123456/Documents/ec1 deploy/sampleproj1/node_modules/@sap/ux-ui5-tooling/dist/cli/index.js
- /Users/i123456/Documents/ec1 deploy/sampleproj1/node_modules/@sap/ux-ui5-tooling/bin/fiori 
2024-03-20 11:52:20 warn    main: Could not get hold of vscode 
2024-03-20 11:52:20 warn    main: Dummy store. Trying to retrieve for service: fiori/v2/system, key: http://ccwdfgl9773.devint.net.sap:50000 
info abap-deploy-task SAMPLEVM1210 Starting to deploy in test mode.
error abap-deploy-task SAMPLEVM1210 Request failed with status code 401
info abap-deploy-task SAMPLEVM1210 Results of validating the deployment configuration settings:
info abap-deploy-task SAMPLEVM1210     ? Development prefix could not be validated. Please check manually.
info abap-deploy-task SAMPLEVM1210     ? Package name contains lower case letter(s). $TMP is used for ADT validation.
warn abap-deploy-task SAMPLEVM1210 Deployment failed with authentication error.
info abap-deploy-task SAMPLEVM1210 Please maintain correct credentials to avoid seeing this error
info abap-deploy-task SAMPLEVM1210      (see help: https://www.npmjs.com/package/@sap/ux-ui5-tooling#setting-environment-variables-in-a-env-file)
info abap-deploy-task SAMPLEVM1210 Please enter your credentials.
✖ Username: … 
error abap-deploy-task SAMPLEVM1210 Deployment has failed.
error abap-deploy-task SAMPLEVM1210 Change logging level to debug your issue
error abap-deploy-task SAMPLEVM1210     (see examples https://github.com/SAP/open-ux-tools/tree/main/packages/deploy-tooling#configuration-with-logging-enabled)
error builder:custom deploy-to-abap Request failed with status code 401
Command deploy failed with error : Request failed with status code 401
```