### PR TITLE
fix return null value for expression type null

### DIFF
--- a/.changeset/two-lions-explode.md
+++ b/.changeset/two-lions-explode.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-annotation-api': patch
+---
+
+fix: return null value for expression type null

--- a/packages/fiori-annotation-api/src/avt/to-internal.ts
+++ b/packages/fiori-annotation-api/src/avt/to-internal.ts
@@ -262,7 +262,7 @@ export function convertPrimitiveValueToInternal(
 ): string {
     const text = value === undefined ? '' : value.toString();
     if (!text) {
-        return text;
+        return type === Edm.Null ? 'null' : text;
     } else if (type === Edm.EnumMember) {
         return getAliasedEnumMember(aliasInfo, text);
     } else if (type.indexOf('Path') >= 0) {


### PR DESCRIPTION
New value is set to empty when set to null leading to compilation errors
https://github.com/SAP/open-ux-tools/blob/e8ac45dcce29fe9ce05178d8f7125edf8a7024a9/packages/fiori-annotation-api/src/change-converter.ts#L584

**Actual Result** `ScaleFactor: `
**ExpectedResult**: `ScaleFactor:  null`