### PR TITLE
fix(odata-service-inquirer): Ensure prompt texts are loaded

### DIFF
--- a/.changeset/fuzzy-eagles-glow.md
+++ b/.changeset/fuzzy-eagles-glow.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for prompt texts not loaded

--- a/packages/odata-service-inquirer/README.md
+++ b/packages/odata-service-inquirer/README.md
@@ -30,7 +30,7 @@ See [Inquirer.js](https://www.npmjs.com/package/inquirer) for valid default prop
 ```TypeScript
 import type { InquirerAdapter } from '@sap-ux/inquirer-common';
 import type { OdataServiceAnswers, OdataServicePromptOptions } from '@sap-ux/odata-service-inquirer';
-import { DatasourceType, prompt, CapService } from '@sap-ux/odata-service-inquirer';
+import { DatasourceType, prompt as serviceInquirerPrompt, CapService } from '@sap-ux/odata-service-inquirer';
 import { generate as generateOdataService, OdataService, ServiceType } from '@sap-ux/odata-service-writer'
 ...
     const promptOpts = {
@@ -56,10 +56,10 @@ import { generate as generateOdataService, OdataService, ServiceType } from '@sa
      * Pass an Inquirer prompt function https://www.npmjs.com/package/inquirer#methods
      */
     const inqAdaptor = {
-        prompt
+        prompt: this.prompt.bind(this) // the inquirer prompting function, here we use the generators reference
     };
 
-    const serviceAnswers: OdataServiceAnswers = await osPrompt(
+    const serviceAnswers: OdataServiceAnswers = await serviceInquirerPrompt(
         inqAdaptor as InquirerAdapter,
         promptOpts
     );

--- a/packages/odata-service-inquirer/src/index.ts
+++ b/packages/odata-service-inquirer/src/index.ts
@@ -15,6 +15,7 @@ import {
     type OdataServiceQuestion
 } from './types';
 import { PromptState, setTelemetryClient } from './utils';
+import { initI18nOdataServiceInquirer } from './i18n';
 
 /**
  * Get the inquirer prompts for odata service.
@@ -33,6 +34,8 @@ async function getPrompts(
     telemetryClient?: ToolsSuiteTelemetryClient,
     isYUI = false
 ): Promise<{ prompts: OdataServiceQuestion[]; answers: { odataService: Partial<OdataServiceAnswers> } }> {
+    // prompt texts must be loaded before the prompts are created, wait for the i18n bundle to be initialized
+    await initI18nOdataServiceInquirer();
     LoggerHelper.logger = logger ?? new ToolsLogger({ logPrefix: '@sap-ux/odata-service-inquirer' });
     ErrorHandler.logger = LoggerHelper.logger;
     ErrorHandler.guidedAnswersEnabled = enableGuidedAnswers;

--- a/packages/odata-service-inquirer/test/unit/index-api.test.ts
+++ b/packages/odata-service-inquirer/test/unit/index-api.test.ts
@@ -1,9 +1,8 @@
-import { initI18nOdataServiceInquirer } from '../../src/i18n';
-import * as prompts from '../../src/prompts';
-import { PromptState } from '../../src/utils';
-import { getPrompts } from '../../src/index';
-import LoggerHelper from '../../src/prompts/logger-helper';
 import { ErrorHandler } from '../../src/error-handler/error-handler';
+import { getPrompts } from '../../src/index';
+import * as prompts from '../../src/prompts';
+import LoggerHelper from '../../src/prompts/logger-helper';
+import { PromptState } from '../../src/utils';
 
 jest.mock('../../src/prompts', () => ({
     __esModule: true, // Workaround to for spyOn TypeError: Jest cannot redefine property
@@ -11,9 +10,8 @@ jest.mock('../../src/prompts', () => ({
 }));
 
 describe('API tests', () => {
-    beforeAll(async () => {
-        // Wait for i18n to bootstrap so we can test localised strings
-        await initI18nOdataServiceInquirer();
+    beforeEach(() => {
+        jest.restoreAllMocks();
     });
 
     test('getPrompts', async () => {
@@ -36,5 +34,98 @@ describe('API tests', () => {
         expect(LoggerHelper.logger).toBeDefined();
         expect(ErrorHandler.guidedAnswersEnabled).toBe(true);
         expect(ErrorHandler.logger).toBeDefined();
+    });
+
+    test('getPrompts, i18n is loaded', async () => {
+        const { prompts: questions } = await getPrompts(undefined, undefined, true, undefined, true);
+
+        expect(questions).toMatchInlineSnapshot(`
+            [
+              {
+                "additionalMessages": [Function],
+                "choices": [
+                  {
+                    "name": "Connect to a SAP System",
+                    "value": "sapSystem",
+                  },
+                  {
+                    "name": "Connect to an OData Service Url",
+                    "value": "odataServiceUrl",
+                  },
+                  {
+                    "name": "Connect to SAP Business Accelerator Hub",
+                    "value": "businessHub",
+                  },
+                  {
+                    "name": "Use a Local CAP Project",
+                    "value": "capProject",
+                  },
+                  {
+                    "name": "Upload a Metadata File",
+                    "value": "metadataFile",
+                  },
+                ],
+                "default": -1,
+                "guiOptions": {
+                  "breadcrumb": true,
+                },
+                "message": "Data source",
+                "name": "datasourceType",
+                "type": "list",
+              },
+              {
+                "guiOptions": {
+                  "breadcrumb": true,
+                  "mandatory": true,
+                },
+                "guiType": "file-browser",
+                "message": "Metadata file path",
+                "name": "metadataFilePath",
+                "type": "input",
+                "validate": [Function],
+                "when": [Function],
+              },
+              {
+                "choices": [Function],
+                "default": [Function],
+                "guiOptions": {
+                  "applyDefaultWhenDirty": true,
+                  "breadcrumb": "CAP Project",
+                  "mandatory": true,
+                },
+                "message": "Choose your CAP project",
+                "name": "capProject",
+                "type": "list",
+                "when": [Function],
+              },
+              {
+                "default": [Function],
+                "guiOptions": {
+                  "breadcrumb": "CAP Project",
+                  "mandatory": true,
+                },
+                "guiType": "folder-browser",
+                "message": "CAP project folder path",
+                "name": "capProjectPath",
+                "type": "input",
+                "validate": [Function],
+                "when": [Function],
+              },
+              {
+                "choices": [Function],
+                "default": [Function],
+                "guiOptions": {
+                  "applyDefaultWhenDirty": true,
+                  "breadcrumb": true,
+                  "mandatory": true,
+                },
+                "message": "OData service",
+                "name": "capService",
+                "type": "list",
+                "validate": [Function],
+                "when": [Function],
+              },
+            ]
+        `);
     });
 });

--- a/packages/odata-service-inquirer/test/unit/prompts/prompt-helpers.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/prompt-helpers.test.ts
@@ -1,4 +1,16 @@
 import { initI18nOdataServiceInquirer } from '../../../src/i18n';
+import { getDatasourceTypeChoices } from '../../../src/prompts/prompt-helpers';
+import * as btpUtils from '@sap-ux/btp-utils';
+
+/**
+ * Workaround to for spyOn TypeError: Jest cannot redefine property
+ */
+jest.mock('@sap-ux/btp-utils', () => {
+    return {
+        __esModule: true,
+        ...jest.requireActual('@sap-ux/btp-utils')
+    };
+});
 
 describe('prompt-helpers', () => {
     beforeAll(async () => {
@@ -7,10 +19,69 @@ describe('prompt-helpers', () => {
     });
 
     afterEach(() => {
-        // Reset all spys (not mocks)
-        // jest.restoreAllMocks() only works when the mock was created with jest.spyOn().
+        // Ensure test isolation
         jest.restoreAllMocks();
     });
 
-    test('appPathExists', () => {});
+    test('getDatasourceTypeChoices', () => {
+        expect(getDatasourceTypeChoices()).toMatchInlineSnapshot(`
+            [
+              {
+                "name": "Connect to a SAP System",
+                "value": "sapSystem",
+              },
+              {
+                "name": "Connect to an OData Service Url",
+                "value": "odataServiceUrl",
+              },
+              {
+                "name": "Connect to SAP Business Accelerator Hub",
+                "value": "businessHub",
+              },
+              {
+                "name": "Use a Local CAP Project",
+                "value": "capProject",
+              },
+              {
+                "name": "Upload a Metadata File",
+                "value": "metadataFile",
+              },
+            ]
+        `);
+
+        jest.spyOn(btpUtils, 'isAppStudio').mockReturnValueOnce(true);
+        expect(getDatasourceTypeChoices({ includeNone: true, includeProjectSpecificDest: true }))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "name": "None",
+                "value": "none",
+              },
+              {
+                "name": "Connect to a SAP System",
+                "value": "sapSystem",
+              },
+              {
+                "name": "Connect to an OData Service Url",
+                "value": "odataServiceUrl",
+              },
+              {
+                "name": "Connect to SAP Business Accelerator Hub",
+                "value": "businessHub",
+              },
+              {
+                "name": "Connect to a Project Specific Destination",
+                "value": "projectSpecificDestination",
+              },
+              {
+                "name": "Use a Local CAP Project",
+                "value": "capProject",
+              },
+              {
+                "name": "Upload a Metadata File",
+                "value": "metadataFile",
+              },
+            ]
+        `);
+    });
 });


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1911

- Wait for load of i18n texts when calling `getPrompts` otherwise we may not have texts
- Add tests to cover
- Add tests for `prompt-helper`
- Update readme example