### PR TITLE
fix(project-access): detect mismatch of global and project installed @sap/cds

### DIFF
--- a/.changeset/slimy-gifts-rescue.md
+++ b/.changeset/slimy-gifts-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Detect mismatching global and project installations of @sap/cds

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -607,5 +607,5 @@ async function getCdsVersionFromPackageJson(packageJsonPath: string): Promise<st
  * @returns - major version as number
  */
 function getMajorVersion(versionString: string): number {
-    return parseInt(versionString.split('.')[0].match(/\d+/)?.[0] ?? '0', 10);
+    return parseInt(/\d+/.exec(versionString.split('.')[0])?.[0] ?? '0', 10);
 }

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -127,8 +127,8 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
 /**
  * Return the CAP model and all services. The cds.root will be set to the provided project root path.
  *
- * @param projectRoot - CAP project root where package.json resides or object specifying project root and optional logger to log additonal info
- * @returns {*}  {Promise<{ model: csn; services: ServiceInfo[] }>} - CAP Model and Services
+ * @param projectRoot - CAP project root where package.json resides or object specifying project root and optional logger to log additional info
+ * @returns {Promise<{ model: csn; services: ServiceInfo[] }>} - CAP Model and Services
  */
 export async function getCapModelAndServices(
     projectRoot: string | { projectRoot: string; logger?: Logger }
@@ -142,7 +142,7 @@ export async function getCapModelAndServices(
         _projectRoot = projectRoot;
     }
 
-    const cds = await loadCdsModuleFromProject(_projectRoot);
+    const cds = await loadCdsModuleFromProject(_projectRoot, true);
     const capProjectPaths = await getCapCustomPaths(_projectRoot);
     const modelPaths = [
         join(_projectRoot, capProjectPaths.app),
@@ -371,12 +371,13 @@ declare const global: {
 /**
  * Load CAP CDS module. First attempt loads @sap/cds for a project based on its root.
  * Second attempt loads @sap/cds from global installed @sap/cds-dk.
- * Throws error if module could not be loaded.
+ * Throws error if module could not be loaded or strict mode is true and there is a version mismatch.
  *
  * @param capProjectPath - project root of a CAP project
+ * @param [strict] - optional, when set true an error is thrown, if global loaded cds version does not match the cds version from package.json dependency. Default is false.
  * @returns - CAP CDS module for a CAP project
  */
-async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFacade> {
+async function loadCdsModuleFromProject(capProjectPath: string, strict: boolean = false): Promise<CdsFacade> {
     let module: CdsFacade | { default: CdsFacade } | undefined;
     let loadProjectError;
     let loadError;
@@ -400,6 +401,20 @@ async function loadCdsModuleFromProject(capProjectPath: string): Promise<CdsFaca
         );
     }
     const cds = 'default' in module ? module.default : module;
+
+    // In case strict is true and there was a fallback to global cds installation for a project that has a cds dependency, check if major versions match
+    if (strict && loadProjectError) {
+        const cdsDependencyVersion = await getCdsVersionFromPackageJson(join(capProjectPath, FileName.Package));
+        if (typeof cdsDependencyVersion === 'string') {
+            const globalCdsVersion = cds.version;
+            if (getMajorVersion(cdsDependencyVersion) !== getMajorVersion(globalCdsVersion)) {
+                throw Error(
+                    `The @sap/cds major version (${cdsDependencyVersion}) specified in your CAP project is different to the @sap/cds version you have installed globally (${globalCdsVersion}). Please run 'npm install' on your CAP project to ensure that the correct CDS version is loaded.`
+                );
+            }
+        }
+    }
+
     // Fix when switching cds versions dynamically
     if (global) {
         global.cds = cds;
@@ -529,6 +544,13 @@ async function loadGlobalCdsModule<T>(): Promise<T> {
 }
 
 /**
+ * Clear cache of path to global cds module.
+ */
+export function clearGlobalCdsPathCache() {
+    globalCdsPathCache = '';
+}
+
+/**
  * Get cds information, which includes versions and also the home path of cds module.
  *
  * @param [cwd] - optional folder in which cds --version should be executed
@@ -557,4 +579,33 @@ async function getCdsVersionInfo(cwd?: string): Promise<Record<string, string>> 
             reject(error);
         });
     });
+}
+
+/**
+ * Read the version string of the @sap/cds module from the package.json file.
+ *
+ * @param packageJsonPath - path to package.json
+ * @returns - version of @sap/cds from package.json or undefined
+ */
+async function getCdsVersionFromPackageJson(packageJsonPath: string): Promise<string | undefined> {
+    let version: string | undefined;
+    try {
+        if (await fileExists(packageJsonPath)) {
+            const packageJson = await readJSON<Package>(packageJsonPath);
+            version = packageJson?.dependencies?.['@sap/cds'];
+        }
+    } catch {
+        // If we can't read or parse the package.json we return undefined
+    }
+    return version;
+}
+
+/**
+ * Get major version from version string.
+ *
+ * @param versionString - version string
+ * @returns - major version as number
+ */
+function getMajorVersion(versionString: string): number {
+    return parseInt(versionString.split('.')[0].match(/\d+/)?.[0] ?? '0', 10);
 }


### PR DESCRIPTION
To retrieve service definitions for CAP project we load module `@sap/cds` from the CAP project. As fallback, we try to load `@sap/cds` from global modules, which will be available in the common case that developer cli tools `@sap/cds-dk` is installed. This is required especially for CAP Java projects.
There is a flaw in this approach, in case the CAP project specifies a dependency to `@sap/cds` e.g. to version 7, but the node modules are not installed yet, so `npm install` was not executed.In this case the fallback to global installed `@sap/cds-dk` applies. However, the version of global installed `@sap/cds` could differ from the one specified in the project, e.g. version 6. This can lead to issues due to incompatible changes of different major versions.

This pull request addresses this issue. Internal function `loadCdsModuleFromProject()`, which is used to load `@sap/cds`, has a new optional parameter `strict`. If set, a check is conducted whether we have the situation:
-  `@sap/cds` is loaded globally
-  a dependency to `@sap/cds` exists in the `package.json` 
- major version differs

If all is true, an error is thrown. Currently, only `getCapModelAndServices()` is setting `strict` due to known incompatibilities. 


