### PR TITLE
fix(fpm-writer): Improve custom section fragments with event handler. Move 'core:require' attribute from inner element(Button) to wrapper(VBox)

### DIFF
--- a/.changeset/big-geese-ring.md
+++ b/.changeset/big-geese-ring.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+fix: fragment of custom section with event handler - move attribute 'core:require' from inner element('Button', 'Input') to wrapper element('VBox', 'FormElement')

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -52,14 +52,18 @@ export function getDefaultFragmentContentData(
         const method = parts.pop();
         const handler = `${parts.join('/')}${isController ? '.controller' : ''}`;
         requireAttribute = `core:require="{ handler: '${handler}'}"`;
+        const attributes = [];
+        if (includeRequireInContent) {
+            attributes.push(requireAttribute);
+        }
         if (prefferInput) {
-            content = `<Input ${
-                includeRequireInContent ? requireAttribute : ''
-            } value="${text}" change="handler.${method}" />`;
+            attributes.push(`value="${text}"`);
+            attributes.push(`change="handler.${method}"`);
+            content = `<Input ${attributes.join(' ')} />`;
         } else {
-            content = `<Button ${
-                includeRequireInContent ? requireAttribute : ''
-            } text="${text}" press="handler.${method}" />`;
+            attributes.push(`text="${text}"`);
+            attributes.push(`press="handler.${method}"`);
+            content = `<Button ${attributes.join(' ')} />`;
         }
     } else if (prefferInput) {
         content = `<Input value="${text}" />`;

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -1,7 +1,8 @@
-import type { CustomElement, InternalCustomElement, Manifest } from './types';
+import type { CustomElement, FragmentContentData, InternalCustomElement, Manifest } from './types';
 import { join, dirname } from 'path';
 
 export const FCL_ROUTER = 'sap.f.routing.Router';
+
 /**
  * Sets the common default values for all custom elements.
  *
@@ -26,6 +27,48 @@ export function setCommonDefaults<T extends CustomElement & Partial<InternalCust
 }
 
 /**
+ * Method to generate default content data for xml fragment.
+ *
+ * @param {string} text - text of button or label
+ * @param {string} [eventHandler] - event handler path
+ *      if value is passed then "Button" control with 'press' event would be generated
+ *      if value is not passed then "Text" control would be generated
+ * @param {boolean} isController - controls if `controller` should be added to handler path
+ * @param {boolean} prefferInput - controls if `input` element should be added to default fragment content
+ * @param {boolean} includeRequireInContent - controls if `core:require` attribute should be included to fragment content
+ * @returns default content for fragment
+ */
+export function getDefaultFragmentContentData(
+    text: string,
+    eventHandler?: string,
+    isController = false,
+    prefferInput = false,
+    includeRequireInContent = true
+): FragmentContentData {
+    let content: string;
+    let requireAttribute: string | undefined;
+    if (eventHandler) {
+        const parts = eventHandler.split('.');
+        const method = parts.pop();
+        const handler = `${parts.join('/')}${isController ? '.controller' : ''}`;
+        requireAttribute = `core:require="{ handler: '${handler}'}"`;
+        if (prefferInput) {
+            content = `<Input ${includeRequireInContent ? requireAttribute : ''} value="${text}" change="handler.${method}" />`;
+        } else {
+            content = `<Button ${includeRequireInContent ? requireAttribute : ''} text="${text}" press="handler.${method}" />`;
+        }
+    } else if (prefferInput) {
+        content = `<Input value="${text}" />`;
+    } else {
+        content = `<Text text="${text}" />`;
+    }
+    return {
+        content,
+        requireAttribute
+    };
+}
+
+/**
  * Method to generate default content for xml fragment.
  *
  * @param {string} text - text of button or label
@@ -42,21 +85,6 @@ export function getDefaultFragmentContent(
     isController = false,
     prefferInput = false
 ): string {
-    let content: string;
-    if (eventHandler) {
-        const parts = eventHandler.split('.');
-        const method = parts.pop();
-        const handler = `${parts.join('/')}${isController ? '.controller' : ''}`;
-        const requireAttr = `core:require="{ handler: '${handler}'}"`;
-        if (prefferInput) {
-            content = `<Input ${requireAttr} value="${text}" change="handler.${method}" />`;
-        } else {
-            content = `<Button ${requireAttr} text="${text}" press="handler.${method}" />`;
-        }
-    } else if (prefferInput) {
-        content = `<Input value="${text}" />`;
-    } else {
-        content = `<Text text="${text}" />`;
-    }
-    return content;
+    const contentData = getDefaultFragmentContentData(text, eventHandler, isController, prefferInput)
+    return contentData.content;
 }

--- a/packages/fe-fpm-writer/src/common/defaults.ts
+++ b/packages/fe-fpm-writer/src/common/defaults.ts
@@ -53,9 +53,13 @@ export function getDefaultFragmentContentData(
         const handler = `${parts.join('/')}${isController ? '.controller' : ''}`;
         requireAttribute = `core:require="{ handler: '${handler}'}"`;
         if (prefferInput) {
-            content = `<Input ${includeRequireInContent ? requireAttribute : ''} value="${text}" change="handler.${method}" />`;
+            content = `<Input ${
+                includeRequireInContent ? requireAttribute : ''
+            } value="${text}" change="handler.${method}" />`;
         } else {
-            content = `<Button ${includeRequireInContent ? requireAttribute : ''} text="${text}" press="handler.${method}" />`;
+            content = `<Button ${
+                includeRequireInContent ? requireAttribute : ''
+            } text="${text}" press="handler.${method}" />`;
         }
     } else if (prefferInput) {
         content = `<Input value="${text}" />`;
@@ -85,6 +89,6 @@ export function getDefaultFragmentContent(
     isController = false,
     prefferInput = false
 ): string {
-    const contentData = getDefaultFragmentContentData(text, eventHandler, isController, prefferInput)
+    const contentData = getDefaultFragmentContentData(text, eventHandler, isController, prefferInput);
     return contentData.content;
 }

--- a/packages/fe-fpm-writer/src/common/types.ts
+++ b/packages/fe-fpm-writer/src/common/types.ts
@@ -186,3 +186,11 @@ export interface CustomFragment {
      */
     fragmentFile?: string;
 }
