### PR TITLE
[WIP] Fixing the odata-service-writer so that it allows adding a 2nd service to a project

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -40,6 +40,8 @@
         "@sap-ux/inquirer-common": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/mockserver-config-writer": "workspace:*",
+        "@sap-ux/odata-service-inquirer": "workspace:*",
+        "@sap-ux/odata-service-writer": "workspace:*",
         "@sap-ux/preview-middleware": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/system-access": "workspace:*",

--- a/packages/create/src/cli/add/html.ts
+++ b/packages/create/src/cli/add/html.ts
@@ -11,7 +11,7 @@ import type { AdpPreviewConfig } from '@sap-ux/adp-tooling';
 /**
  * Adds a command to add the virtual html files hosted by the preview middleware to the file system.
  *
- * @param cmd - commander command for adding navigation inbounds config command
+ * @param cmd - commander command for adding virtual html files
  */
 export function addAddHtmlFilesCmd(cmd: Command): void {
     cmd.command('html [path]')

--- a/packages/create/src/cli/add/index.ts
+++ b/packages/create/src/cli/add/index.ts
@@ -8,6 +8,7 @@ import { addNewModelCommand } from './new-model';
 import { addAnnotationsToOdataCommand } from './annotations-to-odata';
 import { addAddHtmlFilesCmd } from './html';
 import { addComponentUsagesCommand } from './component-usages';
+import { addAddServiceCmd } from './service';
 
 /**
  * Return 'create-fiori add *' commands. Commands include also the handler action.
@@ -34,5 +35,7 @@ export function getAddCommands(): Command {
     addAddHtmlFilesCmd(addCommands);
     // create-fiori add component-usages
     addComponentUsagesCommand(addCommands);
+    // create-fiori add service
+    addAddServiceCmd(addCommands);
     return addCommands;
 }

--- a/packages/create/src/cli/add/service.ts
+++ b/packages/create/src/cli/add/service.ts
@@ -1,0 +1,81 @@
+import type { Command } from 'commander';
+import { getLogger, traceChanges, setLogLevelVerbose } from '../../tracing';
+import { validateBasePath } from '../../validation';
+import { create } from 'mem-fs-editor';
+import { create as createStorage } from 'mem-fs';
+import type { OdataService } from '@sap-ux/odata-service-writer';
+import { generate, OdataVersion } from '@sap-ux/odata-service-writer';
+import type { InquirerAdapter, OdataServiceAnswers, OdataServicePromptOptions } from '@sap-ux/odata-service-inquirer';
+import { DatasourceType, getPrompts, prompt } from '@sap-ux/odata-service-inquirer';
+import { promptYUIQuestions } from '../../common';
+
+/**
+ * Adds a command to add an additional service to the project.
+ *
+ * @param cmd - commander command for adding an additional service
+ */
+export function addAddServiceCmd(cmd: Command): void {
+    cmd.command('service [path]')
+        .option('-s, --simulate', 'simulate only do not write config; sets also --verbose')
+        .option('-v, --verbose', 'show verbose information')
+        .action(async (path, options) => {
+            if (options.verbose === true || options.simulate) {
+                setLogLevelVerbose();
+            }
+            await addService(path || process.cwd(), !!options.simulate);
+        });
+}
+
+/**
+ * Add an additional service to the project.
+ *
+ * @param basePath - path to application root
+ * @param simulate - if true, do not write but just show what would be change; otherwise write
+ */
+async function addService(basePath: string, simulate: boolean): Promise<void> {
+    const logger = getLogger();
+    try {
+        //TBD
+        logger.debug(`Called add service for path '${basePath}', simulate is '${simulate}'`);
+        await validateBasePath(basePath);
+
+        await promptServiceQuestions();
+
+        const fs = create(createStorage());
+        const config: OdataService = {
+            url: 'http://localhost',
+            path: '/sap/odata/testme',
+            version: OdataVersion.v4,
+            destination: {
+                name: 'test'
+            }
+        };
+
+        await generate(basePath, config, fs);
+        if (!simulate) {
+            await new Promise((resolve) => fs.commit(resolve));
+        } else {
+            await traceChanges(fs);
+        }
+    } catch (error) {
+        logger.error(`Error while executing add service '${(error as Error).message}'`);
+        logger.debug(error as Error);
+    }
+}
+
+/**
+ * Prompt for odata service writer inputs.
+ * @returns the prompt answers
+ */
+async function promptServiceQuestions(): Promise<OdataServiceAnswers> {
+    const promptOpts = {
+        datasourceType: {
+            default: DatasourceType.sapSystem
+        }
+    } as OdataServicePromptOptions;
+
+    const { prompts, answers } = await getPrompts(promptOpts);
+    await promptYUIQuestions<OdataServiceAnswers>(prompts, false);
+
+    return answers as OdataServiceAnswers;
+}

--- a/packages/create/tsconfig.json
+++ b/packages/create/tsconfig.json
@@ -31,6 +31,12 @@
       "path": "../mockserver-config-writer"
     },
     {
+      "path": "../odata-service-inquirer"
+    },
+    {
+      "path": "../odata-service-writer"
+    },
+    {
       "path": "../preview-middleware"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,12 @@ importers:
       '@sap-ux/mockserver-config-writer':
         specifier: workspace:*
         version: link:../mockserver-config-writer
+      '@sap-ux/odata-service-inquirer':
+        specifier: workspace:*
+        version: link:../odata-service-inquirer
+      '@sap-ux/odata-service-writer':
+        specifier: workspace:*
+        version: link:../odata-service-writer
       '@sap-ux/preview-middleware':
         specifier: workspace:*
         version: link:../preview-middleware


### PR DESCRIPTION
WIP

The PR (when done) will contain:
- [ ] fix for the `odata-service-writer`
- [ ] new `add service` command in the `create` module