### PR TITLE
Remove unimplemented message for implemented datasource

### DIFF
--- a/.changeset/loud-melons-hope.md
+++ b/.changeset/loud-melons-hope.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Removes unimplemented message for odata service url datasource

--- a/packages/odata-service-inquirer/src/prompts/prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/prompts.ts
@@ -53,7 +53,6 @@ function getDatasourceTypeQuestion(options?: DatasourceTypePromptOptions): YUIQu
                 [
                     DatasourceType.businessHub,
                     DatasourceType.none,
-                    DatasourceType.odataServiceUrl,
                     DatasourceType.projectSpecificDestination,
                     DatasourceType.sapSystem
                 ].includes(source)

--- a/packages/odata-service-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/prompts.test.ts
@@ -193,17 +193,23 @@ describe('getQuestions', () => {
 
     test('datasourceTypeQuestion displays and logs not implemented yet message', async () => {
         const logWarnSpy = jest.spyOn(ToolsLogger.prototype, 'warn');
-        const datasourceType = DatasourceType.sapSystem;
         const datasourceTypeQuestion = (await getQuestions())[0];
         expect(datasourceTypeQuestion.name).toEqual('datasourceType');
 
-        const additionalMessages = (datasourceTypeQuestion.additionalMessages as Function)(datasourceType);
-        expect(additionalMessages).toMatchObject({
-            message: t('prompts.datasourceType.notYetImplementedWarningMessage', { datasourceType }),
-            severity: Severity.warning
+        [
+            DatasourceType.businessHub,
+            DatasourceType.none,
+            DatasourceType.projectSpecificDestination,
+            DatasourceType.sapSystem
+        ].forEach((datasourceType) => {
+            const additionalMessages = (datasourceTypeQuestion.additionalMessages as Function)(datasourceType);
+            expect(additionalMessages).toMatchObject({
+                message: t('prompts.datasourceType.notYetImplementedWarningMessage', { datasourceType }),
+                severity: Severity.warning
+            });
+            expect(logWarnSpy).toHaveBeenCalledWith(
+                t('prompts.datasourceType.notYetImplementedWarningMessage', { datasourceType })
+            );
         });
-        expect(logWarnSpy).toHaveBeenCalledWith(
-            t('prompts.datasourceType.notYetImplementedWarningMessage', { datasourceType })
-        );
     });
 });


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2060

- Remove not-yet-implemented message for now inplemented `odata service url` datasource
- Update test to cover
