### PR TITLE
fix: cpe error message regression

### DIFF
--- a/.changeset/six-cheetahs-rhyme.md
+++ b/.changeset/six-cheetahs-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Fix Error message regression

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -127,7 +127,7 @@ export class ChangeService {
 
                     const error = getError(exception);
                     // eslint-disable-next-line  @typescript-eslint/no-unsafe-call
-                    const modifiedMessage = modifyRTAErrorMessage(error.message, id, name);
+                    const modifiedMessage = modifyRTAErrorMessage(error.toString(), id, name);
                     const errorMessage =
                         modifiedMessage || `RTA Exception applying expression "${action.payload.value}"`;
                     const propertyChangeFailedAction = propertyChangeFailed({ ...action.payload, errorMessage });


### PR DESCRIPTION
Regression after eslint fix https://github.com/SAP/open-ux-tools/pull/1918

Expected error message: "SyntaxError: no closing braces found in '{expression' after pos:0"

Current error message: no closing braces found in '{expression' after pos:0"