### PR TITLE
chore/eslint return type

### DIFF
--- a/.changeset/rare-jars-scream.md
+++ b/.changeset/rare-jars-scream.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/create': patch
+---
+
+chore: added missing return types to functions

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
             "extends": ["plugin:@typescript-eslint/recommended"],
             "rules": {
                 "@typescript-eslint/ban-types": "off",
+                "@typescript-eslint/explicit-function-return-type": "warn",
                 "@typescript-eslint/no-explicit-any": "off",
                 "@typescript-eslint/no-inferrable-types": "off",
                 "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -59,8 +59,9 @@
         },
         {
             "parser": "@typescript-eslint/parser",
-            "files": ["packages/*/test/**/*.js", "packages/*/test/**/*.ts", "packages/*/test/**/*.tsx"],
+            "files": ["**/test/**/*.js", "**/test/**/*.ts", "**/test/**/*.tsx"],
             "rules": {
+                "@typescript-eslint/explicit-function-return-type": "off",
                 "jsdoc/require-param": "off",
                 "jsdoc/require-param-description": "off",
                 "jsdoc/require-param-name": "off",

--- a/packages/create/src/cli/remove/mockserver-config.ts
+++ b/packages/create/src/cli/remove/mockserver-config.ts
@@ -27,7 +27,7 @@ export function addRemoveMockserverConfigCommand(cmd: Command): void {
  * @param basePath - path to application root
  * @param force - if true, do not ask before deleting files; otherwise ask
  */
-async function removeMockserverConfiguration(basePath: string, force: boolean) {
+async function removeMockserverConfiguration(basePath: string, force: boolean): Promise<void> {
     const logger = getLogger();
     try {
         logger.debug(`Called remove mockserver-config for path '${basePath}', force is '${force}'`);

--- a/packages/create/src/common/prompts.ts
+++ b/packages/create/src/common/prompts.ts
@@ -1,5 +1,5 @@
 import prompts from 'prompts';
-import type { PromptType, PromptObject } from 'prompts';
+import type { PromptType, PromptObject, InitialReturnValue } from 'prompts';
 import type { ListQuestion, YUIQuestion } from '@sap-ux/inquirer-common';
 import type { Answers } from 'inquirer';
 import { getLogger } from '../tracing';
@@ -32,7 +32,7 @@ async function enhanceListQuestion(
     listQuestion: ListQuestion,
     prompt: PromptObject,
     answers: { [key: string]: unknown }
-) {
+): Promise<void> {
     const choices: Array<{ name: string; value: unknown } | string | number> = (
         isFunction(listQuestion.choices) ? await listQuestion.choices(answers) : listQuestion.choices
     ) as Array<{ name: string; value: unknown } | string | number>;
@@ -42,7 +42,7 @@ async function enhanceListQuestion(
     }));
     const initialValue = (prompt.initial as Function)();
     prompt.choices = mapppedChoices;
-    prompt.initial = () =>
+    prompt.initial = (): InitialReturnValue =>
         mapppedChoices[initialValue]
             ? initialValue
             : mapppedChoices.findIndex((choice) => choice.value === initialValue);
@@ -55,7 +55,7 @@ async function enhanceListQuestion(
  * @param answers rpeviously given answers
  * @returns message of the question
  */
-async function extractMessage<T extends Answers>(question: YUIQuestion<T>, answers: T) {
+async function extractMessage<T extends Answers>(question: YUIQuestion<T>, answers: T): Promise<string | undefined> {
     const message = isFunction(question.message) ? await question.message(answers) : question.message;
     if (question.guiOptions && !question.guiOptions.mandatory) {
         return `${message} (optional)`;
@@ -119,7 +119,7 @@ export async function promptYUIQuestions<T extends Answers>(
  * @param question question to be prompted
  * @returns a promise with the answer of the question
  */
-async function promptSingleQuestion<T extends Answers>(answers: T, question: YUIQuestion<T>) {
+async function promptSingleQuestion<T extends Answers>(answers: T, question: YUIQuestion<T>): Promise<T[keyof T]> {
     const q = await convertQuestion(question, answers);
     const answer = await prompts(q, {
         onCancel: () => {

--- a/packages/create/src/tracing/logger.ts
+++ b/packages/create/src/tracing/logger.ts
@@ -35,8 +35,8 @@ function setCustomFormatter(logger: ToolsLogger): void {
     }
     const consoleTransport = transports.find((t) => t?.name === 'console');
     if (consoleTransport?.format) {
-        consoleTransport.format.transform = (info: any) => {
-            const colorFn = levelColor[info.level] ? chalk.keyword(levelColor[info.level]) : (m: string) => m;
+        consoleTransport.format.transform = (info: any): any => {
+            const colorFn = levelColor[info.level] ? chalk.keyword(levelColor[info.level]) : (m: string): string => m;
             const formattedMessage = colorFn ? colorFn(info.message) : info.message;
             const symbol = Object.getOwnPropertySymbols(info).find((s: any) => s?.description === 'message');
             if (symbol) {
@@ -59,6 +59,6 @@ function updateLogLevel(logLevel: LogLevel): void {
 /**
  * Set the log level to verbose (debug).
  */
-export function setLogLevelVerbose() {
+export function setLogLevelVerbose(): void {
     updateLogLevel(LogLevel.Debug);
 }


### PR DESCRIPTION
* adding rule `"@typescript-eslint/explicit-function-return-type": "warn"` (only `src`, disabled for `test` folders)
* as example fix all new warnings in `@sap-ux/create`