### PR TITLE
fix(project-access): export 'clearCdsModuleCache ' to allow clear project's cds cache from outside

### DIFF
--- a/.changeset/dirty-flies-develop.md
+++ b/.changeset/dirty-flies-develop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Enhance method 'getCapModelAndService' to validate cache to avoid empty cache for model folders which does not has annotations

--- a/.changeset/dirty-flies-develop.md
+++ b/.changeset/dirty-flies-develop.md
@@ -2,4 +2,4 @@
 '@sap-ux/project-access': patch
 ---
 
-Enhance method 'getCapModelAndService' to validate cache to avoid empty cache for model folders which does not has annotations
+Export method 'clearCdsModuleCache' to provide option to clear cds module cache for passed project root path.

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -30,7 +30,8 @@ export {
     loadModuleFromProject,
     readCapServiceMetadataEdmx,
     readUi5Yaml,
-    toReferenceUri
+    toReferenceUri,
+    clearCdsModuleCache
 } from './project';
 export * from './types';
 export * from './library';

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -221,7 +221,7 @@ export async function getCdsRoots(projectRoot: string, clearCache = false): Prom
     // clear cache is enforced to also resolve newly created cds file at design time
     const cds = await loadCdsModuleFromProject(projectRoot);
     if (clearCache) {
-        _clearCdsModuleCache(cds);
+        clearCdsResolveCache(cds);
     }
     for (const cdsEnvRoot of cdsEnvRoots) {
         const resolvedRoots =
@@ -432,16 +432,17 @@ async function loadCdsModuleFromProject(capProjectPath: string, strict: boolean 
  * @returns True if cache cleared successfully.
  */
 export async function clearCdsModuleCache(projectRoot: string): Promise<boolean> {
+    let result = false;
     try {
         const cds = await loadCdsModuleFromProject(projectRoot);
         if (cds) {
-            _clearCdsModuleCache(cds);
+            clearCdsResolveCache(cds);
+            result = true;
         }
-    } catch (error) {
-        // Do not throw error if wrong path or cds module does not exist
-        return false;
+    } catch (e) {
+        // ignore exception
     }
-    return true;
+    return result;
 }
 
 /**
@@ -449,7 +450,7 @@ export async function clearCdsModuleCache(projectRoot: string): Promise<boolean>
  *
  * @param cds CAP CDS module
  */
-function _clearCdsModuleCache(cds: CdsFacade): void {
+function clearCdsResolveCache(cds: CdsFacade): void {
     cds.resolve.cache = {};
 }
 

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -132,7 +132,8 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
  * @param paths - Paths to validate
  */
 function validateCdsCache(cds: CdsFacade, paths: string[]): void {
-    for (const scope in cds.resolve.cache) {
+    const cache = cds.resolve?.cache ?? {};
+    for (const scope in cache) {
         const entry = cds.resolve.cache[scope];
         for (const path in entry.cached) {
             if (entry.cached[path] === undefined && paths.includes(path)) {

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -428,7 +428,8 @@ async function loadCdsModuleFromProject(capProjectPath: string, strict: boolean 
 /**
  * Method to clear CAP CDS module cache for passed project path.
  *
- * @param projectRoot root of a CAP project
+ * @param projectRoot root of a CAP project.
+ * @returns True if cache cleared successfully.
  */
 export async function clearCdsModuleCache(projectRoot: string): Promise<boolean> {
     try {
@@ -448,7 +449,7 @@ export async function clearCdsModuleCache(projectRoot: string): Promise<boolean>
  *
  * @param cds CAP CDS module
  */
-export async function _clearCdsModuleCache(cds: CdsFacade): Promise<void> {
+function _clearCdsModuleCache(cds: CdsFacade): void {
     cds.resolve.cache = {};
 }
 

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -10,7 +10,8 @@ export {
     isCapNodeJsProject,
     getCapEnvironment,
     readCapServiceMetadataEdmx,
-    toReferenceUri
+    toReferenceUri,
+    clearCdsModuleCache
 } from './cap';
 export { getNodeModulesPath } from './dependencies';
 export { getCapI18nFolderNames, getI18nPropertiesPaths } from './i18n';

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -3,7 +3,7 @@ import * as childProcess from 'child_process';
 import * as projectModuleMock from '../../src/project/module-loader';
 import type { Package } from '../../src';
 import { FileName } from '../../src/constants';
-import { clearGlobalCdsPathCache } from '../../src/project/cap';
+import { clearCdsModuleCache, clearGlobalCdsPathCache } from '../../src/project/cap';
 import {
     getCapCustomPaths,
     getCapEnvironment,
@@ -262,113 +262,6 @@ describe('Test getCapModelAndServices()', () => {
                 expect(error.toString()).toContain(testString);
             });
         }
-    });
-
-    describe('Test validateCdsCache()', () => {
-        const projectRoot = 'PROJECT_ROOT';
-        const modelPaths = {
-            app: join(projectRoot, 'APP'),
-            srv: join(projectRoot, 'SRV'),
-            db: join(projectRoot, 'DB')
-        };
-        const cacheValidateTestCases = [
-            {
-                name: 'Clear all empty cache for "app", "db", "srv"',
-                cache: {
-                    'dummy': {
-                        'cached': {
-                            [modelPaths.app]: undefined,
-                            [modelPaths.db]: undefined,
-                            [modelPaths.srv]: undefined
-                        }
-                    }
-                },
-                expected: {
-                    'dummy': {
-                        'cached': {}
-                    }
-                }
-            },
-            {
-                name: 'Do not clear resolved cache',
-                cache: {
-                    'dummy': {
-                        'cached': {
-                            [modelPaths.app]: 'dummy1',
-                            [modelPaths.db]: 'dummy2',
-                            [modelPaths.srv]: 'dummy3'
-                        }
-                    }
-                },
-                expected: {
-                    'dummy': {
-                        'cached': {
-                            [modelPaths.app]: 'dummy1',
-                            [modelPaths.db]: 'dummy2',
-                            [modelPaths.srv]: 'dummy3'
-                        }
-                    }
-                }
-            },
-            {
-                name: 'Clear only relevant and empty cache',
-                cache: {
-                    'dummy': {
-                        'cached': {
-                            [modelPaths.app]: undefined,
-                            [modelPaths.db]: 'dummy1',
-                            [modelPaths.srv]: 'dummy2',
-                            'nonModel': 'dummy3'
-                        }
-                    }
-                },
-                expected: {
-                    'dummy': {
-                        'cached': {
-                            [modelPaths.db]: 'dummy1',
-                            [modelPaths.srv]: 'dummy2',
-                            'nonModel': 'dummy3'
-                        }
-                    }
-                }
-            }
-        ];
-
-        test.each(cacheValidateTestCases)('$name', async ({ cache, expected }) => {
-            // Mock setup
-            const cdsMock = {
-                env: {
-                    'for': () => ({
-                        folders: {
-                            app: 'APP',
-                            db: 'DB',
-                            srv: 'SRV'
-                        }
-                    })
-                },
-                load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
-                compile: {
-                    to: {
-                        serviceinfo: jest.fn().mockImplementation(() => [
-                            {
-                                'name': 'Forwardslash',
-                                'urlPath': 'odata/service/with/forwardslash/'
-                            }
-                        ])
-                    }
-                },
-                resolve: {
-                    cache
-                }
-            };
-            jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
-
-            // Test execution
-            await getCapModelAndServices(projectRoot);
-
-            // Check results
-            expect(cdsMock.resolve.cache).toStrictEqual(expected);
-        });
     });
 });
 
@@ -941,6 +834,41 @@ describe('Test getCdsServices()', () => {
         } catch (error) {
             expect(error.toString()).toContain('CDS_LOAD_ERROR');
         }
+    });
+});
+
+describe('clearCdsModuleCache', () => {
+    const projectRoot = 'PROJECT_ROOT';
+    test('Clear CDS cache', async () => {
+        // Mock setup
+        const cdsMock = {
+            load: jest.fn().mockImplementation(() => Promise.resolve('MODEL')),
+            resolve: {
+                cache: {
+                    'dummy': {
+                        'cached': {
+                            'dummyPath': 'dummyValue'
+                        }
+                    }
+                }
+            }
+        };
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
+
+        // Test execution
+        const result = await clearCdsModuleCache(projectRoot);
+
+        // Check results
+        expect(result).toEqual(true);
+        expect(cdsMock.resolve.cache).toStrictEqual({});
+    });
+
+    test('Unresolvable cds module', async () => {
+        // Mock setup
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(undefined));
+        // Test execution
+        const result = await clearCdsModuleCache(projectRoot);
+        expect(result).toEqual(false);
     });
 });
 

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -863,9 +863,19 @@ describe('clearCdsModuleCache', () => {
         expect(cdsMock.resolve.cache).toStrictEqual({});
     });
 
-    test('Unresolvable cds module', async () => {
+    test('Unresolvable cds module - error is thrown', async () => {
         // Mock setup
         jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(undefined));
+        // Test execution
+        const result = await clearCdsModuleCache(projectRoot);
+        expect(result).toEqual(false);
+    });
+
+    test('Unresolvable cds module - error is not thrown', async () => {
+        // Mock setup
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() =>
+            Promise.resolve({ default: undefined })
+        );
         // Test execution
         const result = await clearCdsModuleCache(projectRoot);
         expect(result).toEqual(false);


### PR DESCRIPTION
Issue #1975

We noticed issues:
1. app -> https://github.com/SAP-samples/btp-lcnc-capex
2. Please note - this app does not have any annotation in https://github.com/SAP-samples/btp-lcnc-capex/tree/main/app
3. When we call `getCapModelAndService` - then it gets cached following:
![image](https://github.com/SAP/open-ux-tools/assets/90789422/82f70b0a-aa75-4981-8979-8b6fc9e19679)

4. Then after generating new CAP app in `app` folder, calls for `cds.compile` does not return compiled result from newly added app from `app`


1st solution(not in PR anymore - 4b3d877611ee8066cfd9a10067d3f80f1b3439ba):
1. We have hardcoded `modelPaths` -> https://github.com/SAP/open-ux-tools/blob/main/packages/project-access/src/project/cap.ts#L147-L151
2. Validate those paths after `cds.load` calls
3. If modelPath had cached as `undefined`, then delete such cached entry

2nd solution(in PR):
1. export new method `clearCdsModuleCache` with parameter `projectRoot`, which resolve cds module and calls:
```
cds.resolve.cache = {};
```