### PR TITLE
Enable type checking for TS projects from eslint 

### DIFF
--- a/.changeset/many-cycles-drop.md
+++ b/.changeset/many-cycles-drop.md
@@ -1,0 +1,10 @@
+---
+'@sap-ux/eslint-plugin-fiori-tools': patch
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/fiori-freestyle-writer': patch
+'@sap-ux/ui5-application-writer': patch
+'@sap-ux/fiori-elements-writer': patch
+'@sap-ux/ui5-library-writer': patch
+---
+
+Enable Typscript type checking in eslint module @sap-ux/eslint-plugin-fiori-tools

--- a/packages/eslint-plugin-fiori-tools/eslintrc-typescript.js
+++ b/packages/eslint-plugin-fiori-tools/eslintrc-typescript.js
@@ -17,7 +17,10 @@ const overrides = [
             '**/*.d.ts'
         ],
         'parser': '@typescript-eslint/parser',
-        'extends': ['plugin:@typescript-eslint/recommended'],
+        'extends': [
+            'plugin:@typescript-eslint/recommended',
+            'plugin:@typescript-eslint/recommended-requiring-type-checking'
+        ],
         'parserOptions': {
             'project': true // uses local tsconfig.json nearest to file being linted. Especially important for monorepos
         }

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/eslint-plugin-fiori-tools",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "description": "Custom linting plugin for Fiori tools apps",
     "keywords": [
         "eslint",

--- a/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/feop.test.ts.snap
@@ -3677,7 +3677,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -3694,7 +3694,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/lrop.test.ts.snap
@@ -3627,7 +3627,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -36818,7 +36818,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -40291,7 +40291,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -43764,7 +43764,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/ovp.test.ts.snap
@@ -1700,7 +1700,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -9148,7 +9148,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/basic.test.ts.snap
@@ -743,7 +743,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -1370,7 +1370,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -1985,7 +1985,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/listdetail.test.ts.snap
@@ -44,7 +44,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -2719,7 +2719,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -5394,7 +5394,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -8070,7 +8070,7 @@ archive.zip
     \\"eslint\\": \\"8.57.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
     \\"@sapui5/ts-types\\": \\"~1.76.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
@@ -10608,7 +10608,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
+++ b/packages/fiori-freestyle-writer/test/__snapshots__/worklist.test.ts.snap
@@ -13004,7 +13004,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {
@@ -16359,7 +16359,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"@sap-ux/ui5-middleware-fe-mockserver\\": \\"2\\"
   },
   \\"scripts\\": {

--- a/packages/preview-middleware-client/.eslintrc.js
+++ b/packages/preview-middleware-client/.eslintrc.js
@@ -21,7 +21,10 @@ module.exports = {
                 varsIgnorePattern: '^_',
                 argsIgnorePattern: '^_'
             }
-        ]
+        ],
+        '@typescript-eslint/no-unsafe-argument': 'warn',
+        '@typescript-eslint/no-unsafe-member-access': 'warn',
+        '@typescript-eslint/no-unsafe-assignment': 'warn'
     },
     overrides: [
         {

--- a/packages/preview-middleware-client/src/adp/api-handler.ts
+++ b/packages/preview-middleware-client/src/adp/api-handler.ts
@@ -75,7 +75,7 @@ export async function request<T>(endpoint: ApiEndpoints, method: RequestMethod, 
 
         switch (method) {
             case RequestMethod.GET:
-                return response.json();
+                return response.json() as T;
             case RequestMethod.POST:
                 /**
                  * Since POST usually creates something
@@ -83,7 +83,7 @@ export async function request<T>(endpoint: ApiEndpoints, method: RequestMethod, 
                  */
                 return response.text() as T;
             default:
-                return response.json();
+                return response.json() as T;
         }
     } catch (e) {
         throw new Error(e.message);

--- a/packages/preview-middleware-client/src/adp/controllers/ExtensionPoint.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ExtensionPoint.controller.ts
@@ -142,7 +142,7 @@ export default class ExtensionPoint extends BaseDialog {
             throw new Error(e.message);
         }
 
-        await this.createExtensionPointFragmentChange(fragmentName);
+        this.createExtensionPointFragmentChange(fragmentName);
     }
 
     /**
@@ -150,7 +150,7 @@ export default class ExtensionPoint extends BaseDialog {
      *
      * @param fragmentName Fragment name
      */
-    private async createExtensionPointFragmentChange(fragmentName: string): Promise<void> {
+    private createExtensionPointFragmentChange(fragmentName: string): void {
         const extensionPointName = this.model.getProperty('/extensionPointName');
         const modifiedValue = {
             fragmentPath: `fragments/${fragmentName}.fragment.xml`,

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -51,7 +51,7 @@ export default async function (rta: RuntimeAuthoring) {
     }
 
     // also initialize the editor
-    init(rta);
+    await init(rta);
 
     const ui5VersionValidationMsg = getUI5VersionValidationMessage(version);
 

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -120,6 +120,7 @@ export class ChangeService {
                     if (control) {
                         name = control.getMetadata().getName();
                     }
+                    // eslint-disable-next-line  @typescript-eslint/no-unsafe-call
                     const modifiedMessage = modifyRTAErrorMessage(exception?.toString(), id, name);
                     const errorMessage =
                         modifiedMessage || `RTA Exception applying expression "${action.payload.value}"`;
@@ -379,9 +380,10 @@ export class ChangeService {
     private getCommandSelectorId(command: FlexCommand): string | undefined {
         return this.retryOperations([
             () => command.getSelector().id,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             () => command.getElement().getProperty('persistencyKey'),
             () => command.getElement().getId(),
             () => command.getParent()?.getElement().getId()
-        ]);
+        ]) as string | undefined;
     }
 }

--- a/packages/preview-middleware-client/src/cpe/control-data.ts
+++ b/packages/preview-middleware-client/src/cpe/control-data.ts
@@ -102,6 +102,7 @@ function analyzePropertyType(property: ManagedObjectMetadataProperties): Analyze
         if (propertyDataType && !(propertyDataType instanceof DataType)) {
             return analyzedType;
         }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         const name = Object.getPrototypeOf(propertyDataType).getName();
         if (!name) {
             analyzedType.primitiveType = 'enum';

--- a/packages/preview-middleware-client/src/cpe/documentation.ts
+++ b/packages/preview-middleware-client/src/cpe/documentation.ts
@@ -1,5 +1,5 @@
 import { getLibrary } from './utils';
-import type { SchemaForApiJsonFiles, Ui5Property } from './api-json';
+import type { SchemaForApiJsonFiles, Ui5Metadata, Ui5Property } from './api-json';
 import type { Properties } from './utils';
 import Log from 'sap/base/Log';
 import { PropertiesInfo } from '@sap-ux-private/control-property-editor-common';
@@ -18,7 +18,7 @@ export interface ControlMetadata {
  */
 export async function getUi5ApiDtMetadata(libName: string): Promise<SchemaForApiJsonFiles> {
     const libUrl = '/test-resources/' + libName.split('.').join('/') + '/designtime/api.json';
-    return fetch(libUrl).then((res) => res.json());
+    return fetch(libUrl).then((res) => res.json() as unknown as SchemaForApiJsonFiles);
 }
 
 /**
@@ -85,7 +85,9 @@ function parseControlMetaModel(controlLibMetadata: SchemaForApiJsonFiles, contro
         // base type info of control is available on property 'extends'
         controlInfo.baseType = selectedControlMetadata.extends;
         controlInfo.doc = selectedControlMetadata.description ?? '';
-        const properties = selectedControlMetadata['ui5-metadata'].properties;
+        const properties: (Ui5Property & PropertiesInfo)[] | undefined = (
+            selectedControlMetadata['ui5-metadata'] as Ui5Metadata
+        ).properties as (Ui5Property & PropertiesInfo)[] | undefined;
         if (properties) {
             properties.forEach((prop: Ui5Property & PropertiesInfo) => {
                 prop.description = formatHtmlText(prop.description || '');

--- a/packages/preview-middleware-client/src/cpe/logger.ts
+++ b/packages/preview-middleware-client/src/cpe/logger.ts
@@ -4,7 +4,7 @@ import { Logger } from '@sap-ux-private/control-property-editor-common';
 
 function getString(message: string | object): string {
     if (typeof message === 'object') {
-        return message.toString();
+        return JSON.stringify(message).toString();
     }
     return message;
 }

--- a/packages/preview-middleware-client/src/cpe/outline/nodes.ts
+++ b/packages/preview-middleware-client/src/cpe/outline/nodes.ts
@@ -48,7 +48,7 @@ export async function transformNodes(input: OutlineViewNode[], scenario: Scenari
     const items: OutlineNode[] = [];
     while (stack.length) {
         const current = stack.shift();
-        const editable = await isEditable(current?.id);
+        const editable = isEditable(current?.id);
         if (current?.type === 'element') {
             const children = getChildren(current);
             const { text } = getAdditionalData(current.id);

--- a/packages/preview-middleware-client/src/cpe/selection.ts
+++ b/packages/preview-middleware-client/src/cpe/selection.ts
@@ -101,7 +101,7 @@ export class SelectionService implements Service {
      * @param sendAction action sender function
      * @param subscribe subscriber function
      */
-    public async init(sendAction: ActionSenderFunction, subscribe: SubscribeFunction): Promise<void> {
+    public init(sendAction: ActionSenderFunction, subscribe: SubscribeFunction): void {
         const eventOrigin: Set<string> = new Set();
         const onselectionChange = this.createOnSelectionChangeHandler(sendAction, eventOrigin);
         this.rta.attachSelectionChange((event) => {
@@ -185,8 +185,10 @@ export class SelectionService implements Service {
                         const isOutline = eventOrigin.has('outline');
                         const name = controlName.toLowerCase().startsWith('sap') ? controlName : 'Other Control Types';
                         if (isOutline) {
+                            // eslint-disable-next-line @typescript-eslint/no-floating-promises
                             reportTelemetry({ category: 'Outline Selection', controlName: name });
                         } else {
+                            // eslint-disable-next-line @typescript-eslint/no-floating-promises
                             reportTelemetry({ category: 'Overlay Selection', controlName: name });
                         }
                     } catch (error) {

--- a/packages/preview-middleware-client/src/flp/WorkspaceConnector.ts
+++ b/packages/preview-middleware-client/src/flp/WorkspaceConnector.ts
@@ -18,7 +18,7 @@ const connector = merge({}, ObjectStorageConnector, {
 
             if (typeof this.fileChangeRequestNotifier === 'function' && change.fileName) {
                 try {
-                    this.fileChangeRequestNotifier(change.fileName, 'create',  change.changeType);
+                    this.fileChangeRequestNotifier(change.fileName, 'create', change.changeType);
                 } catch (e) {
                     // exceptions in the listener call are ignored
                 }
@@ -62,7 +62,7 @@ const connector = merge({}, ObjectStorageConnector, {
                     'content-type': 'application/json'
                 }
             });
-            const changes = await response.json();
+            const changes = await response.json() as unknown as FlexChange[];
             return changes;
         }
     } as typeof ObjectStorageConnector.storage,

--- a/packages/preview-middleware-client/src/flp/common.ts
+++ b/packages/preview-middleware-client/src/flp/common.ts
@@ -18,11 +18,11 @@ export const CHANGES_API_PATH = '/preview/api/changes';
  * @returns {FlexSettings | undefined} The parsed Flex settings if available, otherwise undefined.
  */
 export function getFlexSettings(): FlexSettings | undefined {
-    let result;
+    let result: FlexSettings | undefined;
     const bootstrapConfig = document.getElementById('sap-ui-bootstrap');
     const flexSetting = bootstrapConfig?.getAttribute('data-open-ux-preview-flex-settings');
     if (flexSetting) {
-        result = JSON.parse(flexSetting);
+        result = JSON.parse(flexSetting) as FlexSettings;
     }
     return result;
 }

--- a/packages/ui5-application-writer/templates/optional/eslint/package.json
+++ b/packages/ui5-application-writer/templates/optional/eslint/package.json
@@ -3,7 +3,7 @@
         "lint": "eslint ./"
     },
     "devDependencies": {
-        "@sap-ux/eslint-plugin-fiori-tools": "^0.3.1",
+        "@sap-ux/eslint-plugin-fiori-tools": "^0.4.0",
         "eslint": "8.57.0",
         "eslint-plugin-fiori-custom": "2.6.7",
         "@babel/eslint-parser": "7.14.7"

--- a/packages/ui5-application-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-application-writer/templates/optional/typescript/package.json
@@ -11,6 +11,6 @@
         "typescript": "^5.1.6",
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
-        "@sap-ux/eslint-plugin-fiori-tools": "^0.3.1"
+        "@sap-ux/eslint-plugin-fiori-tools": "^0.4.0"
     }
 }

--- a/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
+++ b/packages/ui5-application-writer/test/__snapshots__/options.test.ts.snap
@@ -46,7 +46,7 @@ archive.zip
     \\"eslint\\": \\"8.57.0\\",
     \\"@sap/eslint-plugin-ui5-jsdocs\\": \\"2.0.5\\",
     \\"@sapui5/ts-types\\": \\"~1.76.0\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"eslint-plugin-fiori-custom\\": \\"2.6.7\\",
     \\"@babel/eslint-parser\\": \\"7.14.7\\"
   },
@@ -1003,7 +1003,7 @@ exports[`UI5 templates option: \`typescript and code assist\` to check for confl
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\"
   },
   \\"scripts\\": {
     \\"start\\": \\"ui5 serve --config=ui5.yaml --open index.html\\",
@@ -1100,7 +1100,7 @@ archive.zip
     \\"typescript\\": \\"^5.1.6\\",
     \\"@typescript-eslint/eslint-plugin\\": \\"^7.1.1\\",
     \\"@typescript-eslint/parser\\": \\"^7.1.1\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\",
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\",
     \\"ui5-tooling-modules\\": \\"^0.6.0\\"
   },
   \\"scripts\\": {

--- a/packages/ui5-library-writer/templates/optional/typescript/package.json
+++ b/packages/ui5-library-writer/templates/optional/typescript/package.json
@@ -17,7 +17,7 @@
       "typescript": "^5.1.6",
       "@sap/ux-ui5-tooling": "1",
       "ui5-tooling-transpile": "^3.3.7",
-      "@sap-ux/eslint-plugin-fiori-tools": "^0.3.1"
+      "@sap-ux/eslint-plugin-fiori-tools": "^0.4.0"
     },
     "scripts": {
         "build": "run-p -l build-app build-interface",

--- a/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-library-writer/test/__snapshots__/index.test.ts.snap
@@ -599,7 +599,7 @@ module.exports = function (config) {
     \\"npm-run-all\\": \\"^4.1.5\\",
     \\"typescript\\": \\"^5.1.6\\",
     \\"ui5-tooling-transpile\\": \\"^3.3.7\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\"
   },
   \\"scripts\\": {
     \\"build\\": \\"run-p -l build-app build-interface\\",
@@ -1221,7 +1221,7 @@ module.exports = function (config) {
     \\"npm-run-all\\": \\"^4.1.5\\",
     \\"typescript\\": \\"^5.1.6\\",
     \\"ui5-tooling-transpile\\": \\"^3.3.7\\",
-    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.3.1\\"
+    \\"@sap-ux/eslint-plugin-fiori-tools\\": \\"^0.4.0\\"
   },
   \\"scripts\\": {
     \\"build\\": \\"run-p -l build-app build-interface\\",


### PR DESCRIPTION
Enable type checking for TS projects from Eslint in the Fiori project
- Update minor version and consumption in project templates
- Update eslint config in `preview-middleware-client` and address some eslint issues in the code.
