### PR TITLE
fix(cf-deploy-config-writer): refactor hasUI5CliV3 to project-access for common reuse

### DIFF
--- a/.changeset/dull-points-nail.md
+++ b/.changeset/dull-points-nail.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/odata-service-writer': patch
+'@sap-ux/project-access': patch
+---
+
+Move hasUI5CliV3 to project-access for common re-use

--- a/packages/odata-service-writer/src/updates.ts
+++ b/packages/odata-service-writer/src/updates.ts
@@ -5,7 +5,7 @@ import { t } from './i18n';
 import type { OdataService, CdsAnnotationsInfo, EdmxAnnotationsInfo } from './types';
 import semVer from 'semver';
 import prettifyXml from 'prettify-xml';
-import { getMinimumUI5Version, type Manifest } from '@sap-ux/project-access';
+import { getMinimumUI5Version, type Manifest, hasUI5CliV3 } from '@sap-ux/project-access';
 
 /**
  * Internal function that updates the manifest.json based on the given service configuration.
@@ -151,19 +151,4 @@ export function updatePackageJson(path: string, fs: Editor, addMockServer: boole
         }
     }
     fs.writeJSON(path, packageJson);
-}
-
-/**
- * Check if dev dependencies contains @ui5/cli version greater than 2.
- *
- * @param devDependencies dev dependencies from package.json
- * @returns boolean
- */
-export function hasUI5CliV3(devDependencies: any): boolean {
-    let isV3 = false;
-    const ui5CliSemver = semVer.coerce(devDependencies['@ui5/cli']);
-    if (ui5CliSemver && semVer.gte(ui5CliSemver, '3.0.0')) {
-        isV3 = true;
-    }
-    return isV3;
 }

--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -42,7 +42,8 @@ export {
     toReferenceUri,
     filterDataSourcesByType,
     updatePackageScript,
-    findCapProjectRoot
+    findCapProjectRoot,
+    hasUI5CliV3
 } from './project';
 export * from './types';
 export * from './library';

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -38,5 +38,5 @@ export {
 export { getWebappPath, readUi5Yaml } from './ui5-config';
 export { getMtaPath } from './mta';
 export { createApplicationAccess, createProjectAccess } from './access';
-export { updatePackageScript } from './script';
+export { updatePackageScript, hasUI5CliV3 } from './script';
 export { getSpecification, getSpecificationPath, refreshSpecificationDistTags } from './specification';

--- a/packages/project-access/src/project/script.ts
+++ b/packages/project-access/src/project/script.ts
@@ -3,6 +3,7 @@ import { FileName } from '../constants';
 import type { Package } from '../types';
 import type { Editor } from 'mem-fs-editor';
 import { readJSON, updatePackageJSON } from '../file';
+import semVer from 'semver';
 
 /**
  * Updates the package.json with a new script.
@@ -25,4 +26,19 @@ export async function updatePackageScript(
     }
     packageJson.scripts[scriptName] = script;
     await updatePackageJSON(filePath, packageJson, fs);
+}
+
+/**
+ * Check if dev dependencies contains @ui5/cli version greater than 2.
+ *
+ * @param devDependencies dev dependencies from package.json
+ * @returns boolean
+ */
+export function hasUI5CliV3(devDependencies: any): boolean {
+    let isV3 = false;
+    const ui5CliSemver = semVer.coerce(devDependencies['@ui5/cli']);
+    if (ui5CliSemver && semVer.gte(ui5CliSemver, '3.0.0')) {
+        isV3 = true;
+    }
+    return isV3;
 }

--- a/packages/project-access/test/project/script.test.ts
+++ b/packages/project-access/test/project/script.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
-import { FileName, updatePackageScript } from '../../src';
+import { FileName, updatePackageScript, hasUI5CliV3 } from '../../src';
 
 describe('Test updatePackageScript()', () => {
     const sampleRoot = join(__dirname, '../test-data/json/package');
@@ -24,5 +24,11 @@ describe('Test updatePackageScript()', () => {
               },
             }
         `);
+    });
+
+    test('hasUI5CliV3', async () => {
+        expect(hasUI5CliV3({ '@ui5/cli': '3.0.0' })).toBe(true);
+        expect(hasUI5CliV3({})).toBe(false);
+        expect(hasUI5CliV3({ '@ui5/cli': '2.0.0' })).toBe(false);
     });
 });


### PR DESCRIPTION

Fix for https://github.com/SAP/open-ux-tools/issues/2007

- Move method hasUI5CliV3 to allow be resuse in other modules