### PR TITLE
fix: module-loader does not install specification dependency in `.fioritools` folder when node_modules exists on C:\Users\{User} level

### DIFF
--- a/.changeset/good-waves-boil.md
+++ b/.changeset/good-waves-boil.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+fix: module-loader fails to install specification dependecy in '.fioritools' folder when user has 'node_modules' in user home folder

--- a/packages/project-access/src/project/module-loader.ts
+++ b/packages/project-access/src/project/module-loader.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { mkdir, rm } from 'fs/promises';
+import { mkdir, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import type { Logger } from '@sap-ux/logger';
 import { getNodeModulesPath } from './dependencies';
@@ -56,11 +56,13 @@ export async function loadModuleFromProject<T>(projectRoot: string, moduleName: 
 export async function getModule<T>(module: string, version: string, options?: { logger?: Logger }): Promise<T> {
     const logger = options?.logger;
     const moduleDirectory = join(moduleCacheRoot, module, version);
-    if (!existsSync(join(moduleDirectory, FileName.Package))) {
+    const modulePackagePath = join(moduleDirectory, FileName.Package);
+    if (!existsSync(modulePackagePath)) {
         if (existsSync(moduleDirectory)) {
             await rm(moduleDirectory, { recursive: true });
         }
         await mkdir(moduleDirectory, { recursive: true });
+        await writeFile(modulePackagePath, '{}');
         await execNpmCommand(['install', `${module}@${version}`], { cwd: moduleDirectory, logger });
     }
     return loadModuleFromProject<T>(moduleDirectory, module);

--- a/packages/project-access/test/project/module-loader.test.ts
+++ b/packages/project-access/test/project/module-loader.test.ts
@@ -8,7 +8,7 @@ jest.doMock('../../src/constants', () => ({
     ...(jest.requireActual('../../src/constants') as {}),
     moduleCacheRoot
 }));
-import { loadModuleFromProject } from '../../src';
+import { FileName, loadModuleFromProject } from '../../src';
 import { deleteModule, getModule } from '../../src/project/module-loader';
 import * as commandMock from '../../src/command/npm-command';
 import { ToolsLogger } from '@sap-ux/logger';
@@ -23,7 +23,8 @@ jest.mock('fs/promises', () => {
     return {
         ...actual,
         rm: jest.fn().mockImplementation(actual.rm),
-        mkdir: jest.fn().mockImplementation(actual.mkdir)
+        mkdir: jest.fn().mockImplementation(actual.mkdir),
+        writeFile: jest.fn().mockImplementation(actual.writeFile)
     };
 });
 
@@ -65,6 +66,7 @@ describe('Test getModule()', () => {
         const rmSpy = jest.spyOn(promisesMock, 'rm').mockResolvedValueOnce();
         const mkdirSpy = jest.spyOn(promisesMock, 'mkdir').mockResolvedValueOnce('');
         const npmCommandSpy = jest.spyOn(commandMock, 'execNpmCommand').mockResolvedValueOnce('');
+        const writeFileSpy = jest.spyOn(promisesMock, 'writeFile').mockResolvedValueOnce();
 
         // Test execution
         const logger = new ToolsLogger();
@@ -74,6 +76,7 @@ describe('Test getModule()', () => {
         expect(module.exec()).toBe('works');
         expect(rmSpy).toBeCalledWith(modulePath, { recursive: true });
         expect(mkdirSpy).toBeCalledWith(modulePath, { recursive: true });
+        expect(writeFileSpy).toBeCalledWith(join(modulePath, FileName.Package), '{}');
         expect(npmCommandSpy).toBeCalledWith(['install', '@scope/module@1.2.3'], {
             'cwd': modulePath,
             logger


### PR DESCRIPTION
Issues happens in Windows and MACOS

Scenario from #2170
1. install `@sap/ux-specification` in `C:\Users\{USER}` folder(replace with your user or adjust to OS) by running
```
npm install @sap/ux-specification
```
2. delete folder `C:\Users\{USER}\.fioritools\module-cache`(replace with your user or adjust to OS) by running
3. simulate `module-loader` to install `@sap/ux-specification` in  `C:\Users\{USER}\.fioritools` folder

In 3rd step code runs:
```
npm install @sap/ux-specification@1.120.14
```
and with such setup - it does not install dependencies in `C:\Users\{USER}\.fioritools\module-cache\@sap\ux-specification\{version}`

Proposal fixes:
1. use --prefix during install -  - https://stackoverflow.com/questions/14469515/how-to-npm-install-to-a-specified-directory, like:
```
npm install --prefix C:\Users\{USER}\.fioritools\module-cache\@sap\ux-specification\1.120.14 @sap/ux-specification@1.120.14
```
2. create empty package.json if module does not exist


In this PR I am using 2nd approach as it seems most simplest to go
