### PR TITLE
fix(i18n): Update js doc to highlight that relative path should be passed for 'createCapI18nEntries', 'getCapI18nFolder' methods

### DIFF
--- a/.changeset/sharp-ligers-rule.md
+++ b/.changeset/sharp-ligers-rule.md
@@ -3,4 +3,4 @@
 '@sap-ux/i18n': patch
 ---
 
-Update js doc to highlight that relative path should be passed for 'createCapI18nEntries', 'getCapI18nFolder' methods
+Update jsdoc to highlight that relative path should be passed for 'createCapI18nEntries', 'getCapI18nFolder' methods

--- a/.changeset/sharp-ligers-rule.md
+++ b/.changeset/sharp-ligers-rule.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/project-access': patch
+'@sap-ux/i18n': patch
+---
+
+Update js doc to highlight that relative path should be passed for 'createCapI18nEntries', 'getCapI18nFolder' methods

--- a/packages/i18n/src/utils/resolve.ts
+++ b/packages/i18n/src/utils/resolve.ts
@@ -99,7 +99,7 @@ export function getCapI18nFiles(root: string, env: CdsEnvironment, filePaths: st
  * Get an i18n folder for an existing CDS file. A new folder is only created, if it does not exist and optional `mem-fs-editor` instance is not provided.
  *
  * @param root project root
- * @param path path to cds file
+ * @param path Relative path to cds file
  * @param env CDS environment configuration,
  * @param fs optional `mem-fs-editor` instance. If provided, a new folder is not created, even if it does not exist
  * @returns i18n folder path

--- a/packages/i18n/src/write/cap/create.ts
+++ b/packages/i18n/src/write/cap/create.ts
@@ -10,7 +10,7 @@ import type { Editor } from 'mem-fs-editor';
  * Create new i18n entries to an existing file or in a new file if one does not exist.
  *
  * @param root project root, where i18n folder should reside if no i18n file exists
- * @param path path to cds file for which translation should be maintained
+ * @param path Relative path to cds file for which translation should be maintained
  * @param newI18nEntries new i18n entries that will be maintained
  * @param env CDS environment configuration
  * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node

--- a/packages/i18n/test/unit/utils/resolve.test.ts
+++ b/packages/i18n/test/unit/utils/resolve.test.ts
@@ -116,18 +116,24 @@ describe('resolve', () => {
 
         const DATA_ROOT = join(__dirname, '..', 'data');
         const PROJECT_ROOT = join(DATA_ROOT, 'project');
-        test('i18n folder exist', async () => {
+        test('i18n folder exists in passed subpath', async () => {
             const env: CdsEnvironment = {
                 i18n: {
                     folders: ['_i18n', 'i18n', 'assets/i18n'],
                     default_language: 'en'
                 }
             };
-            const result = await getCapI18nFolder(
-                PROJECT_ROOT,
-                join(PROJECT_ROOT, 'app', 'properties-csv', 'service.cds'),
-                env
-            );
+            const result = await getCapI18nFolder(PROJECT_ROOT, join('app', 'properties-csv', 'service.cds'), env);
+            expect(result).toStrictEqual(join(PROJECT_ROOT, 'app', 'properties-csv', '_i18n'));
+        });
+        test('i18n folder exists in root', async () => {
+            const env: CdsEnvironment = {
+                i18n: {
+                    folders: ['_i18n', 'i18n', 'assets/i18n'],
+                    default_language: 'en'
+                }
+            };
+            const result = await getCapI18nFolder(PROJECT_ROOT, join('app', 'dummy'), env);
             expect(result).toStrictEqual(join(PROJECT_ROOT, 'i18n'));
         });
         test('i18n folder does not exist', async () => {

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -129,7 +129,7 @@ class ApplicationAccessImp implements ApplicationAccess {
     /**
      * Maintains new translation entries in CAP i18n files.
      *
-     * @param filePath file in which the translation entry will be used.
+     * @param filePath Relative file path in which the translation entry will be used.
      * @param newI18nEntries translation entries to write in the i18n file.
      * @returns boolean or exception
      */

--- a/packages/project-access/src/project/i18n/write.ts
+++ b/packages/project-access/src/project/i18n/write.ts
@@ -11,7 +11,7 @@ import type { Editor } from 'mem-fs-editor';
  * Maintains new translation entries in CAP i18n files.
  *
  * @param root project root.
- * @param filePath file in which the translation entry will be used.
+ * @param filePath Relative file path in which the translation entry will be used.
  * @param newI18nEntries translation entries to write in the i18n file.
  * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node
  * In case of CAP project, some CDS APIs are used internally which depends on `fs` of node and not `mem-fs-editor`.


### PR DESCRIPTION
alternative to https://github.com/SAP/open-ux-tools/pull/2298
logic stays same as before - methods 'createCapI18nEntries', 'getCapI18nFolder' handle relative file path, but jsdoc is updated and test is corrected(previously it passed absolute path)