### PR TITLE
fix: Remove safeMode from `adp-tooling` types and change order of ui5.yaml custom configuration

### DIFF
--- a/.changeset/tender-wombats-mix.md
+++ b/.changeset/tender-wombats-mix.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/adp-tooling': patch
+'@sap-ux/create': patch
+---
+
+Remove safeMode from adp-tooling types and change order of ui5.yaml custom configuration

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -389,7 +389,6 @@ export interface AdpProjectData {
     name: string;
     layer: UI5FlexLayer;
     environment: string;
-    safeMode: boolean;
     sourceSystem: string;
     applicationIdx: string;
     reference: string;

--- a/packages/adp-tooling/src/writer/options.ts
+++ b/packages/adp-tooling/src/writer/options.ts
@@ -24,9 +24,8 @@ import type {
  * @param config full project configuration
  */
 export function enhanceUI5Yaml(ui5Config: UI5Config, config: AdpWriterConfig) {
-    ui5Config.setConfiguration({ propertiesFileSourceEncoding: 'UTF-8' });
     if (config.options?.fioriTools) {
-        addFioriToolsMiddlwares(ui5Config, config);
+        addFioriToolsMiddlewares(ui5Config, config);
     } else {
         addOpenSourceMiddlewares(ui5Config, config);
     }
@@ -87,7 +86,7 @@ export function enhanceUI5DeployYaml(ui5Config: UI5Config, config: AdpWriterConf
  * @param ui5Config configuration representing the ui5.yaml
  * @param config full project configuration
  */
-function addFioriToolsMiddlwares(ui5Config: UI5Config, config: AdpWriterConfig) {
+function addFioriToolsMiddlewares(ui5Config: UI5Config, config: AdpWriterConfig) {
     const backendConfig: Partial<FioriToolsProxyConfigBackend> = { ...config.target };
     backendConfig.url ??= 'https://REQUIRED_FOR_VSCODE.example';
     backendConfig.path = '/sap';

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -70,8 +70,9 @@ export async function writeUI5Yaml(projectPath: string, data: AdpWriterConfig, f
         const ui5ConfigPath = join(projectPath, 'ui5.yaml');
         const baseUi5ConfigContent = fs.read(ui5ConfigPath);
         const ui5Config = await UI5Config.newInstance(baseUi5ConfigContent);
-        enhanceUI5Yaml(ui5Config, data);
+        ui5Config.setConfiguration({ propertiesFileSourceEncoding: 'UTF-8' });
         enhanceUI5YamlWithCustomConfig(ui5Config, data?.customConfig);
+        enhanceUI5Yaml(ui5Config, data);
         if (data.customConfig?.adp?.environment === 'C') {
             enhanceUI5YamlWithCustomTask(ui5Config, data as AdpWriterConfig & { app: CloudApp });
         }

--- a/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
+++ b/packages/adp-tooling/test/unit/writer/__snapshots__/index.test.ts.snap
@@ -64,6 +64,12 @@ type: application
 resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
+customConfiguration:
+  adp:
+    support:
+      id: '@package/name'
+      toolsId: uuidv4
+      version: 0.0.1
 server:
   customMiddleware:
     - name: fiori-tools-appreload
@@ -92,12 +98,6 @@ server:
             - /test-resources
           url: https://ui5.sap.com
           version: ''
-customConfiguration:
-  adp:
-    support:
-      id: '@package/name'
-      toolsId: uuidv4
-      version: 0.0.1
 builder:
   customTasks:
     - name: app-variant-bundler-build
@@ -178,6 +178,12 @@ type: application
 resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
+customConfiguration:
+  adp:
+    support:
+      id: '@package/name'
+      toolsId: uuidv4
+      version: 0.0.1
 server:
   customMiddleware:
     - name: fiori-tools-appreload
@@ -206,12 +212,6 @@ server:
             - /test-resources
           url: https://ui5.sap.com
           version: ''
-customConfiguration:
-  adp:
-    support:
-      id: '@package/name'
-      toolsId: uuidv4
-      version: 0.0.1
 builder:
   customTasks:
     - name: app-variant-bundler-build
@@ -1181,6 +1181,12 @@ type: application
 resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
+customConfiguration:
+  adp:
+    support:
+      id: '@package/name'
+      toolsId: uuidv4
+      version: 0.0.1
 server:
   customMiddleware:
     - name: fiori-tools-appreload
@@ -1209,12 +1215,6 @@ server:
             - /test-resources
           url: https://ui5.sap.com
           version: ''
-customConfiguration:
-  adp:
-    support:
-      id: '@package/name'
-      toolsId: uuidv4
-      version: 0.0.1
 builder:
   customTasks:
     - name: app-variant-bundler-build
@@ -1335,6 +1335,12 @@ type: application
 resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
+customConfiguration:
+  adp:
+    support:
+      id: '@package/name'
+      toolsId: uuidv4
+      version: 0.0.1
 server:
   customMiddleware:
     - name: fiori-tools-appreload
@@ -1363,12 +1369,6 @@ server:
             - /test-resources
           url: https://ui5.sap.com
           version: ''
-customConfiguration:
-  adp:
-    support:
-      id: '@package/name'
-      toolsId: uuidv4
-      version: 0.0.1
 builder:
   customTasks:
     - name: app-variant-bundler-build
@@ -1471,6 +1471,12 @@ type: application
 resources:
   configuration:
     propertiesFileSourceEncoding: UTF-8
+customConfiguration:
+  adp:
+    support:
+      id: '@package/name'
+      toolsId: uuidv4
+      version: 0.0.1
 server:
   customMiddleware:
     - name: fiori-tools-appreload
@@ -1503,12 +1509,6 @@ server:
             - /test-resources
           url: https://ui5.sap.com
           version: ''
-customConfiguration:
-  adp:
-    support:
-      id: '@package/name'
-      toolsId: uuidv4
-      version: 0.0.1
 ",
     "state": "modified",
   },


### PR DESCRIPTION
Fix for #2151.

- Removes safeMode from `AdpProjectData` interface because it is no longer needed.
- Changes the order of the blocks in ui5.yaml where customConfiguration is at the top for clearer structure.