### PR TITLE
fix(abap-delploy-config): verify destination input

### DIFF
--- a/.changeset/neat-poems-boil.md
+++ b/.changeset/neat-poems-boil.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+update destination validator

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -36,7 +36,7 @@ import {
 export function validateDestinationQuestion(destination: string, destinations?: Destinations): boolean {
     PromptState.resetAbapDeployConfig();
     updateDestinationPromptState(destination, destinations);
-    return true;
+    return !!destination?.trim();
 }
 
 /**

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -45,6 +45,13 @@ describe('Test validators', () => {
             expect(PromptState.abapDeployConfig.url).toBe('https://mock.url.dest2.com');
             expect(result).toBe(true);
         });
+
+        it('should return false for invalid destination', async () => {
+            const result = validateDestinationQuestion('', mockDestinations);
+            expect(PromptState.abapDeployConfig.destination).toBe(undefined);
+            expect(PromptState.abapDeployConfig.url).toBe(undefined);
+            expect(result).toBe(false);
+        });
     });
 
     describe('validateTargetSystem', () => {


### PR DESCRIPTION
Verify the destination prompt has input rather than automatically returning true 