### PR TITLE
fix(abap-deploy-config-inquirer): bug found with showing manual package prompt

### DIFF
--- a/.changeset/rich-carrots-pump.md
+++ b/.changeset/rich-carrots-pump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+cleanup validation around autocomplete

--- a/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
@@ -206,13 +206,13 @@ export function defaultOrShowManualPackageQuestion(
     useAutocomplete = false
 ): boolean {
     return (
-        (!isCli || packageInputChoice === PackageInputChoices.EnterManualChoice || !useAutocomplete) &&
+        ((!isCli && !useAutocomplete) || packageInputChoice === PackageInputChoices.EnterManualChoice) &&
         defaultOrShowPackageQuestion()
     );
 }
 
 /**
- * Determines if the search (autcomplete) package input prompt can be shown based on backend availability.
+ * Determines if the search (autocomplete) package input prompt can be shown based on backend availability.
  *
  * @param isCli - is in CLI
  * @param packageInputChoice - package input choice from previous answers

--- a/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
@@ -195,44 +195,30 @@ export function showPackageInputChoiceQuestion(useAutocomplete = false): boolean
 /**
  * Determines if the manual package input prompt should be shown.
  *
- * @param isCli - is in CLI
  * @param packageInputChoice - package input choice from previous answers
  * @param useAutocomplete - useAutocomplete option from prompt options
  * @returns boolean
  */
