### PR TITLE
fix(abap-deploy-config-inquirer ): remove manadatory field, cleanup translation text

### DIFF
--- a/.changeset/rotten-hotels-fry.md
+++ b/.changeset/rotten-hotels-fry.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+cleanup prompts and translation text

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/abap-target.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/abap-target.ts
@@ -233,7 +233,6 @@ function getClientPrompt(backendTarget?: BackendTarget): Question<AbapDeployConf
         name: abapDeployConfigInternalPromptNames.client,
         message: t('prompts.target.client.message'),
         guiOptions: {
-            mandatory: true,
             breadcrumb: t('prompts.target.client.breadcrumb')
         },
         default: (): string | undefined => backendTarget?.abapTarget?.client,

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -523,7 +523,7 @@ export async function validateTransportChoiceInput(
  */
 export function validateTransportQuestion(input?: string): boolean | string {
     if (PromptState.transportAnswers.transportRequired && !input?.trim()) {
-        return t('prompts.config.transport.provideTransportRequest');
+        return t('prompts.config.transport.common.provideTransportRequest');
     }
     return true;
 }

--- a/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
+++ b/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
@@ -106,7 +106,7 @@
         "packageNotFound": "Package list cannot be fetched. Please enter the Package manually.",
         "providePackage": "Provide a package",
         "transportConfigFailure": "Cannot get transport configuration from the backend. You can still proceed with deployment configuration by manually providing the package and transport request needed. \nFor more information on this error, please see Guided Answers {{helpLink}}",
-        "noTransportReqs": "There are no Transport Requests for the supplied package. You can choose to create a new one now or during deployment",
+        "noTransportReqs": "There are no Transport Requests for the supplied package. You can choose to create a new one now or during deployment.",
         "noExistingTransportReqList": "Transport Request list cannot be fetched. Please enter Transport Request manually.",
         "virtualHost": "The destination is using a virtual host, you will need to replace the host in the URL with the internal host that is configured with your SAP Cloud Connector when viewing your deployed application."
     },

--- a/packages/abap-deploy-config-inquirer/test/prompts/questions/abap-target.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/questions/abap-target.test.ts
@@ -115,7 +115,6 @@ describe('getAbapTargetPrompts', () => {
                 "filter": [Function],
                 "guiOptions": Object {
                   "breadcrumb": "Client",
-                  "mandatory": true,
                 },
                 "message": "Enter client",
                 "name": "client",

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -436,7 +436,7 @@ describe('Test validators', () => {
         it('should return true for valid transport', async () => {
             PromptState.transportAnswers.transportRequired = true;
             const result = validateTransportQuestion('');
-            expect(result).toBe(t('prompts.config.transport.provideTransportRequest'));
+            expect(result).toBe(t('prompts.config.transport.common.provideTransportRequest'));
         });
 
         it('should return true when transport is not required', async () => {


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2128

Two issues found
- mandatory field not required
- translation misconfigured