### PR TITLE
fix(ui5-lib-ref-writer): fix paths and config writers for ui5 lib reference

### DIFF
--- a/.changeset/brown-lies-allow.md
+++ b/.changeset/brown-lies-allow.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/ui5-library-reference-writer': patch
+'@sap-ux/project-access': patch
+'@sap-ux/ui5-config': patch
+---
+
+fix paths and config writers

--- a/.changeset/tame-nails-grin.md
+++ b/.changeset/tame-nails-grin.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-library-reference-writer': patch
+---
+
+fix relative path written to yaml files

--- a/.changeset/tame-nails-grin.md
+++ b/.changeset/tame-nails-grin.md
@@ -1,5 +1,0 @@
----
-'@sap-ux/ui5-library-reference-writer': patch
----
-
-fix relative path written to yaml files

--- a/packages/project-access/test/library/helpers.test.ts
+++ b/packages/project-access/test/library/helpers.test.ts
@@ -28,6 +28,32 @@ describe('library utils', () => {
         expect(libChoices[2].name).toBe('sap.reuse.ex.test.lib.attachmentservice.attachment.components.fscomponent');
         expect(libChoices[3].name).toBe('sap.reuse.ex.test.lib.attachmentservice.attachment.components.stcomponent');
 
+        expect(libChoices[0].path).toBe(
+            join(
+                __dirname,
+                '../test-data/libs/sap.reuse.ex.test.lib.attachmentservice/src/sap/reuse/ex/test/lib/attachmentservice'
+            )
+        );
+        expect(libChoices[1].path).toBe(
+            join(
+                __dirname,
+                '../test-data/libs/sap.reuse.ex.test.lib.attachmentservice/src/sap/reuse/ex/test/lib/attachmentservice/attachment'
+            )
+        );
+        expect(libChoices[2].path).toBe(
+            join(
+                __dirname,
+                '../test-data/libs/sap.reuse.ex.test.lib.attachmentservice/src/sap/reuse/ex/test/lib/attachmentservice/attachment/components/fscomponent'
+            )
+        );
+
+        expect(libChoices[3].path).toBe(
+            join(
+                __dirname,
+                '../test-data/libs/sap.reuse.ex.test.lib.attachmentservice/src/sap/reuse/ex/test/lib/attachmentservice/attachment/components/stcomponent'
+            )
+        );
+
         for (const lib of libChoices) {
             expect(lib.description).toBe('UI Library for Fiori Reuse Attachment Service');
         }

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -416,7 +416,7 @@ export class UI5Config {
      * @returns {UI5Config} the UI5Config instance
      * @memberof UI5Config
      */
-    private mergeCustomMiddleware(middleware: CustomMiddleware<unknown>): UI5Config {
+    private mergeCustomMiddleware(middleware: CustomMiddleware<unknown>): this {
         const name = middleware.name;
         if (this.findCustomMiddleware(name)) {
             this.document.updateAt({

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -410,6 +410,26 @@ export class UI5Config {
     }
 
     /**
+     * Merges existing custom middleware with the passed config.
+     *
+     * @param middleware - middleware config
+     * @returns {UI5Config} the UI5Config instance
+     * @memberof UI5Config
+     */
+    private mergeCustomMiddleware(middleware: CustomMiddleware<unknown>): UI5Config {
+        const name = middleware.name;
+        if (this.findCustomMiddleware(name)) {
+            this.document.updateAt({
+                path: 'server.customMiddleware',
+                matcher: { key: 'name', value: name },
+                value: middleware,
+                mode: 'merge'
+            });
+        }
+        return this;
+    }
+
+    /**
      * Returns the serve static config.
      *
      * @param addFioriToolProxy - if true, `fiori-tools-proxy` config is added, otherwise a `compression` config will be added
@@ -452,6 +472,13 @@ export class UI5Config {
                 this.updateCustomMiddleware({
                     name: serveStatic,
                     beforeMiddleware: fioriToolsProxy,
+                    configuration: {
+                        paths: [...serveStaticConfig.configuration.paths, ...serveStaticPaths]
+                    }
+                });
+            } else {
+                this.mergeCustomMiddleware({
+                    name: serveStatic,
                     configuration: {
                         paths: [...serveStaticConfig.configuration.paths, ...serveStaticPaths]
                     }

--- a/packages/ui5-config/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-config/test/__snapshots__/index.test.ts.snap
@@ -344,6 +344,35 @@ exports[`UI5Config addServeStaticConfig add with multiple paths (existing config
             src: /targetapp/abeppw
           - path: /appconfig
             src: /srcapp/appconfig
+          - path: /~path
+            src: /~src
+            fallthrough: false
+          - path: /~otherPath
+            src: /~otherSrc
+            fallthrough: false
+"
+`;
+
+exports[`UI5Config addServeStaticConfig add with multiple paths (existing config) 2`] = `
+"server:
+  customMiddleware:
+    - name: fiori-tools-servestatic
+      afterMiddleware: compression
+      configuration:
+        paths:
+          - path: /resources/targetapp
+            src: /targetapp/abeppw
+          - path: /appconfig
+            src: /srcapp/appconfig
+          - path: /~path
+            src: /~src
+            fallthrough: false
+          - path: /~otherPath
+            src: /~otherSrc
+            fallthrough: false
+          - path: /~newPath
+            src: /~newSrc
+            fallthrough: false
 "
 `;
 
@@ -356,11 +385,11 @@ exports[`UI5Config addServeStaticConfig add with single path (no existing serve 
         paths:
           - path: /~testpath~
             src: /~src
-            fallthrough: true
+            fallthrough: false
 "
 `;
 
-exports[`UI5Config addServeStaticConfig update serve static ocnfig 1`] = `
+exports[`UI5Config addServeStaticConfig update serve static config 1`] = `
 "server:
   customMiddleware:
     - name: fiori-tools-servestatic
@@ -373,7 +402,7 @@ exports[`UI5Config addServeStaticConfig update serve static ocnfig 1`] = `
             src: /srcapp/appconfig
           - path: /~testpath~
             src: /~src
-            fallthrough: true
+            fallthrough: false
           - path: /~other
             src: /~otherSrc
             fallthrough: false

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -375,7 +375,7 @@ describe('UI5Config', () => {
         };
 
         test('add with single path (no existing serve static config)', () => {
-            ui5Config.addServeStaticConfig([{ path, src: '/~src', fallthrough: true }]);
+            ui5Config.addServeStaticConfig([{ path, src: '/~src', fallthrough: false }]);
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
@@ -383,17 +383,20 @@ describe('UI5Config', () => {
             ui5Config.addCustomMiddleware([serveStaticMiddleware]);
 
             ui5Config.addServeStaticConfig([
-                { path, src: '/~src', fallthrough: true },
-                { path: '/~other', src: '/~otherSrc', fallthrough: false }
+                { path: '/~path', src: '/~src', fallthrough: false },
+                { path: '/~otherPath', src: '/~otherSrc', fallthrough: false }
             ]);
+            expect(ui5Config.toString()).toMatchSnapshot();
+
+            ui5Config.addServeStaticConfig([{ path: '/~newPath', src: '/~newSrc', fallthrough: false }]);
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
-        test('update serve static ocnfig', () => {
+        test('update serve static config', () => {
             ui5Config.addCustomMiddleware([serveStaticMiddleware, fioriToolsProxy]);
 
             ui5Config.addServeStaticConfig([
-                { path, src: '/~src', fallthrough: true },
+                { path, src: '/~src', fallthrough: false },
                 { path: '/~other', src: '/~otherSrc', fallthrough: false }
             ]);
             expect(ui5Config.toString()).toMatchSnapshot();

--- a/packages/ui5-library-reference-writer/src/helpers.ts
+++ b/packages/ui5-library-reference-writer/src/helpers.ts
@@ -2,7 +2,7 @@ import type { Editor } from 'mem-fs-editor';
 import type { ReuseLibConfig } from './types';
 import { UI5Config, type ServeStaticPath } from '@sap-ux/ui5-config';
 import { getWebappPath, type Manifest } from '@sap-ux/project-access';
-import { dirname, join, relative } from 'path';
+import { join, relative } from 'path';
 import { yamlFiles, ManifestReuseType } from './constants';
 
 /**
@@ -64,7 +64,7 @@ function getServeStaticPaths(reuseLibs: ReuseLibConfig[], projectPath: string): 
         const reuseLibRefs: ServeStaticPath[] = [
             {
                 path: `/resources/${lib.name.replace(/\./g, '/')}`,
-                src: relative(projectPath, dirname(lib.path)),
+                src: relative(projectPath, lib.path),
                 fallthrough: false
             }
         ];
@@ -72,7 +72,7 @@ function getServeStaticPaths(reuseLibs: ReuseLibConfig[], projectPath: string): 
         if (lib.uri) {
             reuseLibRefs.push({
                 path: `${lib.uri.replace(/\/bsp\//g, '/ui5_ui5/')}`,
-                src: relative(projectPath, dirname(lib.path)),
+                src: relative(projectPath, lib.path),
                 fallthrough: false
             });
         }

--- a/packages/ui5-library-reference-writer/test/index.test.ts
+++ b/packages/ui5-library-reference-writer/test/index.test.ts
@@ -35,9 +35,7 @@ describe('Test UI5 Library Reference Writer', () => {
         expect(fs.dump(testProjectPath, '**/webapp/*.json')).toMatchSnapshot();
         const ui5YamlContent = fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents;
         expect(ui5YamlContent).toContain(`fiori-tools-servestatic`);
-        expect(ui5YamlContent).toContain(
-            `src: ${join('../../../../../sample/libs/my.namespace.reuse.attachmentservice')}`
-        );
+        expect(ui5YamlContent).toContain(`src: ${join('../../../sample/libs/my.namespace.reuse.attachmentservice')}`);
     });
 
     it('should generate the UI5 library reference in a project with a custom webapp path', async () => {
@@ -52,9 +50,7 @@ describe('Test UI5 Library Reference Writer', () => {
         expect(fs.dump(testProjectPath, '**/src/main/webapp/*.json')).toMatchSnapshot();
         const ui5YamlContent = fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents;
         expect(ui5YamlContent).toContain(`fiori-tools-servestatic`);
-        expect(ui5YamlContent).toContain(
-            `src: ${join('../../../../../sample/libs/my.namespace.reuse.attachmentservice')}`
-        );
+        expect(ui5YamlContent).toContain(`src: ${join('../../../sample/libs/my.namespace.reuse.attachmentservice')}`);
     });
 
     it('should generate the UI5 library reference (sap.ui5.dependencies.libs does not exist)', async () => {

--- a/packages/ui5-library-reference-writer/test/index.test.ts
+++ b/packages/ui5-library-reference-writer/test/index.test.ts
@@ -33,7 +33,11 @@ describe('Test UI5 Library Reference Writer', () => {
         fsextra.copySync(join(__dirname, '/test-input/sample-projects/test_project_lrop_v2'), testProjectPath);
         await generate(testProjectPath, reuseLibs, fs);
         expect(fs.dump(testProjectPath, '**/webapp/*.json')).toMatchSnapshot();
-        expect(fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents).toContain(`fiori-tools-servestatic`);
+        const ui5YamlContent = fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents;
+        expect(ui5YamlContent).toContain(`fiori-tools-servestatic`);
+        expect(ui5YamlContent).toContain(
+            `src: ${join('../../../../../sample/libs/my.namespace.reuse.attachmentservice')}`
+        );
     });
 
     it('should generate the UI5 library reference in a project with a custom webapp path', async () => {
@@ -46,7 +50,11 @@ describe('Test UI5 Library Reference Writer', () => {
         );
         await generate(testProjectPath, reuseLibs, fs);
         expect(fs.dump(testProjectPath, '**/src/main/webapp/*.json')).toMatchSnapshot();
-        expect(fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents).toContain(`fiori-tools-servestatic`);
+        const ui5YamlContent = fs.dump(testProjectPath, '**/ui5.yaml')['ui5.yaml'].contents;
+        expect(ui5YamlContent).toContain(`fiori-tools-servestatic`);
+        expect(ui5YamlContent).toContain(
+            `src: ${join('../../../../../sample/libs/my.namespace.reuse.attachmentservice')}`
+        );
     });
 
     it('should generate the UI5 library reference (sap.ui5.dependencies.libs does not exist)', async () => {


### PR DESCRIPTION
#1856

- `@sap-ux/project-access` : Fix the paths returned for libraries / components i.e the directory rather than a file.
- `@sap-ux/ui5-config`: If there is exisiting config, the new paths need to be merged to `fiori-tools-servestatic` custom middleware 
- `@sap-ux/ui5-library-reference-writer` : The library path (as it is passed in) should be used to determine the relative path written to the yaml files. 