### PR TITLE
Fixes for multiple abap-on-prem new system prompts

### DIFF
--- a/.changeset/mighty-meals-divide.md
+++ b/.changeset/mighty-meals-divide.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fixes multiple issues with Abap On Prem system creation

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -25,7 +25,7 @@ interface Validity {
     urlFormat?: boolean;
     // True if the url is reachable
     reachable?: boolean;
-    // True if the url requires authentication (note even once authenticated, this will remain true)
+    // True if the url requires authentication, i.e. returns a 401/403  (note even once authenticated, this will remain true)
     authRequired?: boolean;
     // True if the url is authenticated and accessible
     authenticated?: boolean;
@@ -46,9 +46,9 @@ const ignorableCertErrors = [ERROR_TYPE.CERT_SELF_SIGNED, ERROR_TYPE.CERT_SELF_S
  */
 export class ConnectionValidator {
     public readonly validity: Validity = {};
-    // The current valid url (not necessarily authenticated)
+    // The current valid url (not necessarily authenticated but the url is in a valid format)
     private _validatedUrl: string | undefined;
-    // The current client code used for requests
+    // The current client code used for requests, the client code has been validated by a successful request
     private _validatedClient: string | undefined;
 
     private _odataService: ODataService;
@@ -441,7 +441,10 @@ export class ConnectionValidator {
                 isSystem,
                 odataVersion
             });
-
+            LoggerHelper.logger.debug(`ConnectionValidator.validateUrl() - status: ${status}; url: ${url}`);
+            // Since an exception was not thrown, this is a valid url
+            this.validity.urlFormat = true;
+            this._validatedUrl = url;
             const valResult = this.getValidationResultFromStatusCode(status);
 
             if (valResult === true) {

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -21,10 +21,15 @@ import { errorHandler } from './prompt-helpers';
  * Structure to store validity information about url to be validated.
  */
 interface Validity {
+    // True if the url is in a valid format
     urlFormat?: boolean;
+    // True if the url is reachable
     reachable?: boolean;
+    // True if the url requires authentication (note even once authenticated, this will remain true)
     authRequired?: boolean;
+    // True if the url is authenticated and accessible
     authenticated?: boolean;
+    // True if the url has a cert error that can be skipped
     canSkipCertError?: boolean;
 }
 
@@ -41,7 +46,11 @@ const ignorableCertErrors = [ERROR_TYPE.CERT_SELF_SIGNED, ERROR_TYPE.CERT_SELF_S
  */
 export class ConnectionValidator {
     public readonly validity: Validity = {};
+    // The current valid url (not necessarily authenticated)
     private _validatedUrl: string | undefined;
+    // The current client code used for requests
+    private _validatedClient: string | undefined;
+
     private _odataService: ODataService;
     private _serviceProvider: ServiceProvider;
     private _axiosConfig: AxiosRequestConfig;
@@ -135,7 +144,7 @@ export class ConnectionValidator {
                 // Full service URL
                 await this.createServiceConnection(axiosConfig, url.pathname);
             }
-
+            this._validatedClient = url.searchParams.get(SAP_CLIENT_KEY) ?? undefined;
             return 200;
         } catch (e) {
             LoggerHelper.logger.debug(`ConnectionValidator.checkSapService() - error: ${e.message}`);
@@ -236,7 +245,7 @@ export class ConnectionValidator {
      * @param serviceUrl the odata service url to validate
      * @param options options for the connection validation
      * @param options.ignoreCertError ignore some certificate errors
-     * @param options.forceReValidation force re-validation of the url
+     * @param options.forceReValidation force re-validation of the url even if the same url has been prevously validated
      * @param options.isSystem if true, the url will be treated as a system url rather than a service url
      * @param options.odataVersion if specified will restrict catalog requests to only the specified odata version
      * @returns true if the url is reachable, false if not, or an error message string
@@ -283,7 +292,7 @@ export class ConnectionValidator {
             // More helpful context specific error
             if (ErrorHandler.getErrorType(error) === ERROR_TYPE.CONNECTION) {
                 this.validity.reachable = false;
-                return errorHandler.logErrorMsgs(t('errors.serviceUrlNotFound', { url: serviceUrl }));
+                return errorHandler.logErrorMsgs(t('errors.systemOrserviceUrlNotFound', { url: serviceUrl }));
             }
 
             this.resetValidity();
@@ -301,9 +310,9 @@ export class ConnectionValidator {
      */
     private getValidationResultFromStatusCode(status: string | number): boolean | string | IValidationLink {
         if (status === 200) {
+            this.validity.reachable = true;
             this.validity.authenticated = true;
-            this.validity.authRequired = false;
-        } else if (status === 404) {
+        } else if (ErrorHandler.getErrorType(status) === ERROR_TYPE.NOT_FOUND) {
             this.validity.reachable = false;
             return ErrorHandler.getErrorMsgFromType(ERROR_TYPE.NOT_FOUND) ?? false;
         } else if (ErrorHandler.isCertError(status)) {
@@ -313,10 +322,11 @@ export class ConnectionValidator {
         } else if (ErrorHandler.getErrorType(status) === ERROR_TYPE.AUTH) {
             this.validity.reachable = true;
             this.validity.authRequired = true;
+            this.validity.authenticated = false;
         } else if (ErrorHandler.getErrorType(status) === ERROR_TYPE.REDIRECT) {
             this.validity.reachable = true;
             return t('errors.urlRedirect');
-        } else if (status !== 404) {
+        } else if (ErrorHandler.getErrorType(status) === ERROR_TYPE.CONNECTION) {
             this.validity.reachable = false;
             return ErrorHandler.getErrorMsgFromType(ERROR_TYPE.CONNECTION, `http code: ${status}`) ?? false;
         }
@@ -346,6 +356,50 @@ export class ConnectionValidator {
         }
         this.resetValidity();
         return false;
+    }
+
+    /**
+     * Check whether basic auth is required for the given url, or for the previously validated url if none specified.
+     * This will also set the validity state for the url. This will not validate the URL.
+     *
+     * @param urlString - the url to validate, if not provided the previously validated url will be used
+     * @param client - optional, sap client code, if not provided the previously validated client will be used
+     * @param ignoreCertError
+     * @returns true if basic auth is required, false if not
+     */
+    public async isAuthRequired(
+        urlString = this._validatedUrl,
+        client = this._validatedClient,
+        ignoreCertError = false
+    ): Promise<boolean> {
+        if (!urlString) {
+            return false;
+        }
+
+        // Dont re-request if already validated
+        if (
+            this._validatedUrl === urlString &&
+            this._validatedClient === client &&
+            this.validity.authRequired !== undefined
+        ) {
+            return this.validity.authRequired;
+        }
+        // New URL or client so we need to re-request
+        try {
+            const url = new URL(urlString);
+            if (client) {
+                url.searchParams.append(SAP_CLIENT_KEY, client);
+            }
+            this.validity.authRequired = this.validity.reachable =
+                ErrorHandler.getErrorType(
+                    await this.checkSapService(url, undefined, undefined, { ignoreCertError })
+                ) === ERROR_TYPE.AUTH;
+
+            return this.validity.authRequired;
+        } catch (error) {
+            errorHandler.logErrorMsgs(error);
+            return false; // Cannot determine if auth required
+        }
     }
 
     /**
@@ -390,8 +444,12 @@ export class ConnectionValidator {
 
             const valResult = this.getValidationResultFromStatusCode(status);
 
-            if (valResult === true && this.validity.authenticated === true) {
-                return true;
+            if (valResult === true) {
+                if (this.validity.authenticated === true) {
+                    return true;
+                } else if (this.validity.authenticated === false) {
+                    return t('errors.authenticationFailed');
+                }
             }
             return valResult;
         } catch (error) {

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -233,7 +233,8 @@ export function getAbapOnPremSystemQuestions(
             validate: (client) => {
                 const valRes = validateClient(client);
                 if (valRes === true) {
-                    return (validClient = true);
+                    validClient = true;
+                    return true;
                 }
                 validClient = false;
                 return valRes;

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/validators.ts
@@ -18,8 +18,10 @@ async function isSystemNameInUse(systemName: string): Promise<boolean> {
  *
  * @param systemName a system name to validate
  * @returns true if the name is valid, otherwise an error message
- */
-export async function validateSystemName(systemName: string): Promise<boolean | string> {
+ */ export async function validateSystemName(systemName: string): Promise<boolean | string> {
+    if (!systemName) {
+        return t('prompts.systemName.emptySystemNameWarning');
+    }
     const systemExists = await isSystemNameInUse(systemName);
     if (systemExists) {
         return t('prompts.systemName.systemNameExistsWarning');

--- a/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
+++ b/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
@@ -96,7 +96,8 @@
             "message": "System name",
             "hint": "Entering a system name will save the connection for re-use.",
             "systemNameExistsWarning": "A system with that name already exists in the secure storage. Please try a different name.",
-            "reservedSystemNameWarning": "'{{ systemName }}' is a reserved system name. Please try a different name."
+            "reservedSystemNameWarning": "'{{ systemName }}' is a reserved system name. Please try a different name.",
+            "emptySystemNameWarning": "System name cannot be empty."
         },
         "systemSelection": {
             "newSystemChoiceLabel": "New system"
@@ -129,7 +130,7 @@
         "noSuchHostError": "No such host is known",
         "odataServiceVersionMismatch": "The template you have chosen supports V{{requiredVersion}} OData services only. The provided version is V{{serviceVersion}}.",
         "destinationAuthError": "The selected system is returning an authentication error. Please verify the destination configuration",
-        "serviceUrlNotFound": "Please verify the service url: {{- url}}, target system configuration and network connectivity",
+        "systemOrserviceUrlNotFound": "Please verify the url: {{- url}}, target system configuration and network connectivity",
         "urlRedirect": "The service URL is redirecting",
         "certValidationRequired": "Certificate validation is required to continue.",
         "exitingGeneration": "Exiting generation. {{exitReason}}",

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -64,7 +64,6 @@ describe('ConnectionValidator', () => {
         const result = await validator.validateUrl(serviceUrl);
         expect(result).toBe(true);
         expect(validator.validity).toEqual({
-            authRequired: false,
             authenticated: true,
             reachable: true,
             urlFormat: true
@@ -106,7 +105,8 @@ describe('ConnectionValidator', () => {
         expect(validator.validity).toEqual({
             urlFormat: true,
             reachable: true,
-            authRequired: true
+            authRequired: true,
+            authenticated: false
         });
 
         const createProviderSpy = jest.spyOn(axiosExtension, 'create');
@@ -226,6 +226,7 @@ describe('ConnectionValidator', () => {
 
         expect(validator.validity).toEqual({
             urlFormat: true,
+            authenticated: false,
             reachable: true,
             authRequired: true
         });
@@ -234,7 +235,6 @@ describe('ConnectionValidator', () => {
         expect(validator.validity).toEqual({
             urlFormat: true,
             reachable: true,
-            authRequired: false,
             authenticated: true
         });
     });
@@ -245,7 +245,6 @@ describe('ConnectionValidator', () => {
         const result = await validator.validateUrl('https://example.com/service');
         expect(result).toBe(true);
         expect(validator.validity).toEqual({
-            authRequired: false,
             authenticated: true,
             reachable: true,
             urlFormat: true
@@ -263,12 +262,17 @@ describe('ConnectionValidator', () => {
         const validator = new ConnectionValidator();
         const result = await validator.validateUrl('https://example.com/service');
         expect(result).toBe(true);
-        expect(validator.validity).toEqual({ authRequired: true, reachable: true, urlFormat: true });
+        expect(validator.validity).toEqual({
+            authenticated: false,
+            authRequired: true,
+            reachable: true,
+            urlFormat: true
+        });
         // Change the response to 200 and force re-validation of the same url
         jest.spyOn(ODataService.prototype, 'get').mockRejectedValueOnce(newAxiosErrorWithStatus(200));
         await validator.validateUrl('https://example.com/service', { forceReValidation: true });
         expect(validator.validity).toEqual({
-            authRequired: false,
+            authRequired: true,
             authenticated: true,
             reachable: true,
             urlFormat: true

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -1,5 +1,5 @@
-import * as axiosExtension from '@sap-ux/axios-extension';
 import type { AxiosRequestConfig } from '@sap-ux/axios-extension';
+import * as axiosExtension from '@sap-ux/axios-extension';
 import { ODataService, ServiceProvider } from '@sap-ux/axios-extension';
 import type { AxiosResponse } from 'axios';
 import { AxiosError } from 'axios';
@@ -8,7 +8,6 @@ import { GUIDED_ANSWERS_LAUNCH_CMD_ID } from '../../../src/error-handler/help/he
 import { GUIDED_ANSWERS_ICON } from '../../../src/error-handler/help/images';
 import { initI18nOdataServiceInquirer, t } from '../../../src/i18n';
 import { ConnectionValidator } from '../../../src/prompts/connectionValidator';
-import { monitorEventLoopDelay } from 'perf_hooks';
 
 /**
  * Workaround to allow spyOn
@@ -126,6 +125,10 @@ describe('ConnectionValidator', () => {
             })
         );
         expect(serviceProviderSpy).toHaveBeenCalledWith('/some/path/to/service/');
+
+        // Username/pword are invalid
+        jest.spyOn(ODataService.prototype, 'get').mockRejectedValue(newAxiosErrorWithStatus(403));
+        expect(await validator.validateAuth(serviceUrl, 'user1', 'password1')).toBe(t('errors.authenticationFailed'));
 
         // Dont authenticate if the url is empty
         getODataServiceSpy.mockReset();
@@ -347,14 +350,14 @@ describe('ConnectionValidator', () => {
         expect(listServicesV4Mock).toHaveBeenCalled();
     });
 
-
     test('should determine if authentication is required', async () => {
-
         const connectValidator = new ConnectionValidator();
         expect(await connectValidator.isAuthRequired()).toBe(false);
 
         // Dont re-request if already validated
-        let getOdataServiceSpy = jest.spyOn(ODataService.prototype, 'get').mockRejectedValue(newAxiosErrorWithStatus(401));
+        let getOdataServiceSpy = jest
+            .spyOn(ODataService.prototype, 'get')
+            .mockRejectedValue(newAxiosErrorWithStatus(401));
         await connectValidator.validateUrl('https://example.com/serviceA');
         expect(connectValidator.validity).toEqual({
             authenticated: false,
@@ -374,7 +377,7 @@ describe('ConnectionValidator', () => {
         // If the client changes, re-request
         getOdataServiceSpy.mockClear();
         getOdataServiceSpy = jest.spyOn(ODataService.prototype, 'get').mockResolvedValue(200);
-        await connectValidator.validateAuth('https://example.com/serviceA', 'user1', 'password1', { sapClient: '999'});
+        await connectValidator.validateAuth('https://example.com/serviceA', 'user1', 'password1', { sapClient: '999' });
         expect(connectValidator.validity).toEqual({
             authenticated: true,
             authRequired: true,
@@ -382,7 +385,7 @@ describe('ConnectionValidator', () => {
             urlFormat: true
         });
         expect(getOdataServiceSpy).toHaveBeenCalled();
-  
+
         getOdataServiceSpy.mockClear();
         // Auth is required even though a 200 since the url initially returned 401
         expect(await connectValidator.isAuthRequired('https://example.com/serviceA', '999')).toBe(true);
@@ -393,6 +396,5 @@ describe('ConnectionValidator', () => {
         getOdataServiceSpy = jest.spyOn(ODataService.prototype, 'get').mockRejectedValue(newAxiosErrorWithStatus(401));
         expect(await connectValidator.isAuthRequired('https://example.com/serviceA', '111')).toBe(true);
         expect(getOdataServiceSpy).toHaveBeenCalled();
-
     });
 });

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
@@ -23,6 +23,7 @@ const v2Annotations = `<?xml version="1.0" encoding="utf-8"?>
         </edmx:Edmx>`;
 const validateUrlMock = jest.fn().mockResolvedValue(true);
 const validateAuthMock = jest.fn().mockResolvedValue(true);
+const isAuthRequiredMock = jest.fn().mockResolvedValue(false);
 const serviceProviderMock = {} as Partial<ServiceProvider>;
 
 const catalogs = {
@@ -37,6 +38,7 @@ const connectionValidatorMock = {
     validity: {} as ConnectionValidator['validity'],
     validateUrl: validateUrlMock,
     validateAuth: validateAuthMock,
+    isAuthRequired: isAuthRequiredMock,
     serviceProvider: serviceProviderMock,
     catalogs
 };
@@ -198,6 +200,7 @@ describe('questions', () => {
             authRequired: true,
             reachable: true
         };
+        connectionValidatorMock.isAuthRequired = jest.fn().mockResolvedValue(true);
         const newSystemQuestions = getAbapOnPremQuestions();
         const userNamePrompt = newSystemQuestions.find((question) => question.name === 'abapSystemUsername');
         const passwordPrompt = newSystemQuestions.find((question) => question.name === 'abapSystemPassword');
@@ -211,6 +214,8 @@ describe('questions', () => {
             authRequired: false,
             reachable: true
         };
+        connectionValidatorMock.isAuthRequired = jest.fn().mockResolvedValue(false);
+
         expect(await (userNamePrompt?.when as Function)()).toBe(false);
         expect(await (passwordPrompt?.when as Function)()).toBe(false);
 
@@ -220,6 +225,8 @@ describe('questions', () => {
             authRequired: true,
             reachable: true
         };
+        connectionValidatorMock.isAuthRequired = jest.fn().mockResolvedValue(true);
+
         expect(await (userNamePrompt?.when as Function)()).toBe(true);
         expect(await (passwordPrompt?.when as Function)()).toBe(true);
     });


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2193

Fixes for :

- failed basic auth allows user to continue
- changing sap-client does not re-authenticate
- new system name is allowing an empty string which breaks storage
- new system names gets overwritten when changing client or system url