-export function defaultOrShowManualPackageQuestion(
-    isCli: boolean,
-    packageInputChoice?: string,
-    useAutocomplete = false
-): boolean {
-    return (
-        (!useAutocomplete || packageInputChoice === PackageInputChoices.EnterManualChoice) &&
-        defaultOrShowPackageQuestion()
-    );
+export function defaultOrShowManualPackageQuestion(packageInputChoice?: string, useAutocomplete = false): boolean {
+    if (!useAutocomplete) {
+        return false;
+    }
+    return packageInputChoice === PackageInputChoices.EnterManualChoice && defaultOrShowPackageQuestion();
 }
 
 /**
  * Determines if the search (autocomplete) package input prompt can be shown based on backend availability.
  *
- * @param isCli - is in CLI
  * @param packageInputChoice - package input choice from previous answers
  * @param useAutocomplete - useAutocomplete option from prompt options
  * @returns boolean
  */
-export function defaultOrShowSearchPackageQuestion(
-    isCli: boolean,
-    packageInputChoice?: string,
-    useAutocomplete = false
-): boolean {
+export function defaultOrShowSearchPackageQuestion(packageInputChoice?: string, useAutocomplete = false): boolean {
     // Only show the autocomplete prompt when the autocomplete prompt is supported; CLI or YUI specific version
     if (!useAutocomplete) {
         return false;
     }
-    return (
-        (isCli || useAutocomplete) &&
-        packageInputChoice === PackageInputChoices.ListExistingChoice &&
-        defaultOrShowPackageQuestion()
-    );
+    return packageInputChoice === PackageInputChoices.ListExistingChoice && defaultOrShowPackageQuestion();
 }
 
 /**

--- a/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
@@ -206,7 +206,7 @@ export function defaultOrShowManualPackageQuestion(
     useAutocomplete = false
 ): boolean {
     return (
-        ((!isCli && !useAutocomplete) || packageInputChoice === PackageInputChoices.EnterManualChoice) &&
+        (!useAutocomplete || packageInputChoice === PackageInputChoices.EnterManualChoice) &&
         defaultOrShowPackageQuestion()
     );
 }
@@ -225,6 +225,9 @@ export function defaultOrShowSearchPackageQuestion(
     useAutocomplete = false
 ): boolean {
     // Only show the autocomplete prompt when the autocomplete prompt is supported; CLI or YUI specific version
+    if (!useAutocomplete) {
+        return false;
+    }
     return (
         (isCli || useAutocomplete) &&
         packageInputChoice === PackageInputChoices.ListExistingChoice &&

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/config/package.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/config/package.ts
@@ -74,7 +74,7 @@ export function getPackagePrompts(options: AbapDeployConfigPromptOptions): Quest
         } as InputQuestion<AbapDeployConfigAnswersInternal>,
         {
             when: (previousAnswers: AbapDeployConfigAnswersInternal): boolean =>
-                defaultOrShowManualPackageQuestion(isCli, previousAnswers.packageInputChoice, options.useAutocomplete),
+                defaultOrShowManualPackageQuestion(previousAnswers.packageInputChoice, options.useAutocomplete),
             type: 'input',
             name: abapDeployConfigInternalPromptNames.packageManual,
             message: t('prompts.config.package.packageManual.message'),
@@ -91,7 +91,7 @@ export function getPackagePrompts(options: AbapDeployConfigPromptOptions): Quest
         {
             when: (previousAnswers: AbapDeployConfigAnswersInternal): boolean =>
                 packageInputChoiceValid === true &&
-                defaultOrShowSearchPackageQuestion(isCli, previousAnswers.packageInputChoice, options.useAutocomplete),
+                defaultOrShowSearchPackageQuestion(previousAnswers.packageInputChoice, options.useAutocomplete),
             type: 'autocomplete',
             name: abapDeployConfigInternalPromptNames.packageAutocomplete,
             message: `${t('prompts.config.package.packageAutocomplete.message')}${

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -130,14 +130,12 @@ export function validateUrl(input: string): boolean | string {
     const result = isValidUrl(input?.trim());
     if (result) {
         const backendSystem = findBackendSystemByUrl(input);
-        if (backendSystem) {
-            updatePromptState({
-                url: backendSystem.url,
-                client: backendSystem.client,
-                scp: !!backendSystem.serviceKeys,
-                isS4HC: backendSystem.authenticationType === AuthenticationType.ReentranceTicket
-            });
-        }
+        updatePromptState({
+            url: input.trim(),
+            client: backendSystem?.client,
+            scp: !!backendSystem?.serviceKeys,
+            isS4HC: backendSystem?.authenticationType === AuthenticationType.ReentranceTicket
+        });
     } else {
         return t('errors.invalidUrl', { url: input?.trim() });
     }
@@ -374,7 +372,6 @@ export async function validatePackage(
         client: PromptState.abapDeployConfig.client,
         destination: PromptState.abapDeployConfig.destination
     };
-
     // checks if package is a local package and will update prompt state accordingly
     await getTransportListFromService(input.toUpperCase(), answers.ui5AbapRepo ?? '', systemConfig, backendTarget);
     return true;

--- a/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
@@ -145,19 +145,19 @@ describe('Test abap deploy config inquirer conditions', () => {
     });
 
     test('should show manual package question', () => {
-        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(false);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(true); // Handles autoComplete
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.EnterManualChoice)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.EnterManualChoice, false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.ListExistingChoice, true)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.ListExistingChoice)).toBe(false);
     });
 
     test('should show search package autocomplete question', () => {
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice)).toBe(false);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(false);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.EnterManualChoice, true)).toBe(false);
     });
 
     test('should show transport input choice question', () => {
@@ -232,40 +232,17 @@ describe('Test abap deploy config inquirer conditions', () => {
         ).toBe(true);
     });
 
-    // Typical flow
-    test('Validate typical flow from YUI as subgenerator with autocomplete enabled', () => {
-        PromptState.isYUI = true;
-        // YUI - Autocomplete List
-        expect(showPackageInputChoiceQuestion(true)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(false);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(true);
-        // YUI - Manual
-        expect(showPackageInputChoiceQuestion(true)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(false);
-    });
-
-    test('Validate typical flow from CLI as subgenerator with autocomplete enabled', () => {
-        PromptState.isYUI = false;
-        // YUI - Autocomplete List
-        expect(showPackageInputChoiceQuestion(true)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(false);
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(true);
-        // YUI - Manual
-        expect(showPackageInputChoiceQuestion(true)).toBe(true);
-        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(false);
-    });
-
-    test('Validate typical flow with autocomplete disabled on YUI and CLI', () => {
-        // Only manual package should be shown if autocomplete is disabled, even if ListExistingChoice is selected
+    test('Validate different state changes i.e. YUI | CLI', () => {
         PromptState.isYUI = false;
         expect(showPackageInputChoiceQuestion(false)).toBe(false);
-        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.ListExistingChoice, false)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.ListExistingChoice, false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice, false)).toBe(false);
         PromptState.isYUI = true;
         expect(showPackageInputChoiceQuestion(false)).toBe(false);
-        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, false)).toBe(true);
-        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.ListExistingChoice, false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(PackageInputChoices.ListExistingChoice, true)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(PackageInputChoices.ListExistingChoice, false)).toBe(false);
     });
 });

--- a/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
@@ -129,6 +129,10 @@ describe('Test abap deploy config inquirer conditions', () => {
         // cli
         PromptState.isYUI = false;
         expect(showPackageInputChoiceQuestion(true)).toBe(true);
+        expect(showPackageInputChoiceQuestion()).toBe(false);
+        // YUI
+        PromptState.isYUI = true;
+        expect(showPackageInputChoiceQuestion(true)).toBe(true);
     });
 
     test('should not show package input choice question', () => {
@@ -142,10 +146,18 @@ describe('Test abap deploy config inquirer conditions', () => {
 
     test('should show manual package question', () => {
         expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(true); // Handles autoComplete
     });
 
-    test('should show search package question', () => {
+    test('should show search package autocomplete question', () => {
         expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(false);
     });
 
     test('should show transport input choice question', () => {
@@ -218,5 +230,30 @@ describe('Test abap deploy config inquirer conditions', () => {
                 existingDeployTaskConfig: {}
             })
         ).toBe(true);
+    });
+
+    // Typical flow
+    test('Validate typical flow from YUI as subgenerator', () => {
+        PromptState.isYUI = true;
+        // YUI - Autocomplete List
+        expect(showPackageInputChoiceQuestion(true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        // YUI - Manual
+        expect(showPackageInputChoiceQuestion(true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(false);
+    });
+
+    test('Validate typical flow from CLI as subgenerator', () => {
+        PromptState.isYUI = false;
+        // YUI - Autocomplete List
+        expect(showPackageInputChoiceQuestion(true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(false);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(true);
+        // YUI - Manual
+        expect(showPackageInputChoiceQuestion(true)).toBe(true);
+        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(false);
     });
 });

--- a/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/conditions.test.ts
@@ -153,7 +153,7 @@ describe('Test abap deploy config inquirer conditions', () => {
     });
 
     test('should show search package autocomplete question', () => {
-        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice)).toBe(false);
         expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice)).toBe(false);
         expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, true)).toBe(true);
         expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, true)).toBe(true);
@@ -233,7 +233,7 @@ describe('Test abap deploy config inquirer conditions', () => {
     });
 
     // Typical flow
-    test('Validate typical flow from YUI as subgenerator', () => {
+    test('Validate typical flow from YUI as subgenerator with autocomplete enabled', () => {
         PromptState.isYUI = true;
         // YUI - Autocomplete List
         expect(showPackageInputChoiceQuestion(true)).toBe(true);
@@ -245,7 +245,7 @@ describe('Test abap deploy config inquirer conditions', () => {
         expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.EnterManualChoice, true)).toBe(false);
     });
 
-    test('Validate typical flow from CLI as subgenerator', () => {
+    test('Validate typical flow from CLI as subgenerator with autocomplete enabled', () => {
         PromptState.isYUI = false;
         // YUI - Autocomplete List
         expect(showPackageInputChoiceQuestion(true)).toBe(true);
@@ -255,5 +255,17 @@ describe('Test abap deploy config inquirer conditions', () => {
         expect(showPackageInputChoiceQuestion(true)).toBe(true);
         expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(true);
         expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.EnterManualChoice, true)).toBe(false);
+    });
+
+    test('Validate typical flow with autocomplete disabled on YUI and CLI', () => {
+        // Only manual package should be shown if autocomplete is disabled, even if ListExistingChoice is selected
+        PromptState.isYUI = false;
+        expect(showPackageInputChoiceQuestion(false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(true, PackageInputChoices.ListExistingChoice, false)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(true, PackageInputChoices.ListExistingChoice, false)).toBe(false);
+        PromptState.isYUI = true;
+        expect(showPackageInputChoiceQuestion(false)).toBe(false);
+        expect(defaultOrShowManualPackageQuestion(false, PackageInputChoices.ListExistingChoice, false)).toBe(true);
+        expect(defaultOrShowSearchPackageQuestion(false, PackageInputChoices.ListExistingChoice, false)).toBe(false);
     });
 });

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -90,7 +90,7 @@ describe('Test validators', () => {
     });
 
     describe('validateUrl', () => {
-        it('should return true for valid URL', () => {
+        it('should return true for valid URL found in backend', () => {
             jest.spyOn(utils, 'findBackendSystemByUrl').mockReturnValue({
                 name: 'Target1',
                 url: 'https://mock.url.target1.com',
@@ -100,9 +100,28 @@ describe('Test validators', () => {
             });
             let result = validateUrl('https://mock.url.target1.com');
             expect(result).toBe(true);
+            expect(PromptState.abapDeployConfig).toStrictEqual({
+                url: 'https://mock.url.target1.com',
+                client: '001',
+                destination: undefined,
+                isS4HC: true,
+                scp: true,
+                targetSystem: undefined
+            });
+        });
 
-            result = validateUrl('https://mock.url.target1.com');
+        it('should return true for valid URL not found in backend', () => {
+            jest.spyOn(utils, 'findBackendSystemByUrl').mockReturnValue(undefined);
+            const result = validateUrl('https://mock.notfound.url.target1.com');
             expect(result).toBe(true);
+            expect(PromptState.abapDeployConfig).toStrictEqual({
+                url: 'https://mock.notfound.url.target1.com',
+                client: undefined,
+                destination: undefined,
+                isS4HC: false,
+                scp: false,
+                targetSystem: undefined
+            });
         });
 
         it('should return false empty URL', () => {


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2128

Two issues found
1. bug found with manual package being shown if package choice is a list
- tests updated to confirm flow

2. Issue with abap state not being updated with the target URL so transport request is returning incorrect error as `createAbapServiceProvider` was throwing the exception `'Unable to handle the configuration in the current environment.'` since the URL was empty.
- tests to cover state change

