### PR TITLE
Add ignore cert error to odata-service-writer 

### DIFF
--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -94,7 +94,7 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
             ui5Config.addBackendToFioriToolsProxydMiddleware(service.previewSettings as ProxyBackend);
         } catch (error: any) {
             if (error instanceof YAMLError && error.code === yamlErrorCode.nodeNotFound) {
-                ui5Config.addFioriToolsProxydMiddleware({ 
+                ui5Config.addFioriToolsProxydMiddleware({
                     backend: [service.previewSettings as ProxyBackend],
                     ignoreCertError: service.ignoreCertError
                 });

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -94,7 +94,10 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
             ui5Config.addBackendToFioriToolsProxydMiddleware(service.previewSettings as ProxyBackend);
         } catch (error: any) {
             if (error instanceof YAMLError && error.code === yamlErrorCode.nodeNotFound) {
-                ui5Config.addFioriToolsProxydMiddleware({ backend: [service.previewSettings as ProxyBackend] });
+                ui5Config.addFioriToolsProxydMiddleware({ 
+                    backend: [service.previewSettings as ProxyBackend],
+                    ignoreCertError: service.ignoreCertError
+                });
             } else {
                 throw error;
             }
@@ -106,7 +109,10 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
         ui5LocalConfigPath = join(dirname(paths.ui5Yaml), 'ui5-local.yaml');
         if (fs.exists(ui5LocalConfigPath)) {
             ui5LocalConfig = await UI5Config.newInstance(fs.read(ui5LocalConfigPath));
-            ui5LocalConfig.addFioriToolsProxydMiddleware({ backend: [service.previewSettings as ProxyBackend] });
+            ui5LocalConfig.addFioriToolsProxydMiddleware({
+                backend: [service.previewSettings as ProxyBackend],
+                ignoreCertError: service.ignoreCertError
+            });
         }
     }
 

--- a/packages/odata-service-writer/src/types.ts
+++ b/packages/odata-service-writer/src/types.ts
@@ -74,5 +74,8 @@ export interface OdataService {
     annotations?: EdmxAnnotationsInfo | CdsAnnotationsInfo;
     localAnnotationsName?: string; // The name used in the manifest.json and as the filename for local annotations
     previewSettings?: Partial<ProxyBackend>;
+    /**
+     * Indicates whether certificate errors should be ignored.
+     */
     ignoreCertError?: boolean;
 }

--- a/packages/odata-service-writer/src/types.ts
+++ b/packages/odata-service-writer/src/types.ts
@@ -74,4 +74,5 @@ export interface OdataService {
     annotations?: EdmxAnnotationsInfo | CdsAnnotationsInfo;
     localAnnotationsName?: string; // The name used in the manifest.json and as the filename for local annotations
     previewSettings?: Partial<ProxyBackend>;
+    ignoreCertError?: boolean;
 }

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -54,12 +54,14 @@ export function getBackendComments(
  * @param backends configuration of backends
  * @param ui5 UI5 configuration
  * @param afterMiddleware middleware after which fiori-tools-proxy middleware will be started
+ * @param ignoreCertError ignore certificate errors
  * @returns {{config, comments}} configuration and comments
  */
 export function getFioriToolsProxyMiddlewareConfig(
     backends?: FioriToolsProxyConfigBackend[],
     ui5?: Partial<FioriToolsProxyConfigUI5>,
-    afterMiddleware = 'compression'
+    afterMiddleware = 'compression', 
+    ignoreCertError: boolean = false
 ): {
     config: CustomMiddleware<FioriToolsProxyConfig>;
     comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[];
@@ -68,7 +70,7 @@ export function getFioriToolsProxyMiddlewareConfig(
         name: 'fiori-tools-proxy',
         afterMiddleware,
         configuration: {
-            ignoreCertError: false
+            ignoreCertError: ignoreCertError
         }
     };
     let comments: NodeComment<CustomMiddleware<FioriToolsProxyConfig>>[] = [

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -60,7 +60,7 @@ export function getBackendComments(
 export function getFioriToolsProxyMiddlewareConfig(
     backends?: FioriToolsProxyConfigBackend[],
     ui5?: Partial<FioriToolsProxyConfigUI5>,
-    afterMiddleware = 'compression', 
+    afterMiddleware = 'compression',
     ignoreCertError: boolean = false
 ): {
     config: CustomMiddleware<FioriToolsProxyConfig>;

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -238,7 +238,8 @@ export class UI5Config {
         const { config, comments } = getFioriToolsProxyMiddlewareConfig(
             proxyConfig.backend,
             proxyConfig.ui5,
-            afterMiddleware
+            afterMiddleware,
+            proxyConfig.ignoreCertError
         );
         this.document.appendTo({
             path: 'server.customMiddleware',

--- a/packages/ui5-config/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-config/test/__snapshots__/index.test.ts.snap
@@ -211,13 +211,13 @@ exports[`UI5Config addFioriToolsProxydMiddleware add / get commonly configured b
 "
 `;
 
-exports[`UI5Config addFioriToolsProxydMiddleware add backend with flexible parameters (and UI5 defaults) 1`] = `
+exports[`UI5Config addFioriToolsProxydMiddleware add backend with flexible parameters (and UI5 defaults) & writes ignoreCertError true if enabled 1`] = `
 "server:
   customMiddleware:
     - name: fiori-tools-proxy
       afterMiddleware: compression
       configuration:
-        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ignoreCertError: true # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
         backend:
           - url: http://localhost:8080
             path: /~testpath~

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -194,7 +194,7 @@ describe('UI5Config', () => {
         test('add backend with flexible parameters (and UI5 defaults) & writes ignoreCertError true if enabled', () => {
             ui5Config.addFioriToolsProxydMiddleware({
                 backend: [{ url, path, pathPrefix: '/~prefix', scp: true }],
-                ignoreCertError: true, 
+                ignoreCertError: true,
                 ui5: {}
             });
             expect(ui5Config.toString()).toMatchSnapshot();

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -191,9 +191,10 @@ describe('UI5Config', () => {
             expect(backendConfigs).toEqual(backend);
         });
 
-        test('add backend with flexible parameters (and UI5 defaults)', () => {
+        test('add backend with flexible parameters (and UI5 defaults) & writes ignoreCertError true if enabled', () => {
             ui5Config.addFioriToolsProxydMiddleware({
                 backend: [{ url, path, pathPrefix: '/~prefix', scp: true }],
+                ignoreCertError: true, 
                 ui5: {}
             });
             expect(ui5Config.toString()).toMatchSnapshot();


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2326

- `odata-service-writer`
Extended the `OdataService` interface to include the `ignoreCertError` property.
- `ui5-config`
Added logic to include `ignoreCertError` value in yaml file if provided.