### PR TITLE
Revert "fix: revert cds root set"

### DIFF
--- a/.changeset/cool-years-deny.md
+++ b/.changeset/cool-years-deny.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Remove setting of cds.root.

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -404,8 +404,6 @@ async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFaca
     if (global) {
         global.cds = cds;
     }
-    // Ensure we use a known root path, otherwise `cwd` is used which varies between invocations.
-    cds.root = capProjectPath;
 
     return cds;
 }

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -107,8 +107,7 @@ describe('Test getCapModelAndServices()', () => {
                         }
                     ])
                 }
-            },
-            root: undefined
+            }
         };
         jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
 
@@ -139,7 +138,6 @@ describe('Test getCapModelAndServices()', () => {
             { root: 'PROJECT_ROOT' }
         );
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL', { root: 'PROJECT_ROOT' });
-        expect(cdsMock.root).toEqual('PROJECT_ROOT');
     });
 
     test('Get model and services, but services are empty', async () => {


### PR DESCRIPTION
Reverts SAP/open-ux-tools#1774

After investigation we found that following code is executed if we change `cds.root`:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/41e4be28-7f34-404f-94a9-d1aa2e2cb5ac)

It is executed in following scope:
1. project path(changed value of `cds.root`) had `spec` dependency;
2. there no `spec` dependency in node_modules yet(install is in progress);
3. then there is call for `require.resolve` for `spec` with cds, which creates cached value with failure state(package.json reader cache);

Then we try to access dependency on next round(when node_modules is installed) - `resolve` throws error based on failure state

