### PR TITLE
fix(odata-service-inquirer): fix adding backend system to prompt state

### DIFF
--- a/.changeset/gorgeous-boats-look.md
+++ b/.changeset/gorgeous-boats-look.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+fix adding backend system to prompt state

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/new-system/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/new-system/questions.ts
@@ -101,15 +101,16 @@ export function getUserSystemNameQuestion(): InputQuestion<NewSystemAnswers> {
             return answers.userSystemName;
         },
         validate: async (systemName: string, answers: AbapOnPremAnswers & NewSystemAnswers) => {
+            let isValid: string | boolean = false;
             // Dont validate the suggested default system name
             if (systemName === defaultSystemName) {
-                return true;
-            }
-            const validationResult = await validateSystemName(systemName);
-
-            if (validationResult === true) {
-                // Not the default system name, so the user modified
+                isValid = true;
+            } else {
                 userModifiedSystemName = true;
+                isValid = await validateSystemName(systemName);
+            }
+            if (isValid === true) {
+                // Not the default system name, so the user modified
                 const backendSystem = new BackendSystem({
                     name: systemName,
                     url: answers.systemUrl!,
@@ -121,7 +122,7 @@ export function getUserSystemNameQuestion(): InputQuestion<NewSystemAnswers> {
                     PromptState.odataService.connectedSystem.backendSystem = backendSystem;
                 }
             }
-            return validationResult;
+            return isValid;
         }
     } as InputQuestion<NewSystemAnswers>;
 

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/new-system/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/new-system/questions.test.ts
@@ -13,7 +13,7 @@ jest.mock('@sap-ux/store', () => ({
     }))
 }));
 
-describe('Test mew system prompt', () => {
+describe('Test new system prompt', () => {
     beforeAll(async () => {
         await initI18nOdataServiceInquirer();
     });
@@ -76,6 +76,41 @@ describe('Test mew system prompt', () => {
             url: 'http://abap.on.prem:1234',
             userDisplayName: undefined,
             username: 'user01'
+        });
+    });
+
+    test('Should update prompt state when default system name is used', async () => {
+        const userSystemNamePrompt = getUserSystemNameQuestion();
+
+        PromptState.odataService.connectedSystem = {
+            serviceProvider: {} as ServiceProvider
+        };
+
+        await userSystemNamePrompt.default({
+            newSystemType: 'abapOnPrem' as SapSystemType,
+            systemUrl: 'http://mock.abap.on.prem:4300',
+            sapClient: '000'
+        });
+
+        expect(
+            await (userSystemNamePrompt.validate as Function)('http://mock.abap.on.prem:4300, client 000', {
+                systemUrl: 'http://mock.abap.on.prem:4300',
+                sapClient: '000',
+                abapSystemUsername: 'testUser',
+                abapSystemPassword: 'testPassword'
+            })
+        ).toBe(true);
+
+        expect(PromptState.odataService.connectedSystem.backendSystem).toEqual({
+            authenticationType: undefined,
+            client: '000',
+            name: 'http://mock.abap.on.prem:4300, client 000',
+            password: 'testPassword',
+            refreshToken: undefined,
+            serviceKeys: undefined,
+            url: 'http://mock.abap.on.prem:4300',
+            userDisplayName: undefined,
+            username: 'testUser'
         });
     });
 });


### PR DESCRIPTION
Fixes issue where the backend system is not added to the Prompt state when the default system name is used