### PR TITLE
fix(axios-entension): Prevent `createServiceForUrl` param over-writing

### DIFF
--- a/.changeset/chilled-mangos-appear.md
+++ b/.changeset/chilled-mangos-appear.md
@@ -2,4 +2,4 @@
 '@sap-ux/axios-extension': patch
 ---
 
-Prevents overwritting axios config params
+Prevents overwriting axios config params

--- a/.changeset/chilled-mangos-appear.md
+++ b/.changeset/chilled-mangos-appear.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+Prevents overwritting axios config params

--- a/packages/axios-extension/src/factory.ts
+++ b/packages/axios-extension/src/factory.ts
@@ -242,7 +242,13 @@ export function createServiceForUrl(
 ): ODataService {
     const urlObject = new URL(url);
     config.baseURL = urlObject.origin;
-    config.params = urlObject.searchParams;
+
+    const searchParams = new URLSearchParams(config.params);
+    for (const [key, val] of urlObject.searchParams.entries()) {
+        searchParams.append(key, val);
+    }
+    config.params = searchParams;
+
     const provider = createInstance(ServiceProvider, config);
 
     return provider.service(urlObject.pathname);

--- a/packages/axios-extension/test/factory.test.ts
+++ b/packages/axios-extension/test/factory.test.ts
@@ -60,6 +60,13 @@ test('createForServiceUrl', async () => {
     const metadata = await service.metadata();
     expect(metadata).toBeDefined();
     expect(metadata).toBe(expectedMetadata);
+
+    // Ensure axios config params are not overwritten
+    const serviceWithParams = createServiceForUrl(`${server}${servicePath}?sap-client=999`, {
+        params: { 'abc': '123' }
+    });
+    expect((serviceWithParams.defaults.params as URLSearchParams).get('abc')).toEqual('123');
+    expect((serviceWithParams.defaults.params as URLSearchParams).get('sap-client')).toEqual('999');
 });
 
 describe('createForDestination', () => {


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2026

- Apply existing Axios config params
- Adds test to cover