### PR TITLE
Enhancing the `generatePreviewFiles` to support all configurations and CAP

### DIFF
--- a/.changeset/twelve-walls-teach.md
+++ b/.changeset/twelve-walls-teach.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': minor
+---
+
+Add support for using the preview in CAP projects

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -22,7 +22,7 @@ npx sap-ux
 Calling `sap-ux add` allows adding a feature to a project.
 
 ### html
-Calling `sap-ux add html` will add html files for local preview and testing to the project. It will use the configuration from the `preview-middleware` from the `ui5.yaml` as default but also allows pointing to a different yaml e.g.:
+Calling `sap-ux add html` will add html files for local preview and testing to the project. It will use the configuration from the `ui5.yaml` as default, as provided by the `fiori-tools-preview` or `preview-middleware` e.g.:
 ```sh
 sap-ux change add html ui5-test.yaml
 ```

--- a/packages/create/src/cli/add/html.ts
+++ b/packages/create/src/cli/add/html.ts
@@ -13,7 +13,7 @@ import type { AdpPreviewConfig } from '@sap-ux/adp-tooling';
  *
  * @param cmd - commander command for adding navigation inbounds config command
  */
-export function addLocalHtmlFiles(cmd: Command): void {
+export function addAddHtmlFilesCmd(cmd: Command): void {
     cmd.command('html [path]')
         .option('-c, --config <string>', 'Path to project configuration file in YAML format', 'ui5.yaml')
         .option('-s, --simulate', 'simulate only do not write config; sets also --verbose')

--- a/packages/create/src/cli/add/index.ts
+++ b/packages/create/src/cli/add/index.ts
@@ -4,7 +4,7 @@ import { addAddSmartLinksConfigCommand } from './smartlinks-config';
 import { addAddCdsPluginUi5Command } from './cds-plugin-ui';
 import { addInboundNavigationConfigCommand } from './navigation-config';
 import { addCardsEditorConfigCommand } from './cards-editor';
-import { addLocalHtmlFiles } from './html';
+import { addAddHtmlFilesCmd } from './html';
 
 /**
  * Return 'create-fiori add *' commands. Commands include also the handler action.
@@ -24,6 +24,6 @@ export function getAddCommands(): Command {
     // create-fiori add cards-editor
     addCardsEditorConfigCommand(addCommands);
     // create-fiori add html
-    addLocalHtmlFiles(addCommands);
+    addAddHtmlFilesCmd(addCommands);
     return addCommands;
 }

--- a/packages/create/test/unit/cli/add/html.test.ts
+++ b/packages/create/test/unit/cli/add/html.test.ts
@@ -1,6 +1,6 @@
 import * as tracer from '../../../../src/tracing/trace';
 import * as preview from '@sap-ux/preview-middleware';
-import { addLocalHtmlFiles } from '../../../../src/cli/add/html';
+import { addAddHtmlFilesCmd } from '../../../../src/cli/add/html';
 import { Command } from 'commander';
 import type { Store } from 'mem-fs';
 import type { Editor, create } from 'mem-fs-editor';
@@ -32,7 +32,7 @@ describe('add/html', () => {
     test('add html', async () => {
         // Test execution
         const command = new Command('add');
-        addLocalHtmlFiles(command);
+        addAddHtmlFilesCmd(command);
         await command.parseAsync(testArgv([]));
 
         // Flow check
@@ -43,7 +43,7 @@ describe('add/html', () => {
     test('add html --simulate', async () => {
         // Test execution
         const command = new Command('add');
-        addLocalHtmlFiles(command);
+        addAddHtmlFilesCmd(command);
         await command.parseAsync(testArgv(['--simulate']));
 
         // Flow check

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -335,20 +335,19 @@ const TEMPLATE_PATH = join(__dirname, '../../templates');
  * Generate test runners.
  *
  * @param configs array of test configurations
- * @param templatePath path to the templates folder
  * @param manifest application manifest
  * @param fs mem fs editor instance
  * @param webappPath webapp path
  * @param flpTemplConfig FLP configuration
  */
 function generateTestRunners(
-    configs: TestConfig[],
+    configs: TestConfig[] | undefined,
     manifest: Manifest,
     fs: Editor,
     webappPath: string,
     flpTemplConfig: TemplateConfig
 ) {
-    for (const test of configs) {
+    for (const test of configs ?? []) {
         const testConfig = mergeTestConfigDefaults(test);
         if (['QUnit', 'OPA5'].includes(test.framework)) {
             const testTemlpate = readFileSync(join(TEMPLATE_PATH, 'test/qunit.html'), 'utf-8');
@@ -413,6 +412,7 @@ export async function generatePreviewFiles(
             },
             logger
         );
+        generateTestRunners(config.test, manifest, fs, webappPath, flpTemplConfig);
     } else {
         flpTemplConfig = createFlpTemplateConfig(flpConfig, {});
         flpPath = join(basePath, flpConfig.path);
@@ -432,11 +432,6 @@ export async function generatePreviewFiles(
         }
     }
     fs.write(flpPath, render(flpTemplate, flpTemplConfig));
-
-    // optional test files
-    if (config.test && manifest) {
-        generateTestRunners(config.test, manifest, fs, webappPath, flpTemplConfig);
-    }
 
     return fs;
 }

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -371,6 +371,15 @@ export async function generatePreviewFiles(
         },
         logger
     );
+    if (flpConfig.apps.length > 0) {
+        for (const app of flpConfig.apps) {
+            if (app.local) {
+                const appWebappPath = await getWebappPath(join(basePath, app.local), fs);
+                const appManifest = (await fs.readJSON(join(appWebappPath, 'manifest.json'))) as unknown as Manifest;
+                await addApp(flpTemplConfig, appManifest, app, logger);
+            }
+        }
+    }
     fs.write(join(webappPath, flpConfig.path), render(flpTemplate, flpTemplConfig));
 
     // optional test files

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -1,16 +1,8 @@
-import type { Logger } from '@sap-ux/logger';
-import { ToolsLogger } from '@sap-ux/logger';
+import { ToolsLogger, type Logger } from '@sap-ux/logger';
 import type { App, FlpConfig, Intent, InternalTestConfig, MiddlewareConfig } from '../types';
 import { render } from 'ejs';
 import { join, posix } from 'path';
-import {
-    createProjectAccess,
-    getWebappPath,
-    isCapNodeJsProject,
-    isCapProject,
-    type Manifest,
-    type UI5FlexLayer
-} from '@sap-ux/project-access';
+import { createProjectAccess, getWebappPath, type Manifest, type UI5FlexLayer } from '@sap-ux/project-access';
 import { readFileSync } from 'fs';
 import { mergeTestConfigDefaults } from './test';
 import { type Editor, create } from 'mem-fs-editor';
@@ -408,7 +400,6 @@ export async function generatePreviewFiles(
 
     // optional test files
     if (config.test && manifest) {
-        const webappPath = await getWebappPath(basePath, fs);
         for (const test of config.test) {
             const testConfig = mergeTestConfigDefaults(test);
             if (['QUnit', 'OPA5'].includes(test.framework)) {

--- a/packages/preview-middleware/test/unit/base/__snapshots__/config.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/config.test.ts.snap
@@ -111,6 +111,86 @@ exports[`config generatePreviewFiles minimum settings 1`] = `
 </html>"
 `;
 
+exports[`config generatePreviewFiles multi-app setup e.g. in CAP 1`] = `
+Object {
+  "webapp/test/flpSandbox.thml": Object {
+    "contents": "<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\",\\"applicationDependencies\\":{\\"manifest\\":true}},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/apps/other-simple-app\\",\\"applicationDependencies\\":{\\"manifest\\":true}}}
+        };
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-bindingSyntax=\\"complex\\"
+        data-sap-ui-flexibilityServices='[{\\"connector\\":\\"LrepConnector\\",\\"layers\\":[],\\"url\\":\\"/sap/bc/lrep\\"},{\\"applyConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"writeConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"custom\\":true},{\\"connector\\":\\"LocalStorageConnector\\",\\"layers\\":[\\"CUSTOMER\\",\\"USER\\"]}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/apps/other-simple-app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">
+    </script>
+
+    <script type=\\"text/javascript\\">
+        (() => sap.ui.require(['open/ux/preview/client/flp/initConnectors']))()
+    </script>
+
+
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>",
+    "state": "modified",
+  },
+}
+`;
+
 exports[`config generatePreviewFiles tests included and a custom path 1`] = `
 Object {
   "webapp/test/flpSandbox.html": Object {

--- a/packages/preview-middleware/test/unit/base/__snapshots__/config.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/config.test.ts.snap
@@ -113,7 +113,7 @@ exports[`config generatePreviewFiles minimum settings 1`] = `
 
 exports[`config generatePreviewFiles multi-app setup e.g. in CAP 1`] = `
 Object {
-  "webapp/test/flpSandbox.thml": Object {
+  "test/flpSandbox.thml": Object {
     "contents": "<!DOCTYPE HTML>
 <html lang=\\"en\\">
 <!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
@@ -152,7 +152,7 @@ Object {
                     }
                 }
             },
-            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\",\\"applicationDependencies\\":{\\"manifest\\":true}},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/apps/other-simple-app\\",\\"applicationDependencies\\":{\\"manifest\\":true}}}
+            applications:  {\\"simpleApp-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/apps/simple-app\\",\\"applicationDependencies\\":{\\"manifest\\":true}},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/apps/other-app\\",\\"applicationDependencies\\":{\\"manifest\\":true}}}
         };
     </script>
 
@@ -160,15 +160,15 @@ Object {
     <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"'' is a NON-SECURE setting for test environments -->
     <script id=\\"sap-ui-bootstrap\\"
         src=\\"../resources/sap-ui-core.js\\"
-        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell\\"
         data-sap-ui-async=\\"true\\"
         data-sap-ui-preload=\\"async\\"
-        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-theme=\\"sap_horizon\\"
         data-sap-ui-compatVersion=\\"edge\\"
         data-sap-ui-language=\\"en\\"
         data-sap-ui-bindingSyntax=\\"complex\\"
         data-sap-ui-flexibilityServices='[{\\"connector\\":\\"LrepConnector\\",\\"layers\\":[],\\"url\\":\\"/sap/bc/lrep\\"},{\\"applyConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"writeConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"custom\\":true},{\\"connector\\":\\"LocalStorageConnector\\",\\"layers\\":[\\"CUSTOMER\\",\\"USER\\"]}]'
-        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/apps/other-simple-app\\"}'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"/preview/client\\",\\"test.fe.v2.app\\":\\"/apps/simple-app\\",\\"test.fe.v2.other\\":\\"/apps/other-app\\"}'
         data-sap-ui-frameOptions=\\"allow\\"
         data-sap-ui-xx-componentPreload=\\"off\\"
         data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -111,5 +111,21 @@ describe('config', () => {
             const fs = await generatePreviewFiles(basePath, config);
             expect(fs.dump(basePath)).toMatchSnapshot();
         });
+
+        test('multi-app setup e.g. in CAP', async () => {
+            const config = {
+                flp: {
+                    path: '/test/flpSandbox.thml',
+                    apps: [
+                        {
+                            local: '../multi-app',
+                            target: '/apps/other-simple-app'
+                        }
+                    ]
+                }
+            } satisfies MiddlewareConfig;
+            const fs = await generatePreviewFiles(basePath, config);
+            expect(fs.dump(basePath)).toMatchSnapshot();
+        });
     });
 });

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -90,8 +90,8 @@ describe('config', () => {
     });
 
     describe('generatePreviewFiles', () => {
-        const basePath = join(__dirname, '../../fixtures/simple-app');
         test('minimum settings', async () => {
+            const basePath = join(__dirname, '../../fixtures/simple-app');
             const fs = await generatePreviewFiles(basePath, {});
             const files = fs.dump(basePath);
             const paths = Object.keys(files);
@@ -101,6 +101,7 @@ describe('config', () => {
         });
 
         test('tests included and a custom path', async () => {
+            const basePath = join(__dirname, '../../fixtures/simple-app');
             const config = {
                 flp: {
                     path: '/test/flpSandbox.html',
@@ -113,13 +114,22 @@ describe('config', () => {
         });
 
         test('multi-app setup e.g. in CAP', async () => {
+            const basePath = join(__dirname, '../../fixtures');
             const config = {
                 flp: {
                     path: '/test/flpSandbox.thml',
                     apps: [
                         {
-                            local: '../multi-app',
-                            target: '/apps/other-simple-app'
+                            local: '/simple-app',
+                            target: '/apps/simple-app',
+                            intent: {
+                                object: 'simpleApp',
+                                action: 'preview'
+                            }
+                        },
+                        {
+                            local: '/multi-app',
+                            target: '/apps/other-app'
                         }
                     ]
                 }


### PR DESCRIPTION
Adds support for #2089 

Improvements for #1332:
* improved README
* more meaningful function names
* more flexible internal functions
* handles the previously ignored `apps` config