### PR TITLE
fix(ui-components): UIContextualMenu.getUIContextualMenuItemStyles - make `props` param option

### DIFF
--- a/.changeset/stale-falcons-cry.md
+++ b/.changeset/stale-falcons-cry.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIContextualMenu.getUIContextualMenuItemStyles - make `props` param option

--- a/.changeset/stale-falcons-cry.md
+++ b/.changeset/stale-falcons-cry.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-components': patch
 ---
 
-UIContextualMenu.getUIContextualMenuItemStyles - make `props` param option
+UIContextualMenu.getUIContextualMenuItemStyles - make `props` param optional

--- a/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
+++ b/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
@@ -68,11 +68,11 @@ export function getUIcontextualMenuStyles(): Partial<IContextualMenuStyles> {
  * @returns - consumable styles property for ContextualMenuItem
  */
 export function getUIContextualMenuItemStyles(
-    props: UIIContextualMenuProps,
+    props?: UIIContextualMenuProps,
     currentItemHasSubmenu?: boolean,
     itemsHaveSubMenu?: boolean
 ): Partial<IContextualMenuItemStyles> {
-    const { iconToLeft } = props;
+    const { iconToLeft } = props ?? {};
     const padding: { label?: number; root?: string; rootRight?: string } = {};
     if (iconToLeft && itemsHaveSubMenu) {
         padding.label = currentItemHasSubmenu ? 10 : 19;

--- a/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
+++ b/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
 import type { UIIContextualMenuProps } from '../../../src/components/UIContextualMenu';
-import { UIContextualMenu } from '../../../src/components/UIContextualMenu';
+import { getUIContextualMenuItemStyles, UIContextualMenu } from '../../../src/components/UIContextualMenu';
 import { ContextualMenu } from '@fluentui/react';
 import { UiIcons, initIcons } from '../../../src/components/Icons';
 
@@ -141,5 +141,43 @@ describe('<UIDropdown />', () => {
         expect(wrapper.find(`i[data-icon-name="${UiIcons.GuidedDevelopment}"]`).length).toEqual(1);
         // Check if two menu items are rendered
         expect(wrapper.find('.ms-ContextualMenu-linkContent').length).toEqual(2);
+    });
+
+    it('getUIContextualMenuItemStyles - call without params', () => {
+        const styles = getUIContextualMenuItemStyles();
+        expect(styles).toEqual({
+            'checkmarkIcon': {
+                'color': 'var(--vscode-foreground)',
+                'fontSize': 16,
+                'lineHeight': 18,
+                'margin': 0,
+                'maxHeight': 18
+            },
+            'icon': {
+                'marginLeft': 0,
+                'marginRight': 6
+            },
+            'label': {
+                'fontFamily': 'var(--vscode-font-family)',
+                'height': 18,
+                'lineHeight': 18,
+                'paddingLeft': undefined
+            },
+            'linkContent': {
+                'fontSize': 13,
+                'height': 'auto'
+            },
+            'root': {
+                'padding': undefined,
+                'paddingRight': undefined
+            },
+            'subMenuIcon': {
+                'height': 16,
+                'lineHeight': 0,
+                'transform': 'rotate(-90deg)',
+                'transformOrigin': '50% 50%',
+                'width': 16
+            }
+        });
     });
 });


### PR DESCRIPTION
During updating `ui-components` to latest version, we noticed that method `getUIContextualMenuItemStyles` expects first param `props` to be required. 
![image](https://github.com/user-attachments/assets/8ede7fff-6939-4741-abf2-1e78121a60bc)


It was introduced during -> https://github.com/SAP/open-ux-tools/pull/2234

but according to code - method can be adjusted to make `props` as optional. 