### PR TITLE
feat(deploy-tooling): 1821 change TR description

### DIFF
--- a/.changeset/polite-needles-sleep.md
+++ b/.changeset/polite-needles-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+Change TR description

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -198,7 +198,7 @@ export async function createTransportRequest(
     const transportRequest = await adtService?.createTransportRequest({
         packageName: config.app.package ?? '',
         ui5AppName,
-        description: `Created by SAP Fiori tools for ABAP repository ${ui5AppName}`
+        description: `Created by SAP Open UX Tools for ABAP repository ${ui5AppName}`
     });
     if (transportRequest) {
         logger.info(`Transport request ${transportRequest} created for application ${ui5AppName}.`);

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -198,7 +198,7 @@ export async function createTransportRequest(
     const transportRequest = await adtService?.createTransportRequest({
         packageName: config.app.package ?? '',
         ui5AppName,
-        description: 'Created by @sap-ux/deploy-tooling'
+        description: `Created by SAP Fiori tools for ABAP repository ${ui5AppName}`
     });
     if (transportRequest) {
         logger.info(`Transport request ${transportRequest} created for application ${ui5AppName}.`);

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -234,7 +234,7 @@ describe('base/deploy', () => {
             expect(config.createTransport).toBe(false);
             expect(mockedAdtService.createTransportRequest).toBeCalledTimes(1);
             expect(mockedAdtService.createTransportRequest).toBeCalledWith(
-                expect.objectContaining({ description: 'Created by SAP Fiori tools for ABAP repository ~name' })
+                expect.objectContaining({ description: 'Created by SAP Open UX Tools for ABAP repository ~name' })
             );
         });
 

--- a/packages/deploy-tooling/test/unit/base/deploy.test.ts
+++ b/packages/deploy-tooling/test/unit/base/deploy.test.ts
@@ -233,6 +233,9 @@ describe('base/deploy', () => {
             });
             expect(config.createTransport).toBe(false);
             expect(mockedAdtService.createTransportRequest).toBeCalledTimes(1);
+            expect(mockedAdtService.createTransportRequest).toBeCalledWith(
+                expect.objectContaining({ description: 'Created by SAP Fiori tools for ABAP repository ~name' })
+            );
         });
 
         test('Throws error if transport is not returned from ADT service', async () => {


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1821

Change the default TR description to include the name of the ABAP repo used in deploy config so that users can more easily see what the TR relates to. The suggested new default text should be:

`Created by SAP Open UX Tools for ABAP repository <repository name>`