### PR TITLE
fix(axios-extension): parsing of service gen response

### DIFF
--- a/.changeset/mean-ladybugs-try.md
+++ b/.changeset/mean-ladybugs-try.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+fix for ui service generation response parsing

--- a/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
@@ -124,6 +124,6 @@ export class UiServiceGenerator extends AdtService {
                 corrNr: transport
             }
         });
-        return JSON.parse(response.data);
+        return this.parseResponse(response.data);
     }
 }

--- a/packages/axios-extension/test/abap/abap-adt-service.test.ts
+++ b/packages/axios-extension/test/abap/abap-adt-service.test.ts
@@ -835,7 +835,7 @@ describe('Generator Service', () => {
             .post(
                 '/sap/bc/adt/rap/generators/webapi/published-ui-service?referencedObject=%2Fsap%2Fbc%2Fadt%2Fbo%2Fbehaviordefinitions%2Fi_banktp&corrNr=test_transport'
             )
-            .replyWithFile(200, join(__dirname, 'mockResponses/generateResponse.json'));
+            .replyWithFile(200, join(__dirname, 'mockResponses/generateResponse.xml'));
 
         const gen = await provider.getUiServiceGenerator({
             name: businessObjectName,

--- a/packages/axios-extension/test/abap/mockResponses/generateResponse.json
+++ b/packages/axios-extension/test/abap/mockResponses/generateResponse.json
@@ -1,7 +1,0 @@
-{
-    "?xml": {
-        "version": 1,
-        "encoding": "utf-8"
-    },
-    "objectReferences": ""
-}

--- a/packages/axios-extension/test/abap/mockResponses/generateResponse.xml
+++ b/packages/axios-extension/test/abap/mockResponses/generateResponse.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2087

Fix parsing of ui service generation response, use `parseResponse` instead of json.parse