### PR TITLE
fix: Custom action path within custom section

### DIFF
--- a/.changeset/cool-tables-fetch.md
+++ b/.changeset/cool-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fixed custom action path when it's generated within custom section.

--- a/packages/fe-fpm-writer/src/action/index.ts
+++ b/packages/fe-fpm-writer/src/action/index.ts
@@ -45,6 +45,7 @@ function enhanceConfig(data: CustomAction, manifestPath: string, manifest: Manif
  */
 export function enhanceManifestAndGetActionsElementReference(manifest: any, target: CustomActionTarget): any {
     const page = manifest['sap.ui5'].routing.targets[target.page];
+    const SECTIONS = 'sections';
     page.options = page.options || {};
     page.options.settings = page.options.settings || {};
     if (target.control === TargetControl.header || target.control === TargetControl.footer) {
@@ -56,11 +57,12 @@ export function enhanceManifestAndGetActionsElementReference(manifest: any, targ
     } else if (target.control === TargetControl.body && target.customSectionKey) {
         // custom section actions
         page.options.settings[target.control] = page.options.settings[target.control] || {};
-        page.options.settings[target.control][target.customSectionKey] =
-            page.options.settings[target.control][target.customSectionKey] || {};
-        page.options.settings[target.control][target.customSectionKey].actions =
-            page.options.settings[target.control][target.customSectionKey].actions || {};
-        return page.options.settings[target.control][target.customSectionKey].actions;
+        page.options.settings[target.control][SECTIONS] = page.options.settings[target.control][SECTIONS] || {};
+        page.options.settings[target.control][SECTIONS][target.customSectionKey] =
+            page.options.settings[target.control][SECTIONS][target.customSectionKey] || {};
+        page.options.settings[target.control][SECTIONS][target.customSectionKey].actions =
+            page.options.settings[target.control][SECTIONS][target.customSectionKey].actions || {};
+        return page.options.settings[target.control][SECTIONS][target.customSectionKey].actions;
     } else {
         const controlPrefix = target.navProperty ? target.navProperty + '/' : '';
         const controlSuffix = target.qualifier ? '#' + target.qualifier : '';

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/action.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/action.test.ts.snap
@@ -238,13 +238,15 @@ Object {
           "options": Object {
             "settings": Object {
               "body": Object {
-                "CustomSectionOne": Object {
-                  "actions": Object {
-                    "MyCustomAction": Object {
-                      "enabled": true,
-                      "press": "",
-                      "text": "My custom action text",
-                      "visible": true,
+                "sections": Object {
+                  "CustomSectionOne": Object {
+                    "actions": Object {
+                      "MyCustomAction": Object {
+                        "enabled": true,
+                        "press": "",
+                        "text": "My custom action text",
+                        "visible": true,
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
Fixes path for custom action when it is generated within custom section.

Previously it was generated in:
page.settings.body.CustomSection.actions.CustomAction

Now:
page.settings.body.**sections**.CustomSection.actions.CustomAction

Sections part was missing.