### PR TITLE
fix(deploy-tooling): hide stack trace on error

### DIFF
--- a/.changeset/stale-pumpkins-teach.md
+++ b/.changeset/stale-pumpkins-teach.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+hide stack trace on error

--- a/packages/deploy-tooling/src/base/validate.ts
+++ b/packages/deploy-tooling/src/base/validate.ts
@@ -315,7 +315,8 @@ async function validatePackageWithAdt(
             output.result = false;
         }
     } catch (e) {
-        logger.error(e);
+        logger.error(e.message);
+        logger.debug(e);
         output.summary.push({
             message: summaryMessage.pacakgeAdtAccessError,
             status: SummaryStatus.Unknown
@@ -379,7 +380,8 @@ async function validateTransportRequestWithAdt(
                 status: SummaryStatus.Valid
             });
         } else {
-            logger.error(e);
+            logger.error(e.message);
+            logger.debug(e);
             output.summary.push({
                 message: summaryMessage.transportAdtAccessError,
                 status: SummaryStatus.Unknown

--- a/packages/deploy-tooling/test/unit/base/validate.test.ts
+++ b/packages/deploy-tooling/test/unit/base/validate.test.ts
@@ -480,7 +480,7 @@ describe('deploy-test validation', () => {
             }
         );
     });
-    describe.only('Validate error does not show full stack trace', () => {
+    describe('Validate error does not show full stack trace', () => {
         jest.resetAllMocks();
         const mockLogger = {
             error: jest.fn(),

--- a/packages/deploy-tooling/test/unit/base/validate.test.ts
+++ b/packages/deploy-tooling/test/unit/base/validate.test.ts
@@ -480,7 +480,7 @@ describe('deploy-test validation', () => {
             }
         );
     });
-    describe('Validate error does not show full stack trace', () => {
+    describe.only('Validate error does not show full stack trace', () => {
         jest.resetAllMocks();
         const mockLogger = {
             error: jest.fn(),
@@ -493,6 +493,13 @@ describe('deploy-test validation', () => {
                 ToolsLogger: jest.fn(() => mockLogger)
             };
         });
+        const mockAxiosError403 = {
+            response: {
+                status: 403,
+                statusText: 'Forbidden'
+            },
+            message: 'Request failed with status code 403'
+        } as AxiosError;
         test('Only error message shown when error is thrown', async () => {
             const logMock = jest.spyOn(mockLogger, 'error');
             const mockAxiosError401 = {
@@ -508,6 +515,25 @@ describe('deploy-test validation', () => {
 
             expect(output.result).toBe(false);
             expect(logMock).toHaveBeenCalledWith(mockAxiosError401.message);
+        });
+        test('Only error message shown when error is thrown - validateTransport', async () => {
+            const logMock = jest.spyOn(mockLogger, 'error');
+
+            mockedAdtService.listPackages.mockResolvedValueOnce(['TESTPACKAGE', 'MYPACKAGE']);
+            mockedAdtService.getTransportRequests.mockRejectedValueOnce(mockAxiosError403);
+
+            const output = await validateBeforeDeploy(testConfig, mockedProvider as any, mockLogger as any);
+
+            expect(output.result).toBe(false);
+            expect(logMock).toHaveBeenLastCalledWith(mockAxiosError403.message);
+        });
+        test('Only error message shown when error is thrown - validatePackage', async () => {
+            const logMock = jest.spyOn(mockLogger, 'error');
+            mockedAdtService.listPackages.mockRejectedValueOnce(mockAxiosError403);
+
+            const output = await validateBeforeDeploy(testConfig, mockedProvider as any, mockLogger as any);
+            expect(output.result).toBe(false);
+            expect(logMock).toHaveBeenLastCalledWith(mockAxiosError403.message);
         });
     });
 });


### PR DESCRIPTION
Fixes: Additional bug from #1758 where stack trace from axios was still shown.
- Fix for internal issue no: 27150