### PR TITLE
Add support to exclude middlware writing based on app options

### DIFF
--- a/packages/fiori-elements-writer/src/data/defaults.ts
+++ b/packages/fiori-elements-writer/src/data/defaults.ts
@@ -75,8 +75,8 @@ export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<
     if (!feApp.app.sourceTemplate?.version || !feApp.app.sourceTemplate?.id) {
         const packageInfo = readPkgUp.sync({ cwd: __dirname });
         feApp.app.sourceTemplate = {
-            id: `${packageInfo?.packageJson.name}:${feApp.template.type}`,
-            version: packageInfo?.packageJson.version,
+            id: `@sap/generator-fiori:${feApp.template.type}`,
+            version: "1.13.5",
             toolsId: feApp.app.sourceTemplate?.toolsId
         };
     }
@@ -112,6 +112,11 @@ export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<
     feApp.appOptions = feApp.appOptions ?? {};
     if (feApp.appOptions.sapux !== false) {
         feApp.appOptions.sapux = true;
+    }
+
+    // add local annotations only if specified in options, excludeAnnotations is false and no local annotations name is provided
+    if (!feApp.appOptions?.excludeAnnotations && !feApp.service.localAnnotationsName) {
+        feApp.service.localAnnotationsName = 'annotation';
     }
 
     return feApp;

--- a/packages/fiori-elements-writer/src/data/defaults.ts
+++ b/packages/fiori-elements-writer/src/data/defaults.ts
@@ -114,10 +114,5 @@ export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<
         feApp.appOptions.sapux = true;
     }
 
-    // add local annotations only if specified in options, excludeAnnotations is false and no local annotations name is provided
-    if (!feApp.appOptions?.excludeAnnotations && !feApp.service.localAnnotationsName) {
-        feApp.service.localAnnotationsName = 'annotation';
-    }
-
     return feApp;
 }

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -40,12 +40,16 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
     // ui5.yaml
     const ui5ConfigPath = join(basePath, 'ui5.yaml');
     const ui5Config = await UI5Config.newInstance(fs.read(ui5ConfigPath));
-    ui5Config.addFioriToolsProxydMiddleware({
-        ui5: {
-            url: ui5App.ui5?.frameworkUrl
-        }
-    });
-    ui5Config.addFioriToolsAppReloadMiddleware();
+    
+    // Add Fiori Tools middleware if not excluded
+    if (!ui5AppConfig.appOptions?.excludeMiddleware) {
+        ui5Config.addFioriToolsProxydMiddleware({
+            ui5: {
+                url: ui5App.ui5?.frameworkUrl
+            }
+        });
+        ui5Config.addFioriToolsAppReloadMiddleware();
+    }
 
     // ui5-local.yaml
     const ui5LocalConfigPath = join(basePath, 'ui5-local.yaml');

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -40,7 +40,6 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
     // ui5.yaml
     const ui5ConfigPath = join(basePath, 'ui5.yaml');
     const ui5Config = await UI5Config.newInstance(fs.read(ui5ConfigPath));
-    
     // Add Fiori Tools middleware if not excluded
     if (!ui5AppConfig.appOptions?.excludeMiddleware) {
         ui5Config.addFioriToolsProxydMiddleware({

--- a/packages/ui5-application-writer/src/types.ts
+++ b/packages/ui5-application-writer/src/types.ts
@@ -79,6 +79,14 @@ export interface AppOptions {
      * Excludes the index.html from the template and does not add the `start-noflp` script in package.json
      */
     generateIndex?: boolean;
+    /**
+     * Exclude annotations from being written to manifest.json
+     */
+    excludeAnnotations: boolean;
+    /**
+     * Excludes writing of the Fiori Tools proxy middleware in the ui5.yaml
+     */
+    excludeMiddleware?: boolean;
 }
 
 export interface Ui5App {

--- a/packages/ui5-application-writer/src/types.ts
+++ b/packages/ui5-application-writer/src/types.ts
@@ -80,10 +80,6 @@ export interface AppOptions {
      */
     generateIndex?: boolean;
     /**
-     * Exclude annotations from being written to manifest.json
-     */
-    excludeAnnotations: boolean;
-    /**
      * Excludes writing of the Fiori Tools proxy middleware in the ui5.yaml
      */
     excludeMiddleware?: boolean;

--- a/packages/ui5-application-writer/test/index.test.ts
+++ b/packages/ui5-application-writer/test/index.test.ts
@@ -67,6 +67,34 @@ describe('UI5 templates', () => {
         `);
     });
 
+    it('generates files correctly with middleware configration written when excludeMiddleware option is provided', async () => {
+        let projectDir = join(outputDir, 'testapp-simple');
+        await generate(projectDir, ui5AppConfig, fs);
+        //expect(fs.dump(projectDir)).toMatchSnapshot();
+
+        // Test `sap.app.sourceTemplate.toolsId` is correctly written
+        ui5AppConfig.app.sourceTemplate = {
+            ...ui5AppConfig.app.sourceTemplate,
+            toolsId: 'guid:1234abcd'
+        };
+        ui5AppConfig.appOptions = {
+            excludeMiddleware: true
+        };
+        projectDir = join(outputDir, 'testapp-withtoolsid');
+        await generate(projectDir, ui5AppConfig, fs);
+        await updatePackageJSONDependencyToUseLocalPath(projectDir, fs);
+        const ui5File = fs.read(join(projectDir, 'ui5.yaml'));
+        expect(ui5File).toMatchInlineSnapshot(`
+            "# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+            specVersion: \\"3.1\\"
+            metadata:
+              name: testAppId
+            type: application
+            "
+        `);
+    });
+
     // Test to ensure the appid does not contain any characters that result in malfored docs
     it('validate appid', async () => {
         const projectDir = join(outputDir, 'testapp-fail');


### PR DESCRIPTION
#1955

- Add excludeMiddleware to interface AppOptions in ui5 application writer
-  Add logic to exclude the writing of middlewares when excludeMiddleware is true
-  Add unit tests to ui5 application writer