### PR TITLE
move fiori updates

### DIFF
--- a/packages/fiori-elements-writer/src/data/defaults.ts
+++ b/packages/fiori-elements-writer/src/data/defaults.ts
@@ -108,10 +108,15 @@ export function getManifestLibs(type: TemplateType, version: OdataVersion, libs?
 export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<T> {
     // Add template information
     if (!feApp.app.sourceTemplate?.version || !feApp.app.sourceTemplate?.id) {
-        const packageInfo = readPkgUp.sync({ cwd: __dirname });
+        // const packageInfo = readPkgUp.sync({ cwd: __dirname });
+        // feApp.app.sourceTemplate = {
+        //     id: `${packageInfo?.packageJson.name}:${feApp.template.type}`,
+        //     version: packageInfo?.packageJson.version,
+        //     toolsId: feApp.app.sourceTemplate?.toolsId
+        // };
         feApp.app.sourceTemplate = {
-            id: `${packageInfo?.packageJson.name}:${feApp.template.type}`,
-            version: packageInfo?.packageJson.version,
+            id: `@sap/generator-fiori:${feApp.template.type}`,
+            version: '1.13.5',
             toolsId: feApp.app.sourceTemplate?.toolsId
         };
     }

--- a/packages/fiori-elements-writer/src/packageConfig.ts
+++ b/packages/fiori-elements-writer/src/packageConfig.ts
@@ -1,5 +1,6 @@
 import { t } from './i18n';
 import type { PackageJsonScripts } from './types';
+import { getVariantPreviewAppScript } from '@sap-ux/fiori-generator-shared';
 
 /**
  * Get an object reflecting the scripts that need to be added to the package.json.
@@ -75,6 +76,10 @@ export function getPackageJsonTasks({
     if (addTest) {
         scripts['int-test'] = 'fiori run --config ./ui5-mock.yaml --open "test/integration/opaTests.qunit.html"';
     }
+
+    scripts['start-variants-management'] = localOnly
+        ? `echo \\"${t('info.mockOnlyWarning')}\\"`
+        : getVariantPreviewAppScript(sapClient);
 
     return scripts;
 }

--- a/packages/fiori-elements-writer/src/types.ts
+++ b/packages/fiori-elements-writer/src/types.ts
@@ -126,4 +126,5 @@ export interface PackageJsonScripts {
     'start-noflp'?: string;
     'start-mock'?: string;
     'int-test'?: string;
+    'start-variants-management'?: string;
 }

--- a/packages/fiori-freestyle-writer/src/packageConfig.ts
+++ b/packages/fiori-freestyle-writer/src/packageConfig.ts
@@ -1,5 +1,6 @@
 import { t } from './i18n';
 import type { PackageJsonScripts } from './types';
+import { getVariantPreviewAppScript } from '@sap-ux/fiori-generator-shared';
 
 /**
  * Get an object reflecting the scripts that need to be added to the package.json.
@@ -67,6 +68,10 @@ export function getPackageJsonTasks({
     if (addMock) {
         scripts['start-mock'] = `fiori run --config ./ui5-mock.yaml --open "test/flpSandbox.html${params}"`;
     }
+
+    scripts['start-variants-management'] = localOnly
+        ? `echo \\"${t('info.mockOnlyWarning')}\\"`
+        : getVariantPreviewAppScript(sapClient);
 
     return scripts;
 }

--- a/packages/fiori-freestyle-writer/src/types.ts
+++ b/packages/fiori-freestyle-writer/src/types.ts
@@ -51,4 +51,5 @@ export interface PackageJsonScripts {
     'start-local': string;
     'start-noflp'?: string;
     'start-mock'?: string;
+    'start-variants-management'?: string;
 }

--- a/packages/fiori-generator-shared/src/helpers.ts
+++ b/packages/fiori-generator-shared/src/helpers.ts
@@ -29,3 +29,23 @@ export function getBootstrapResourceUrls(
 
     return { uShellBootstrapResourceUrl, uiBootstrapResourceUrl };
 }
+
+/**
+ * Generates a variant management script in preview mode.
+ *
+ * @param {string} sapClient - The SAP client parameter to include in the URL. If not provided, the URL will not include the `sap-client` parameter.
+ * @returns {string} A variant management script to run the application in preview mode.
+ */
+export function getVariantPreviewAppScript(sapClient?: string): string {
+    const previewAppAnchor = '#preview-app';
+    const DisableCacheParam = 'sap-ui-xx-viewCache=false';
+    const sapClientParam = sapClient ? `sap-client=${sapClient}` : '';
+    const urlParam = `?${[
+        sapClientParam,
+        DisableCacheParam,
+        'fiori-tools-rta-mode=true',
+        'sap-ui-rta-skip-flex-validation=true'
+    ].filter(Boolean)
+    .join('&')}`;
+    return `fiori run --open \"preview.html${urlParam}${previewAppAnchor}\"`;
+}

--- a/packages/fiori-generator-shared/src/index.ts
+++ b/packages/fiori-generator-shared/src/index.ts
@@ -1,5 +1,5 @@
 export * from './cap';
 export * from './environment';
-export { getBootstrapResourceUrls } from './helpers';
+export { getBootstrapResourceUrls, getVariantPreviewAppScript } from './helpers';
 export { generateReadMe } from './read-me';
 export * from './system-utils';

--- a/packages/fiori-generator-shared/test/helpers.test.ts
+++ b/packages/fiori-generator-shared/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { getBootstrapResourceUrls } from '../src/index';
+import { getBootstrapResourceUrls, getVariantPreviewAppScript } from '../src/index';
 
 describe('getResourceUrlsForUi5Bootstrap', () => {
     it('should return relative paths for Edmx projects', () => {
@@ -40,5 +40,30 @@ describe('getResourceUrlsForUi5Bootstrap', () => {
             uShellBootstrapResourceUrl: '../test-resources/sap/ushell/bootstrap/sandbox.js',
             uiBootstrapResourceUrl: '../resources/sap-ui-core.js'
         });
+    });
+});
+
+describe('getVariantPreviewAppScript', () => {
+    it('should return the correct command with a given SAP client', () => {
+        const sapClient = '100';
+        const expectedCommand = 'fiori run --open "preview.html?sap-client=100&sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app"';
+        expect(getVariantPreviewAppScript(sapClient)).toBe(expectedCommand);
+    });
+
+    it('should return the correct command with an empty SAP client', () => {
+        const sapClient = '';
+        const expectedCommand = 'fiori run --open "preview.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app"';
+        expect(getVariantPreviewAppScript(sapClient)).toBe(expectedCommand);
+    });
+
+    it('should return the correct command with no SAP client argument', () => {
+        const sapClient = undefined;
+        const expectedCommand = 'fiori run --open "preview.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app"';
+        expect(getVariantPreviewAppScript(sapClient)).toBe(expectedCommand);
+    });
+
+    it('should handle default parameter value correctly', () => {
+        const expectedCommand = 'fiori run --open "preview.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app"';
+        expect(getVariantPreviewAppScript()).toBe(expectedCommand);
     });
 });

--- a/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
+++ b/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
@@ -92,6 +92,7 @@ async function generateUi5MockYamlBasedOnUi5Yaml(
 ): Promise<UI5Config> {
     const ui5MockYamlConfig = await UI5Config.newInstance(fs.read(join(basePath, 'ui5.yaml')));
     ui5MockYamlConfig.updateCustomMiddleware(await getNewMockserverMiddleware(path, annotationsConfig));
+    ui5MockYamlConfig.removeFioriToolsPreviewMiddleware();
     return ui5MockYamlConfig;
 }
 

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -94,7 +94,10 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
             ui5Config.addBackendToFioriToolsProxydMiddleware(service.previewSettings as ProxyBackend);
         } catch (error: any) {
             if (error instanceof YAMLError && error.code === yamlErrorCode.nodeNotFound) {
-                ui5Config.addFioriToolsProxydMiddleware({ backend: [service.previewSettings as ProxyBackend] });
+                ui5Config.addFioriToolsProxydMiddleware({
+                    backend: [service.previewSettings as ProxyBackend],
+                    ignoreCertError: service.ignoreCertError
+                });
             } else {
                 throw error;
             }
@@ -106,7 +109,10 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
         ui5LocalConfigPath = join(dirname(paths.ui5Yaml), 'ui5-local.yaml');
         if (fs.exists(ui5LocalConfigPath)) {
             ui5LocalConfig = await UI5Config.newInstance(fs.read(ui5LocalConfigPath));
-            ui5LocalConfig.addFioriToolsProxydMiddleware({ backend: [service.previewSettings as ProxyBackend] });
+            ui5LocalConfig.addFioriToolsProxydMiddleware({
+                backend: [service.previewSettings as ProxyBackend],
+                ignoreCertError: service.ignoreCertError
+            });
         }
     }
 

--- a/packages/odata-service-writer/src/types.ts
+++ b/packages/odata-service-writer/src/types.ts
@@ -74,4 +74,5 @@ export interface OdataService {
     annotations?: EdmxAnnotationsInfo | CdsAnnotationsInfo;
     localAnnotationsName?: string; // The name used in the manifest.json and as the filename for local annotations
     previewSettings?: Partial<ProxyBackend>;
+    ignoreCertError?: boolean;
 }

--- a/packages/ui5-application-writer/package.json
+++ b/packages/ui5-application-writer/package.json
@@ -44,6 +44,7 @@
     "devDependencies": {
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
+        "@sap-ux/feature-toggle": "workspace:*",
         "@types/ejs": "3.1.2",
         "@types/fs-extra": "9.0.13",
         "@types/lodash": "4.14.202",

--- a/packages/ui5-application-writer/src/data/defaults.ts
+++ b/packages/ui5-application-writer/src/data/defaults.ts
@@ -6,6 +6,8 @@ import semVer from 'semver';
 import type { SemVer } from 'semver';
 import { t } from '../i18n';
 import merge from 'lodash/mergeWith';
+import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
+import { SapUxLayer } from '../types';
 
 /**
  * Returns a package instance with default properties.
@@ -32,7 +34,8 @@ export function packageDefaults(version?: string, description?: string, isEdmxPr
                 start: 'ui5 serve --config=ui5.yaml --open index.html',
                 'start-local': 'ui5 serve --config=ui5-local.yaml --open index.html',
                 build: 'ui5 build --config=ui5.yaml --clean-dest --dest dist'
-            }
+            },
+            sapuxLayer: isInternalFeaturesSettingEnabled() ? SapUxLayer.VENDOR : SapUxLayer.CUSTOMER_BASE
         };
     }
     return {

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -8,7 +8,7 @@ import { getMinimumUI5Version, type Manifest } from '@sap-ux/project-access';
 import { mergeWithDefaults } from './data';
 import { ui5TSSupport } from './data/ui5Libs';
 import { applyOptionalFeatures, enableTypescript as enableTypescriptOption, getTemplateOptions } from './options';
-import { Ui5App, API_HUB_API_KEY, API_HUB_TYPE } from './types';
+import { Ui5App } from './types';
 
 /**
  * Writes the template to the memfs editor instance.
@@ -19,7 +19,6 @@ import { Ui5App, API_HUB_API_KEY, API_HUB_TYPE } from './types';
  * @returns the updated memfs editor instance
  */
 async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Promise<Editor> {
-    console.log("---- basePath ----", basePath);
     if (!fs) {
         fs = create(createStorage());
     }
@@ -86,11 +85,13 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
     // write ui5 yaml
     fs.write(ui5ConfigPath, ui5Config.toString());
 
-    // Create the files for apiHub integration.
-    fs.write(
-        `${basePath}/.env`,
-        `${API_HUB_API_KEY}=${ui5App.appOptions.apiHubConfig?.apiHubKey}\n${API_HUB_TYPE}=${ui5App.appOptions.apiHubConfig?.apiHubType}`
-    );
+    if(ui5App.appOptions.apiHubConfig) {
+        // Create .env to store apiHub integration.
+        fs.write(
+            `${basePath}/.env`,
+            `API_HUB_API_KEY=${ui5App.appOptions.apiHubConfig.apiHubKey}\nAPI_HUB_TYPE=${ui5App.appOptions.apiHubConfig.apiHubType}`
+        );
+    }
 
     return fs;
 }

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -2,13 +2,13 @@ import { join } from 'path';
 import { create as createStorage } from 'mem-fs';
 import type { Editor } from 'mem-fs-editor';
 import { create } from 'mem-fs-editor';
-import type { App, AppOptions, Package, UI5 } from './types';
+import type { App, AppOptions, Package, UI5, ApiHubConfig } from './types';
 import { UI5Config, getEsmTypesVersion, getTypesPackage } from '@sap-ux/ui5-config';
 import { getMinimumUI5Version, type Manifest } from '@sap-ux/project-access';
 import { mergeWithDefaults } from './data';
 import { ui5TSSupport } from './data/ui5Libs';
 import { applyOptionalFeatures, enableTypescript as enableTypescriptOption, getTemplateOptions } from './options';
-import { Ui5App } from './types';
+import { Ui5App, API_HUB_API_KEY, API_HUB_TYPE } from './types';
 
 /**
  * Writes the template to the memfs editor instance.
@@ -19,6 +19,7 @@ import { Ui5App } from './types';
  * @returns the updated memfs editor instance
  */
 async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Promise<Editor> {
+    console.log("---- basePath ----", basePath);
     if (!fs) {
         fs = create(createStorage());
     }
@@ -58,7 +59,10 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
         }
     });
     ui5Config.addFioriToolsAppReloadMiddleware();