+
+/**
+ * Interface represents content data of generated fragment.
+ */
+export interface FragmentContentData {
+    content: string;
+    requireAttribute?: string;
+}

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { render } from 'ejs';
 import { validateVersion, validateBasePath } from '../common/validate';
 import type { CustomElement, Manifest } from '../common/types';
-import { setCommonDefaults, getDefaultFragmentContent, getDefaultFragmentContentData } from '../common/defaults';
+import { setCommonDefaults, getDefaultFragmentContentData } from '../common/defaults';
 import { applyEventHandlerConfiguration } from '../common/event-handler';
 import { extendJSON } from '../common/file';
 import { getTemplatePath } from '../templates';
@@ -71,9 +71,7 @@ function enhanceConfig(
     if (config.control) {
         config.content = config.control;
     } else {
-        const fragmentContentData = getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false);
-        config.content = fragmentContentData.content;
-        config.requireAttribute = fragmentContentData.requireAttribute;
+        Object.assign(config, getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false));
     }
     // Additional dependencies to include into 'Fragment.xml'
     config.dependencies = getAdditionalDependencies(config.minUI5Version);
@@ -165,8 +163,11 @@ export function generateCustomHeaderSection(
             });
         }
         // Generate edit fragment content
-        editSection.content =
-            editSection.control ?? getDefaultFragmentContent(editSection.name, editSection.eventHandler, false, true);
+        if (editSection.control) {
+            editSection.content = editSection.control;
+        } else {
+            Object.assign(editSection, getDefaultFragmentContentData(editSection.name, editSection.eventHandler, false, true, false));
+        }
         if (editSection.path) {
             const viewPath = join(editSection.path, `${editSection.name}.fragment.xml`);
             if (!editor.exists(viewPath)) {

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -6,7 +6,7 @@ import { join } from 'path';
 import { render } from 'ejs';
 import { validateVersion, validateBasePath } from '../common/validate';
 import type { CustomElement, Manifest } from '../common/types';
-import { setCommonDefaults, getDefaultFragmentContent } from '../common/defaults';
+import { setCommonDefaults, getDefaultFragmentContent, getDefaultFragmentContentData } from '../common/defaults';
 import { applyEventHandlerConfiguration } from '../common/event-handler';
 import { extendJSON } from '../common/file';
 import { getTemplatePath } from '../templates';
@@ -68,7 +68,13 @@ function enhanceConfig(
     }
 
     // generate section content
-    config.content = config.control || getDefaultFragmentContent(config.name, config.eventHandler);
+    if (config.control) {
+        config.content = config.control;
+    } else {
+        const fragmentContentData = getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false);
+        config.content = fragmentContentData.content;
+        config.requireAttribute = fragmentContentData.requireAttribute;
+    }
     // Additional dependencies to include into 'Fragment.xml'
     config.dependencies = getAdditionalDependencies(config.minUI5Version);
 

--- a/packages/fe-fpm-writer/src/section/index.ts
+++ b/packages/fe-fpm-writer/src/section/index.ts
@@ -71,7 +71,10 @@ function enhanceConfig(
     if (config.control) {
         config.content = config.control;
     } else {
-        Object.assign(config, getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false));
+        Object.assign(
+            config,
+            getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false)
+        );
     }
     // Additional dependencies to include into 'Fragment.xml'
     config.dependencies = getAdditionalDependencies(config.minUI5Version);
