### PR TITLE
fix(i18n): CAP scenario. `getCapI18nFolder` -> handle absolute path instead of relative path to resolve i18n folder

### DIFF
--- a/.changeset/dull-pillows-grab.md
+++ b/.changeset/dull-pillows-grab.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': minor
+---
+
+Method `createCapI18nEntries` - handle absolute path to cds file instead of relative path

--- a/.changeset/eleven-scissors-mate.md
+++ b/.changeset/eleven-scissors-mate.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/i18n': patch
+---
+
+getCapI18nFolder - handle absolute path to cds file instead of relative path

--- a/.changeset/eleven-scissors-mate.md
+++ b/.changeset/eleven-scissors-mate.md
@@ -1,5 +1,5 @@
 ---
-'@sap-ux/i18n': patch
+'@sap-ux/i18n': minor
 ---
 
 getCapI18nFolder - handle absolute path to cds file instead of relative path

--- a/.changeset/eleven-scissors-mate.md
+++ b/.changeset/eleven-scissors-mate.md
@@ -2,4 +2,4 @@
 '@sap-ux/i18n': minor
 ---
 
-getCapI18nFolder - handle absolute path to cds file instead of relative path
+Methods `createCapI18nEntries`, `getCapI18nFolder` - handle absolute path to cds file instead of relative path

--- a/packages/i18n/src/utils/resolve.ts
+++ b/packages/i18n/src/utils/resolve.ts
@@ -99,14 +99,14 @@ export function getCapI18nFiles(root: string, env: CdsEnvironment, filePaths: st
  * Get an i18n folder for an existing CDS file. A new folder is only created, if it does not exist and optional `mem-fs-editor` instance is not provided.
  *
  * @param root project root
- * @param path path to cds file
+ * @param path absolute path to cds file
  * @param env CDS environment configuration,
  * @param fs optional `mem-fs-editor` instance. If provided, a new folder is not created, even if it does not exist
  * @returns i18n folder path
  */
 export async function getCapI18nFolder(root: string, path: string, env: CdsEnvironment, fs?: Editor): Promise<string> {
     const { folders } = getI18nConfiguration(env);
-    let i18nFolderPath = resolveCapI18nFolderForFile(root, env, join(root, path));
+    let i18nFolderPath = resolveCapI18nFolderForFile(root, env, path);
     if (!i18nFolderPath) {
         const folder = folders[0];
         i18nFolderPath = join(root, folder);

--- a/packages/i18n/src/write/cap/create.ts
+++ b/packages/i18n/src/write/cap/create.ts
@@ -10,7 +10,7 @@ import type { Editor } from 'mem-fs-editor';
  * Create new i18n entries to an existing file or in a new file if one does not exist.
  *
  * @param root project root, where i18n folder should reside if no i18n file exists
- * @param path path to cds file for which translation should be maintained
+ * @param path absolute path to cds file for which translation should be maintained
  * @param newI18nEntries new i18n entries that will be maintained
  * @param env CDS environment configuration
  * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node

--- a/packages/i18n/test/unit/utils/resolve.test.ts
+++ b/packages/i18n/test/unit/utils/resolve.test.ts
@@ -116,7 +116,7 @@ describe('resolve', () => {
 
         const DATA_ROOT = join(__dirname, '..', 'data');
         const PROJECT_ROOT = join(DATA_ROOT, 'project');
-        test('i18n folder exist', async () => {
+        test('i18n folder exists in passed subpath', async () => {
             const env: CdsEnvironment = {
                 i18n: {
                     folders: ['_i18n', 'i18n', 'assets/i18n'],
@@ -128,6 +128,16 @@ describe('resolve', () => {
                 join(PROJECT_ROOT, 'app', 'properties-csv', 'service.cds'),
                 env
             );
+            expect(result).toStrictEqual(join(PROJECT_ROOT, 'app', 'properties-csv', '_i18n'));
+        });
+        test('i18n folder exists in root', async () => {
+            const env: CdsEnvironment = {
+                i18n: {
+                    folders: ['_i18n', 'i18n', 'assets/i18n'],
+                    default_language: 'en'
+                }
+            };
+            const result = await getCapI18nFolder(PROJECT_ROOT, join(PROJECT_ROOT, 'app', 'dummy'), env);
             expect(result).toStrictEqual(join(PROJECT_ROOT, 'i18n'));
         });
         test('i18n folder does not exist', async () => {

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -129,7 +129,7 @@ class ApplicationAccessImp implements ApplicationAccess {
     /**
      * Maintains new translation entries in CAP i18n files.
      *
-     * @param filePath file in which the translation entry will be used.
+     * @param filePath absolute path to file in which the translation entry will be used.
      * @param newI18nEntries translation entries to write in the i18n file.
      * @returns boolean or exception
      */

--- a/packages/project-access/src/project/i18n/write.ts
+++ b/packages/project-access/src/project/i18n/write.ts
@@ -11,7 +11,7 @@ import type { Editor } from 'mem-fs-editor';
  * Maintains new translation entries in CAP i18n files.
  *
  * @param root project root.
- * @param filePath file in which the translation entry will be used.
+ * @param filePath absolute path to file in which the translation entry will be used.
  * @param newI18nEntries translation entries to write in the i18n file.
  * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node
  * In case of CAP project, some CDS APIs are used internally which depends on `fs` of node and not `mem-fs-editor`.

--- a/packages/project-access/src/types/access/index.ts
+++ b/packages/project-access/src/types/access/index.ts
@@ -70,7 +70,7 @@ export interface ApplicationAccess extends BaseAccess {
     /**
      * Maintains new translation entries in CAP i18n files.
      *
-     * @param filePath file in which the translation entry will be used.
+     * @param filePath absolute path to file in which the translation entry will be used.
      * @param newI18nEntries translation entries to write in the i18n file.
      * @returns boolean or exception
      */


### PR DESCRIPTION
We noticed that method `getCapI18nFolder` expects that second parameter `path` should be relative path to cds file, while other methods and also `ApplicationStructure` expects/contains absolute paths, then proposal is to adjust function `getCapI18nFolder` to same expectation.