### PR TITLE
feat: add `getSpecificationPath` to retrieve specification path

### DIFF
--- a/.changeset/young-garlics-smell.md
+++ b/.changeset/young-garlics-smell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+feat: Add path to specification

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -21,6 +21,7 @@ export {
     getCdsServices,
     getCapI18nFolderNames,
     getSpecification,
+    getSpecificationPath,
     getI18nPropertiesPaths,
     getMinUI5VersionFromManifest,
     getMinUI5VersionAsArray,

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -31,4 +31,4 @@ export { getWebappPath, readUi5Yaml } from './ui5-config';
 export { getMtaPath } from './mta';
 export { createApplicationAccess, createProjectAccess } from './access';
 export { updatePackageScript } from './script';
-export { getSpecification, refreshSpecificationDistTags } from './specification';
+export { getSpecification, getSpecificationPath, refreshSpecificationDistTags } from './specification';

--- a/packages/project-access/src/project/specification.ts
+++ b/packages/project-access/src/project/specification.ts
@@ -14,7 +14,7 @@ import { execNpmCommand } from '../command';
 const specificationDistTagPath = join(fioriToolsDirectory, FileName.SpecificationDistTags);
 
 /**
- * Gets the dist-tag for the provided project/app and returns it
+ * Gets the dist-tag for the provided project/app and returns it.
  *
  * @param root - root path of the project/app
  * @param [options] - optional options
@@ -49,7 +49,7 @@ async function hasSpecificationDevDependency(root: string): Promise<boolean> {
 }
 
 /**
- * Loads the specification module from cache and returns it
+ * Loads the specification module from cache and returns it.
  *
  * @param root - root path of the project/app
  * @param [options] - optional options
@@ -162,12 +162,29 @@ async function convertDistTagToVersion(distTag: string, options?: { logger?: Log
     return version;
 }
 
+/**
+ * Gets the dist-tag of a project specification and returns the version from it.
+ *
+ * @param root - root path of the project/app
+ * @param [options] - optional options
+ * @param [options.logger] - optional logger instance
+ * @returns - version of specification
+ */
 async function getSpecificationVersion(root: string, options?: { logger?: Logger }): Promise<string> {
     const logger = options?.logger;
     const distTag = await getProjectDistTag(root, { logger });
     return await convertDistTagToVersion(distTag, { logger });
 }
 
+/**
+ * Returns the path to the specification used.
+ * Can be path to node_modules in project, or cache.
+ *
+ * @param root - root path of the project/app
+ * @param [options] - optional options
+ * @param [options.logger] - optional logger instance
+ * @returns - path to specification
+ */
 export async function getSpecificationPath(root: string, options?: { logger?: Logger }): Promise<string> {
     const logger = options?.logger;
     const moduleName = '@sap/ux-specification';

--- a/packages/project-access/test/project/specification.test.ts
+++ b/packages/project-access/test/project/specification.test.ts
@@ -7,7 +7,7 @@ jest.doMock('../../src/constants', () => ({
 }));
 import * as fsMock from 'fs';
 import type { Logger } from '@sap-ux/logger';
-import { getSpecification, refreshSpecificationDistTags } from '../../src';
+import { getSpecification, getSpecificationPath, refreshSpecificationDistTags } from '../../src';
 import * as commandMock from '../../src/command';
 import * as moduleMock from '../../src/project/module-loader';
 import * as fileMock from '../../src/file';
@@ -74,6 +74,28 @@ describe('Test getSpecification', () => {
         } catch (error) {
             expect(error.message).toContain('Failed to load specification');
         }
+    });
+
+    test('Get specification path from project', async () => {
+        const logger = getMockLogger();
+        const root = join(__dirname, '../test-data/module-loader/@sap/ux-specification/0.1.2');
+        const path = await getSpecificationPath(root, { logger });
+        expect(path).toBe(join(root, 'node_modules', '@sap', 'ux-specification'));
+        expect(logger.debug).toHaveBeenCalledWith(`Specification root found in project '${root}'`);
+    });
+
+    test('Get specification path from cache', async () => {
+        const logger = getMockLogger();
+        const moduleRoot = join(
+            __dirname,
+            '../test-data/module-loader/@sap/ux-specification/0.1.2/node_modules/@sap/ux-specification'
+        );
+        const root = join(__dirname, '../test-data/specification/app');
+        const path = await getSpecificationPath(root, { logger });
+        expect(path).toBe(moduleRoot);
+        expect(logger.debug).toHaveBeenCalledWith(
+            `Specification not found in project '${root}', trying to find in cache`
+        );
     });
 });
 


### PR DESCRIPTION
# Issue
#2066

- With rework of spec handling, this adds function `getSpecificationPath` to retrieve the specification path, depending if installed in project or cache.
- If installed in project, path is in `$project/node_modules/@sap/ux-specification`
- If provided by cache, path will be in `~/.fioritools/module-cache/@sap/ux-specification/$version/node_modules/@sap/ux-specification'`