### PR TITLE
fix(axios-extension): rename SCENARIO to FIORI_TOOLS_SCENARIO

### DIFF
--- a/.changeset/brave-games-rest.md
+++ b/.changeset/brave-games-rest.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+Rename SCENARIO to FIORI_TOOLS_SCENARIO

--- a/packages/axios-extension/src/auth/reentrance-ticket/index.ts
+++ b/packages/axios-extension/src/auth/reentrance-ticket/index.ts
@@ -37,7 +37,7 @@ export async function getReentranceTicket({
         const redirectPort = (server.address() as AddressInfo).port;
 
         // Open browser to handle SAML flow and return the reentrance ticket
-        const scenario = process.env.SCENARIO ?? 'FIORI';
+        const scenario = process.env.FIORI_TOOLS_SCENARIO ?? 'FIORI';
         const url = `${backend.uiHostname()}${ADT_REENTRANCE_ENDPOINT}?scenario=${scenario}&redirect-url=${redirectUrl(
             redirectPort
         )}`;

--- a/packages/axios-extension/test/auth/reentrance-ticket/index.test.ts
+++ b/packages/axios-extension/test/auth/reentrance-ticket/index.test.ts
@@ -42,5 +42,17 @@ describe('getReentranceTicket()', () => {
             logger: new ToolsLogger({ transports: [new NullTransport()] })
         });
         expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining(REDIRECT_URL));
+        // default SCENARIO is FIORI if none provided via env variable
+        expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining('FIORI'));
+    });
+
+    it('Sets scenario from env variable', async () => {
+        process.env.FIORI_TOOLS_SCENARIO = 'MYSCENARIO';
+        await getReentranceTicket({
+            backendUrl: 'http://some_url.example',
+            logger: new ToolsLogger({ transports: [new NullTransport()] })
+        });
+        expect(mockOpen).toHaveBeenCalledWith(expect.stringContaining('MYSCENARIO'));
+        delete process.env.FIORI_TOOLS_SCENARIO;
     });
 });


### PR DESCRIPTION
Renames `SCENARIO` to `FIORI_TOOLS_SCENARIO` in order to be consistent to other env variables expected by the middlewares.