### PR TITLE
Add skipLiveScripts flag to `DebugConfig` options 

### DIFF
--- a/.changeset/cold-hotels-marry.md
+++ b/.changeset/cold-hotels-marry.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/launch-config': minor
+---
+
+Remove ProjectDataSourceType from DebugConfig and Replace with skipLiveScripts Flag

--- a/packages/launch-config/src/debug-config/config.ts
+++ b/packages/launch-config/src/debug-config/config.ts
@@ -1,7 +1,7 @@
 import { basename } from 'path';
 import { getLaunchConfig } from '../launch-config-crud/utils';
 import type { LaunchConfig, LaunchJSON, DebugOptions, LaunchConfigEnv } from '../types';
-import { FIORI_TOOLS_LAUNCH_CONFIG_HANDLER_ID, ProjectDataSourceType } from '../types';
+import { FIORI_TOOLS_LAUNCH_CONFIG_HANDLER_ID } from '../types';
 
 // debug constants
 const testFlpSandboxHtml = 'test/flpSandbox.html';
@@ -63,7 +63,7 @@ function configureLaunchConfig(
 export function configureLaunchJsonFile(rootFolder: string, cwd: string, configOpts: DebugOptions): LaunchJSON {
     const {
         isAppStudio,
-        datasourceType,
+        skipLiveScript = false,
         flpAppId,
         flpSandboxAvailable,
         sapClientParam,
@@ -86,7 +86,7 @@ export function configureLaunchJsonFile(rootFolder: string, cwd: string, configO
     const launchFile: LaunchJSON = { version: '0.2.0', configurations: [] };
 
     // Add live configuration if the datasource is not from a metadata file
-    if (datasourceType !== ProjectDataSourceType.metadataFile) {
+    if (!skipLiveScript) {
         const startCommand = `${startHtmlFile}${flpAppIdWithHash}`;
         const liveConfig = configureLaunchConfig(
             `Start ${projectName}`,

--- a/packages/launch-config/src/launch-config-crud/create.ts
+++ b/packages/launch-config/src/launch-config-crud/create.ts
@@ -144,8 +144,7 @@ async function handleDebugOptions(
     );
     const configurations = configureLaunchJsonFile(rootFolder, cwd, debugOptions).configurations;
 
-    const skipLiveScript = debugOptions.skipLiveScript ?? false;
-    const npmCommand = skipLiveScript ? 'run start-mock' : 'start';
+    const npmCommand = debugOptions.skipLiveScript ? 'run start-mock' : 'start';
     logger?.info(
         t('startServerMessage', {
             folder: basename(rootFolder),

--- a/packages/launch-config/src/launch-config-crud/create.ts
+++ b/packages/launch-config/src/launch-config-crud/create.ts
@@ -2,7 +2,7 @@ import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
 import { join, basename } from 'path';
 import { DirName } from '@sap-ux/project-access';
-import { LAUNCH_JSON_FILE, ProjectDataSourceType } from '../types';
+import { LAUNCH_JSON_FILE } from '../types';
 import type { FioriOptions, LaunchJSON, UpdateWorkspaceFolderOptions, DebugOptions, LaunchConfig } from '../types';
 import type { Editor } from 'mem-fs-editor';
 import { generateNewFioriLaunchConfig } from './utils';
@@ -144,7 +144,8 @@ async function handleDebugOptions(
     );
     const configurations = configureLaunchJsonFile(rootFolder, cwd, debugOptions).configurations;
 
-    const npmCommand = debugOptions.datasourceType === ProjectDataSourceType.metadataFile ? 'run start-mock' : 'start';
+    const skipLiveScript = debugOptions.skipLiveScript ?? false;
+    const npmCommand = skipLiveScript ? 'run start-mock' : 'start';
     logger?.info(
         t('startServerMessage', {
             folder: basename(rootFolder),
@@ -194,10 +195,6 @@ export async function createLaunchConfig(
         return await handleNoDebugOptions(rootFolder, fioriOptions, fs);
     }
     if (!debugOptions.vscode) {
-        return fs;
-    }
-    if (debugOptions.datasourceType === ProjectDataSourceType.capProject) {
-        logger?.info(t('startApp', { npmStart: '`npm start`', cdsRun: '`cds run --in-memory`' }));
         return fs;
     }
     return await handleDebugOptions(rootFolder, fs, debugOptions, logger);

--- a/packages/launch-config/src/translations/launch-config.i18n.json
+++ b/packages/launch-config/src/translations/launch-config.i18n.json
@@ -1,6 +1,5 @@
 {
     "info": {
-        "startApp": "To start the application, type {{npmStart}} or {{cdsRun}}",
         "startServerMessage": "To start the server, launch a terminal and browse to the {{folder}} folder and type npm {{npmCommand}}"
     },
     "error": {

--- a/packages/launch-config/src/types/types.ts
+++ b/packages/launch-config/src/types/types.ts
@@ -61,21 +61,9 @@ export interface LaunchConfigInfo {
 }
 
 /**
- * Enum representing the types of data sources or origins for a project.
- * These types indicate how a project is generated.
- */
-export enum ProjectDataSourceType {
-    capProject = 'capProject',
-    odataServiceUrl = 'odataServiceUrl',
-    metadataFile = 'metadataFile'
-}
-
-/**
  * Configuration options for debugging launch configurations.
  */
 export interface DebugOptions {
-    /** Type of the data source used in the project. */
-    datasourceType: ProjectDataSourceType;
     /** SAP client parameter for the connection. */
     sapClientParam: string;
     /** FLP application ID. */
@@ -96,6 +84,8 @@ export interface DebugOptions {
     writeToAppOnly?: boolean;
     /** Reference to the VS Code instance. */
     vscode?: any;
+    /** skips live script if set to true. */
+    skipLiveScript?: boolean;
 }
 
 /**

--- a/packages/launch-config/test/debug-config/config.test.ts
+++ b/packages/launch-config/test/debug-config/config.test.ts
@@ -1,7 +1,7 @@
 import { configureLaunchJsonFile } from '../../src/debug-config/config';
 import type { DebugOptions, LaunchConfig, LaunchJSON } from '../../src/types';
 import path from 'path';
-import { FIORI_TOOLS_LAUNCH_CONFIG_HANDLER_ID, ProjectDataSourceType } from '../../src/types';
+import { FIORI_TOOLS_LAUNCH_CONFIG_HANDLER_ID } from '../../src/types';
 
 const projectName = 'project1';
 const cwd = `\${workspaceFolder}`;
@@ -60,9 +60,8 @@ describe('debug config tests', () => {
             sapClientParam: '',
             flpAppId: 'project1-tile',
             isFioriElement: true,
-            flpSandboxAvailable: true,
-            datasourceType: ProjectDataSourceType.odataServiceUrl
-        };
+            flpSandboxAvailable: true
+        } as DebugOptions;
     });
 
     afterEach(() => {
@@ -90,7 +89,7 @@ describe('debug config tests', () => {
     });
 
     it('Should return correct configuration for local metadata', () => {
-        configOptions.datasourceType = ProjectDataSourceType.metadataFile;
+        configOptions.skipLiveScript = true;
         const launchFile = configureLaunchJsonFile(projectPath, cwd, configOptions);
         expect(launchFile.configurations.length).toBe(2);
 
@@ -133,7 +132,6 @@ describe('debug config tests', () => {
 
     it('Should return correct configuration on BAS and sapClientParam is available', () => {
         configOptions.odataVersion = '2.0';
-        configOptions.datasourceType = ProjectDataSourceType.odataServiceUrl;
         configOptions.sapClientParam = 'sapClientParam';
         configOptions.isAppStudio = true;
 

--- a/packages/launch-config/test/launch-config-crud/create.test.ts
+++ b/packages/launch-config/test/launch-config-crud/create.test.ts
@@ -5,7 +5,7 @@ import { createLaunchConfig } from '../../src/launch-config-crud/create';
 import { DirName, FileName } from '@sap-ux/project-access';
 import { TestPaths } from '../test-data/utils';
 import type { DebugOptions } from '../../src/types';
-import { LAUNCH_JSON_FILE, ProjectDataSourceType } from '../../src/types';
+import { LAUNCH_JSON_FILE } from '../../src/types';
 import type { Logger } from '@sap-ux/logger';
 import { t } from '../../src/i18n';
 import { isFolderInWorkspace } from '../../src/debug-config/helpers';
@@ -187,7 +187,6 @@ describe('create', () => {
                 name: 'test-projects',
                 projectRoot: projectPath,
                 debugOptions: {
-                    datasourceType: ProjectDataSourceType.odataServiceUrl,
                     vscode: true
                 } as DebugOptions
             },
@@ -246,30 +245,6 @@ describe('create', () => {
         });
     });
 
-    test('launch.json file is missing, will not create config when debug options provided and app source is cap project', async () => {
-        const projectPath = join(TestPaths.tmpDir, 'test-projects');
-        const launchConfigPath = join(projectPath, DirName.VSCode, LAUNCH_JSON_FILE);
-        clearMemFsPaths(launchConfigPath);
-
-        const fs = await createLaunchConfig(
-            TestPaths.tmpDir,
-            {
-                name: 'test-projects',
-                projectRoot: projectPath,
-                debugOptions: {
-                    datasourceType: ProjectDataSourceType.capProject,
-                    vscode: true
-                } as DebugOptions
-            },
-            memFs,
-            mockLog
-        );
-        expect(fs.exists(launchConfigPath)).toBe(false);
-        expect(mockLog.info).toHaveBeenCalledWith(
-            t('startApp', { npmStart: '`npm start`', cdsRun: '`cds run --in-memory`' })
-        );
-    });
-
     test('Should create launch.json or run in Yeoman CLI or if vscode not found', async () => {
         const projectPath = join(TestPaths.tmpDir, 'test-projects');
         const launchConfigPath = join(projectPath, DirName.VSCode, LAUNCH_JSON_FILE);
@@ -280,7 +255,6 @@ describe('create', () => {
                 name: 'test-projects',
                 projectRoot: projectPath,
                 debugOptions: {
-                    datasourceType: ProjectDataSourceType.capProject,
                     vscode: false
                 } as DebugOptions
             },
@@ -309,7 +283,6 @@ describe('create', () => {
                 name: 'test-projects',
                 projectRoot: projectPath,
                 debugOptions: {
-                    datasourceType: ProjectDataSourceType.odataServiceUrl,
                     vscode: {
                         workspace: {
                             workspaceFile: { scheme: 'file' }
@@ -389,7 +362,6 @@ describe('create', () => {
                 name: 'test-projects',
                 projectRoot: projectPath,
                 debugOptions: {
-                    datasourceType: ProjectDataSourceType.odataServiceUrl,
                     vscode: {
                         workspace: {
                             workspaceFile: { scheme: 'file' }


### PR DESCRIPTION
This update removes the `ProjectDataSourceType` from `DebugConfig` and introduces the use of a new flag, `skipLiveScripts`. Now, live scripts are only generated when `skipLiveScripts` is set to false.
