### PR TITLE
test: simplify virtual fs logic

### DIFF
--- a/.changeset/tasty-plants-kick.md
+++ b/.changeset/tasty-plants-kick.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/store': minor
+---
+
+Load keytar from application modeler extension

--- a/packages/fiori-annotation-api/test/data/cds/layering/package.json
+++ b/packages/fiori-annotation-api/test/data/cds/layering/package.json
@@ -14,8 +14,7 @@
     "travel-analytics": "cds watch --open travel_analytics/webapp/index.html?sap-ui-xx-viewCache=false"
   },
   "dependencies": {
-    "@sap/cds": "7.9.2",
-    "express": "*"
+    "@sap/cds": "7.9.2"
   },
   "cds": {
     "log": {

--- a/packages/fiori-annotation-api/test/unit/virtual-fs.ts
+++ b/packages/fiori-annotation-api/test/unit/virtual-fs.ts
@@ -1,56 +1,8 @@
-import { existsSync, promises } from 'fs';
-import { join } from 'path';
 import { create as createStore } from 'mem-fs';
 import type { Editor } from 'mem-fs-editor';
 import { create as createEditor } from 'mem-fs-editor';
 
-async function collectPaths(root: string): Promise<string[]> {
-    const fileOrFolder = await promises.readdir(root);
-    const children = await Promise.all(
-        fileOrFolder.flatMap(async function (relativePath: string) {
-            const path = join(root, relativePath);
-            const stats = await promises.lstat(path);
-            if (stats.isSymbolicLink() && !existsSync(path)) {
-                return Promise.resolve([null]);
-            }
-            if (stats.isDirectory()) {
-                return collectPaths(path);
-            } else {
-                return Promise.resolve([path]);
-            }
-        })
-    );
-
-    return children.flat().filter((path) => path !== null) as string[];
-}
-
-const projectCache = new Map<string, Record<string, string>>();
-
-async function getFileSystemForProject(root: string): Promise<Record<string, string>> {
-    const cachedFileSystem = projectCache.get(root);
-    if (cachedFileSystem) {
-        return cachedFileSystem;
-    }
-    const fileSystem: Record<string, string> = {};
-    const paths = await collectPaths(root);
-    const files = await Promise.all(
-        paths.map(async (path) => {
-            const content = await promises.readFile(path, { encoding: 'utf-8' });
-            return { path, content };
-        })
-    );
-    for (const { path, content } of files) {
-        fileSystem[path] = content;
-    }
-    projectCache.set(root, fileSystem);
-    return fileSystem;
-}
-
-export async function createFsEditorForProject(root: string): Promise<Editor> {
-    const fs = await getFileSystemForProject(root);
+export async function createFsEditorForProject(_root: string): Promise<Editor> {
     const editor = createEditor(createStore());
-    Object.keys(fs).forEach((path) => {
-        editor.write(path, fs[path]);
-    });
     return editor;
 }


### PR DESCRIPTION
CDS layering test started failing after dce8838a2dcd93fc9922ade4e2a8118f9d950f9a. It was caused due to some changes in `node_modules`. However, since we're now using `mem-fs-editor` in the tests we can remove the logic that pre-fills file caches and just use the `Editor` object.

Adding changeset from #2230, since it failed to publish.