### PR TITLE
fix: Duplicate i18n model in manifest.appdescr_variant for Adp Project

### DIFF
--- a/.changeset/perfect-peas-rest.md
+++ b/.changeset/perfect-peas-rest.md
@@ -1,0 +1,6 @@
+---
+"@sap-ux/adp-tooling": patch
+"@sap-ux/create": patch
+---
+
+fix: Duplicate i18n model in manifest.appdescr_variant for Adp Project

--- a/.changeset/perfect-peas-rest.md
+++ b/.changeset/perfect-peas-rest.md
@@ -1,6 +1,0 @@
----
-"@sap-ux/adp-tooling": patch
-"@sap-ux/create": patch
----
-
-fix: Duplicate i18n model in manifest.appdescr_variant for Adp Project

--- a/.changeset/pretty-carrots-smoke.md
+++ b/.changeset/pretty-carrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/adp-tooling": patch
+---
+
+fix: Duplicate i18n model in manifest.appdescr_variant for Adp Project

--- a/packages/adp-tooling/templates/project/webapp/manifest.appdescr_variant
+++ b/packages/adp-tooling/templates/project/webapp/manifest.appdescr_variant
@@ -16,17 +16,6 @@
       "texts": {
         "i18n": "i18n/i18n.properties"
       }
-    },
-    {
-      "changeType": "appdescr_ui5_addNewModelEnhanceWith",
-      "content": {
-        "modelId": "i18n",
-        "bundleUrl": "i18n/i18n.properties",
-        "supportedLocales": [
-          ""
-        ],
-        "fallbackLocale": ""
-      }
     }
   ]
 }

--- a/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
+++ b/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
@@ -389,17 +389,6 @@ my.test.app_sap.app.title=Adaptation of the.original.app
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
       }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
-      }
     }
   ]
 }
@@ -614,17 +603,6 @@ my.test.app_sap.app.title=Adaptation of the.original.app
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
       }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
-      }
     }
   ]
 }
@@ -767,17 +745,6 @@ my.test.app_sap.app.title=Adaptation of the.original.app
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
       }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
-      }
     }
   ]
 }
@@ -911,17 +878,6 @@ my.test.app_sap.app.title=Adaptation of the.original.app
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
       }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
-      }
     }
   ]
 }
@@ -1032,17 +988,6 @@ my.test.app_sap.app.title=Adaptation of the.original.app
       \\"content\\": {},
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
-      }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
       }
     }
   ]
@@ -1195,17 +1140,6 @@ my.test.app_sap.app.crossNavigation.inbounds.my.test.app.InboundID.subTitle=test
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
       }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
-      }
     }
   ]
 }
@@ -1356,17 +1290,6 @@ my.test.app_sap.app.crossNavigation.inbounds.sampleId.subTitle=sampleSubTitle
       \\"content\\": {},
       \\"texts\\": {
         \\"i18n\\": \\"i18n/i18n.properties\\"
-      }
-    },
-    {
-      \\"changeType\\": \\"appdescr_ui5_addNewModelEnhanceWith\\",
-      \\"content\\": {
-        \\"modelId\\": \\"i18n\\",
-        \\"bundleUrl\\": \\"i18n/i18n.properties\\",
-        \\"supportedLocales\\": [
-          \\"\\"
-        ],
-        \\"fallbackLocale\\": \\"\\"
       }
     }
   ]

--- a/packages/create/src/cli/generate/adaptation-project.ts
+++ b/packages/create/src/cli/generate/adaptation-project.ts
@@ -71,6 +71,7 @@ async function generateAdaptationProject(
         if (!basePath) {
             basePath = join(process.cwd(), config.app.id);
         }
+        addChangeForResourceModel(config);
         const fs = await generate(basePath, config);
 
         if (!simulate) {
@@ -116,4 +117,23 @@ function createConfigFromDefaults(defaults: PromptDefaults): AdpWriterConfig {
     } else {
         throw new Error('Missing required parameters. Please provide --id, --reference and --url.');
     }
+}
+
+/**
+ * Add a change for a new resource model to the given configuration.
+ *
+ * @param config configuration to be enhanced
+ */
+function addChangeForResourceModel(config: AdpWriterConfig): void {
+    config.app.content = [
+        {
+            changeType: 'appdescr_ui5_addNewModelEnhanceWith',
+            content: {
+                modelId: 'i18n',
+                bundleUrl: 'i18n/i18n.properties',
+                supportedLocales: [''],
+                fallbackLocale: ''
+            }
+        }
+    ];
 }

--- a/packages/create/test/unit/cli/generate/adaptation-project.test.ts
+++ b/packages/create/test/unit/cli/generate/adaptation-project.test.ts
@@ -28,6 +28,17 @@ describe('generate/adaptation-project', () => {
     const reference = 'test.reference';
     const layer = 'CUSTOMER_BASE';
     const url = 'http://sap.example';
+    const content = [
+        {
+            changeType: 'appdescr_ui5_addNewModelEnhanceWith',
+            content: {
+                modelId: 'i18n',
+                bundleUrl: 'i18n/i18n.properties',
+                supportedLocales: [''],
+                fallbackLocale: ''
+            }
+        }
+    ];
 
     // mocks
     const traceSpy = jest.spyOn(tracer, 'traceChanges');
@@ -55,7 +66,7 @@ describe('generate/adaptation-project', () => {
         expect(generateSpy).toBeCalledWith(
             expectedAppRoot,
             expect.objectContaining({
-                app: { id, reference, layer },
+                app: { id, reference, layer, content },
                 target: { url, client: '123' }
             } as Partial<adp.AdpWriterConfig>)
         );
@@ -139,7 +150,7 @@ describe('generate/adaptation-project', () => {
         expect(generateSpy).toBeCalledWith(
             appRoot,
             expect.objectContaining({
-                app: { id, reference, layer },
+                app: { id, reference, layer, content },
                 target: { url }
             } as Partial<adp.AdpWriterConfig>)
         );


### PR DESCRIPTION
fix for: https://github.com/SAP/open-ux-tools/issues/2080
- Remove  i18n model from template and only handle it dynamically in code