### PR TITLE
fix(abap-deploy-config): add autocomplete option and tidy add return types

### DIFF
--- a/.changeset/five-onions-draw.md
+++ b/.changeset/five-onions-draw.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+remove feature toggle usage

--- a/packages/abap-deploy-config-inquirer/package.json
+++ b/packages/abap-deploy-config-inquirer/package.json
@@ -31,7 +31,6 @@
     "dependencies": {
         "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/btp-utils": "workspace:*",
-        "@sap-ux/feature-toggle": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/guided-answers-helper": "workspace:*",
         "@sap-ux/inquirer-common": "workspace:*",

--- a/packages/abap-deploy-config-inquirer/src/index.ts
+++ b/packages/abap-deploy-config-inquirer/src/index.ts
@@ -34,6 +34,7 @@ async function getPrompts(
     await initI18n();
     LoggerHelper.logger = logger ?? new ToolsLogger({ logPrefix: '@sap-ux/abap-deploy-config-inquirer' });
     PromptState.isYUI = isYUI;
+    PromptState.resetAbapDeployConfig();
 
     return {
         prompts: await getAbapDeployConfigQuestions(promptOptions),

--- a/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
@@ -5,7 +5,6 @@ import { findBackendSystemByUrl, initTransportConfig } from '../utils';
 import { handleTransportConfigError } from '../error-handler';
 import { t } from '../i18n';
 import { getHelpUrl, HELP_TREE } from '@sap-ux/guided-answers-helper';
-import { isFeatureEnabled } from '@sap-ux/feature-toggle';
 import LoggerHelper from '../logger-helper';
 import {
     ClientChoiceValue,
@@ -182,13 +181,12 @@ function defaultOrShowPackageQuestion(): boolean {
 /**
  * Determines if the choice of package input options should include both manual input and search (autocomplete) input options.
  *
+ * @param useAutocomplete - useAutocomplete option from prompt options
  * @returns boolean
  */
-export function showPackageInputChoiceQuestion(): boolean {
-    // Only show the input choice (manual/search) when the autocomplete prompt is supported; CLI or YUI specific version
-    return Boolean(
-        (!PromptState.isYUI || isFeatureEnabled('enableAutocompleteUIPrompt')) && defaultOrShowPackageQuestion()
-    );
+export function showPackageInputChoiceQuestion(useAutocomplete = false): boolean {
+    // Only show the input choice (manual/search) when the autocomplete option is true, the prompt is supported; CLI or YUI specific version
+    return Boolean((!PromptState.isYUI || useAutocomplete) && defaultOrShowPackageQuestion());
 }
 
 /**
@@ -196,13 +194,17 @@ export function showPackageInputChoiceQuestion(): boolean {
  *
  * @param isCli - is in CLI
  * @param packageInputChoice - package input choice from previous answers
+ * @param useAutocomplete - useAutocomplete option from prompt options
  * @returns boolean
  */
-export function defaultOrShowManualPackageQuestion(isCli: boolean, packageInputChoice?: string): boolean {
+export function defaultOrShowManualPackageQuestion(
+    isCli: boolean,
+    packageInputChoice?: string,
+    useAutocomplete = false
+): boolean {
     // Until the version of YUI installed supports auto-complete we must continue to show a manual input for packages
     return (
-        ((!isCli && !isFeatureEnabled('enableAutocompleteUIPrompt')) ||
-            packageInputChoice === PackageInputChoices.EnterManualChoice) &&
+        (!isCli || packageInputChoice === PackageInputChoices.EnterManualChoice || !useAutocomplete) &&
         defaultOrShowPackageQuestion()
     );
 }
@@ -212,12 +214,17 @@ export function defaultOrShowManualPackageQuestion(isCli: boolean, packageInputC
  *
  * @param isCli - is in CLI
  * @param packageInputChoice - package input choice from previous answers
+ * @param useAutocomplete - useAutocomplete option from prompt options
  * @returns boolean
  */
-export function defaultOrShowSearchPackageQuestion(isCli: boolean, packageInputChoice?: string): boolean {
+export function defaultOrShowSearchPackageQuestion(
+    isCli: boolean,
+    packageInputChoice?: string,
+    useAutocomplete = false
+): boolean {
     // Only show the autocomplete prompt when the autocomplete prompt is supported; CLI or YUI specific version
     return (
-        (isCli || isFeatureEnabled('enableAutocompleteUIPrompt')) &&
+        (isCli || useAutocomplete) &&
         packageInputChoice === PackageInputChoices.ListExistingChoice &&
         defaultOrShowPackageQuestion()
     );

--- a/packages/abap-deploy-config-inquirer/src/prompts/defaults.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/defaults.ts
@@ -82,6 +82,6 @@ export function defaultTransportRequestChoice(
  * @param numTransportListChoice - number of transport requests
  * @returns default client choice
  */
-export function defaultTransportListChoice(numTransportListChoice?: number) {
+export function defaultTransportListChoice(numTransportListChoice?: number): number | undefined {
     return numTransportListChoice && numTransportListChoice > 1 ? undefined : 0;
 }

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/config/package.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/config/package.ts
@@ -30,7 +30,7 @@ export function getPackagePrompts(options: AbapDeployConfigPromptOptions): Quest
 
     const questions: Question[] = [
         {
-            when: (): boolean => showPackageInputChoiceQuestion(),
+            when: (): boolean => showPackageInputChoiceQuestion(options.useAutocomplete),
             type: 'list',
             name: abapDeployConfigInternalPromptNames.packageInputChoice,
             message: t('prompts.config.package.packageInputChoice.message'),
@@ -74,7 +74,7 @@ export function getPackagePrompts(options: AbapDeployConfigPromptOptions): Quest
         },
         {
             when: (previousAnswers: AbapDeployConfigAnswersInternal): boolean =>
-                defaultOrShowManualPackageQuestion(isCli, previousAnswers.packageInputChoice),
+                defaultOrShowManualPackageQuestion(isCli, previousAnswers.packageInputChoice, options.useAutocomplete),
             type: 'input',
             name: abapDeployConfigInternalPromptNames.packageManual,
             message: t('prompts.config.package.packageManual.message'),
@@ -91,7 +91,7 @@ export function getPackagePrompts(options: AbapDeployConfigPromptOptions): Quest
         {
             when: (previousAnswers: AbapDeployConfigAnswersInternal): boolean =>
                 packageInputChoiceValid === true &&
-                defaultOrShowSearchPackageQuestion(isCli, previousAnswers.packageInputChoice),
+                defaultOrShowSearchPackageQuestion(isCli, previousAnswers.packageInputChoice, options.useAutocomplete),
             type: 'autocomplete',
             name: abapDeployConfigInternalPromptNames.packageAutocomplete,
             message: `${t('prompts.config.package.packageAutocomplete.message')}${

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
@@ -98,6 +98,6 @@ async function createNewServiceProvider(credentials?: Credentials): Promise<Abap
  * we need to clear the cached service provider, and allow createNewServiceProvider to be called again
  * after user provided user credentials.
  */
-export async function deleteCachedServiceProvider() {
+export function deleteCachedServiceProvider(): void {
     abapServiceProvider = undefined;
 }

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
@@ -134,7 +134,7 @@ class DefaultTransportConfig implements TransportConfig {
                 result.error = this.handleAtoResponse(atoSettings);
             }
         } catch (err) {
-            await deleteCachedServiceProvider();
+            deleteCachedServiceProvider();
 
             if (err.response?.status === 401) {
                 const auth: string = err.response.headers['www-authenticate'];

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-list.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-list.ts
@@ -1,9 +1,10 @@
 import { TransportChecksService } from '@sap-ux/axios-extension';
 import { t } from '../i18n';
 import { getOrCreateServiceProvider } from './abap-service-provider';
-import type { BackendTarget, SystemConfig, TransportListItem } from '../types';
 import LoggerHelper from '../logger-helper';
 import { PromptState } from '../prompts/prompt-state';
+import type { BackendTarget, SystemConfig, TransportListItem } from '../types';
+import type { ListChoiceOptions } from 'inquirer';
 
 /**
  * Get the transport list from the service.
@@ -46,7 +47,7 @@ export async function getTransportListFromService(
     return transportListItems;
 }
 
-export const transportName = (transport: TransportListItem) => {
+export const transportName = (transport: TransportListItem): ListChoiceOptions => {
     const name = transport.transportReqDescription
         ? `${transport.transportReqNumber} (${transport.transportReqDescription})`
         : `${transport.transportReqNumber}`;

--- a/packages/abap-deploy-config-inquirer/src/types.ts
+++ b/packages/abap-deploy-config-inquirer/src/types.ts
@@ -40,6 +40,7 @@ export interface DeployTaskConfig {
  * @param hideUi5AbapRepoPrompt - whether to hide the UI5 ABAP repository prompt
  * @param showOverwriteQuestion - whether to show the overwrite question (this can be determined by the caller)
  * @param indexGenerationAllowed - whether generating an index.html is allowed
+ * @param useAutocomplete -  determines if the prompt(s) (currently only package prompt) should use auto completion
  */
 export interface AbapDeployConfigPromptOptions {
     backendTarget?: BackendTarget;
@@ -47,6 +48,7 @@ export interface AbapDeployConfigPromptOptions {
     hideUi5AbapRepoPrompt?: boolean;
     showOverwriteQuestion?: boolean;
     indexGenerationAllowed?: boolean;
+    useAutocomplete?: boolean;
 }
 
 export interface AbapSystemChoice {

--- a/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
@@ -21,7 +21,6 @@ import {
 import * as utils from '../../src/utils';
 import { PromptState } from '../../src/prompts/prompt-state';
 import { getHelpUrl } from '@sap-ux/guided-answers-helper';
-import { isFeatureEnabled } from '@sap-ux/feature-toggle';
 
 jest.mock('@sap-ux/btp-utils', () => ({
     isAppStudio: jest.fn()

--- a/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
@@ -1,11 +1,5 @@
 import { isAppStudio } from '@sap-ux/btp-utils';
-import {
-    AbapDeployConfigPromptOptions,
-    ClientChoiceValue,
-    PackageInputChoices,
-    TransportChoices,
-    TransportConfig
-} from '../../src/types';
+import { ClientChoiceValue, PackageInputChoices, TransportChoices, TransportConfig } from '../../src/types';
 import {
     defaultOrShowManualPackageQuestion,
     defaultOrShowManualTransportQuestion,
@@ -33,10 +27,6 @@ jest.mock('@sap-ux/btp-utils', () => ({
     isAppStudio: jest.fn()
 }));
 
-jest.mock('@sap-ux/feature-toggle', () => ({
-    isFeatureEnabled: jest.fn()
-}));
-
 jest.mock('@sap-ux/guided-answers-helper', () => ({
     ...jest.requireActual('@sap-ux/guided-answers-helper'),
     getHelpUrl: jest.fn()
@@ -44,7 +34,6 @@ jest.mock('@sap-ux/guided-answers-helper', () => ({
 
 const mockIsAppStudio = isAppStudio as jest.Mock;
 const mockGetHelpUrl = getHelpUrl as jest.Mock;
-const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 describe('Test abap deploy config inquirer conditions', () => {
     beforeEach(() => {
@@ -141,35 +130,22 @@ describe('Test abap deploy config inquirer conditions', () => {
         // cli
         PromptState.isYUI = false;
         expect(showPackageInputChoiceQuestion()).toBe(true);
-
-        // feature enabled
-        mockIsFeatureEnabled.mockReturnValueOnce(true);
-        expect(showPackageInputChoiceQuestion()).toBe(true);
     });
 
     test('should not show package input choice question', () => {
         PromptState.isYUI = true;
-        mockIsFeatureEnabled.mockReturnValueOnce(true);
         PromptState.transportAnswers.transportConfig = {
             getPackage: () => 'ZPACKAGE1'
         } as unknown as TransportConfig;
-        expect(showPackageInputChoiceQuestion()).toBe(false);
+        expect(showPackageInputChoiceQuestion(true)).toBe(false);
         expect(PromptState.abapDeployConfig.package).toBe('ZPACKAGE1');
     });
 
     test('should show manual package question', () => {
-        mockIsFeatureEnabled.mockReturnValueOnce(false);
-        expect(defaultOrShowManualPackageQuestion(false, '')).toBe(true);
-
-        // cli
         expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice)).toBe(true);
     });
 
     test('should show search package question', () => {
-        mockIsFeatureEnabled.mockReturnValueOnce(true);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(true);
-
-        // cli
         expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice)).toBe(true);
     });
 

--- a/packages/abap-deploy-config-inquirer/tsconfig.json
+++ b/packages/abap-deploy-config-inquirer/tsconfig.json
@@ -1,43 +1,37 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": [
-    "src",
-    "src/**/*.json"
-  ],
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "references": [
-    {
-      "path": "../axios-extension"
+    "extends": "../../tsconfig.json",
+    "include": ["src", "src/**/*.json"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist"
     },
-    {
-      "path": "../btp-utils"
-    },
-    {
-      "path": "../feature-toggle"
-    },
-    {
-      "path": "../fiori-generator-shared"
-    },
-    {
-      "path": "../guided-answers-helper"
-    },
-    {
-      "path": "../inquirer-common"
-    },
-    {
-      "path": "../logger"
-    },
-    {
-      "path": "../store"
-    },
-    {
-      "path": "../system-access"
-    },
-    {
-      "path": "../ui5-config"
-    }
-  ]
+    "references": [
+        {
+            "path": "../axios-extension"
+        },
+        {
+            "path": "../btp-utils"
+        },
+        {
+            "path": "../fiori-generator-shared"
+        },
+        {
+            "path": "../guided-answers-helper"
+        },
+        {
+            "path": "../inquirer-common"
+        },
+        {
+            "path": "../logger"
+        },
+        {
+            "path": "../store"
+        },
+        {
+            "path": "../system-access"
+        },
+        {
+            "path": "../ui5-config"
+        }
+    ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,9 +317,6 @@ importers:
       '@sap-ux/btp-utils':
         specifier: workspace:*
         version: link:../btp-utils
-      '@sap-ux/feature-toggle':
-        specifier: workspace:*
-        version: link:../feature-toggle
       '@sap-ux/fiori-generator-shared':
         specifier: workspace:*
         version: link:../fiori-generator-shared


### PR DESCRIPTION
#2128

- Removes use of feature toggle and adds `useAutocomplete` as an option
- Add return type to functions to fix lint warnings