### PR TITLE
fix(service-inq): determine sap client from cookies - sap-usercontext=sap-client

### DIFF
--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -259,7 +259,11 @@ export class ConnectionValidator {
                 // Full service URL
                 await this.createOdataServiceConnection(axiosConfig, url.pathname);
             }
-            this._validatedClient = url.searchParams.get(SAP_CLIENT_KEY) ?? undefined;
+            this._validatedClient =
+                url.searchParams.get(SAP_CLIENT_KEY) ??
+                this.getSapClient(this._serviceProvider?.cookies?.toString()) ??
+                undefined;
+
             return 200;
         } catch (e) {
             LoggerHelper.logger.debug(`ConnectionValidator.checkSapService() - error: ${e.message}`);
@@ -453,6 +457,16 @@ export class ConnectionValidator {
     }
 
     /**
+     * Checks the cookies for the sap-client value.
+     *
+     * @param cookies - cookies as a string
+     * @returns sap-client value if found in the cookies
+     */
+    private getSapClient(cookies?: string): string | undefined {
+        return cookies?.match(/sap-client=(\w+)/)?.[1];
+    }
+
+    /**
      * Validate the system connectivity with the specified service info (containing UAA details).
      *
      * @param serviceInfo the service info containing the UAA details
@@ -470,6 +484,7 @@ export class ConnectionValidator {
             this._connectedUserName = await (this.serviceProvider as AbapServiceProvider).user();
             this._serviceInfo = serviceInfo;
             this._validatedUrl = serviceInfo.url;
+            this._validatedClient = this.getSapClient(this._serviceProvider?.cookies?.toString());
             return this.getValidationResultFromStatusCode(200);
         } catch (error) {
             LoggerHelper.logger.debug(`ConnectionValidator.validateServiceInfo() - error: ${error.message}`);

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -28,6 +28,7 @@ jest.mock('@sap-ux/axios-extension', () => ({
     createForAbapOnCloud: jest.fn().mockImplementation(() => ({
         interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
         catalog: catalogServiceMock,
+        cookies: 'sap-usercontext=sap-client=100;',
         user: jest.fn().mockReturnValue('user1@acme.com')
     }))
 }));
@@ -448,6 +449,7 @@ describe('ConnectionValidator', () => {
         expect(connectValidator.serviceInfo).toEqual(serviceInfoMock);
         expect(connectValidator.validatedUrl).toBe(serviceInfoMock.url);
         expect(connectValidator.connectedSystemName).toBe('abap_btp_001');
+        expect(connectValidator.validatedClient).toBe('100');
     });
 
     test('should attempt to validate auth using v4 catalog where v2 is not available or user is not authorized', async () => {


### PR DESCRIPTION
For BTP systems the sap-client can be found in the cookies e.g `sap-usercontext=sap-client=100`