### PR TITLE
fix(ui-components): Applied missing styles for the disabled state of UILink.

### DIFF
--- a/.changeset/rude-walls-clap.md
+++ b/.changeset/rude-walls-clap.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Applied missing styles for the disabled state of UILink.

--- a/packages/ui-components/src/components/UILink/UILink.tsx
+++ b/packages/ui-components/src/components/UILink/UILink.tsx
@@ -40,7 +40,7 @@ export class UILink extends React.Component<UILinkProps, {}> {
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
-        const { secondary, underline } = this.props;
+        const { secondary, underline, disabled } = this.props;
         const styles = secondary ? linkStyle.secondary : linkStyle.primary;
         const linkStyles = (): Partial<ILinkStyles> => {
             return {
@@ -48,23 +48,26 @@ export class UILink extends React.Component<UILinkProps, {}> {
                     color: styles.color,
                     fontFamily: 'var(--vscode-font-family)',
                     textDecoration: underline === false ? undefined : 'underline',
-                    selectors: {
-                        '&:hover, &:hover:focus, &:hover:active': {
-                            color: styles.hoverColor,
-                            textDecoration: underline === false ? 'underline' : 'none'
-                        },
-                        '&:active, &:focus': {
-                            color: styles.hoverColor,
-                            textDecoration: underline === false ? 'underline' : 'none',
-                            outline: 'none'
-                        },
-                        // Focus through tab navigation
-                        '.ms-Fabric--isFocusVisible &:focus': {
-                            boxShadow: 'none',
-                            outline: '1px solid var(--vscode-focusBorder)',
-                            outlineOffset: '-1px'
-                        }
-                    }
+                    selectors: !disabled
+                        ? {
+                              '&:hover, &:hover:focus, &:hover:active': {
+                                  color: styles.hoverColor,
+                                  textDecoration: underline === false ? 'underline' : 'none'
+                              },
+                              '&:active, &:focus': {
+                                  color: styles.hoverColor,
+                                  textDecoration: underline === false ? 'underline' : 'none',
+                                  outline: 'none'
+                              },
+                              // Focus through tab navigation
+                              '.ms-Fabric--isFocusVisible &:focus': {
+                                  boxShadow: 'none',
+                                  outline: '1px solid var(--vscode-focusBorder)',
+                                  outlineOffset: '-1px'
+                              }
+                          }
+                        : undefined,
+                    opacity: disabled ? 0.4 : undefined
                 }
             };
         };

--- a/packages/ui-components/stories/UILink.story.tsx
+++ b/packages/ui-components/stories/UILink.story.tsx
@@ -1,21 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { IStackTokens } from '@fluentui/react';
 import { Text, Stack } from '@fluentui/react';
 
 import { UILink } from '../src/components/UILink';
+import { UICheckbox } from '../src/components/UICheckbox';
 
 export default { title: 'Basic Inputs/Link' };
 const stackTokens: IStackTokens = { childrenGap: 40 };
 
 export const defaultUsage = (): JSX.Element => {
+    const [disabled, setDisabled] = useState(false);
     return (
         <Stack tokens={stackTokens}>
+            <Stack tokens={stackTokens}>
+                <Stack horizontal tokens={stackTokens}>
+                    <UICheckbox
+                        label="Disabled"
+                        checked={disabled}
+                        onChange={(ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => {
+                            setDisabled(!!checked);
+                        }}
+                    />
+                </Stack>
+            </Stack>
+
             <Stack tokens={stackTokens}>
                 <Text variant={'large'} className="textColor" block>
                     Primary UILink
                 </Text>
                 <Stack horizontal tokens={stackTokens}>
-                    <UILink href="JavaScript:void(0)">I am a link</UILink>
+                    <UILink href="JavaScript:void(0)" disabled={disabled}>
+                        I am a link
+                    </UILink>
                 </Stack>
             </Stack>
 
@@ -24,7 +40,9 @@ export const defaultUsage = (): JSX.Element => {
                     Primary UILink with no underline
                 </Text>
                 <Stack horizontal tokens={stackTokens}>
-                    <UILink underline={false} href="JavaScript:void(0)">I am a link</UILink>
+                    <UILink underline={false} href="JavaScript:void(0)" disabled={disabled}>
+                        I am a link
+                    </UILink>
                 </Stack>
             </Stack>
 
@@ -33,7 +51,9 @@ export const defaultUsage = (): JSX.Element => {
                     Secondary UILink
                 </Text>
                 <Stack horizontal tokens={stackTokens}>
-                    <UILink secondary href="JavaScript:void(0)">I am a secondary link</UILink>
+                    <UILink secondary href="JavaScript:void(0)" disabled={disabled}>
+                        I am a secondary link
+                    </UILink>
                 </Stack>
             </Stack>
         </Stack>

--- a/packages/ui-components/test/unit/components/UILink.test.tsx
+++ b/packages/ui-components/test/unit/components/UILink.test.tsx
@@ -30,6 +30,7 @@ describe('<UILink />', () => {
             Object {
               "color": "var(--vscode-textLink-foreground)",
               "fontFamily": "var(--vscode-font-family)",
+              "opacity": undefined,
               "selectors": Object {
                 "&:active, &:focus": Object {
                   "color": "var(--vscode-textLink-activeForeground)",
@@ -60,6 +61,7 @@ describe('<UILink />', () => {
             Object {
               "color": "var(--vscode-foreground)",
               "fontFamily": "var(--vscode-font-family)",
+              "opacity": undefined,
               "selectors": Object {
                 "&:active, &:focus": Object {
                   "color": "var(--vscode-foreground)",
@@ -90,6 +92,7 @@ describe('<UILink />', () => {
             Object {
               "color": "var(--vscode-textLink-foreground)",
               "fontFamily": "var(--vscode-font-family)",
+              "opacity": undefined,
               "selectors": Object {
                 "&:active, &:focus": Object {
                   "color": "var(--vscode-textLink-activeForeground)",
@@ -107,6 +110,22 @@ describe('<UILink />', () => {
                 },
               },
               "textDecoration": undefined,
+            }
+        `);
+    });
+
+    it('Styles - disabled', () => {
+        wrapper.setProps({
+            disabled: true
+        });
+        const styles = getStyles();
+        expect(styles.root).toMatchInlineSnapshot(`
+            Object {
+              "color": "var(--vscode-textLink-foreground)",
+              "fontFamily": "var(--vscode-font-family)",
+              "opacity": 0.4,
+              "selectors": undefined,
+              "textDecoration": "underline",
             }
         `);
     });


### PR DESCRIPTION
It was reported that when UIlink is disabled using property `disabled`, then there no any visual difference that link is disabled.
Changes:
1. Apply styles for link when property 'disabled' is 'true';
2. Update storybook with option to disable links in example


![image](https://github.com/user-attachments/assets/11b89175-26ff-4e03-a0bb-debd937d05d3)


![image](https://github.com/user-attachments/assets/d894f802-60c3-44c7-ad6b-836b3d076555)