+    
     if (isEdmxProjectType) {
+        // add preview middleware to ui5Config
+        ui5Config.addFioriToolsPreviewMiddleware(ui5App.app.id, ui5App.ui5?.ui5Theme);
         const ui5LocalConfigPath = join(basePath, 'ui5-local.yaml');
         // write ui5-local.yaml only for non-CAP applications
         const ui5LocalConfig = await UI5Config.newInstance(fs.read(ui5LocalConfigPath));
@@ -71,6 +75,8 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
         ui5LocalConfig.addFioriToolsAppReloadMiddleware();
         // Add optional features
         await applyOptionalFeatures(ui5App, fs, basePath, tmplPath, [ui5Config, ui5LocalConfig]);
+        // add preview middleware to ui5LocalConfig
+        ui5LocalConfig.addFioriToolsPreviewMiddleware(ui5App.app.id, ui5App.ui5?.ui5Theme);
         // write ui5 local yaml
         fs.write(ui5LocalConfigPath, ui5LocalConfig.toString());
     } else {
@@ -79,6 +85,12 @@ async function generate(basePath: string, ui5AppConfig: Ui5App, fs?: Editor): Pr
     }
     // write ui5 yaml
     fs.write(ui5ConfigPath, ui5Config.toString());
+
+    // Create the files for apiHub integration.
+    fs.write(
+        `${basePath}/.env`,
+        `${API_HUB_API_KEY}=${ui5App.appOptions.apiHubConfig?.apiHubKey}\n${API_HUB_TYPE}=${ui5App.appOptions.apiHubConfig?.apiHubType}`
+    );
 
     return fs;
 }
