### PR TITLE
fix: revert cds root set

### DIFF
--- a/.changeset/dry-spiders-warn.md
+++ b/.changeset/dry-spiders-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Revert setting of cds.root

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -404,6 +404,8 @@ async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFaca
     if (global) {
         global.cds = cds;
     }
+    // Ensure we use a known root path, otherwise `cwd` is used which varies between invocations.
+    cds.root = capProjectPath;
 
     return cds;
 }

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -107,7 +107,8 @@ describe('Test getCapModelAndServices()', () => {
                         }
                     ])
                 }
-            }
+            },
+            root: undefined
         };
         jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
 
@@ -138,6 +139,7 @@ describe('Test getCapModelAndServices()', () => {
             { root: 'PROJECT_ROOT' }
         );
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
+        expect(cdsMock.root).toEqual('PROJECT_ROOT');
     });
 
     test('Get model and services, but services are empty', async () => {


### PR DESCRIPTION
Partially reverts SAP/open-ux-tools#1748

It was reported that #1748 causes follow up issues regarding `cds.root` - reason of revert.

Additionally we found reason of why there was error of failing `require.resolve` - it was not issue on `open-ux-side`.
We had call for `require.resolve` outside of `open-ux-tools` source.
