### PR TITLE
Fix/2346/odata service inquirer client prompt issues

### DIFF
--- a/.changeset/proud-months-punch.md
+++ b/.changeset/proud-months-punch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fixes for client issues when running in YUI

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -142,6 +142,15 @@ export class ConnectionValidator {
     }
 
     /**
+     * Get the validated client code. This is the client code that has been successfully validated by a request.
+     *
+     * @returns the validated client code
+     */
+    public get validatedClient(): string | undefined {
+        return this._validatedClient;
+    }
+
+    /**
      * Get the service info used to connect to the system.
      *
      * @returns the service info
@@ -329,7 +338,7 @@ export class ConnectionValidator {
         this._connectedUserName = undefined;
         this._refreshToken = undefined;
         this._connectedSystemName = undefined;
-        this.resetValidity();
+        // this.resetValidity();
     }
 
     /**

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -338,7 +338,6 @@ export class ConnectionValidator {
         this._connectedUserName = undefined;
         this._refreshToken = undefined;
         this._connectedSystemName = undefined;
-        // this.resetValidity();
     }
 
     /**

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -442,8 +442,7 @@ describe('ConnectionValidator', () => {
         );
         expect(connectValidator.validity).toEqual({
             authenticated: true,
-            reachable: true,
-            urlFormat: false // URL property format is not validated in service info
+            reachable: true
         });
         expect(connectValidator.connectedUserName).toBe('user1@acme.com');
         expect(connectValidator.serviceInfo).toEqual(serviceInfoMock);


### PR DESCRIPTION
Fix for #2346 

Various client prompt related issues

-  Re-request services if client changes
-  Adds client to system name prompt default value
-  Maintain validated client in ConnectionValidator 
-  Dont reset validity when creating system (we need this state)