@@ -147,5 +159,5 @@ async function enableTypescript(basePath: string, fs?: Editor): Promise<Editor> 
     return fs;
 }
 
-export { Ui5App, generate, enableTypescript, isTypescriptEnabled };
+export { Ui5App, generate, enableTypescript, isTypescriptEnabled, type ApiHubConfig };
 export { App, Package, UI5, AppOptions };

--- a/packages/ui5-application-writer/src/types.ts
+++ b/packages/ui5-application-writer/src/types.ts
@@ -9,6 +9,7 @@ export interface Package {
     ui5?: {
         dependencies?: string[];
     };
+    sapuxLayer?: SapUxLayer;
 }
 
 export interface App {
@@ -145,6 +146,30 @@ export interface UI5 {
     customUi5Libs?: string[];
 }
 
+export const API_HUB_API_KEY = 'API_HUB_API_KEY';
+export const API_HUB_TYPE = 'API_HUB_TYPE';
+
+const enum ApiHubType {
+    apiHub = 'API_HUB',
+    apiHubEnterprise = 'API_HUB_ENTERPRISE'
+}
+
+/**
+ * SAP UX Layer
+ */
+export enum SapUxLayer {
+    VENDOR = 'VENDOR',
+    CUSTOMER_BASE = 'CUSTOMER_BASE'
+}
+
+/**
+ * Defines the api hub service properties or enterprise and non-enterprise versions
+ */
+export interface ApiHubConfig {
+    apiHubKey: string;
+    apiHubType: ApiHubType;
+}
+
 // Additional configurable features
 export interface AppOptions {
     codeAssist: boolean; // Enables code assist
@@ -171,6 +196,10 @@ export interface AppOptions {
      * Excludes the index.html from the template and does not add the `start-noflp` script in package.json
      */
     generateIndex?: boolean;
+    /**
+     * Api Hub configuration
+     */
+    apiHubConfig?: ApiHubConfig;
 }
 
 export interface Ui5App {

--- a/packages/ui5-application-writer/src/types.ts
+++ b/packages/ui5-application-writer/src/types.ts
@@ -146,20 +146,17 @@ export interface UI5 {
     customUi5Libs?: string[];
 }
 
-export const API_HUB_API_KEY = 'API_HUB_API_KEY';
-export const API_HUB_TYPE = 'API_HUB_TYPE';
-
-const enum ApiHubType {
-    apiHub = 'API_HUB',
-    apiHubEnterprise = 'API_HUB_ENTERPRISE'
-}
-
 /**
  * SAP UX Layer
  */
 export enum SapUxLayer {
     VENDOR = 'VENDOR',
     CUSTOMER_BASE = 'CUSTOMER_BASE'
+}
+
+export const enum ApiHubType {
+    apiHub = 'API_HUB',
+    apiHubEnterprise = 'API_HUB_ENTERPRISE'
 }
 
 /**

--- a/packages/ui5-application-writer/templates/core/package.json
+++ b/packages/ui5-application-writer/templates/core/package.json
@@ -11,4 +11,7 @@
     "dependencies": {},
     "devDependencies": <%- JSON.stringify(package.devDependencies, null, 8) -%>,
     "scripts": <%- JSON.stringify(package.scripts, null, 4) -%>
+    <% if (package.sapuxLayer) { %>
+    ,"sapuxLayer": "<%= package.sapuxLayer %>"
+    <% } %>
 }

--- a/packages/ui5-application-writer/test/index.test.ts
+++ b/packages/ui5-application-writer/test/index.test.ts
@@ -5,6 +5,7 @@ import { create } from 'mem-fs-editor';
 import type { Ui5App } from '../src';
 import { generate, isTypescriptEnabled, enableTypescript } from '../src';
 import { updatePackageJSONDependencyToUseLocalPath } from './common';
+import { ApiHubType } from '../src/types';
 
 describe('UI5 templates', () => {
     const fs = create(createStorage());
@@ -150,5 +151,20 @@ describe('UI5 templates', () => {
         expect(fs.exists(join(projectDir, '.gitignore'))).toBe(false);
         // Check if ui5.yaml exist
         expect(fs.exists(join(projectDir, 'ui5.yaml'))).toBe(true);
+    });
+
+    it('Check that .env file is generated when apiHubConfig is provided', async () => {
+        let projectDir = join(outputDir, 'testapp-simple');
+        ui5AppConfig.appOptions = {
+            apiHubConfig: {
+                apiHubKey: 'apiHubKeyTest:abcd1234',
+                apiHubType: ApiHubType.apiHub
+            }
+        }
+        projectDir = join(outputDir, 'testapp-withtoolsid');
+        await generate(projectDir, ui5AppConfig, fs);
+        const envConfig = (fs.read(join(projectDir, '/.env')) as any)
+        expect(envConfig).toContain('API_HUB_API_KEY=apiHubKeyTest:abcd1234')
+        expect(envConfig).toContain('API_HUB_TYPE=API_HUB')
     });
 });

--- a/packages/ui5-application-writer/tsconfig.json
+++ b/packages/ui5-application-writer/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../eslint-plugin-fiori-tools"
     },
     {
+      "path": "../feature-toggle"
+    },
+    {
       "path": "../project-access"
     },
     {

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -4,7 +4,8 @@ import type {
     FioriAppReloadConfig,
     FioriToolsProxyConfig,
     MockserverConfig,
-    FioriToolsProxyConfigUI5
+    FioriToolsProxyConfigUI5,
+    FioriPreviewConfig
 } from './types';
 import type { NodeComment } from '@sap-ux/yaml';
 
@@ -21,6 +22,24 @@ export function getAppReloadMiddlewareConfig(): CustomMiddleware<FioriAppReloadC
             port: 35729,
             path: 'webapp',
             delay: 300
+        }
+    };
+}
+
+/**
+ * Generates the configuration for a Fiori preview middleware.
+ *
+ * @param {string} appId - The ID of the application for which the preview middleware is being configured.
+ * @param {string} ui5Theme - The theme to be used for the application.
+ * @returns {CustomMiddleware<FioriPreviewConfig>} The configuration object for the middleware.
+ */
+export function getPreviewMiddlewareConfig(appId: string, ui5Theme: string): CustomMiddleware<FioriPreviewConfig> {
+    return {
+        name: 'fiori-tools-preview',
+        afterMiddleware: 'fiori-tools-appreload',
+        configuration: {
+            component: appId,
+            ui5Theme: ui5Theme
         }
     };
 }
@@ -54,12 +73,14 @@ export function getBackendComments(
  * @param backends configuration of backends
  * @param ui5 UI5 configuration
  * @param afterMiddleware middleware after which fiori-tools-proxy middleware will be started
+ * @param ignoreCertError
  * @returns {{config, comments}} configuration and comments
  */
 export function getFioriToolsProxyMiddlewareConfig(
     backends?: FioriToolsProxyConfigBackend[],
     ui5?: Partial<FioriToolsProxyConfigUI5>,
-    afterMiddleware = 'compression'
+    afterMiddleware = 'compression',
+    ignoreCertError = false
 ): {
     config: CustomMiddleware<FioriToolsProxyConfig>;
     comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[];
@@ -68,7 +89,7 @@ export function getFioriToolsProxyMiddlewareConfig(
         name: 'fiori-tools-proxy',
         afterMiddleware,
         configuration: {
-            ignoreCertError: false
+            ignoreCertError: ignoreCertError
         }
     };
     let comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] = [

--- a/packages/ui5-config/src/types/index.ts
+++ b/packages/ui5-config/src/types/index.ts
@@ -43,6 +43,11 @@ export interface FioriAppReloadConfig {
     delay: number;
 }
 
+export interface FioriPreviewConfig {
+    component: string;
+    ui5Theme: string;
+}
+
 export interface ServeStaticPath {
     path: string;
     src: string;

--- a/packages/ui5-config/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-config/test/__snapshots__/index.test.ts.snap
@@ -32,6 +32,28 @@ exports[`UI5Config add/find/update/removeCustomMiddleware addCustomMiddleware 1`
 "
 `;
 
+exports[`UI5Config add/find/update/removeCustomMiddleware removeFioriToolsPreviewMiddleware does not do anything when fiori-tools-preview not available 1`] = `
+"server:
+  customMiddleware:
+    - name: custom-middleware
+      afterMiddleware: ~otherMiddleware
+      configuration:
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: http://ui5.example
+        version: 1.95.1
+        debug: true
+"
+`;
+
+exports[`UI5Config add/find/update/removeCustomMiddleware removeFioriToolsPreviewMiddleware if provided in ui5 config 1`] = `
+"server:
+  customMiddleware: []
+"
+`;
+
 exports[`UI5Config add/find/update/removeCustomMiddleware removeMiddleware 1`] = `
 "server:
   customMiddleware: []

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -297,6 +297,38 @@ describe('UI5Config', () => {
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
+        test('removeFioriToolsPreviewMiddleware if provided in ui5 config', () => {
+            const customPreviewMiddleware = {
+                name: 'fiori-tools-preview',
+                afterMiddleware: 'fiori-tools-appreload',
+                configuration: {
+                    component: 'felropv2tsodatanone',
+                    ui5Theme: 'sap_horizon'
+                }
+            };
+            ui5Config.addCustomMiddleware([customPreviewMiddleware]);
+            ui5Config.removeFioriToolsPreviewMiddleware();
+            expect(ui5Config.toString()).toMatchSnapshot();
+        });
+
+        test('removeFioriToolsPreviewMiddleware does not do anything when fiori-tools-preview not available', () => {
+            const customPreviewMiddleware = {
+                name: 'custom-middleware',
+                afterMiddleware: '~otherMiddleware',
+                configuration: {
+                    ui5: {
+                        path: ['/resources', '/test-resources'],
+                        url: 'http://ui5.example'
+                    },
+                    version: '1.95.1',
+                    debug: true
+                } as UI5ProxyConfig
+            };
+            ui5Config.addCustomMiddleware([customPreviewMiddleware]);
+            ui5Config.removeFioriToolsPreviewMiddleware();
+            expect(ui5Config.toString()).toMatchSnapshot();
+        });
+
         test('updateMiddleware existing middleware', () => {
             const middlewareUpdate = {
                 name: 'custom-middleware',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2688,6 +2688,9 @@ importers:
       '@sap-ux/eslint-plugin-fiori-tools':
         specifier: workspace:*
         version: link:../eslint-plugin-fiori-tools
+      '@sap-ux/feature-toggle':
+        specifier: workspace:*
+        version: link:../feature-toggle
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access


### PR DESCRIPTION
- Added `start-variants-management` script to package.json for both FE && FF

- `odata-service-writer`
Extended the `OdataService` interface to include the `ignoreCertError` property.

- `ui5-application-writer`
Added logic to write the `SapUxLayer` property to package.json templates.
Introduced the `fiori-tools-preview` middleware to both ui5 and ui5-local.yaml configurations.
Incorporated `ApiHubConfig` as part of the `ui5.appOptions` interface, and automatically created a .env file if `apiHubConfig` is provided.

- `mockserver-config-writer`
Ensured that adding `fiori-tools-preview` middleware to ui5.yaml will not result in writing it to ui5-mock.yaml, and removed it specifically in ui5-mock-yaml.ts.

- `ui5-config`
Added a function `addFioriToolsPreviewMiddleware` to insert the `fiori-tools-preview` middleware into the yaml configuration.
Added a function `removeFioriToolsPreviewMiddleware` to remove the `fiori-tools-preview` middleware from the yaml configuration.
