### PR TITLE
fix: CPE does not start UI Adaptation for ui5 versions lower than 1.120 for Adaptation Projects

### DIFF
--- a/.changeset/smart-ads-melt.md
+++ b/.changeset/smart-ads-melt.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Fix for CPE does not start UI Adaptation for ADP Projects with lower UI5 Version than 1.120

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -1,7 +1,5 @@
 import log from 'sap/base/Log';
 import type RuntimeAuthoring from 'sap/ui/rta/RuntimeAuthoring';
-import UI5ElementRegistry from 'sap/ui/core/ElementRegistry';
-
 import init from '../cpe/init';
 import { initDialogs } from './init-dialogs';
 import {
@@ -46,7 +44,7 @@ export default async function (rta: RuntimeAuthoring) {
         }
     );
 
-    const syncViewsIds = getAllSyncViewsIds();
+    const syncViewsIds = await getAllSyncViewsIds(minor);
     initDialogs(rta, syncViewsIds);
 
     if (minor > 77) {
@@ -79,17 +77,37 @@ export default async function (rta: RuntimeAuthoring) {
 /**
  *
  * Get Ids for all sync views
+ * @param minor UI5 Version
  *
  * @returns array of Ids for application sync views
  */
-function getAllSyncViewsIds(): string[] {
-    const elements = UI5ElementRegistry.all() as Record<string, UI5Element>;
+async function getAllSyncViewsIds(minor: number): Promise<string[]> {
     const syncViewIds: string[] = [];
-    Object.entries(elements).forEach(([key, ui5Element]) => {
-        if (ui5Element?.getMetadata()?.getName()?.includes('XMLView') && ui5Element?.oAsyncState === undefined) {
-            syncViewIds.push(key);
+    try {
+        if (minor < 120) {
+            const Element = (await import('sap/ui/core/Element')).default;
+            const elements = Element.registry.filter(() => true) as UI5Element[];
+            elements.forEach((ui5Element) => {
+                if (isSyncView(ui5Element)) {
+                    syncViewIds.push(ui5Element.getId());
+                }
+            });
+        } else {
+            const ElementRegistry = (await import('sap/ui/core/ElementRegistry')).default;
+            const elements = ElementRegistry.all() as Record<string, UI5Element>;
+            Object.entries(elements).forEach(([key, ui5Element]) => {
+                if (isSyncView(ui5Element)) {
+                    syncViewIds.push(key);
+                }
+            });
         }
-    });
+    } catch (error) {
+        log.error('Could not get application sync views', error);
+    }
 
     return syncViewIds;
 }
+
+const isSyncView = (element: UI5Element): boolean => {
+    return element?.getMetadata()?.getName()?.includes('XMLView') && element?.oAsyncState === undefined;
+};

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -75,8 +75,8 @@ export default async function (rta: RuntimeAuthoring) {
 }
 
 /**
- *
  * Get Ids for all sync views
+ * 
  * @param minor UI5 Version
  *
  * @returns array of Ids for application sync views
@@ -108,6 +108,12 @@ async function getAllSyncViewsIds(minor: number): Promise<string[]> {
     return syncViewIds;
 }
 
+/**
+ * Check if element is sync view
+ *
+ * @param element UI5Element
+ * @returns boolean if element is sync view or not
+ */
 const isSyncView = (element: UI5Element): boolean => {
     return element?.getMetadata()?.getName()?.includes('XMLView') && element?.oAsyncState === undefined;
 };

--- a/packages/preview-middleware-client/test/__mock__/sap/ui/core/Element.ts
+++ b/packages/preview-middleware-client/test/__mock__/sap/ui/core/Element.ts
@@ -1,0 +1,5 @@
+export default {
+    registry: {
+        filter: jest.fn().mockReturnValue([])
+    }
+};


### PR DESCRIPTION
fixes #1929 

I successfully tested with UI5 Versions lower and bigger than 1.120