### PR TITLE
fix(locate-reuse-lib): corrected extraction of component name

### DIFF
--- a/packages/ui5-application-writer/templates/optional/loadReuseLibs/webapp/test/locate-reuse-libs.js
+++ b/packages/ui5-application-writer/templates/optional/loadReuseLibs/webapp/test/locate-reuse-libs.js
@@ -41,6 +41,35 @@
             });
             return libOrCompKeysStringTmp;
         }
+        /* "sap.ui5"/componentUsages has a structure like: 
+         componentUsages: {
+            "componentUsage1": {
+                "name": "sap.nw.core.applogs.lib.reuse.smarttemplate",
+                "lazy": true
+            }, 
+            "componentUsage2": {
+                "name": "sap.s4.cfnd.bpf.lib.reuse.component.smarttemplate",
+                "lazy": true
+            }
+            So the call to /sap/bc/ui2/app_index/ui5_app_info should include component name not the local reference key.
+        }*/
+        function getComponentUsageNames(compUsages, libOrCompKeysString) {
+            var libOrCompKeysStringTmp = libOrCompKeysString;
+            var compNames = Object.keys(compUsages).map(function (compUsageKey) {
+                return compUsages[compUsageKey].name;
+            });
+            compNames.forEach(function (compName) {
+                // ignore libs or Components that start with SAPUI5 delivered namespaces
+                if (!ui5Libs.some(function (substring) { return compName === substring || compName.startsWith(substring + "."); })) {
+                    if (libOrCompKeysStringTmp.length > 0) {
+                        libOrCompKeysStringTmp = libOrCompKeysStringTmp + "," + compName;
+                    } else {
+                        libOrCompKeysStringTmp = compName;
+                    }
+                }
+            });
+            return libOrCompKeysStringTmp;
+        }
         return new Promise(function (resolve, reject) {
             $.ajax(url)
                 .done(function (manifest) {
@@ -60,7 +89,7 @@
                             manifest["sap.ui5"] &&
                             manifest["sap.ui5"].componentUsages
                         ) {
-                            result = getKeys(manifest["sap.ui5"].componentUsages, result);
+                            result = getComponentUsageNames(manifest["sap.ui5"].componentUsages, result);
                         }
                     }
                     resolve(result);


### PR DESCRIPTION
"sap.ui5"/"componentUsages" contains object map having "name" property where component name is specified. 
e.g. 

componentUsages: {
            "componentUsage1": {
                "name": "sap.nw.core.applogs.lib.reuse.smarttemplate",
                "lazy": true
            }, 
            "componentUsage2": {
                "name": "sap.s4.cfnd.bpf.lib.reuse.component.smarttemplate",
                "lazy": true
            }
}

So instead of key of componentUsages object, logic should extract component name from "name" property inside the object.