### PR TITLE
fix(ui5-info): Fix for UI5 version offline fallbacks

### DIFF
--- a/.changeset/late-avocados-stare.md
+++ b/.changeset/late-avocados-stare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-info': minor
+---
+
+Will not return `Latest` as fallback UI5 version

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -1,6 +1,6 @@
 import { coerce, gte } from 'semver';
 import type { UI5VersionOverview } from './types';
-import { defaultMinUi5Version, defaultVersion } from './constants';
+import { defaultMinUi5Version } from './constants';
 
 export const supportState = {
     maintenance: 'Maintenance',
@@ -10,6 +10,14 @@ export const supportState = {
 
 // Updated Feb-28-2024
 export const ui5VersionFallbacks = [
+    {
+        version: '1.122.*',
+        support: supportState.maintenance
+    },
+    {
+        version: '1.121.*',
+        support: supportState.maintenance
+    },
     {
         version: '1.120.*',
         support: supportState.maintenance
@@ -36,7 +44,7 @@ export const ui5VersionFallbacks = [
     },
     {
         version: '1.114.*',
-        support: supportState.maintenance
+        support: supportState.outOfMaintenance
     },
     {
         version: '1.113.*',
@@ -349,5 +357,4 @@ const supportedUi5VersionFallbacks = ui5VersionFallbacks
     .map((maintainedVersion) => coerce(maintainedVersion.version)?.version ?? '0.0.0');
 
 const defaultUi5Versions = [...supportedUi5VersionFallbacks];
-defaultUi5Versions.unshift(defaultVersion);
 export { defaultUi5Versions, supportedUi5VersionFallbacks };

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -8,7 +8,7 @@ export const supportState = {
     skipped: 'Skipped'
 } as const;
 
-// Updated Feb-28-2024
+// Updated April-16-2024 from https://ui5.sap.com/versionoverview.json
 export const ui5VersionFallbacks = [
     {
         version: '1.122.*',

--- a/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
+++ b/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
@@ -4109,16 +4109,16 @@ exports[`getUI5Versions filterOptions: snapshots included - snapshotVersionsHost
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback for specified min UI5 version, if request fails 1`] = `
 [
   {
-    "version": "Latest",
+    "version": "1.122.0",
+  },
+  {
+    "version": "1.121.0",
   },
   {
     "version": "1.120.0",
   },
   {
     "version": "1.117.0",
-  },
-  {
-    "version": "1.114.0",
   },
   {
     "version": "1.108.0",
@@ -4138,16 +4138,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback if official is not available  1`] = `
 [
   {
-    "version": "Latest",
+    "version": "1.122.0",
+  },
+  {
+    "version": "1.121.0",
   },
   {
     "version": "1.120.0",
   },
   {
     "version": "1.117.0",
-  },
-  {
-    "version": "1.114.0",
   },
   {
     "version": "1.108.0",
@@ -4167,16 +4167,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback if snapshot is not available  1`] = `
 [
   {
-    "version": "Latest",
+    "version": "1.122.0",
+  },
+  {
+    "version": "1.121.0",
   },
   {
     "version": "1.120.0",
   },
   {
     "version": "1.117.0",
-  },
-  {
-    "version": "1.114.0",
   },
   {
     "version": "1.108.0",
@@ -4196,16 +4196,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 versions fallback if official is not available  1`] = `
 [
   {
-    "version": "Latest",
+    "version": "1.122.0",
+  },
+  {
+    "version": "1.121.0",
   },
   {
     "version": "1.120.0",
   },
   {
     "version": "1.117.0",
-  },
-  {
-    "version": "1.114.0",
   },
   {
     "version": "1.108.0",
@@ -4225,16 +4225,16 @@ exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 versions fallback if snapshot is not available  1`] = `
 [
   {
-    "version": "Latest",
+    "version": "1.122.0",
+  },
+  {
+    "version": "1.121.0",
   },
   {
     "version": "1.120.0",
   },
   {
     "version": "1.117.0",
-  },
-  {
-    "version": "1.114.0",
   },
   {
     "version": "1.108.0",

--- a/packages/ui5-info/test/commands.test.ts
+++ b/packages/ui5-info/test/commands.test.ts
@@ -104,18 +104,21 @@ describe('Retrieve NPM UI5 mocking spawn process', () => {
         const retrievedUI5Versions = await getUI5Versions({
             onlyNpmVersion: true
         }); // expect defaults
-        expect(retrievedUI5Versions[0]).toEqual({ version: '1.120.0' });
-        expect(retrievedUI5Versions.length).toEqual(7);
+        expect(retrievedUI5Versions[0]).toEqual({ version: '1.122.0' });
+        expect(retrievedUI5Versions.length).toEqual(8);
         expect(retrievedUI5Versions).toMatchInlineSnapshot(`
             [
+              {
+                "version": "1.122.0",
+              },
+              {
+                "version": "1.121.0",
+              },
               {
                 "version": "1.120.0",
               },
               {
                 "version": "1.117.0",
-              },
-              {
-                "version": "1.114.0",
               },
               {
                 "version": "1.108.0",


### PR DESCRIPTION
Fixes https://github.com/SAP/open-ux-tools/issues/1835

- Dont return invalid sem ver as fallback, `Latest` would need to be resolved anyway and this doesnt make sense in an offline environment.
- Updates fallback to today
- Updates tests