### PR TITLE
fix(odata-service-writer): fs param mockserver logic

### DIFF
--- a/.changeset/short-badgers-hear.md
+++ b/.changeset/short-badgers-hear.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': minor
+---
+
+support for memfs within mockserver logic

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -108,7 +108,7 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
     if (service.metadata) {
         // copy existing `ui5.yaml` as starting point for ui5-mock.yaml
         if (paths.ui5Yaml && ui5Config) {
-            const webappPath = await getWebappPath(basePath);
+            const webappPath = await getWebappPath(basePath, fs);
             const config = {
                 webappPath: webappPath,
                 ui5MockYamlConfig: { path: service.path }

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -9,6 +9,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { UI5Config } from '@sap-ux/ui5-config';
 import { tmpdir } from 'os';
 import { t } from '../../src/i18n';
+import * as projectAccess from '@sap-ux/project-access';
 
 const testDir = tmpdir();
 const commonConfig = {
@@ -86,6 +87,7 @@ describe('generate', () => {
         });
 
         it('Standard folder structure - all files updated', async () => {
+            const getWebappPathMock = jest.spyOn(projectAccess, 'getWebappPath');
             const packagePath = join(root, 'package.json');
             fs.writeJSON(packagePath, {});
             const ui5YamlWithOutMiddleware = (await UI5Config.newInstance('')).setConfiguration({}).toString();
@@ -95,6 +97,8 @@ describe('generate', () => {
             const manifest = fs.readJSON(join(root, 'webapp/manifest.json')) as any;
             expect(manifest['sap.app'].dataSources.mainService.uri).toBe(config.path);
             expect(fs.exists(join(root, 'ui5-mock.yaml'))).toBe(true);
+            // verify getWebappPath is called with fs
+            expect(getWebappPathMock).toHaveBeenCalledWith(expect.anything(), fs);
         });
 
         it('Nested folder structure - all files updated', async () => {


### PR DESCRIPTION
Fix for #1793 
- added `fs` for `await getWebappPath(basePath, fs)` to support memfs