### PR TITLE
fix: "Open in VS Code" button for Controller Extension dialog does not work in BAS

### DIFF
--- a/.changeset/six-eggs-eat.md
+++ b/.changeset/six-eggs-eat.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/adp-tooling': patch
+'@sap-ux/preview-middleware': patch
+---
+
+"Open in VS Code" button for Controller Extension dialog does not work in BAS

--- a/packages/adp-tooling/package.json
+++ b/packages/adp-tooling/package.json
@@ -39,6 +39,7 @@
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/system-access": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
+        "@sap-ux/btp-utils": "workspace:*",
         "sanitize-filename": "1.6.3",
         "ejs": "3.1.9",
         "mem-fs": "2.1.0",

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { renderFile } from 'ejs';
 import sanitize from 'sanitize-filename';
+import { isAppStudio } from '@sap-ux/btp-utils';
 import type { ToolsLogger } from '@sap-ux/logger';
 import type { MiddlewareUtils } from '@ui5/server';
 import type { ReaderCollection, Resource } from '@ui5/fs';
@@ -221,10 +222,13 @@ export default class RoutesHandler {
                 return;
             }
 
+            const isRunningInBAS = isAppStudio();
+
             this.sendFilesResponse(res, {
                 controllerExists,
                 controllerPath: os.platform() === 'win32' ? `/${controllerPath}` : controllerPath,
-                controllerPathFromRoot
+                controllerPathFromRoot,
+                isRunningInBAS
             });
             this.logger.debug(
                 controllerExists

--- a/packages/adp-tooling/tsconfig.json
+++ b/packages/adp-tooling/tsconfig.json
@@ -1,32 +1,35 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": [
-        "../../types/ui5.d.ts",
-        "../../types/mem-fs-editor.d.ts",
-        "src"
-    ],
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist"
+  "extends": "../../tsconfig.json",
+  "include": [
+    "../../types/ui5.d.ts",
+    "../../types/mem-fs-editor.d.ts",
+    "src"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {
+      "path": "../axios-extension"
     },
-    "references": [
-        {
-            "path": "../axios-extension"
-        },
-        {
-            "path": "../logger"
-        },
-        {
-            "path": "../project-access"
-        },
-        {
-            "path": "../store"
-        },
-        {
-            "path": "../system-access"
-        },
-        {
-            "path": "../ui5-config"
-        }
-    ]
+    {
+      "path": "../btp-utils"
+    },
+    {
+      "path": "../logger"
+    },
+    {
+      "path": "../project-access"
+    },
+    {
+      "path": "../store"
+    },
+    {
+      "path": "../system-access"
+    },
+    {
+      "path": "../ui5-config"
+    }
+  ]
 }

