### PR TITLE
fix(axios-ext): add cookies for embedded steampunk service providers

### DIFF
--- a/.changeset/six-buttons-build.md
+++ b/.changeset/six-buttons-build.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+add cookies for embedded steampunk service providers

--- a/packages/axios-extension/src/factory.ts
+++ b/packages/axios-extension/src/factory.ts
@@ -153,6 +153,7 @@ export function createForAbapOnCloud(options: AbapCloudOptions & Partial<Provide
             const { url, cookies, ...config } = options;
             provider = createInstance<AbapServiceProvider>(AbapServiceProvider, {
                 baseURL: url,
+                cookies,
                 ...config
             });
             if (!cookies) {


### PR DESCRIPTION
#1977 

Adds cookies to the instance of the abap service provider returned for embedded steampunk