### PR TITLE
fix: isS4Cloud

### DIFF
--- a/.changeset/violet-pianos-own.md
+++ b/.changeset/violet-pianos-own.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+fix: isS4Cloud returned wrong value when checking a development client

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -16,8 +16,6 @@ import { AdtService, AtoService } from './adt-catalog/services';
  * Extension of the service provider for ABAP services.
  */
 export class AbapServiceProvider extends ServiceProvider {
-    public s4Cloud: boolean | undefined;
-
     protected atoSettings: AtoSettings;
 
     /**
@@ -91,21 +89,15 @@ export class AbapServiceProvider extends ServiceProvider {
      * @returns true if it an S/4HANA cloud system
      */
     public async isS4Cloud(): Promise<boolean> {
-        if (this.s4Cloud === undefined) {
-            try {
-                const settings = await this.getAtoInfo();
-                this.s4Cloud =
-                    settings.tenantType === TenantType.Customer &&
-                    settings.operationsType === 'C' &&
-                    settings.isExtensibilityDevelopmentSystem === true &&
-                    settings.developmentPrefix !== '' &&
-                    settings.developmentPackage !== '';
-            } catch (error) {
-                this.log.warn('Failed to detect whether this is an SAP S/4HANA Cloud system or not.');
-                this.s4Cloud = false;
-            }
+        if (this.atoSettings === undefined) {
+            await this.getAtoInfo();
         }
-        return this.s4Cloud;
+        return (
+            this.atoSettings.tenantType === TenantType.Customer &&
+            this.atoSettings.operationsType === 'C' &&
+            this.atoSettings.developmentPrefix !== '' &&
+            this.atoSettings.developmentPackage !== ''
+        );
     }
 
     /**

--- a/packages/axios-extension/src/abap/types/adt-types.ts
+++ b/packages/axios-extension/src/abap/types/adt-types.ts
@@ -91,7 +91,13 @@ export type OperationsType = 'C' | 'P';
 export interface AtoSettings {
     developmentPackage?: string;
     developmentPrefix?: string;
+    /**
+     * Operations type cloud or on premise.
+     */
     operationsType?: OperationsType;
+    /**
+     * True if it is an S/4HANA Cloud Public Edition client for key user extensibility.
+     */
     isExtensibilityDevelopmentSystem?: boolean;
     tenantType?: TenantType;
     isTransportRequestRequired?: boolean;

--- a/packages/axios-extension/test/abap/abap-service-provider.test.ts
+++ b/packages/axios-extension/test/abap/abap-service-provider.test.ts
@@ -110,8 +110,13 @@ describe('AbapServiceProvider', () => {
 
         test('No request if known', async () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
-            expect(await provider.isS4Cloud()).toBe(provider.s4Cloud);
+            nock(server)
+                .get(AdtServices.DISCOVERY)
+                .replyWithFile(200, join(__dirname, 'mockResponses/discovery-1.xml'))
+                .get(AdtServices.ATO_SETTINGS)
+                .replyWithFile(200, join(__dirname, 'mockResponses/atoSettingsS4C.xml'));
+            await provider.isS4Cloud();
+            expect(await provider.isS4Cloud()).toBe(true);
         });
 
         test('Request failed', async () => {
@@ -125,9 +130,16 @@ describe('AbapServiceProvider', () => {
     });
 
     describe('catalog', () => {
+        beforeEach(() => {
+            nock(server)
+                .get(AdtServices.DISCOVERY)
+                .replyWithFile(200, join(__dirname, 'mockResponses/discovery-1.xml'))
+                .get(AdtServices.ATO_SETTINGS)
+                .replyWithFile(200, join(__dirname, 'mockResponses/atoSettingsNotS4C.xml'));
+        });
+
         test('V2', () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
 
             const catalog = provider.catalog(ODataVersion.v2);
             expect(catalog).toBeDefined();
@@ -137,7 +149,6 @@ describe('AbapServiceProvider', () => {
 
         test('V4', () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
 
             const catalog = provider.catalog(ODataVersion.v4);
             expect(catalog).toBeDefined();
@@ -147,7 +158,6 @@ describe('AbapServiceProvider', () => {
 
         test('Invalid version', async () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
             try {
                 provider.catalog('v9' as ODataVersion);
                 fail('Error should have been thrown');

--- a/packages/axios-extension/test/abap/catalog/v2-catalog-service.test.ts
+++ b/packages/axios-extension/test/abap/catalog/v2-catalog-service.test.ts
@@ -88,7 +88,6 @@ describe('V2CatalogService', () => {
 
         // create a catalog for testing
         const provider = createForAbap(config);
-        provider.s4Cloud = false;
         const catalog = provider.catalog(ODataVersion.v2);
 
         beforeAll(() => {

--- a/packages/axios-extension/test/abap/catalog/v4-catalog-service.test.ts
+++ b/packages/axios-extension/test/abap/catalog/v4-catalog-service.test.ts
@@ -28,7 +28,6 @@ describe('V4CatalogService', () => {
 
         test('service groups', async () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
             const catalog = provider.catalog(ODataVersion.v4);
 
             nock(server).get(`${V4CatalogService.PATH}/$metadata`).reply(200, join(__dirname, '<METADTA />'));
@@ -47,7 +46,6 @@ describe('V4CatalogService', () => {
 
         test('service groups with paging', async () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
             const catalog = provider.catalog(ODataVersion.v4);
 
             // mock response for paging
@@ -68,7 +66,6 @@ describe('V4CatalogService', () => {
 
         test('recommended service groups with paging', async () => {
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
             const catalog = provider.catalog(ODataVersion.v4);
 
             nock(server)
@@ -100,7 +97,6 @@ describe('V4CatalogService', () => {
                 });
 
             const provider = createForAbap(config);
-            provider.s4Cloud = false;
             const catalog = provider.catalog(ODataVersion.v4);
             try {
                 await catalog.listServices();

--- a/packages/axios-extension/test/abap/mockResponses/atoSettingsNotS4C.xml
+++ b/packages/axios-extension/test/abap/mockResponses/atoSettingsNotS4C.xml
@@ -8,7 +8,7 @@
     isExtensibilityDevelopmentSystem="false" 
     isTransportRequestRequired="false" 
     transportationMode="COL" 
-    operationsType="C" 
+    operationsType="P" 
     tenantType="CUSTOMER" 
     tenantRole="07" 
     isPrefixNamespace="false" 


### PR DESCRIPTION
This PR fixes an incorrect implementation of the `isS4Cloud` function in the `axios-extension`. The function was incorrectly returning false if the client is configured for development (embedded Steampunk) and not extensibility.
While fixing it, I also removed a variable that was only exposed for testing and fixed the corresponding tests.