### PR TITLE
feat(deploy-tooling): add auth type to cli params

### DIFF
--- a/.changeset/serious-lizards-hunt.md
+++ b/.changeset/serious-lizards-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-tooling': patch
+---
+
+adds auth type param to deploy tooling

--- a/packages/deploy-tooling/README.md
+++ b/packages/deploy-tooling/README.md
@@ -126,6 +126,7 @@ Options:
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables. Secrets in your .env should not be committed to source control.
   --username                           ABAP Service username
   --password                           ABAP Service password
+  --authentication-type                Authentication type for the app (e.g. 'basic', 'reentranceTicket'). Required for 'reentranceTicket'.
   --create-transport                   Create a transport request during deployment
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --name <bsp-name>                    Project name of the app
@@ -202,6 +203,7 @@ Options:
   --cloud-service-env                  Load ABAP cloud service properties from either a .env file or your environment variables
   --username                           ABAP Service username
   --password                           ABAP Service password
+  --authentication-type                Authentication type for the app (e.g. 'basic', 'reentranceTicket'). Required for 'reentranceTicket'.
   --transport <transport-request>      Transport number to record the change in the ABAP system
   --create-transport                   Create a transport request during deployment
   --package <abap-package>             Package name for deploy target ABAP system (only required when --create-transport is used)

--- a/packages/deploy-tooling/src/cli/index.ts
+++ b/packages/deploy-tooling/src/cli/index.ts
@@ -32,6 +32,7 @@ export function createCommand(name: 'deploy' | 'undeploy'): Command {
         .addOption(new Option('--client <sap-client>', 'Client number of target ABAP system').conflicts('destination'))
         .addOption(new Option('--cloud', 'Target is an ABAP Cloud system').conflicts('destination'))
         .addOption(new Option('--service <service-path>', 'Target alias for deployment service'))
+        .addOption(new Option('--authentication-type <authentication-type>', 'Authentication type for the app'))
         .addOption(
             new Option(
                 '--cloud-service-key <file-location>',

--- a/packages/deploy-tooling/test/unit/cli/index.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/index.test.ts
@@ -79,7 +79,7 @@ describe('cli', () => {
         ];
 
         const cliCmdWithUaa = [...cliCmd, '--cloud-service-env', '--service', '/bc/my/uaa/deploy/service'];
-        const cliCmdWithAuthTyp = [...cliCmd, '--authentication-type', 'reentranceTicket'];
+        const cliCmdWithAuthType = [...cliCmd, '--authentication-type', 'reentranceTicket'];
 
         test.each([
             {
@@ -116,7 +116,7 @@ describe('cli', () => {
                 provider: '/bc/my/uaa/deploy/service'
             },
             {
-                params: cliCmdWithAuthTyp,
+                params: cliCmdWithAuthType,
                 writeFileSyncCalled: 0,
                 deployFn: mockedUi5RepoService.deploy,
                 object: { authenticationType: 'reentranceTicket' }

--- a/packages/deploy-tooling/test/unit/cli/index.test.ts
+++ b/packages/deploy-tooling/test/unit/cli/index.test.ts
@@ -79,6 +79,7 @@ describe('cli', () => {
         ];
 
         const cliCmdWithUaa = [...cliCmd, '--cloud-service-env', '--service', '/bc/my/uaa/deploy/service'];
+        const cliCmdWithAuthTyp = [...cliCmd, '--authentication-type', 'reentranceTicket'];
 
         test.each([
             {
@@ -113,6 +114,12 @@ describe('cli', () => {
                 deployFn: mockedUi5RepoService.deploy,
                 object: { retry: false, strictSsl: false },
                 provider: '/bc/my/uaa/deploy/service'
+            },
+            {
+                params: cliCmdWithAuthTyp,
+                writeFileSyncCalled: 0,
+                deployFn: mockedUi5RepoService.deploy,
+                object: { authenticationType: 'reentranceTicket' }
             }
         ])(
             'successful deploy with different options %s',


### PR DESCRIPTION
Add `--authentication-type` to the available CLI params in deploy tooling (considerations for reentrance tickets)