### PR TITLE
tbi(cap-config-writer): Move type only dependency -> dev dependency

### DIFF
--- a/.changeset/twelve-lemons-joke.md
+++ b/.changeset/twelve-lemons-joke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cap-config-writer': patch
+---
+
+Moves type only dep as dev dep to odata-service-inquier

--- a/.changeset/twelve-lemons-joke.md
+++ b/.changeset/twelve-lemons-joke.md
@@ -2,4 +2,4 @@
 '@sap-ux/cap-config-writer': patch
 ---
 
-Moves type only dep as dev dep to odata-service-inquier
+Moves type only dep as dev dep to odata-service-inquirer

--- a/packages/cap-config-writer/package.json
+++ b/packages/cap-config-writer/package.json
@@ -30,7 +30,6 @@
     "dependencies": {
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
-        "@sap-ux/odata-service-inquirer": "workspace:*",
         "@sap-ux/yaml": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "i18next": "20.6.1",
@@ -40,6 +39,7 @@
         "xml-js": "1.6.11"
     },
     "devDependencies": {
+        "@sap-ux/odata-service-inquirer": "workspace:*",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/semver": "7.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,9 +733,6 @@ importers:
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
-      '@sap-ux/odata-service-inquirer':
-        specifier: workspace:*
-        version: link:../odata-service-inquirer
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access
@@ -758,6 +755,9 @@ importers:
         specifier: 1.6.11
         version: 1.6.11
     devDependencies:
+      '@sap-ux/odata-service-inquirer':
+        specifier: workspace:*
+        version: link:../odata-service-inquirer
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2365

Moves dep only types are consumed