### PR TITLE
fix(security): update webpack-dev-middleware

### DIFF
--- a/.changeset/serious-pets-rush.md
+++ b/.changeset/serious-pets-rush.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Security upgrade fixes - `webpack-dev-middleware` from `6.1.1` to `6.1.3`

--- a/docs/version-overrides.md
+++ b/docs/version-overrides.md
@@ -94,3 +94,22 @@ No fix available for `http-proxy` to upgrade to latest `follow-redirects`
 `socks` updated to no longer use `ip`, but `socks-proxy-agent` not upgraded to use the latest `socks`
 
 `@storybook/core-server` involves major version upgrade to consume the `ip` module fix
+
+┌─────────────────────┬────────────────────────────────────────────────────────┐
+│ high                │ Path traversal in webpack-dev-middleware               │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Package             │ webpack-dev-middleware                                 │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Vulnerable versions │ >=6.0.0 <6.1.2                                         │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Patched versions    │ >=6.1.2                                                │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Paths               │ packages/ui-components >                               │
+│                     │ @storybook/react-webpack5@7.4.3 >                      │
+│                     │ @storybook/builder-webpack5@7.4.3 >                    │
+│                     │ webpack-dev-middleware@6.1.1                           │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ More info           │ https://github.com/advisories/GHSA-wr3j-pwj9-hqq6      │
+└─────────────────────┴────────────────────────────────────────────────────────┘
+
+No fix available for `@storybook/builder-webpack5` to upgrade to latest `webpack-dev-middleware`

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
             "@sap/bas-sdk>axios@<1.6.8": ">=1.6.8",
             "http-proxy>follow-redirects@<1.15.6": ">=1.15.6",
             "socks-proxy-agent>socks@<2.8.1": ">=2.8.1",
-            "ip@<2.0.1": ">=2.0.1"
+            "ip@<2.0.1": ">=2.0.1",
+            "webpack-dev-middleware": ">=6.1.3"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
             "http-proxy>follow-redirects@<1.15.6": ">=1.15.6",
             "socks-proxy-agent>socks@<2.8.1": ">=2.8.1",
             "ip@<2.0.1": ">=2.0.1",
-            "webpack-dev-middleware": ">=6.1.3"
+            "webpack-dev-middleware": ">=6.1.2"
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   http-proxy>follow-redirects@<1.15.6: '>=1.15.6'
   socks-proxy-agent>socks@<2.8.1: '>=2.8.1'
   ip@<2.0.1: '>=2.0.1'
-  webpack-dev-middleware: '>=6.1.3'
+  webpack-dev-middleware: '>=6.1.2'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   http-proxy>follow-redirects@<1.15.6: '>=1.15.6'
   socks-proxy-agent>socks@<2.8.1: '>=2.8.1'
   ip@<2.0.1: '>=2.0.1'
+  webpack-dev-middleware: '>=6.1.3'
 
 importers:
 
@@ -7615,7 +7616,7 @@ packages:
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.88.0(@swc/core@1.3.81)(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.1(webpack@5.88.0)
+      webpack-dev-middleware: 6.1.3(webpack@5.88.0)
       webpack-hot-middleware: 2.25.2
       webpack-virtual-modules: 0.5.0
     transitivePeerDependencies:
@@ -21215,8 +21216,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-dev-middleware@6.1.1(webpack@5.88.0):
-    resolution: {integrity: sha512-y51HrHaFeeWir0YO4f0g+9GwZawuigzcAdRNon6jErXy/SqV/+O6eaVAzDqE6t3e3NpGeR5CS+cCDaTC+V3yEQ==}
+  /webpack-dev-middleware@6.1.3(webpack@5.88.0):
+    resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.0.0


### PR DESCRIPTION
Fix for:
```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ Path traversal in webpack-dev-middleware               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ webpack-dev-middleware                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=6.0.0 <6.1.2                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=6.1.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ packages/ui-components >                               │
│                     │ @storybook/react-webpack5@7.4.3 >                      │
│                     │ @storybook/builder-webpack5@7.4.3 >                    │
│                     │ webpack-dev-middleware@6.1.1                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-wr3j-pwj9-hqq6      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```

As I tried update of `@storybook/react-webpack5` from `7.4.3` to latest `8.0.6` does not update `webpack-dev-middleware` dependency - https://github.com/storybookjs/storybook/blob/next/code/builders/builder-webpack5/package.json#L97

As solution - using `overrides` to specifify version above `6.1.2`