### PR TITLE
Fix/2397/ampersand escaping metadata

### DIFF
--- a/.changeset/twelve-lemons-joke.md
+++ b/.changeset/twelve-lemons-joke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cap-config-writer': patch
+---
+
+Moves type only dep as dev dep to odata-service-inquier

--- a/packages/cap-config-writer/package.json
+++ b/packages/cap-config-writer/package.json
@@ -30,7 +30,6 @@
     "dependencies": {
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
-        "@sap-ux/odata-service-inquirer": "workspace:*",
         "@sap-ux/yaml": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "i18next": "20.6.1",
@@ -40,6 +39,7 @@
         "xml-js": "1.6.11"
     },
     "devDependencies": {
+        "@sap-ux/odata-service-inquirer": "workspace:*",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/semver": "7.5.2"

--- a/packages/odata-service-inquirer/src/prompts/datasources/metadata-file/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/metadata-file/validators.ts
@@ -27,8 +27,8 @@ export const validateMetadataFile = async (
     }
 
     try {
-        const metadata = await readFile(path, 'utf-8');
-        metadata.replace(/ & /g, ' &amp; ');
+        let metadata = await readFile(path, 'utf-8');
+        metadata = metadata.replace(/ & /g, ' &amp; ');
         const { validationMsg, version } = validateODataVersion(metadata, odataVersion);
         if (validationMsg) {
             return validationMsg;

--- a/packages/odata-service-inquirer/test/unit/prompts/metadata-file/fixtures/validatorTest.xml
+++ b/packages/odata-service-inquirer/test/unit/prompts/metadata-file/fixtures/validatorTest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0" 
+    xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
+    <edmx:DataServices m:DataServiceVersion="1.0" m:MaxDataServiceVersion="3.0" 
+        xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+        <Schema Namespace="NorthwindModel" 
+            xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+            <EntityType Name="Category">
+                <Key>
+                    <PropertyRef Name="CategoryID" />
+                </Key>
+                <Property Name="CategoryID" Type="Edm.Int32" Nullable="false" p6:StoreGeneratedPattern="Identity" 
+                    xmlns:p6="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+                <Property Name="CategoryName" Type="Edm.String" Nullable="false" MaxLength="15" FixedLength="false" Unicode="true" />
+                <Property Name="Description" Type="Edm.String" MaxLength="Max" FixedLength="false" Unicode="true" />
+                <Property Name="Picture" Type="Edm.Binary" MaxLength="Max" FixedLength="false" />
+                <NavigationProperty Name="Products" Relationship="NorthwindModel.FK_Products_Categories" ToRole="Products" FromRole="Categories" />
+            </EntityType>
+            <Annotation Term="UI.Facets">
+               <Collection>
+                  <Record Type="UI.CollectionFacet">
+                     <PropertyValue Property="Label" String="Terms & Conditions" />
+                  </Record>  
+               </Collection>
+            </Annotation>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/odata-service-inquirer/test/unit/prompts/metadata-file/validators.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/metadata-file/validators.test.ts
@@ -1,0 +1,12 @@
+import path from 'path';
+import { validateMetadataFile } from '../../../../src/prompts/datasources/metadata-file/validators';
+
+describe('metadata valiadtors', () => {
+    test('validateMetadataFile', async () => {
+        const testXmlPath = path.join(__dirname, 'fixtures/validatorTest.xml');
+        expect(await validateMetadataFile(testXmlPath)).toMatchObject({
+            version: '2',
+            metadata: expect.stringContaining('Terms &amp; Conditions') //Ensure that the & is replaced with &amp;
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,9 +733,6 @@ importers:
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
-      '@sap-ux/odata-service-inquirer':
-        specifier: workspace:*
-        version: link:../odata-service-inquirer
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access
@@ -758,6 +755,9 @@ importers:
         specifier: 1.6.11
         version: 1.6.11
     devDependencies:
+      '@sap-ux/odata-service-inquirer':
+        specifier: workspace:*
+        version: link:../odata-service-inquirer
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2397

- Correctly escapes and assigns result
- Adds test to cover