@@ -166,7 +169,10 @@ export function generateCustomHeaderSection(
         if (editSection.control) {
             editSection.content = editSection.control;
         } else {
-            Object.assign(editSection, getDefaultFragmentContentData(editSection.name, editSection.eventHandler, false, true, false));
+            Object.assign(
+                editSection,
+                getDefaultFragmentContentData(editSection.name, editSection.eventHandler, false, true, false)
+            );
         }
         if (editSection.path) {
             const viewPath = join(editSection.path, `${editSection.name}.fragment.xml`);

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -1,4 +1,11 @@
-import type { CustomElement, InternalCustomElement, Position, EventHandler, CustomFragment, FragmentContentData } from '../common/types';
+import type {
+    CustomElement,
+    InternalCustomElement,
+    Position,
+    EventHandler,
+    CustomFragment,
+    FragmentContentData
+} from '../common/types';
 
 export interface CustomSection extends CustomElement, EventHandler, CustomFragment {
     /**

--- a/packages/fe-fpm-writer/src/section/types.ts
+++ b/packages/fe-fpm-writer/src/section/types.ts
@@ -1,4 +1,4 @@
-import type { CustomElement, InternalCustomElement, Position, EventHandler, CustomFragment } from '../common/types';
+import type { CustomElement, InternalCustomElement, Position, EventHandler, CustomFragment, FragmentContentData } from '../common/types';
 
 export interface CustomSection extends CustomElement, EventHandler, CustomFragment {
     /**
@@ -26,8 +26,8 @@ export interface InternalCustomSection
     extends CustomHeaderSection,
         CustomSection,
         CustomSubSection,
-        InternalCustomElement {
-    content: string;
+        InternalCustomElement,
+        FragmentContentData {
     dependencies?: string;
 }
 

--- a/packages/fe-fpm-writer/templates/common/FragmentWithForm.xml
+++ b/packages/fe-fpm-writer/templates/common/FragmentWithForm.xml
@@ -1,5 +1,5 @@
 <core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m" xmlns:f="sap.ui.layout.form"<%- typeof dependencies !== 'undefined' ? ` ${dependencies}` : '' %>>
-    <f:FormElement>
+    <f:FormElement<%- typeof requireAttribute !== 'undefined' ? ` ${requireAttribute}` : '' %>>
         <f:fields>
             <%- content %>
         </f:fields>

--- a/packages/fe-fpm-writer/templates/common/FragmentWithVBox.xml
+++ b/packages/fe-fpm-writer/templates/common/FragmentWithVBox.xml
@@ -1,5 +1,5 @@
 <core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m"<%- typeof dependencies !== 'undefined' ? ` ${dependencies}` : '' %>>
-	<VBox>
+	<VBox<%- typeof requireAttribute !== 'undefined' ? ` ${requireAttribute}` : '' %>>
 		<%- content %>
 	</VBox>
 </core:FragmentDefinition>

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
@@ -140,7 +140,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in different extension folders for version 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -164,7 +164,7 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
     <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/different/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"
@@ -221,7 +221,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.85 (edit mode not supported) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -266,7 +266,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 (edit mode disabled) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -312,7 +312,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 (eventHandler should not generate) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -358,7 +358,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -382,7 +382,7 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
     <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"
@@ -429,7 +429,7 @@ Object {
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.98 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
-		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -453,7 +453,7 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
     <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
@@ -162,9 +162,9 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in different extension folders for version 1.86 4`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
-    <f:FormElement>
+    <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/different/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/different/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"
@@ -370,9 +370,9 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 4`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
-    <f:FormElement>
+    <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"
@@ -441,9 +441,9 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.98 4`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
-    <f:FormElement>
+    <f:FormElement core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\">
         <f:fields>
-            <Input core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSectionEdit'}\\" value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
+            <Input  value=\\"NewCustomHeaderSectionEdit\\" change=\\"handler.onChange\\" />
         </f:fields>
     </f:FormElement>
 </core:FragmentDefinition>"

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
@@ -185,6 +185,16 @@ exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode
 "
 `;
 
+exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder custom control for edit mode 1`] = `
+"<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:f=\\"sap.ui.layout.form\\">
+    <f:FormElement>
+        <f:fields>
+            <CustomXML text=\\"\\" />
+        </f:fields>
+    </f:FormElement>
+</core:FragmentDefinition>"
+`;
+
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.85 (edit mode not supported) 1`] = `
 Object {
   "body": Object {

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/header-section.test.ts.snap
@@ -139,8 +139,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in different extension folders for version 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -210,8 +210,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.85 (edit mode not supported) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -255,8 +255,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 (edit mode disabled) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -301,8 +301,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 (eventHandler should not generate) 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -347,8 +347,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -418,8 +418,8 @@ Object {
 
 exports[`CustomHeaderSection generateCustomHeaderSection View mode and edit mode fragments in same extension folder for version 1.98 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\" text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomHeaderSection'}\\">
+		<Button  text=\\"NewCustomHeaderSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -62,7 +62,7 @@ Object {
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom file and function names 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/dummyAction'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -85,7 +85,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -108,7 +108,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is empty "object" - create new file with default function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -131,7 +131,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with absolute position 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -157,7 +157,7 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with position as object 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -209,7 +209,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -258,7 +258,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.85, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -306,7 +306,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.86, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -354,7 +354,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.89, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -402,7 +402,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.90, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -450,7 +450,7 @@ Object {
 exports[`CustomSection generateCustomSection Versions 1.98, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -713,7 +713,7 @@ Object {
 exports[`CustomSection generateCustomSection with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
-		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/section.test.ts.snap
@@ -61,8 +61,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom file and function names 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/dummyAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/dummyAction'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -84,8 +84,8 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is "object" - create new file with custom function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.DummyOnAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -107,8 +107,8 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is empty "object" - create new file with default function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -130,8 +130,8 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with absolute position 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -156,8 +156,8 @@ exports[`CustomSection generateCustomSection Test property "eventHandler" "event
 
 exports[`CustomSection generateCustomSection Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with position as object 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onHandleSecondAction\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -208,8 +208,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.84, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -257,8 +257,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.85, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -305,8 +305,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.86, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -353,8 +353,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.89, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -401,8 +401,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.90, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -449,8 +449,8 @@ Object {
 
 exports[`CustomSection generateCustomSection Versions 1.98, with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -712,8 +712,8 @@ Object {
 
 exports[`CustomSection generateCustomSection with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\" text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSection'}\\">
+		<Button  text=\\"NewCustomSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/subsection.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/subsection.test.ts.snap
@@ -151,8 +151,8 @@ Object {
 
 exports[`SubCustomSection generateCustomSubSection Versions 1.85 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\" text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
+		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -195,8 +195,8 @@ Object {
 
 exports[`SubCustomSection generateCustomSubSection Versions 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\" text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
+		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -239,8 +239,8 @@ Object {
 
 exports[`SubCustomSection generateCustomSubSection Versions 1.98 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
-	<VBox>
-		<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\" text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
+		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/subsection.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/subsection.test.ts.snap
@@ -152,7 +152,7 @@ Object {
 exports[`SubCustomSection generateCustomSubSection Versions 1.85 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
-		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -196,7 +196,7 @@ Object {
 exports[`SubCustomSection generateCustomSubSection Versions 1.86 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
-		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;
@@ -240,7 +240,7 @@ Object {
 exports[`SubCustomSection generateCustomSubSection Versions 1.98 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\" xmlns:macros=\\"sap.fe.macros\\">
 	<VBox core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomSubSection'}\\">
-		<Button  text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
+		<Button text=\\"NewCustomSubSection\\" press=\\"handler.onPress\\" />
 	</VBox>
 </core:FragmentDefinition>"
 `;

--- a/packages/fe-fpm-writer/test/unit/header-section.test.ts
+++ b/packages/fe-fpm-writer/test/unit/header-section.test.ts
@@ -175,6 +175,21 @@ describe('CustomHeaderSection generateCustomHeaderSection', () => {
                 expect(fs.read(expectedEditFragmentPath.replace('.fragment.xml', '.js'))).toMatchSnapshot();
             });
         });
+
+        test('custom control for edit mode', () => {
+            const customHeaderSection = createCustomHeaderSectionWithEditFragment('1.98', {
+                name: 'NewCustomHeaderSectionEdit',
+                folder: 'extensions/custom',
+                control: '<CustomXML text="" />'
+            } as HeaderSectionEditProperty);
+            const expectedFragmentPath = join(
+                testDir,
+                `webapp/${customHeaderSection.edit?.folder}/${customHeaderSection.edit?.name}.fragment.xml`
+            );
+            generateCustomHeaderSection(testDir, customHeaderSection, fs);
+
+            expect(fs.read(expectedFragmentPath)).toMatchSnapshot();
+        });
     });
 
     describe('View mode and edit mode fragments in different extension folders', () => {


### PR DESCRIPTION
Issue #1855

Previous version generated fragment content like:
```
<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m" xmlns:macros="sap.fe.macros">
	<VBox>
		<Button core:require="{ handler: 'project1/ext/fragment/Fsefsf'}" text="Fsefsf" press="handler.onPress" />
	</VBox>
</core:FragmentDefinition>
```

Then if we add new button without `core:require` then press will not work:
```
<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m" xmlns:macros="sap.fe.macros">
	<VBox>
		<Button core:require="{ handler: 'project1/ext/fragment/Fsefsf'}" text="Fsefsf" press="handler.onPress" />
		<Button text="Fsefsf" press="handler.onPress" />
	</VBox>
</core:FragmentDefinition>
```

To improve usability - move `core:require` from inner element to wrapper element like:
```
<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m" xmlns:macros="sap.fe.macros">
	<VBox core:require="{ handler: 'project1/ext/fragment/Fsefsf'}">
		<Button text="Fsefsf" press="handler.onPress" />
		<Button text="Fsefsf" press="handler.onPress" />
	</VBox>
</core:FragmentDefinition>
```