### PR TITLE
feature(odata-service-inquirer): Return cds info with cds services

### DIFF
--- a/packages/odata-service-inquirer/src/prompts/datasources/cap-project/cap-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/cap-project/cap-helpers.ts
@@ -1,4 +1,4 @@
-import type { CSN } from '@sap-ux/project-access';
+import type { CSN, ServiceInfo, CdsInfo } from '@sap-ux/project-access';
 import {
     findCapProjects,
     getCapCustomPaths,
@@ -72,9 +72,6 @@ export async function getCapProjectChoices(paths: string[]): Promise<CapProjectC
     ];
 }
 
-// Remove when exported from `@sap-ux/project-access`
-type ServiceInfo = Awaited<ReturnType<typeof getCapModelAndServices>>['services'][0];
-
 /**
  * Create a cap service choice from the service info.
  *
@@ -82,13 +79,15 @@ type ServiceInfo = Awaited<ReturnType<typeof getCapModelAndServices>>['services'
  * @param serviceInfo - The service info
  * @param projectPath - The project path
  * @param appPath - The app path
+ * @param cdsInfo
  * @returns a cap service choice
  */
 function createCapServiceChoice(
     capModel: CSN,
     serviceInfo: ServiceInfo,
     projectPath: string,
-    appPath: string
+    appPath: string,
+    cdsInfo: CdsInfo
 ): CapServiceChoice | undefined {
     const srvDef = capModel.definitions?.[serviceInfo.name];
     /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
@@ -117,7 +116,8 @@ function createCapServiceChoice(
             projectPath,
             appPath,
             // Assume Node.js if not defined
-            capType: serviceInfo.runtime ? (serviceInfo.runtime as 'Node.js' | 'Java') : 'Node.js'
+            capType: serviceInfo.runtime ? (serviceInfo.runtime as 'Node.js' | 'Java') : 'Node.js',
+            cdsInfo
         };
         return {
             name: capService.capType
@@ -148,18 +148,20 @@ export async function getCapServiceChoices(capProjectPaths: CapProjectPaths): Pr
     try {
         let capServices = [];
         let capModel: CSN;
+        let cdsVersionInfo: CdsInfo;
 
         try {
             // Workaround for missing clear cache functionality in `getCapModelAnsdServices`, this resets the cds.resolve.cache.
             // If this is not done then errors can be thrown where out-of-processs changes to the files system have occurred
             await getCdsRoots(capProjectPaths.path, true);
             // Load the CAP model and services
-            const { model, services } = await getCapModelAndServices({
+            const { model, services, cdsInfo } = await getCapModelAndServices({
                 projectRoot: capProjectPaths.path,
                 logger: LoggerHelper.logger
             });
             capServices = services;
             capModel = model;
+            cdsVersionInfo = cdsInfo;
         } catch (error) {
             errorHandler.logErrorMsgs(error);
             LoggerHelper.logger.error(t('errors.capModelAndServicesLoadError', { error: error?.message }));
@@ -172,7 +174,7 @@ export async function getCapServiceChoices(capProjectPaths: CapProjectPaths): Pr
         LoggerHelper.logger.debug(`CDS model source paths: ${JSON.stringify(capModel.$sources)}`);
         const serviceChoices = capServices
             .map((service) => {
-                return createCapServiceChoice(capModel, service, projectPath, appPath);
+                return createCapServiceChoice(capModel, service, projectPath, appPath, cdsVersionInfo);
             })
             .filter((service) => !!service) as CapServiceChoice[]; // filter undefined entries
         return serviceChoices ?? [];

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -1,6 +1,7 @@
 import type { IValidationLink } from '@sap-devx/yeoman-ui-types';
 import type { YUIQuestion } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
+import type { CdsInfo } from '@sap-ux/project-access';
 import type { ListChoiceOptions } from 'inquirer';
 
 /**
@@ -83,6 +84,10 @@ export interface CapService {
      */
     projectPath: string;
     /**
+     * The CDS info for the Cds instance that was used to compile the project when determining the service.
+     */
+    cdsInfo?: CdsInfo;
+    /**
      * The name of the CAP service as identified by the cds model.
      */
     serviceName: string;
@@ -96,7 +101,7 @@ export interface CapService {
      */
     serviceCdsPath?: string;
     /**
-     * The runtime of the CAP service.
+     * The runtime of the Cds instance that was used to compile the project when determining the service.
      */
     capType?: CapRuntime;
     /**

--- a/packages/odata-service-inquirer/test/unit/prompts/cap-project/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/cap-project/questions.test.ts
@@ -12,6 +12,7 @@ import {
 import * as capValidators from '../../../../src/prompts/datasources/cap-project/validators';
 import type { CapCustomPaths } from '@sap-ux/project-access';
 import { errorHandler } from '../../../../src/prompts/prompt-helpers';
+import { type CdsInfo } from '@sap-ux/project-access';
 
 jest.mock('../../../../src/utils', () => ({
     ...jest.requireActual('../../../../src/utils'),
@@ -36,6 +37,12 @@ jest.mock('@sap-ux/project-access', () => ({
     getCapCustomPaths: jest.fn().mockImplementation(async () => mockCapCustomPaths)
 }));
 
+const mockCdsInfo: CdsInfo = {
+    version: '7.0.0',
+    home: '/path/to/cd/home',
+    root: '/path/to/cds/root'
+};
+
 const initialMockCapServicesChoices: CapServiceChoice[] = [
     {
         name: 'AdminService',
@@ -43,7 +50,8 @@ const initialMockCapServicesChoices: CapServiceChoice[] = [
             serviceName: 'AdminService',
             urlPath: '/admin/',
             serviceCdsPath: '../bookshop/srv/admin-service',
-            projectPath: '/cap/path/to/project1'
+            projectPath: '/cap/path/to/project1',
+            cdsInfo: mockCdsInfo
         }
     },
     {
@@ -52,7 +60,8 @@ const initialMockCapServicesChoices: CapServiceChoice[] = [
             serviceName: 'CatalogService',
             urlPath: '/browse/',
             serviceCdsPath: '../bookshop/srv/cat-service',
-            projectPath: '/cap/path/to/project1'
+            projectPath: '/cap/path/to/project1',
+            cdsInfo: mockCdsInfo
         }
     }
 ];
@@ -240,7 +249,8 @@ describe('getLocalCapProjectPrompts', () => {
             appPath: 'app',
             capType: 'Node.js',
             serviceCdsPath: '../relative/services/path',
-            urlPath: 'odatav4/service/path'
+            urlPath: 'odatav4/service/path',
+            cdsInfo: mockCdsInfo
         };
         expect(await (capServicePrompt!.validate as Function)(capService)).toBe(true);
         expect(PromptState.odataService).toMatchInlineSnapshot(`
@@ -272,7 +282,8 @@ describe('getLocalCapProjectPrompts', () => {
             appPath: 'app',
             capType: 'Node.js',
             serviceCdsPath: '../relative/services/path',
-            urlPath: 'odatav4/service/path'
+            urlPath: 'odatav4/service/path',
+            cdsInfo: mockCdsInfo
         };
         expect(await (capCliStateSetterPrompt!.when as Function)({ capService })).toEqual(false);
         expect(PromptState.odataService).toMatchInlineSnapshot(`

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -8,7 +8,9 @@ import type {
     csn,
     LinkedModel,
     Package,
-    ServiceDefinitions
+    ServiceDefinitions,
+    ServiceInfo,
+    CdsInfo
 } from '../types';
 import { fileExists, readFile, readJSON } from '../file';
 import { loadModuleFromProject } from './module-loader';
@@ -33,12 +35,6 @@ interface CdsFacade {
 interface ResolveWithCache {
     (files: string | string[], options?: { skipModelCache: boolean }): string[];
     cache: Record<string, { cached: Record<string, string[]>; paths: string[] }>;
-}
-
-interface ServiceInfo {
-    name: string;
-    urlPath: string;
-    runtime?: string;
 }
 
 /**
@@ -128,11 +124,11 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
  * Return the CAP model and all services. The cds.root will be set to the provided project root path.
  *
  * @param projectRoot - CAP project root where package.json resides or object specifying project root and optional logger to log additional info
- * @returns {Promise<{ model: csn; services: ServiceInfo[] }>} - CAP Model and Services
+ * @returns {Promise<{ model: csn; services: ServiceInfo[]; cdsInfo: CdsInfo }>} - CAP Model and Services
  */
 export async function getCapModelAndServices(
     projectRoot: string | { projectRoot: string; logger?: Logger }
-): Promise<{ model: csn; services: ServiceInfo[] }> {
+): Promise<{ model: csn; services: ServiceInfo[]; cdsInfo: CdsInfo }> {
     let _projectRoot;
     let _logger;
     if (typeof projectRoot === 'object') {
@@ -167,7 +163,12 @@ export async function getCapModelAndServices(
     }
     return {
         model,
-        services
+        services,
+        cdsInfo: {
+            home: cds.home,
+            version: cds.version,
+            root: cds.root
+        }
     };
 }
 

--- a/packages/project-access/src/types/cap/index.ts
+++ b/packages/project-access/src/types/cap/index.ts
@@ -214,3 +214,15 @@ export interface LinkedModel extends CSN {
     services: Definitions & ((namespace: string) => Definitions);
     definitions: Definitions;
 }
+
+export interface ServiceInfo {
+    name: string;
+    urlPath: string;
+    runtime?: string;
+}
+
+export interface CdsInfo {
+    home: string;
+    version: string;
+    root: string;
+}

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -133,7 +133,12 @@ describe('Test getCapModelAndServices()', () => {
                     'urlPath': 'url',
                     'runtime': 'Node.js'
                 }
-            ]
+            ],
+            cdsInfo: {
+                home: undefined,
+                version: undefined,
+                root: undefined
+            }
         });
         expect(cdsMock.load).toBeCalledWith(
             [join('PROJECT_ROOT', 'APP'), join('PROJECT_ROOT', 'SRV'), join('PROJECT_ROOT', 'DB')],


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/1934

- Adds and exports type `CdsInfo` to `@sap/project-access`
- Exports type `ServiceInfo` from `@sap/project-access`
- Returns `CdsInfo`, cds version information, from `getCapModelAndServices`
- Returns `CdsInfo` from `@sap-ux/odata-service-inquirer` when a cap service is prompted and selected