### PR TITLE
fix: output specification version in cache

### DIFF
--- a/.changeset/grumpy-doors-rescue.md
+++ b/.changeset/grumpy-doors-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+fix: outputs specification version when loading from cache

--- a/packages/project-access/src/project/specification.ts
+++ b/packages/project-access/src/project/specification.ts
@@ -59,10 +59,10 @@ async function hasSpecificationDevDependency(root: string): Promise<boolean> {
 async function getSpecificationModule<T>(root: string, options?: { logger?: Logger }): Promise<T> {
     const logger = options?.logger;
     let specification: T;
-    const distTag = await getProjectDistTag(root, { logger });
+    const version = await getSpecificationVersion(root, { logger });
     try {
-        specification = await getSpecificationByDistTag<T>(distTag, { logger });
-        logger?.debug(`Specification loaded from cache using dist-tag '${distTag}'`);
+        specification = await getSpecificationByVersion<T>(version, { logger });
+        logger?.debug(`Specification loaded from cache using version '${version}'`);
     } catch (error) {
         logger?.error(`Failed to load specification: ${error}`);
         throw new Error(`Failed to load specification: ${error}`);
@@ -129,16 +129,15 @@ export async function refreshSpecificationDistTags(options?: { logger?: Logger }
 }
 
 /**
- * Loads and return specification from cache by dist-tag.
+ * Loads and return specification from cache by version.
  *
- * @param distTag - dist-tag of the specification, like 'latest' or 'UI5-1.71'
+ * @param version - version of the specification
  * @param [options] - optional options
  * @param [options.logger] - optional logger instance
  * @returns - specification instance
  */
-async function getSpecificationByDistTag<T>(distTag: string, options?: { logger?: Logger }): Promise<T> {
+async function getSpecificationByVersion<T>(version: string, options?: { logger?: Logger }): Promise<T> {
     const logger = options?.logger;
-    const version = await convertDistTagToVersion(distTag, { logger });
     const specification = await getModule<T>('@sap/ux-specification', version, { logger });
     return specification;
 }
@@ -193,9 +192,9 @@ export async function getSpecificationPath(root: string, options?: { logger?: Lo
         logger?.debug(`Specification root found in project '${root}'`);
         return modulePath.slice(0, modulePath.lastIndexOf(moduleName) + moduleName.length);
     }
-    logger?.debug(`Specification not found in project '${root}', trying to find in cache`);
     await getSpecificationModule(root, { logger });
     const version = await getSpecificationVersion(root, { logger });
+    logger?.debug(`Specification not found in project '${root}', using path from cache with version '${version}'`);
     const moduleRoot = join(moduleCacheRoot, moduleName, version);
     const modulePath = await getModulePath(moduleRoot, moduleName);
     return modulePath.slice(0, modulePath.lastIndexOf(moduleName) + moduleName.length);

--- a/packages/project-access/test/project/specification.test.ts
+++ b/packages/project-access/test/project/specification.test.ts
@@ -39,7 +39,7 @@ describe('Test getSpecification', () => {
         const root = join(__dirname, '../test-data/specification/app');
         const specification = await getSpecification<Specification>(root, { logger });
         expect(specification.exec()).toBe('specification-mock');
-        expect(logger.debug).toHaveBeenCalledWith("Specification loaded from cache using dist-tag 'UI5-1.2'");
+        expect(logger.debug).toHaveBeenCalledWith("Specification loaded from cache using version '0.1.2'");
     });
 
     test('Get specification from cache with dist tag refresh', async () => {
@@ -94,7 +94,7 @@ describe('Test getSpecification', () => {
         const path = await getSpecificationPath(root, { logger });
         expect(path).toBe(moduleRoot);
         expect(logger.debug).toHaveBeenCalledWith(
-            `Specification not found in project '${root}', trying to find in cache`
+            `Specification not found in project '${root}', using path from cache with version '0.1.2'`
         );
     });
 });


### PR DESCRIPTION
# Issue

#2066

- Outputs the specification `version` instead of `dist-tag` when loading from cache