### PR TITLE
fix(cpe): quick action titles

### DIFF
--- a/.changeset/four-roses-pull.md
+++ b/.changeset/four-roses-pull.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: quick action titles

--- a/packages/preview-middleware-client/src/adp/quick-actions/load.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/load.ts
@@ -8,6 +8,9 @@ import type { ApplicationType } from '../../utils/application';
  * @returns Quick Action registries.
  */
 export async function loadDefinitions(appType: ApplicationType): Promise<QuickActionDefinitionRegistry<string>[]> {
+    if (localStorage.getItem('com.sap.ux.control-property-editor.features.quick-actions') !== 'true') {
+        return [];
+    }
     if (appType === 'fe-v2') {
         const FEV2QuickActionRegistry = (await import('open/ux/preview/client/adp/quick-actions/fe-v2/registry'))
             .default;

--- a/packages/preview-middleware-client/src/adp/quick-actions/load.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/load.ts
@@ -8,6 +8,7 @@ import type { ApplicationType } from '../../utils/application';
  * @returns Quick Action registries.
  */
 export async function loadDefinitions(appType: ApplicationType): Promise<QuickActionDefinitionRegistry<string>[]> {
+    // eslint-disable-next-line fiori-custom/sap-no-localstorage
     if (localStorage.getItem('com.sap.ux.control-property-editor.features.quick-actions') !== 'true') {
         return [];
     }

--- a/packages/preview-middleware-client/src/messagebundle.properties
+++ b/packages/preview-middleware-client/src/messagebundle.properties
@@ -1,17 +1,17 @@
-QUICK_ACTION_ADD_PAGE_CONTROLLER=Add controller to page
-QUICK_ACTION_SHOW_PAGE_CONTROLLER=Show page controller
+QUICK_ACTION_ADD_PAGE_CONTROLLER=Add Controller to Page
+QUICK_ACTION_SHOW_PAGE_CONTROLLER=Show Page Controller
 QUICK_ACTION_OP_ADD_HEADER_FIELD=Add Header Field
 
-V2_QUICK_ACTION_CHANGE_TABLE_COLUMNS=Change table columns
+V2_QUICK_ACTION_CHANGE_TABLE_COLUMNS=Change Table Columns
 
-V2_QUICK_ACTION_LR_ENABLE_CLEAR_FILTER_BAR=Enable clear filterbar button
-V2_QUICK_ACTION_LR_DISABLE_CLEAR_FILTER_BAR=Disable clear filterbar button
+V2_QUICK_ACTION_LR_ENABLE_CLEAR_FILTER_BAR=Enable "Clear" Button in Filter Bar
+V2_QUICK_ACTION_LR_DISABLE_CLEAR_FILTER_BAR=Disable "Clear" Button in Filter Bar
 
 
-V4_QUICK_ACTION_CHANGE_TABLE_COLUMNS=Change table columns
+V4_QUICK_ACTION_CHANGE_TABLE_COLUMNS=Change Table Columns
 
-V4_QUICK_ACTION_LR_ENABLE_CLEAR_FILTER_BAR=Enable clear filterbar button
-V4_QUICK_ACTION_LR_DISABLE_CLEAR_FILTER_BAR=Disable clear filterbar button
+V4_QUICK_ACTION_LR_ENABLE_CLEAR_FILTER_BAR=Enable "Clear" Button in Filter Bar
+V4_QUICK_ACTION_LR_DISABLE_CLEAR_FILTER_BAR=Disable "Clear" Button in Filter Bar
 
 ADP_SYNC_VIEWS_MESSAGE = Have in mind that synchronous views are detected for this application and controller extensions are not supported for such views. Controller extension functionality on these views will be disabled.
 ADP_REUSE_COMPONENTS_MESSAGE = Have in mind that reuse components are detected for some views in this application and controller extensions and adding fragments are not supported for such views. Controller extension and adding fragment functionality on these views will be disabled.

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -116,7 +116,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'simple',
                                     id: 'listReport0-enable-clear-filter-bar',
-                                    title: 'Enable clear filterbar button',
+                                    title: 'Enable "Clear" Button in Filter Bar',
                                     enabled: true
                                 }
                             ]
@@ -237,7 +237,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'simple',
                                     id: 'listReport0-add-controller-to-page',
-                                    title: 'Add controller to page',
+                                    title: 'Add Controller to Page',
                                     enabled: true
                                 }
                             ]
@@ -348,7 +348,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'nested',
                                     id: 'listReport0-change-table-columns',
-                                    title: 'Change table columns',
+                                    title: 'Change Table Columns',
                                     enabled: true,
                                     children: [
                                         {
@@ -475,7 +475,7 @@ describe('FE V2 quick actions', () => {
                                     kind: 'simple',
                                     id: 'objectPage0-add-controller-to-page',
                                     enabled: true,
-                                    title: 'Add controller to page'
+                                    title: 'Add Controller to Page'
                                 },
                                 {
                                     kind: 'simple',

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -120,7 +120,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'simple',
                                     id: 'listReport0-enable-clear-filter-bar',
-                                    title: 'Enable clear filterbar button',
+                                    title: 'Enable "Clear" Button in Filter Bar',
                                     enabled: true
                                 }
                             ]
@@ -250,7 +250,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'simple',
                                     id: 'listReport0-add-controller-to-page',
-                                    title: 'Add controller to page',
+                                    title: 'Add Controller to Page',
                                     enabled: true
                                 }
                             ]
@@ -361,7 +361,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'kind': 'nested',
                                     id: 'listReport0-change-table-columns',
-                                    title: 'Change table columns',
+                                    title: 'Change Table Columns',
                                     enabled: true,
                                     children: [
                                         {
@@ -487,7 +487,7 @@ describe('FE V2 quick actions', () => {
                                         kind: 'simple',
                                         id: 'objectPage0-add-controller-to-page',
                                         enabled: true,
-                                        title: 'Add controller to page'
+                                        title: 'Add Controller to Page'
                                     },
                                     {
                                         kind: 'simple',

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/load.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/load.test.ts
@@ -3,6 +3,14 @@ import FEV4QuickActionRegistry from 'open/ux/preview/client/adp/quick-actions/fe
 import FEV2QuickActionRegistry from 'open/ux/preview/client/adp/quick-actions/fe-v2/registry';
 
 describe('quick action dyncmic loading', () => {
+    beforeEach(() => {
+        jest.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation((key) => {
+            if (key === 'com.sap.ux.control-property-editor.features.quick-actions') {
+                return 'true';
+            }
+            return null;
+        });
+    });
     test('fe-v2', async () => {
         const definitions = await loadDefinitions('fe-v2');
         expect(definitions[0]).toBeInstanceOf(FEV2QuickActionRegistry);


### PR DESCRIPTION
Use correct case in quick action titles.

Also added feature toggle to enable quick actions. By default they will be disabled.