### PR TITLE
fix(ui-components): UIContextualMenu.getUIcontextualMenuCalloutStyles- change `props` param to `styles` param and make it as optional

### DIFF
--- a/.changeset/moody-frogs-battle.md
+++ b/.changeset/moody-frogs-battle.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-components': patch
 ---
 
-UIContextualMenu.getUIcontextualMenuCalloutStyles - make `props` param optional
+UIContextualMenu.getUIcontextualMenuCalloutStyles - change parameter from `props?: IContextualMenuProps` to `styles?: IStyleFunctionOrObject<IContextualMenuStyleProps, IContextualMenuStyles>` and make parameter as optional

--- a/.changeset/moody-frogs-battle.md
+++ b/.changeset/moody-frogs-battle.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIContextualMenu.getUIcontextualMenuCalloutStyles - make `props` param optional

--- a/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
+++ b/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
@@ -124,13 +124,13 @@ export function getUIContextualMenuItemStyles(
  * @returns consumable styles property for Callout
  */
 export function getUIcontextualMenuCalloutStyles(
-    props: IContextualMenuProps,
+    props?: IContextualMenuProps,
     maxWidth?: number
 ): Partial<ICalloutContentStyles> {
     return {
         root: {
             maxWidth: maxWidth,
-            ...extractRawStyles(props.styles, 'root')
+            ...(props ? extractRawStyles(props.styles, 'root') : undefined)
         }
     };
 }

--- a/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
+++ b/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.tsx
@@ -119,18 +119,18 @@ export function getUIContextualMenuItemStyles(
 /**
  * ContextualMenu sub-component styles prop generator.
  *
- * @param props Contextual menu properties.
+ * @param styles External styles of contextual menu.
  * @param maxWidth Maximal width of callout
  * @returns consumable styles property for Callout
  */
 export function getUIcontextualMenuCalloutStyles(
-    props?: IContextualMenuProps,
+    styles?: IStyleFunctionOrObject<IContextualMenuStyleProps, IContextualMenuStyles>,
     maxWidth?: number
 ): Partial<ICalloutContentStyles> {
     return {
         root: {
             maxWidth: maxWidth,
-            ...(props ? extractRawStyles(props.styles, 'root') : undefined)
+            ...(styles ? extractRawStyles(styles, 'root') : undefined)
         }
     };
 }
@@ -257,7 +257,7 @@ export const UIContextualMenu: React.FC<UIIContextualMenuProps> = (props) => {
             className={getClassNames(props)}
             items={injectContextualMenuItemsStyle(props)}
             calloutProps={{
-                styles: getUIcontextualMenuCalloutStyles(props, props.maxWidth),
+                styles: getUIcontextualMenuCalloutStyles(props.styles, props.maxWidth),
                 ...props.calloutProps,
                 className: getCalloutClassName(props)
             }}

--- a/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
+++ b/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
@@ -203,10 +203,7 @@ describe('<UIDropdown />', () => {
         });
 
         it('getUIcontextualMenuCalloutStyles - pass maxWidth', () => {
-            const defaultStyles = getUIcontextualMenuCalloutStyles(
-                { styles: { root: { background: 'green' } }, items: [] },
-                100
-            );
+            const defaultStyles = getUIcontextualMenuCalloutStyles({ root: { background: 'green' } }, 100);
             expect(defaultStyles).toEqual({
                 root: {
                     maxWidth: 100,

--- a/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
+++ b/packages/ui-components/test/unit/components/UIContextualMenu.test.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
 import type { UIIContextualMenuProps } from '../../../src/components/UIContextualMenu';
-import { getUIContextualMenuItemStyles, UIContextualMenu } from '../../../src/components/UIContextualMenu';
+import {
+    getUIcontextualMenuCalloutStyles,
+    getUIContextualMenuItemStyles,
+    UIContextualMenu
+} from '../../../src/components/UIContextualMenu';
 import { ContextualMenu } from '@fluentui/react';
 import { UiIcons, initIcons } from '../../../src/components/Icons';
 
@@ -178,6 +182,37 @@ describe('<UIDropdown />', () => {
                 'transformOrigin': '50% 50%',
                 'width': 16
             }
+        });
+    });
+
+    describe('<getUIcontextualMenuCalloutStyles />', () => {
+        it('getUIcontextualMenuCalloutStyles - call without params', () => {
+            const defaultStyles = getUIcontextualMenuCalloutStyles();
+            expect(defaultStyles).toEqual({
+                root: {}
+            });
+        });
+
+        it('getUIcontextualMenuCalloutStyles - pass maxWidth', () => {
+            const defaultStyles = getUIcontextualMenuCalloutStyles(undefined, 100);
+            expect(defaultStyles).toEqual({
+                root: {
+                    maxWidth: 100
+                }
+            });
+        });
+
+        it('getUIcontextualMenuCalloutStyles - pass maxWidth', () => {
+            const defaultStyles = getUIcontextualMenuCalloutStyles(
+                { styles: { root: { background: 'green' } }, items: [] },
+                100
+            );
+            expect(defaultStyles).toEqual({
+                root: {
+                    maxWidth: 100,
+                    background: 'green'
+                }
+            });
         });
     });
 });


### PR DESCRIPTION
During updating `ui-components` to latest version, we noticed that method `getUIcontextualMenuCalloutStyles` expects first param `props` to be required. 
![image](https://github.com/user-attachments/assets/ee1c24c3-adc7-4efd-85cb-d7044ebe3652)


It was introduced during -> https://github.com/SAP/open-ux-tools/pull/2234

but according to code - method can be adjusted to make `props` as optional. 
Additionally - as only `styles` are used from `props`, then changed param from `props` to `styles` to allow pass styles without required properties like `items`