--- a/packages/preview-middleware-client/src/adp/api-handler.ts
+++ b/packages/preview-middleware-client/src/adp/api-handler.ts
@@ -28,6 +28,7 @@ export interface CodeExtResponse {
     controllerExists: boolean;
     controllerPath: string;
     controllerPathFromRoot: string;
+    isRunningInBAS: boolean;
 }
 
 export interface ControllersResponse {

--- a/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ControllerExtension.controller.ts
@@ -158,12 +158,16 @@ export default class ControllerExtension extends BaseDialog {
 
         const { controllerName, viewId } = this.getControllerInfo(overlayControl);
 
-        const { controllerExists, controllerPath, controllerPathFromRoot } = await this.getExistingController(
-            controllerName
-        );
+        const { controllerExists, controllerPath, controllerPathFromRoot, isRunningInBAS } =
+            await this.getExistingController(controllerName);
 
         if (controllerExists) {
-            this.updateModelForExistingController(controllerExists, controllerPath, controllerPathFromRoot);
+            this.updateModelForExistingController(
+                controllerExists,
+                controllerPath,
+                controllerPathFromRoot,
+                isRunningInBAS
+            );
         } else {
             this.updateModelForNewController(viewId);
 
@@ -188,14 +192,16 @@ export default class ControllerExtension extends BaseDialog {
     /**
      * Updates the model properties for an existing controller.
      *
-     * @param controllerExists Whether the controller exists
-     * @param controllerPath The controller path
-     * @param controllerPathFromRoot The controller path from the project root
+     * @param {boolean} controllerExists - Whether the controller exists.
+     * @param {string} controllerPath - The controller path.
+     * @param {string} controllerPathFromRoot - The controller path from the project root.
+     * @param {boolean} isRunningInBAS - Whether the environment is BAS or VS Code.
      */
     private updateModelForExistingController(
         controllerExists: boolean,
         controllerPath: string,
-        controllerPathFromRoot: string
+        controllerPathFromRoot: string,
+        isRunningInBAS: boolean
     ): void {
         this.model.setProperty('/controllerExists', controllerExists);
         this.model.setProperty('/controllerPath', controllerPath);
@@ -209,7 +215,11 @@ export default class ControllerExtension extends BaseDialog {
         const messageForm = content[1] as SimpleForm;
         messageForm.setVisible(true);
 
-        this.dialog.getBeginButton().setText('Open in VS Code').setEnabled(true);
+        if (isRunningInBAS) {
+            this.dialog.getBeginButton().setVisible(false);
+        } else {
+            this.dialog.getBeginButton().setText('Open in VS Code').setEnabled(true);
+        }
         this.dialog.getEndButton().setText('Close');
     }
 

--- a/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
@@ -76,7 +76,7 @@ describe('ControllerExtension', () => {
             expect(openSpy).toHaveBeenCalledTimes(1);
         });
 
-        test('fills json model with data (controller exists: true)', async () => {
+        test('fills json model with data (controller exists: true | env: VS Code)', async () => {
             const overlays = {
                 getId: jest.fn().mockReturnValue('some-id')
             };
@@ -98,7 +98,8 @@ describe('ControllerExtension', () => {
                 json: jest.fn().mockReturnValue({
                     controllerExists: true,
                     controllerPath: 'C:/users/projects/adp.app/webapp/changes/coding/share.js',
-                    controllerPathFromRoot: 'adp.app/webapp/changes/coding/share.js'
+                    controllerPathFromRoot: 'adp.app/webapp/changes/coding/share.js',
+                    isRunningInBAS: false
                 }),
                 text: jest.fn(),
                 ok: true
@@ -125,6 +126,57 @@ describe('ControllerExtension', () => {
 
             expect(openSpy).toHaveBeenCalledTimes(1);
             expect(setEnabledSpy).toHaveBeenCalledWith(true);
+            expect(setTextSpy).toHaveBeenCalledWith('Close');
+        });
+
+        test('fills json model with data (controller exists: true | env: BAS)', async () => {
+            const overlays = {
+                getId: jest.fn().mockReturnValue('some-id')
+            };
+
+            const overlayControl = {
+                getElement: jest.fn().mockReturnValue({
+                    getId: jest.fn().mockReturnValue('::Toolbar')
+                })
+            };
+            sapCoreMock.byId.mockReturnValue(overlayControl);
+
+            const controllerExt = new ControllerExtension(
+                'adp.extension.controllers.ControllerExtension',
+                overlays as unknown as UI5Element,
+                {} as unknown as RuntimeAuthoring
+            );
+
+            fetchMock.mockResolvedValue({
+                json: jest.fn().mockReturnValue({
+                    controllerExists: true,
+                    controllerPath: 'C:/users/projects/adp.app/webapp/changes/coding/share.js',
+                    controllerPathFromRoot: 'adp.app/webapp/changes/coding/share.js',
+                    isRunningInBAS: true
+                }),
+                text: jest.fn(),
+                ok: true
+            });
+
+            const openSpy = jest.fn();
+            const setTextSpy = jest.fn();
+            const setVisibleSpy = jest.fn();
+
+            controllerExt.byId = jest.fn().mockReturnValueOnce({}).mockReturnValue({
+                setVisible: jest.fn()
+            });
+
+            await controllerExt.setup({
+                open: openSpy,
+                getBeginButton: jest.fn().mockReturnValue({ setVisible: setVisibleSpy }),
+                getEndButton: jest.fn().mockReturnValue({ setText: setTextSpy }),
+                setEscapeHandler: jest.fn(),
+                setModel: jest.fn(),
+                getContent: jest.fn().mockReturnValue([{ setVisible: jest.fn() }, { setVisible: jest.fn() }])
+            } as unknown as Dialog);
+
+            expect(openSpy).toHaveBeenCalledTimes(1);
+            expect(setVisibleSpy).toHaveBeenCalledWith(false);
             expect(setTextSpy).toHaveBeenCalledWith('Close');
         });
 

--- a/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/ControllerExtension.controller.test.ts
@@ -17,7 +17,12 @@ describe('ControllerExtension', () => {
         fetchMock.mockResolvedValue({
             json: jest
                 .fn()
-                .mockReturnValueOnce({ controllerExists: false, controllerPath: '', controllerPathFromRoot: '' })
+                .mockReturnValueOnce({
+                    controllerExists: false,
+                    controllerPath: '',
+                    controllerPathFromRoot: '',
+                    isRunningInBAS: false
+                })
                 .mockReturnValueOnce({ controllers: [] }),
             text: jest.fn(),
             ok: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@sap-ux/axios-extension':
         specifier: workspace:*
         version: link:../axios-extension
+      '@sap-ux/btp-utils':
+        specifier: workspace:*
+        version: link:../btp-utils
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger


### PR DESCRIPTION
Fix for #1750.

- Enhance route to return environment in the response to then dynamically show/hide button in the Controller dialog.