### PR TITLE
Fix: Include Templates in 'files' Array of fiori-generator-shared Package.json

### DIFF
--- a/.changeset/chilly-hounds-beg.md
+++ b/.changeset/chilly-hounds-beg.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-generator-shared': patch
+---
+
+Fix: Include Templates in 'files' Array of fiori-generator-shared Package.json

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -23,6 +23,7 @@
     "files": [
         "LICENSE",
         "dist",
+        "templates",
         "!dist/*.map",
         "!dist/**/*.map"
     ],


### PR DESCRIPTION
#2111

Added missing templates folder to the files array in the `package.json` of `fiori-generator-shared` to be included in installation of package.