### PR TITLE
fix(mock-server-config): Updates ui5-mock.yaml with annotations

### DIFF
--- a/.changeset/kind-owls-act.md
+++ b/.changeset/kind-owls-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/mockserver-config-writer': minor
+---
+
+ui5-mock.yaml updated with annotations config

--- a/packages/mockserver-config-writer/test/unit/mockserver-config/__snapshots__/ui5-mock-yaml.test.ts.snap
+++ b/packages/mockserver-config-writer/test/unit/mockserver-config/__snapshots__/ui5-mock-yaml.test.ts.snap
@@ -30,6 +30,40 @@ server:
 "
 `;
 
+exports[`Test enhanceYaml() Create new ui5-mock.yaml based on ui5.yaml, updated with annotations 1`] = `
+"# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: \\"2.5\\"
+metadata:
+  name: dummy.application
+type: application
+server:
+  customMiddleware:
+    - name: first-middleware
+      firstProp: firstValue
+      nested:
+        nestedPropA: nestedValueA # comment for nested value A
+        list:
+          - listValueA
+          - listValueB
+    - name: second-middleware
+    - name: sap-fe-mockserver
+      beforeMiddleware: csp
+      configuration:
+        mountPath: /
+        services:
+          - urlPath: new/path/to/service
+            metadataPath: ./webapp/localService/metadata.xml
+            mockdataPath: ./webapp/localService/data
+            generateMockData: true
+        annotations:
+          - localPath: ./webapp/localService/SEPMRA_PROD_MAN.xml
+            urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+          - localPath: ./webapp/annotations/annotation.xml
+            urlPath: annotations/annotation.xml
+"
+`;
+
 exports[`Test enhanceYaml() Create new ui5-mock.yaml with annotations from mock manifest.json 1`] = `
 "# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
 
@@ -148,6 +182,32 @@ server:
             mockdataPath: ./webapp/localService/data
             generateMockData: true
         annotations: []
+    - name: middleware-after
+"
+`;
+
+exports[`Test enhanceYaml() Update ui5-mock.yaml, path from manifest with annotations 1`] = `
+"specVersion: '2.0'
+metadata:
+  name: 'app'
+type: application
+server:
+  customMiddleware:
+    - name: middleware-before
+    - name: sap-fe-mockserver
+      beforeMiddleware: csp
+      configuration:
+        mountPath: /
+        services:
+          - urlPath: ''
+            metadataPath: ./webapp/localService/metadata.xml
+            mockdataPath: ./webapp/localService/data
+            generateMockData: true
+        annotations:
+          - localPath: ./webapp/localService/SEPMRA_PROD_MAN.xml
+            urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+          - localPath: ./webapp/annotations/annotation.xml
+            urlPath: annotations/annotation.xml
     - name: middleware-after
 "
 `;

--- a/packages/mockserver-config-writer/test/unit/mockserver-config/ui5-mock-yaml.test.ts
+++ b/packages/mockserver-config-writer/test/unit/mockserver-config/ui5-mock-yaml.test.ts
@@ -12,37 +12,35 @@ describe('Test enhanceYaml()', () => {
     const webappPath = join('/webapp');
     const manifestJsonPath = join(webappPath, 'manifest.json');
     const manifestWithMainService = `{"sap.ui5": { "models": { "": { "dataSource": "ds" } } },"sap.app": { "dataSources": { "ds": { "uri": "ds/uri/" } } }}`;
-
+    const mockManifestJson = `{
+        "sap.app": {
+            "id": "mockserverv2",
+            "dataSources": {
+                "mainService": {
+                    "uri": "/sap/opu/odata/sap/SEPMRA_PROD_MAN/"
+                },
+                "SEPMRA_PROD_MAN": {
+                    "uri": "/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/",
+                    "type": "ODataAnnotation",
+                    "settings": {
+                        "localUri": "localService/SEPMRA_PROD_MAN.xml"
+                    }
+                },
+                "annotation": {
+                    "type": "ODataAnnotation",
+                    "uri": "annotations/annotation.xml",
+                    "settings": {
+                        "localUri": "annotations/annotation.xml"
+                    }
+                }
+            }
+        }
+    }`;
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     test('Create new ui5-mock.yaml with annotations from mock manifest.json', async () => {
-        const mockManifestJson = `{
-            "sap.app": {
-                "id": "mockserverv2",
-                "dataSources": {
-                    "mainService": {
-                        "uri": "/sap/opu/odata/sap/SEPMRA_PROD_MAN/"
-                    },
-                    "SEPMRA_PROD_MAN": {
-                        "uri": "/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/",
-                        "type": "ODataAnnotation",
-                        "settings": {
-                            "localUri": "localService/SEPMRA_PROD_MAN.xml"
-                        }
-                    },
-                    "annotation": {
-                        "type": "ODataAnnotation",
-                        "uri": "annotations/annotation.xml",
-                        "settings": {
-                            "localUri": "annotations/annotation.xml"
-                        }
-                    }
-                }
-            }
-        }`;
-
         const fs = getFs({ [manifestJsonPath]: mockManifestJson });
         await enhanceYaml(fs, basePath, webappPath, { path: '/path/for/new/config' });
 
@@ -67,10 +65,37 @@ describe('Test enhanceYaml()', () => {
         expect(fs.read(ui5MockYamlPath)).toMatchSnapshot();
     });
 
+    test('Update ui5-mock.yaml, path from manifest with annotations', async () => {
+        const fs = getFsWithUi5MockYaml(mockManifestJson);
+        await enhanceYaml(fs, basePath, webappPath);
+        expect(fs.read(ui5MockYamlPath)).toMatchSnapshot();
+    });
+
     test('Update old ui5-mock.yaml with given path', async () => {
         const fs = getFsWithUi5MockYaml('{}');
         await enhanceYaml(fs, basePath, webappPath, { path: 'path/to/service' });
         expect(fs.read(ui5MockYamlPath)).toMatchSnapshot();
+    });
+
+    test('Create new ui5-mock.yaml based on ui5.yaml, updated with annotations', async () => {
+        const fs = getFsWithUi5Yaml(mockManifestJson);
+        await enhanceYaml(fs, basePath, webappPath, { path: 'new/path/to/service' });
+        expect(fs.read(ui5MockYamlPath)).toMatchSnapshot();
+        // additional check of urlPath, even if snapshot test get lightheartedly updated, the urlPath should remain stable.
+        const ui5Config = await UI5Config.newInstance(fs.read(ui5MockYamlPath));
+        expect(
+            ui5Config.findCustomMiddleware<MockserverConfig>('sap-fe-mockserver')?.configuration.services?.[0].urlPath
+        ).toBe('new/path/to/service');
+        expect(
+            ui5Config.findCustomMiddleware<MockserverConfig>('sap-fe-mockserver')?.configuration.annotations
+        ).toEqual([
+            {
+                localPath: './webapp/localService/SEPMRA_PROD_MAN.xml',
+                urlPath:
+                    "/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/"
+            },
+            { localPath: './webapp/annotations/annotation.xml', urlPath: 'annotations/annotation.xml' }
+        ]);
     });
 
     test('Create new ui5-mock.yaml based on ui5.yaml', async () => {


### PR DESCRIPTION
#1735

If ui5-mock.yaml exists, updates existing ui5-mock.yaml config with annotations. 
If ui5-mock.yaml doesn't exist but ui5.yaml exists, creates it based on ui5.yaml and updates with annotations