### PR TITLE
fix: Component Usages writer produces incorrect content of a change

### DIFF
--- a/.changeset/breezy-pants-greet.md
+++ b/.changeset/breezy-pants-greet.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/adp-tooling': patch
+'@sap-ux/preview-middleware': patch
+'@sap-ux/create': patch
+---
+
+Component Usages writer produces incorrect content of a change

--- a/packages/adp-tooling/src/writer/changes/writers/component-usages-writer.ts
+++ b/packages/adp-tooling/src/writer/changes/writers/component-usages-writer.ts
@@ -22,10 +22,10 @@ export class ComponentUsagesWriter implements IWriter<ComponentUsagesData> {
      * @returns {object} The constructed content object for the component usages change.
      */
     private constructContent({ component }: ComponentUsagesData): object {
-        const { data, usageId, settings, isLazy } = component;
+        const { data, usageId, settings, isLazy, name } = component;
         const componentUsages = {
             [usageId]: {
-                name: usageId,
+                name,
                 lazy: isLazy === 'true',
                 settings: parseStringToObject(settings),
                 data: parseStringToObject(data)


### PR DESCRIPTION
Fix for #1829.

- Changes the content of the change to use name instead of usageId for name property.