### PR TITLE
fix: ensure that the controller template include an example call to super

### DIFF
--- a/.changeset/weak-peaches-battle.md
+++ b/.changeset/weak-peaches-battle.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+fix: ensure that the controller template include an example call to super.onInit()

--- a/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.js
+++ b/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.js
@@ -12,7 +12,7 @@ sap.ui.define(
              * @memberOf <%- ns %>.<%- name %>
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**

--- a/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.ts
+++ b/packages/fe-fpm-writer/templates/page/custom/1.84/ext/Controller.ts
@@ -11,7 +11,7 @@ export default class <%- name %> extends Controller {
      * @memberOf <%- ns %>.<%- name %>
      */
     // public onInit(): void {
-    //
+    //    super.onInit(); // needs to be called to properly initialize the page controller
     //}
 
     /**

--- a/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.js
+++ b/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.js
@@ -12,7 +12,7 @@ sap.ui.define(
              * @memberOf <%- ns %>.<%- name %>
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**

--- a/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.ts
+++ b/packages/fe-fpm-writer/templates/page/custom/1.94/ext/Controller.ts
@@ -11,7 +11,7 @@ export default class <%- name %> extends Controller {
      * @memberOf <%- ns %>.<%- name %>
      */
     // public onInit(): void {
-    //
+    //     super.onInit(); // needs to be called to properly initialize the page controller
     //}
 
     /**

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
@@ -38,7 +38,7 @@ export default class CustomPage extends Controller {
      * @memberOf my.test.App.ext.customPage.CustomPage
      */
     // public onInit(): void {
-    //
+    //     super.onInit(); // needs to be called to properly initialize the page controller
     //}
 
     /**
@@ -83,7 +83,7 @@ export default class CustomPage extends Controller {
      * @memberOf my.test.App.ext.customPage.CustomPage
      */
     // public onInit(): void {
-    //
+    //    super.onInit(); // needs to be called to properly initialize the page controller
     //}
 
     /**
@@ -377,7 +377,7 @@ exports[`CustomPage generateCustomPage: different versions or target folder late
              * @memberOf my.test.App.ext.customPage.CustomPage
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**
@@ -478,7 +478,7 @@ exports[`CustomPage generateCustomPage: different versions or target folder late
              * @memberOf my.test.App.ext.customPage.CustomPage
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**
@@ -580,7 +580,7 @@ exports[`CustomPage generateCustomPage: different versions or target folder late
              * @memberOf my.test.App.ext.customPage.CustomPage
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**
@@ -682,7 +682,7 @@ exports[`CustomPage generateCustomPage: different versions or target folder late
              * @memberOf my.test.App.ext.different.CustomPage
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**
@@ -870,7 +870,7 @@ exports[`CustomPage generateCustomPage: different versions or target folder with
              * @memberOf my.test.App.ext.customPage.CustomPage
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**

--- a/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
+++ b/packages/fiori-elements-writer/test/__snapshots__/fpm.test.ts.snap
@@ -215,7 +215,7 @@ server:
              * @memberOf fefpmjs.ext.main.Main
              */
             //  onInit: function () {
-            //
+            //      PageController.prototype.onInit.apply(this, arguments); // needs to be called to properly initialize the page controller
             //  },
 
             /**
@@ -3984,7 +3984,7 @@ export default class Main extends Controller {
      * @memberOf fefpmts.ext.main.Main
      */
     // public onInit(): void {
-    //
+    //     super.onInit(); // needs to be called to properly initialize the page controller
     //}
 
     /**


### PR DESCRIPTION
The current template don't include any example of calling back super.onInit() or PageController.prototype.onInit.apply(this, arguments).

This is mandatory for application otherwise the controllers are not properly instantiated :)