### PR TITLE
fix(ui5-application-inquirer): Bug fix #1770 - use available ui5 versions only

### DIFF
--- a/.changeset/green-windows-yell.md
+++ b/.changeset/green-windows-yell.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-application-inquirer': minor
+'@sap-ux/inquirer-common': patch
+---
+
+When passing a default UI5 version its availability will be verified before offering as a choice

--- a/packages/inquirer-common/package.json
+++ b/packages/inquirer-common/package.json
@@ -34,11 +34,13 @@
         "fuzzy": "0.1.3",
         "i18next": "23.5.1",
         "chalk": "4.1.2",
-        "figures": "3.2.0"
+        "figures": "3.2.0",
+        "semver": "7.5.4"
     },
     "devDependencies": {
         "@sap-devx/yeoman-ui-types": "1.14.4",
-        "@types/inquirer": "8.2.6"
+        "@types/inquirer": "8.2.6",
+        "@types/semver": "7.5.4"
     },
     "engines": {
         "node": ">=18.x"

--- a/packages/inquirer-common/src/prompts/utility.ts
+++ b/packages/inquirer-common/src/prompts/utility.ts
@@ -102,11 +102,11 @@ export function ui5VersionsGrouped(
 
 /**
  * Get the default UI5 version choice that should be selected based on the provided default choice.
- * Note that if the default choice is not found in the provided versions, the closest maintained version is returned.
+ * Note that if the default choice is not found in the provided versions, the closest provided version is returned.
  *
  * @param ui5Versions - UI5 versions ordered by version descending latest first
- * @param [defaultChoice] - optional default choice to use if found in the provided versions, otherwise the closest maintained version is returned
- * @returns The default UI5 version choice that is closest to the provided default choice or the latest maintained version
+ * @param [defaultChoice] - optional default choice to use if found in the provided versions, otherwise the closest provided version is returned
+ * @returns The default UI5 version choice that is closest to the provided default choice or the latest provided version
  */
 export function getDefaultUI5VersionChoice(
     ui5Versions: UI5Version[],
@@ -125,7 +125,7 @@ export function getDefaultUI5VersionChoice(
             }
         }
     }
-    // defaultChoice was not coercable, not found or not provided, return the latest maintained version
+    // defaultChoice was not coercable, not found or not provided, return the latest version from the ui5 versions provided
     const defaultVersion = ui5Versions.find((ui5Ver) => ui5Ver.default && ui5Ver.version)?.version;
 
     if (defaultVersion) {

--- a/packages/inquirer-common/test/unit/prompts/utility.test.ts
+++ b/packages/inquirer-common/test/unit/prompts/utility.test.ts
@@ -2,7 +2,12 @@ import * as ui5Info from '@sap-ux/ui5-info';
 import { ui5ThemeIds, type UI5Version } from '@sap-ux/ui5-info';
 import type { ListChoiceOptions } from 'inquirer';
 import { initI18nInquirerCommon } from '../../../src/i18n';
-import { getUI5ThemesChoices, searchChoices, ui5VersionsGrouped } from '../../../src/prompts/utility';
+import {
+    getDefaultUI5VersionChoice,
+    getUI5ThemesChoices,
+    searchChoices,
+    ui5VersionsGrouped
+} from '../../../src/prompts/utility';
 
 describe('utility.ts', () => {
     beforeAll(async () => {
@@ -134,7 +139,7 @@ describe('utility.ts', () => {
             }
         ];
 
-        // SIngle result
+        // Single result
         expect(searchChoices('2', searchList)).toMatchInlineSnapshot(`
             [
               {
@@ -226,5 +231,75 @@ describe('utility.ts', () => {
             }
         ]);
         expect(getUI5ThemesSpy).toHaveBeenCalledWith(testUI5Version);
+    });
+
+    it.only('getDefaultUI5VersionChoice', () => {
+        const mockUI5Versions = [
+            {
+                version: '1.118.0',
+                maintained: true,
+                default: true
+            },
+            {
+                version: '1.117.1',
+                maintained: true
+            },
+            {
+                version: '1.117.0',
+                maintained: true
+            },
+            {
+                version: '1.116.0',
+                maintained: false
+            }
+        ];
+        let testUI5Version = '1.117.1';
+
+        // Test exact match
+        expect(getDefaultUI5VersionChoice(mockUI5Versions, { name: testUI5Version, value: testUI5Version })).toEqual({
+            'name': '1.117.1',
+            'value': '1.117.1'
+        });
+
+        // Closest maintained version
+        testUI5Version = '1.119.1';
+        expect(getDefaultUI5VersionChoice(mockUI5Versions, { name: testUI5Version, value: testUI5Version })).toEqual({
+            'name': '1.118.0',
+            'value': '1.118.0'
+        });
+
+        // Not valid semver
+        testUI5Version = '1.116.1-SNAPSHOT';
+        expect(getDefaultUI5VersionChoice(mockUI5Versions, { name: testUI5Version, value: testUI5Version })).toEqual({
+            'name': '1.116.0',
+            'value': '1.116.0'
+        });
+
+        expect(getDefaultUI5VersionChoice(mockUI5Versions)).toEqual({
+            'name': '1.118.0',
+            'value': '1.118.0'
+        });
+
+        const noDefaultUI5Versions = [
+            {
+                version: '1.118.0',
+                maintained: true
+            },
+            {
+                version: '1.117.1',
+                maintained: true
+            },
+            {
+                version: '1.117.0',
+                maintained: true
+            },
+            {
+                version: '1.116.0',
+                maintained: false
+            }
+        ];
+
+        // No default, returns undefined
+        expect(getDefaultUI5VersionChoice(noDefaultUI5Versions)).toBe(undefined);
     });
 });

--- a/packages/inquirer-common/test/unit/prompts/utility.test.ts
+++ b/packages/inquirer-common/test/unit/prompts/utility.test.ts
@@ -233,7 +233,7 @@ describe('utility.ts', () => {
         expect(getUI5ThemesSpy).toHaveBeenCalledWith(testUI5Version);
     });
 
-    it.only('getDefaultUI5VersionChoice', () => {
+    it('getDefaultUI5VersionChoice', () => {
         const mockUI5Versions = [
             {
                 version: '1.118.0',

--- a/packages/ui5-application-inquirer/src/prompts/prompts.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts.ts
@@ -8,7 +8,8 @@ import {
     type ConfirmQuestion,
     type FileBrowserQuestion,
     type InputQuestion,
-    type ListQuestion
+    type ListQuestion,
+    getDefaultUI5VersionChoice
 } from '@sap-ux/inquirer-common';
 import { getMtaPath } from '@sap-ux/project-access';
 import { validateModuleName, validateNamespace, validateProjectFolder } from '@sap-ux/project-input-validator';
@@ -309,10 +310,12 @@ function getUI5VersionPrompt(
     ui5Versions: UI5Version[] = [],
     ui5VersionPromptOptions?: UI5ApplicationPromptOptions[promptNames.ui5Version]
 ): UI5ApplicationQuestion {
+    // Set the default to be closest to the passed value or the default as defined by ui5 version service
+    const defaultChoice = getDefaultUI5VersionChoice(ui5Versions, ui5VersionPromptOptions?.defaultChoice);
     const ui5VersionChoices = ui5VersionsGrouped(
         ui5Versions,
-        ui5VersionPromptOptions?.includeSeparators,
-        ui5VersionPromptOptions?.defaultChoice
+        ui5VersionPromptOptions?.includeSeparators
+        // defaultChoice - this is added to support systemn versions however currently the middleware preview does not support this
     );
     return {
         when: () => !!ui5VersionChoices,
@@ -327,11 +330,7 @@ function getUI5VersionPrompt(
             searchChoices(input, ui5VersionChoices as ListChoiceOptions[]),
         message: t('prompts.appUi5VersionMessage'),
         default: () => {
-            // Set the default to be the passed value or the default as defined by ui5 version service
-            return (
-                ui5VersionPromptOptions?.defaultChoice?.value ??
-                ui5Versions.find((ui5Ver) => ui5Ver.default && ui5Ver.version)?.version
-            );
+            return defaultChoice?.value;
         }
     } as ListQuestion<UI5ApplicationAnswers>;
 }

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -269,7 +269,7 @@ describe('getQuestions', () => {
         // Default version should be used
         expect((ui5VersionPrompt?.default as Function)()).toEqual(expectedUI5VerChoices[0].value);
 
-        // Provide a non-returned version as a choice and default
+        // This choice is not a maintained version and so the closest maintained version should be returned
         const defaultChoice = {
             'name': '1.120.99',
             'value': '1.120.99'
@@ -281,11 +281,8 @@ describe('getQuestions', () => {
         });
 
         ui5VersionPrompt = questions.find((question) => question.name === promptNames.ui5Version);
-        expect(((ui5VersionPrompt as ListQuestion)?.choices as Function)()).toEqual([
-            defaultChoice,
-            ...expectedUI5VerChoices
-        ]);
-        expect((ui5VersionPrompt?.default as Function)()).toEqual('1.120.99');
+        expect(((ui5VersionPrompt as ListQuestion)?.choices as Function)()).toEqual([...expectedUI5VerChoices]);
+        expect((ui5VersionPrompt?.default as Function)()).toEqual('1.118.0');
     });
 
     test('getQuestions, prompt: `addDeployConfig` conditions and message based on mta.yaml discovery', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1029,6 +1029,9 @@ importers:
       i18next:
         specifier: 23.5.1
         version: 23.5.1
+      semver:
+        specifier: 7.5.4
+        version: 7.5.4
     devDependencies:
       '@sap-devx/yeoman-ui-types':
         specifier: 1.14.4
@@ -1036,6 +1039,9 @@ importers:
       '@types/inquirer':
         specifier: 8.2.6
         version: 8.2.6
+      '@types/semver':
+        specifier: 7.5.4
+        version: 7.5.4
 
   packages/jest-file-matchers:
     dependencies:


### PR DESCRIPTION
Fix for #1770 

- Adds new function `getDefaultUI5VersionChoice` which will return the closest match from a known list of ui5 versions
- Updates `@sap-ux/ui5-application-inquirer` to use the new function, instead of adding anyway (system versions may not be available generally)
- Adds/updates tests to cover