### PR TITLE
tbi(ui5-config): add authType option and comments to yaml config

### DIFF
--- a/.changeset/spicy-vans-lick.md
+++ b/.changeset/spicy-vans-lick.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-config': patch
+'@sap-ux/yaml': patch
+---
+
+adds authenticationType to fiori tools proxy backend and ability to add inline comments to yaml nodes

--- a/packages/ui5-config/package.json
+++ b/packages/ui5-config/package.json
@@ -31,6 +31,7 @@
         "!dist/**/*.map"
     ],
     "dependencies": {
+        "@sap-ux/store": "workspace:*",
         "@sap-ux/yaml": "workspace:*",
         "lodash": "4.17.21",
         "semver": "7.5.4"

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -80,9 +80,9 @@ export function getFioriToolsProxyMiddlewareConfig(
     if (backends && backends.length > 0) {
         backends.forEach((element, index) => {
             element.path = element.path ?? '/';
-            const backendComment = getBackendComments(element, index);
-            if (backendComment) {
-                comments = [...comments, ...backendComment];
+            const backendComments = getBackendComments(element, index);
+            if (backendComments) {
+                comments = [...comments, ...backendComments];
             }
         });
         fioriToolsProxy.configuration.backend = backends;

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -1,3 +1,4 @@
+import { AuthenticationType } from '@sap-ux/store';
 import type {
     FioriToolsProxyConfigBackend,
     CustomMiddleware,
@@ -38,7 +39,7 @@ export function getBackendComments(
 ): NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] {
     const comment = [];
 
-    if (backend.authenticationType === 'reentranceTicket') {
+    if (backend.authenticationType === AuthenticationType.ReentranceTicket) {
         comment.push({
             path: `configuration.backend.${index}.authenticationType`,
             comment: ' SAML support for vscode',

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -26,6 +26,29 @@ export function getAppReloadMiddlewareConfig(): CustomMiddleware<FioriAppReloadC
 }
 
 /**
+ * Returns default comments for the given backend configuration values.
+ *
+ * @param backend backend config
+ * @param index - optional index of backend entry
+ * @returns the node comments for the backend config
+ */
+export function getBackendComments(
+    backend: FioriToolsProxyConfigBackend,
+    index?: number
+): NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] {
+    const comment = [];
+
+    if (backend.authenticationType === 'reentranceTicket') {
+        comment.push({
+            path: `configuration.backend.${index}.authenticationType`,
+            comment: ' SAML support for vscode',
+            key: 'authenticationType'
+        });
+    }
+    return comment;
+}
+
+/**
  * Get the configuration for the Fiori tools middleware.
  *
  * @param backends configuration of backends
@@ -46,7 +69,7 @@ export function getFioriToolsProxyMiddlewareConfig(
             ignoreCertError: false
         }
     };
-    const comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] = [
+    let comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] = [
         {
             path: 'configuration.ignoreCertError',
             comment:
@@ -55,8 +78,12 @@ export function getFioriToolsProxyMiddlewareConfig(
     ];
 
     if (backends && backends.length > 0) {
-        backends.forEach((element) => {
+        backends.forEach((element, index) => {
             element.path = element.path ?? '/';
+            const backendComment = getBackendComments(element, index);
+            if (backendComment) {
+                comments = [...comments, ...backendComment];
+            }
         });
         fioriToolsProxy.configuration.backend = backends;
     }

--- a/packages/ui5-config/src/types/middlewares.ts
+++ b/packages/ui5-config/src/types/middlewares.ts
@@ -16,6 +16,7 @@ export interface FioriToolsProxyConfigBackend {
     path?: string;
     url: string;
     client?: string;
+    authenticationType?: string;
     destination?: string;
     destinationInstance?: string;
     pathPrefix?: string;

--- a/packages/ui5-config/src/types/middlewares.ts
+++ b/packages/ui5-config/src/types/middlewares.ts
@@ -1,3 +1,4 @@
+import { AuthenticationType } from '@sap-ux/store';
 export interface UI5ProxyConfigTarget {
     path: string | string[];
     url: string;
@@ -16,7 +17,7 @@ export interface FioriToolsProxyConfigBackend {
     path?: string;
     url: string;
     client?: string;
-    authenticationType?: string;
+    authenticationType?: AuthenticationType;
     destination?: string;
     destinationInstance?: string;
     pathPrefix?: string;

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -18,6 +18,7 @@ import type { NodeComment, YAMLMap, YAMLSeq } from '@sap-ux/yaml';
 import { YamlDocument } from '@sap-ux/yaml';
 import {
     getAppReloadMiddlewareConfig,
+    getBackendComments,
     getFioriToolsProxyMiddlewareConfig,
     getMockServerMiddlewareConfig
 } from './middlewares';
@@ -244,7 +245,13 @@ export class UI5Config {
         if (!proxyMiddleware) {
             throw new Error('Could not find fiori-tools-proxy');
         }
-        this.document.getMap({ start: proxyMiddleware as YAMLMap, path: 'configuration' }).set('backend', [backend]);
+        const comments = getBackendComments(backend);
+        const backendNode = this.document.createNode({ value: backend, comments });
+
+        this.document
+            .getMap({ start: proxyMiddleware as YAMLMap, path: 'configuration' })
+            .set('backend', [backendNode]);
+
         return this;
     }
 

--- a/packages/ui5-config/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-config/test/__snapshots__/index.test.ts.snap
@@ -164,6 +164,25 @@ exports[`UI5Config addBackendToFioriToolsProxydMiddleware add proxy without out 
 "
 `;
 
+exports[`UI5Config addBackendToFioriToolsProxydMiddleware should add comments with backend authentication type as reentrance ticket 1`] = `
+"server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+        backend:
+          - url: http://localhost:8080
+            path: /~testpath~
+            authenticationType: reentranceTicket # SAML support for vscode
+"
+`;
+
 exports[`UI5Config addFioriToolsProxydMiddleware add backend with flexible parameters (and UI5 defaults) 1`] = `
 "server:
   customMiddleware:
@@ -233,6 +252,11 @@ exports[`UI5Config addFioriToolsProxydMiddleware add commonly configured backend
             path: /~testpath~
             destination: ~destination~
             destinationInstance: ~destinationInstance~
+          - url: http://localhost:8080
+            path: /~testpath~
+            destination: ~destination~
+            destinationInstance: ~destinationInstance~
+            authenticationType: reentranceTicket # SAML support for vscode
         ui5:
           path:
             - /resources

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -154,8 +154,23 @@ describe('UI5Config', () => {
         });
 
         test('add commonly configured backend (and UI5 defaults)', () => {
+            const authenticationType = 'reentranceTicket';
             ui5Config.addFioriToolsProxydMiddleware({
-                backend: [{ url, path, destination, destinationInstance }],
+                backend: [
+                    {
+                        url,
+                        path,
+                        destination,
+                        destinationInstance
+                    },
+                    {
+                        url,
+                        path,
+                        destination,
+                        destinationInstance,
+                        authenticationType
+                    }
+                ],
                 ui5: {}
             });
             expect(ui5Config.toString()).toMatchSnapshot();
@@ -183,7 +198,20 @@ describe('UI5Config', () => {
     describe('addBackendToFioriToolsProxydMiddleware', () => {
         test('add proxy without out backend first and then call add backend', () => {
             ui5Config.addFioriToolsProxydMiddleware({ ui5: {} });
-            ui5Config.addBackendToFioriToolsProxydMiddleware({ url, path });
+            ui5Config.addBackendToFioriToolsProxydMiddleware({
+                url,
+                path
+            });
+            expect(ui5Config.toString()).toMatchSnapshot();
+        });
+
+        test('should add comments with backend authentication type as reentrance ticket', () => {
+            ui5Config.addFioriToolsProxydMiddleware({ ui5: {} });
+            ui5Config.addBackendToFioriToolsProxydMiddleware({
+                url,
+                path,
+                authenticationType: 'reentranceTicket'
+            });
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -1,3 +1,4 @@
+import { AuthenticationType } from '@sap-ux/store';
 import type { BspApp, UI5ProxyConfig } from '../src';
 import { UI5Config } from '../src';
 
@@ -154,7 +155,6 @@ describe('UI5Config', () => {
         });
 
         test('add commonly configured backend (and UI5 defaults)', () => {
-            const authenticationType = 'reentranceTicket';
             ui5Config.addFioriToolsProxydMiddleware({
                 backend: [
                     {
@@ -168,7 +168,7 @@ describe('UI5Config', () => {
                         path,
                         destination,
                         destinationInstance,
-                        authenticationType
+                        authenticationType: AuthenticationType.ReentranceTicket
                     }
                 ],
                 ui5: {}
@@ -210,7 +210,7 @@ describe('UI5Config', () => {
             ui5Config.addBackendToFioriToolsProxydMiddleware({
                 url,
                 path,
-                authenticationType: 'reentranceTicket'
+                authenticationType: AuthenticationType.ReentranceTicket
             });
             expect(ui5Config.toString()).toMatchSnapshot();
         });

--- a/packages/ui5-config/tsconfig.json
+++ b/packages/ui5-config/tsconfig.json
@@ -1,9 +1,18 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": ["src"],
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist"
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {
+      "path": "../store"
     },
-    "references": [{ "path": "../yaml" }]
+    {
+      "path": "../yaml"
+    }
+  ]
 }

--- a/packages/yaml/src/yaml-document.ts
+++ b/packages/yaml/src/yaml-document.ts
@@ -9,6 +9,7 @@ import { interpolate } from './texts';
 export interface NodeComment<T> {
     path: string;
     comment: string;
+    key?: string;
 }
 
 /**
@@ -93,6 +94,29 @@ export class YamlDocument {
                 break;
         }
         return this;
+    }
+
+    /**
+     * Creates a Node element and adds the provided comments.
+     *
+     * @param options - Options
+     * @param options.value - the object's value
+     * @param options.comments - optional comments for subnodes in value being added
+     * @returns the node create from the value with any added comments
+     */
+    createNode({ value, comments }: { value: unknown; comments?: NodeComment<unknown>[] }): yaml.YAMLSeq<Node> {
+        const newNode = this.documents[0].createNode(value) as YAMLSeq<yaml.Node>;
+        if (comments?.length) {
+            for (const c of comments) {
+                const nodeIndex = newNode.items.findIndex((item) => {
+                    const keyValue = ((item as yaml.Pair).key as yaml.Scalar).value;
+                    return keyValue === c.key;
+                });
+                ((newNode.items[nodeIndex] as yaml.Pair).value as yaml.Scalar).comment = c.comment;
+            }
+        }
+
+        return newNode;
     }
 
     /**
@@ -375,11 +399,12 @@ export class YamlDocument {
      * @returns {string[]} - the path array
      * @memberof YamlDocument
      */
-    private toPathArray(path: string): string[] {
+    private toPathArray(path: string): (string | number)[] {
         const result = path
             ?.toString()
             .split('.')
-            .filter((p) => p !== '');
+            .filter((p) => p !== '')
+            .map((p) => (isNaN(Number(p)) ? p : Number(p))); // to add comments to array elements e.g arr.0.prop
 
         if (!result || result.length === 0) {
             throw new YAMLError(errorTemplate.pathCannotBeEmpty, errorCode.pathCannotBeEmpty);

--- a/packages/yaml/src/yaml-document.ts
+++ b/packages/yaml/src/yaml-document.ts
@@ -98,10 +98,11 @@ export class YamlDocument {
 
     /**
      * Creates a Node element and adds the provided comments.
+     * To add the comments the value must be flat JSON.
      *
      * @param options - Options
-     * @param options.value - the object's value
-     * @param options.comments - optional comments for subnodes in value being added
+     * @param options.value - the object's value (must be flat json)
+     * @param options.comments - optional comments for no in value being added
      * @returns the node create from the value with any added comments
      */
     createNode({ value, comments }: { value: unknown; comments?: NodeComment<unknown>[] }): yaml.YAMLSeq<Node> {

--- a/packages/yaml/test/yaml-document.test.ts
+++ b/packages/yaml/test/yaml-document.test.ts
@@ -1,7 +1,8 @@
 import { errorTemplate } from '../src/errors';
 import { YamlDocument } from '../src';
-import type { YAMLMap, YAMLSeq } from '../src';
+import type { NodeComment, YAMLMap, YAMLSeq } from '../src';
 import { interpolate } from '../src/texts';
+import type yaml from 'yaml';
 
 describe('YamlDocument', () => {
     it('throws an error when instantiated with malformed YAML contents', async () => {
@@ -249,6 +250,28 @@ key1: 42
 #This goes at the end
 `;
             expect(doc.toString()).toEqual(expectedValue);
+        });
+    });
+
+    describe('addNodeComments', () => {
+        it('creates a node from the value and adds comments', async () => {
+            const value = {
+                b: '2',
+                c: '3'
+            };
+            const comments = [
+                {
+                    path: 'b',
+                    comment: 'Y',
+                    key: 'b'
+                }
+            ] as NodeComment<unknown>[];
+
+            const serializedYaml = 'a: 1';
+
+            const doc = await YamlDocument.newInstance(serializedYaml);
+            const newNode = doc.createNode({ value, comments });
+            expect(((newNode.items[0] as yaml.Pair).value as yaml.Scalar).comment).toBe('Y');
         });
     });
 
@@ -959,8 +982,9 @@ seq1:
         const doc = await YamlDocument.newInstance(serializedYaml);
         doc.appendTo({
             path: 'seq1.1.a.b.d',
-            value: { w: 1, x: { y: { z: 42 } } },
+            value: { w: 1, v: [{ f: 1 }, { f: 2 }], x: { y: { z: 42 } } },
             comments: [
+                { path: 'v.0.f', comment: ' Y' },
                 { path: 'w', comment: 'W' },
                 { path: 'x.y.z', comment: 'The answer!' }
             ]
@@ -973,6 +997,9 @@ seq1:
         d:
           - w: 13
           - w: 1 #W
+            v:
+              - f: 1 # Y
+              - f: 2
             x:
               y:
                 z: 42 #The answer!

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,6 +2022,9 @@ importers:
 
   packages/ui5-config:
     dependencies:
+      '@sap-ux/store':
+        specifier: workspace:*
+        version: link:../store
       '@sap-ux/yaml':
         specifier: workspace:*
         version: link:../yaml


### PR DESCRIPTION
#1965
 
- (`ui5-config`): Adds new property `authenticationType` to `FioriToolsProxyConfigBackend` interface
- (`ui5-config`): Adds function `getBackendComments` to retrieve comments for backend values
- (`ui5-config`): Updates `addBackendToFioriToolsProxydMiddleware` to check provided backend value for applicable comments and add them to the config

- (`yaml`): adds method `createNode` which creates a `Node` from the provided value and adds any relevant comments to the values
- (`yaml`): updates `toPathArray` to convert index values passed as strings to numbers, to be enable adding or updating config items within an array