### PR TITLE
Revert "fix(project-access): remove setting of cds.root"

### DIFF
--- a/.changeset/lemon-fans-shout.md
+++ b/.changeset/lemon-fans-shout.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Remove setting of cds.root.

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -17,7 +17,7 @@ import type { Logger } from '@sap-ux/logger';
 interface CdsFacade {
     env: { for: (mode: string, path: string) => CdsEnvironment };
     linked: (model: csn) => LinkedModel;
-    load: (paths: string | string[], options?: { root?: string }) => Promise<csn>;
+    load: (paths: string | string[]) => Promise<csn>;
     compile: {
         to: {
             serviceinfo: (model: csn, options?: { root?: string }) => ServiceInfo[];
@@ -143,18 +143,18 @@ export async function getCapModelAndServices(
     }
 
     const cds = await loadCdsModuleFromProject(_projectRoot);
+
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.home': ${cds.home}`);
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.version': ${cds.version}`);
+    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.root': ${cds.root}`);
+
     const capProjectPaths = await getCapCustomPaths(_projectRoot);
     const modelPaths = [
         join(_projectRoot, capProjectPaths.app),
         join(_projectRoot, capProjectPaths.srv),
         join(_projectRoot, capProjectPaths.db)
     ];
-    const model = await cds.load(modelPaths, { root: _projectRoot });
-
-    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.home': ${cds.home}`);
-    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.version': ${cds.version}`);
-    _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.root': ${cds.root}`);
-
+    const model = await cds.load(modelPaths);
     let services = cds.compile.to.serviceinfo(model, { root: _projectRoot }) ?? [];
     if (services.map) {
         services = services.map((value) => {
@@ -190,7 +190,7 @@ export async function getCdsFiles(
         envRoot ??= await getCdsRoots(projectRoot);
         try {
             const cds = await loadCdsModuleFromProject(projectRoot);
-            csn = await cds.load(envRoot, { root: projectRoot });
+            csn = await cds.load(envRoot);
             cdsFiles = [...(csn['$sources'] ?? [])];
         } catch (e) {
             if (ignoreErrors && e.model?.sources && typeof e.model.sources === 'object') {
@@ -249,7 +249,7 @@ export async function getCdsServices(projectRoot: string, ignoreErrors = true): 
         const roots: string[] = await getCdsRoots(projectRoot);
         let model;
         try {
-            model = await cds.load(roots, { root: projectRoot });
+            model = await cds.load(roots);
         } catch (e) {
             if (ignoreErrors && e.model) {
                 model = e.model;
@@ -404,7 +404,8 @@ async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFaca
     if (global) {
         global.cds = cds;
     }
-
+    // Ensure we use a known root path, otherwise `cwd` is used which varies between invocations.
+    cds.root = capProjectPath;
     return cds;
 }
 

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -133,10 +133,11 @@ describe('Test getCapModelAndServices()', () => {
                 }
             ]
         });
-        expect(cdsMock.load).toBeCalledWith(
-            [join('PROJECT_ROOT', 'APP'), join('PROJECT_ROOT', 'SRV'), join('PROJECT_ROOT', 'DB')],
-            { root: 'PROJECT_ROOT' }
-        );
+        expect(cdsMock.load).toBeCalledWith([
+            join('PROJECT_ROOT', 'APP'),
+            join('PROJECT_ROOT', 'SRV'),
+            join('PROJECT_ROOT', 'DB')
+        ]);
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
     });
 
@@ -169,7 +170,7 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: 'ROOT_PATH' });
     });
 
-    test('Get model and service', async () => {
+    test('Get model and service, project root sets `cds.root`', async () => {
         // Mock setup
         const cdsMock = {
             env: {
@@ -204,7 +205,7 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: projectRoot });
         expect(loggerSpy).toHaveBeenNthCalledWith(1, expect.stringContaining("'cds.home': /cds/home/path"));
         expect(loggerSpy).toHaveBeenNthCalledWith(2, expect.stringContaining("'cds.version': 7.4.2"));
-        expect(loggerSpy).toHaveBeenNthCalledWith(3, expect.stringContaining("'cds.root':"));
+        expect(loggerSpy).toHaveBeenNthCalledWith(3, expect.stringContaining("'cds.root': /some/test/path"));
     });
 });
 
@@ -564,10 +565,7 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual(['file1', 'file2']);
-        expect(cdsMock.load).toBeCalledWith(
-            [join('db/'), join('srv/'), join('app/'), 'schema', 'services'],
-            expect.any(Object)
-        );
+        expect(cdsMock.load).toBeCalledWith([join('db/'), join('srv/'), join('app/'), 'schema', 'services']);
     });
 
     test('Get CDS files from project, but no $sources', async () => {
@@ -639,7 +637,7 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual([`${sep}file1`]);
-        expect(cdsMock.load).toBeCalledWith('envroot', expect.any(Object));
+        expect(cdsMock.load).toBeCalledWith('envroot');
     });
 
     test('Get CDS files from project with envRoot and ignoreErrors true and model data in exception', async () => {
@@ -658,7 +656,7 @@ describe('Test getCdsFiles()', () => {
 
         // Check results
         expect(cdsFiles).toEqual([`${sep}file1`, `${sep}file2`]);
-        expect(cdsMock.load).toBeCalledWith('envroot', expect.any(Object));
+        expect(cdsMock.load).toBeCalledWith('envroot');
     });
 });
 


### PR DESCRIPTION
Reverts SAP/open-ux-tools#1748

We found reason of why there was error of failing `require.resolve` - it was not issue on `open-ux-side`.
We had call for `require.resolve` outside of `open-ux-tools` source.

It was reported that #1748 causes follow up issues regarding `cds.root` - reason of revert.

But still retesting to double check...