### PR TITLE
fix: Export JSON update functions

### DIFF
--- a/.changeset/six-garlics-provide.md
+++ b/.changeset/six-garlics-provide.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Exports updatePackageJSON and updateManifestJSON functions.

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -1,5 +1,5 @@
 export { FileName, DirName, FioriToolsSettings } from './constants';
-export { getFilePaths } from './file';
+export { getFilePaths, updateManifestJSON, updatePackageJSON } from './file';
 export {
     createApplicationAccess,
     createProjectAccess,


### PR DESCRIPTION
Exports `updatePackageJSON` and `updateManifestJSON` functions for external use.