### PR TITLE
fix(fe-fpm-writer): add `@sap-ux/project-access` to dependencies

### DIFF
--- a/.changeset/warm-shirts-warn.md
+++ b/.changeset/warm-shirts-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+fix: add `@sap-ux/project-access` dependency

--- a/packages/fe-fpm-writer/package.json
+++ b/packages/fe-fpm-writer/package.json
@@ -29,6 +29,7 @@
         "!dist/**/*.map"
     ],
     "dependencies": {
+        "@sap-ux/project-access": "workspace:*",
         "@xmldom/xmldom": "0.8.10",
         "ejs": "3.1.10",
         "mem-fs": "2.1.0",
@@ -38,7 +39,6 @@
         "xpath": "0.0.33"
     },
     "devDependencies": {
-        "@sap-ux/project-access": "workspace:*",
         "@types/ejs": "3.1.2",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,9 @@ importers:
 
   packages/fe-fpm-writer:
     dependencies:
+      '@sap-ux/project-access':
+        specifier: workspace:*
+        version: link:../project-access
       '@xmldom/xmldom':
         specifier: 0.8.10
         version: 0.8.10
@@ -1044,9 +1047,6 @@ importers:
         specifier: 0.0.33
         version: 0.0.33
     devDependencies:
-      '@sap-ux/project-access':
-        specifier: workspace:*
-        version: link:../project-access
       '@types/ejs':
         specifier: 3.1.2
         version: 3.1.2


### PR DESCRIPTION
With #2175, functions (not only types any longer) from `@sap-ux/project-access` were added to fe-fpm-writer: https://github.com/SAP/open-ux-tools/pull/2175/files#diff-128f273a33ffbb49ddbdff27138d11ef5be6d7deaedcb60e65b52aba00f7932bR6

During consumption of `@sap-ux/fe-fpm-writer` that dependency is now required.

Adding to `dependencies` to add the required module.