### PR TITLE
export getFioriToolsDirectory, FioriToolsSettings from store

### DIFF
--- a/.changeset/gentle-ligers-allow.md
+++ b/.changeset/gentle-ligers-allow.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/store": patch
+---
+
+export getFioriToolsDirectory, FioriToolsSettings

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -46,3 +46,5 @@ export * from './entities/api-hub';
 export { getFilesystemWatcherFor } from './data-access';
 export { ServiceOptions };
 export { Entity };
+
+export { getFioriToolsDirectory, FioriToolsSettings } from './utils';


### PR DESCRIPTION
allow getFioriToolsDirectory, FioriToolsSettings to be used by other modules in place of common utils in tools suite