### PR TITLE
`@sap-ux/odata-service-inquirer` adds additional exports

### DIFF
--- a/.changeset/ten-mails-lay.md
+++ b/.changeset/ten-mails-lay.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Exports needed for open source migration

--- a/packages/odata-service-inquirer/src/index.ts
+++ b/packages/odata-service-inquirer/src/index.ts
@@ -2,7 +2,7 @@ import { type InquirerAdapter } from '@sap-ux/inquirer-common';
 import { ToolsLogger, type Logger } from '@sap-ux/logger';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import { type ToolsSuiteTelemetryClient } from '@sap-ux/telemetry';
-import { ErrorHandler } from './error-handler/error-handler';
+import { ErrorHandler, ERROR_TYPE } from './error-handler/error-handler';
 import { getQuestions } from './prompts';
 import LoggerHelper from './prompts/logger-helper';
 import {
@@ -86,5 +86,8 @@ export {
     type CapService,
     type InquirerAdapter,
     type OdataServiceAnswers,
-    type OdataServicePromptOptions
+    type OdataServicePromptOptions,
+    // These exports are to facilitate migration to open-ux-tools and will be removed in a future release
+    ERROR_TYPE,
+    ErrorHandler
 };


### PR DESCRIPTION
#1932 

Exports, for use in not-yet-moved datasources (to remove duplication):

- `ErrorHandler`
- `ERROR_TYPE`