### PR TITLE
fix(odata-service-inquirer): #2309 fix for annotations not retrieved using service url prompt

### DIFF
--- a/.changeset/bright-spiders-carry.md
+++ b/.changeset/bright-spiders-carry.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for annotations not retrieved by service url prompt

--- a/packages/odata-service-inquirer/jest.config.js
+++ b/packages/odata-service-inquirer/jest.config.js
@@ -4,4 +4,5 @@ config.snapshotFormat = {
     escapeString: false,
     printBasicPrototype: false
 };
+config.collectCoverage = false;
 module.exports = config;

--- a/packages/odata-service-inquirer/jest.config.js
+++ b/packages/odata-service-inquirer/jest.config.js
@@ -4,5 +4,4 @@ config.snapshotFormat = {
     escapeString: false,
     printBasicPrototype: false
 };
-config.collectCoverage = false;
 module.exports = config;

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -68,7 +68,7 @@ export class ConnectionValidator {
 
     private _odataService: ODataService | undefined;
     private _serviceProvider: ServiceProvider | undefined;
-    private _axiosConfig: (AxiosExtensionRequestConfig & ProviderConfiguration) | undefined;
+    private _axiosConfig: AxiosExtensionRequestConfig & ProviderConfiguration;
     private _catalogV2: CatalogService | undefined;
     private _catalogV4: CatalogService | undefined;
     private _systemAuthType: SystemAuthType | undefined;
@@ -82,7 +82,7 @@ export class ConnectionValidator {
      *
      * @returns the axios configuration
      */
-    public get axiosConfig(): AxiosRequestConfig | undefined {
+    public get axiosConfig(): AxiosRequestConfig {
         return this._axiosConfig;
     }
 

--- a/packages/odata-service-inquirer/src/prompts/datasources/service-url/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/service-url/questions.ts
@@ -6,11 +6,10 @@ import { t } from '../../../i18n';
 import type { OdataServiceAnswers, OdataServicePromptOptions } from '../../../types';
 import { hostEnvironment, promptNames } from '../../../types';
 import { PromptState, getHostEnvironment } from '../../../utils';
-import LoggerHelper from '../../logger-helper';
 import { ConnectionValidator } from '../../connectionValidator';
+import LoggerHelper from '../../logger-helper';
 import { serviceUrlInternalPromptNames } from './types';
 import { validateService } from './validators';
-import type { AbapServiceProvider } from '@sap-ux/axios-extension';
 
 /**
  * Internal only answers to service URL prompting not returned with OdataServiceAnswers.
@@ -64,7 +63,7 @@ function getServiceUrlPrompt(connectValidator: ConnectionValidator, requiredVers
                         url,
                         {
                             odataService: connectValidator.odataService,
-                            abapServiceProvider: connectValidator.serviceProvider as AbapServiceProvider
+                            axiosConfig: connectValidator.axiosConfig
                         },
                         requiredVersion
                     );
@@ -118,7 +117,7 @@ function getIgnoreCertErrorsPrompt(
                         serviceUrl,
                         {
                             odataService: connectValidator.odataService,
-                            abapServiceProvider: connectValidator.serviceProvider as AbapServiceProvider
+                            axiosConfig: connectValidator.axiosConfig
                         },
                         requiredVersion,
                         ignoreCertError
@@ -167,7 +166,7 @@ function getCliIgnoreCertValidatePrompt(
                         serviceUrl,
                         {
                             odataService: connectValidator.odataService,
-                            abapServiceProvider: connectValidator.serviceProvider as AbapServiceProvider
+                            axiosConfig: connectValidator.axiosConfig
                         },
                         requiredVersion,
                         true
@@ -237,7 +236,7 @@ function getPasswordPrompt(
                     serviceUrl,
                     {
                         odataService: connectValidator.odataService,
-                        abapServiceProvider: connectValidator.serviceProvider as AbapServiceProvider
+                        axiosConfig: connectValidator.axiosConfig
                     },
                     requiredVersion,
                     ignoreCertError

--- a/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
@@ -1,4 +1,4 @@
-import type { AbapServiceProvider, ODataService, ODataVersion } from '@sap-ux/axios-extension';
+import { createForAbap, type AxiosRequestConfig, type ODataService, type ODataVersion } from '@sap-ux/axios-extension';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { ERROR_TYPE, ErrorHandler } from '../../../error-handler/error-handler';
 import { t } from '../../../i18n';
@@ -15,14 +15,14 @@ import { errorHandler } from '../../prompt-helpers';
  * @param url the full odata service url including query parameters
  * @param connectionConfig the connection configuration to use for the validation, a subset of the ConnectionValidator properties
  * @param connectionConfig.odataService the odata service instance used to retrieve the metadata (as used by ConnectionValidator)
- * @param connectionConfig.abapServiceProvider the abap service provider instance used to retrieve annotations (as used by ConnectionValidator)
+ * @param connectionConfig.axiosConfig the axios config to use for the annotations request (as used by ConnectionValidator)
  * @param requiredVersion if specified and the service odata version does not match this version, an error is returned
  * @param ignoreCertError if true some certificate errors are ignored
  * @returns true if a valid odata service was returned, false or an error message string otherwise
  */
 export async function validateService(
     url: string,
-    { odataService, abapServiceProvider }: { odataService: ODataService; abapServiceProvider: AbapServiceProvider },
+    { odataService, axiosConfig }: { odataService: ODataService; axiosConfig: AxiosRequestConfig },
     requiredVersion: OdataVersion | undefined = undefined,
     ignoreCertError = false
 ): Promise<boolean | string> {
@@ -56,7 +56,8 @@ export async function validateService(
         // Best effort attempt to get annotations but dont throw an error if it fails as this may not even be an Abap system
         try {
             // Create an abap provider instance to get the annotations using the same request config
-            const catalogService = abapServiceProvider.catalog(serviceOdataVersion as unknown as ODataVersion);
+            const abapProvider = createForAbap(axiosConfig);
+            const catalogService = abapProvider.catalog(serviceOdataVersion as unknown as ODataVersion);
             LoggerHelper.attachAxiosLogger(catalogService.interceptors);
             LoggerHelper.logger.debug('Getting annotations for service');
             const annotations = await catalogService.getAnnotations({ path: fullUrl.pathname });

--- a/packages/odata-service-inquirer/test/unit/prompts/service-url/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/service-url/questions.test.ts
@@ -18,7 +18,8 @@ const connectionValidatorMock = {
     validateUrl: validateUrlMockTrue,
     validateAuth: validateAuthTrue,
     odataService: odataServiceMock,
-    serviceProvider: serviceProviderMock
+    serviceProvider: serviceProviderMock,
+    axiosConfig: {}
 };
 jest.mock('../../../../src/prompts/connectionValidator', () => {
     return {
@@ -129,6 +130,7 @@ describe('Service URL prompts', () => {
             authRequired: false,
             authenticated: false
         };
+        connectionValidatorMock.axiosConfig = {};
 
         // Should validate service and return true if valid
         const serviceUrl = 'https://some.host:1234/service/path';
@@ -140,7 +142,7 @@ describe('Service URL prompts', () => {
 
         expect(serviceValidatorSpy).toHaveBeenCalledWith(
             serviceUrl,
-            expect.objectContaining({ 'abapServiceProvider': {}, 'odataService': {} }),
+            expect.objectContaining({ 'axiosConfig': {}, 'odataService': {} }),
             undefined
         );
         expect(validateUrlMockTrue).toHaveBeenCalledWith(serviceUrl);
@@ -155,7 +157,7 @@ describe('Service URL prompts', () => {
         expect(connectionValidatorMock.validateUrl).toHaveBeenCalledWith(serviceUrl);
         expect(serviceValidatorSpy).toHaveBeenCalledWith(
             serviceUrl,
-            expect.objectContaining({ 'abapServiceProvider': {}, 'odataService': {} }),
+            expect.objectContaining({ 'axiosConfig': {}, 'odataService': {} }),
             OdataVersion.v4
         );
 
@@ -243,7 +245,7 @@ describe('Service URL prompts', () => {
         });
         expect(serviceValidatorSpy).toHaveBeenCalledWith(
             serviceUrl,
-            expect.objectContaining({ 'abapServiceProvider': {}, 'odataService': {} }),
+            expect.objectContaining({ 'axiosConfig': {}, 'odataService': {} }),
             undefined,
             true
         );
@@ -321,7 +323,7 @@ describe('Service URL prompts', () => {
         });
         expect(serviceValidatorSpy).toHaveBeenCalledWith(
             serviceUrl,
-            expect.objectContaining({ 'abapServiceProvider': {}, 'odataService': {} }),
+            expect.objectContaining({ 'axiosConfig': {}, 'odataService': {} }),
             undefined,
             true
         );
@@ -400,7 +402,7 @@ describe('Service URL prompts', () => {
         });
         expect(serviceValidatorSpy).toHaveBeenCalledWith(
             serviceUrl,
-            expect.objectContaining({ 'abapServiceProvider': {}, 'odataService': {} }),
+            expect.objectContaining({ 'axiosConfig': {}, 'odataService': {} }),
             undefined,
             undefined
         );

--- a/packages/odata-service-inquirer/test/unit/prompts/service-url/validators.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/service-url/validators.test.ts
@@ -19,7 +19,8 @@ jest.mock('@sap-ux/axios-extension', () => ({
     ...jest.requireActual('@sap-ux/axios-extension'),
     AbapServiceProvider: jest.fn().mockImplementation(() => ({
         catalog: catalogServiceMock
-    }))
+    })),
+    createForAbap: jest.fn().mockImplementation(() => new AbapServiceProvider())
 }));
 
 describe('Test service url validators', () => {
@@ -59,7 +60,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                axiosConfig: {}
             })
         ).toMatch(t('prompts.validationMessages.metadataInvalid'));
 
@@ -68,31 +69,19 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                axiosConfig: {}
             })
         ).toBe(true);
         expect(catalogServiceMock).toHaveBeenCalledWith(OdataVersion.v2);
 
         // Valid metadata with required version
-        expect(
-            await validateService(
-                serviceUrl,
-                { odataService, abapServiceProvider: new AbapServiceProvider() },
-                OdataVersion.v4
-            )
-        ).toBe(
+        expect(await validateService(serviceUrl, { odataService, axiosConfig: {} }, OdataVersion.v4)).toBe(
             t('prompts.validationMessages.odataVersionMismatch', {
                 requiredOdataVersion: OdataVersion.v4,
                 providedOdataVersion: OdataVersion.v2
             })
         );
-        expect(
-            await validateService(
-                serviceUrl,
-                { odataService, abapServiceProvider: new AbapServiceProvider() },
-                OdataVersion.v2
-            )
-        ).toBe(true);
+        expect(await validateService(serviceUrl, { odataService, axiosConfig: {} }, OdataVersion.v2)).toBe(true);
     });
 
     test('should set the prompt state', async () => {
@@ -111,7 +100,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                'axiosConfig': {}
             })
         ).toBe(true);
         expect(PromptState.odataService).toEqual({
@@ -140,7 +129,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                'axiosConfig': {}
             })
         ).toBe(true);
         expect(loggerSpy).toHaveBeenCalledWith(t('prompts.validationMessages.annotationsNotFound'));
@@ -151,7 +140,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                'axiosConfig': {}
             })
         ).toBe(true);
         expect(loggerSpy).toHaveBeenCalledWith(t('prompts.validationMessages.annotationsNotFound'));
@@ -167,7 +156,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                'axiosConfig': {}
             })
         ).toBe(t('errors.unknownError', { error: metadataRequestError.message }));
         expect(loggerSpy).toHaveBeenCalled();
@@ -179,7 +168,7 @@ describe('Test service url validators', () => {
         expect(
             await validateService(serviceUrl, {
                 odataService,
-                abapServiceProvider: new AbapServiceProvider()
+                'axiosConfig': {}
             })
         ).toBe(t('errors.odataServiceUrlNotFound'));
     });


### PR DESCRIPTION
Fix for: https://github.com/SAP/open-ux-tools/issues/2309

- Reverts behaviour to earlier version when annotations were retrieved
- Updates unit tests