### PR TITLE
Fix for CommandRunner not spawning child processes on Windows with shell opt

### DIFF
--- a/.changeset/popular-bees-sip.md
+++ b/.changeset/popular-bees-sip.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/nodejs-utils': patch
+---
+
+Fixes CommandRunner child proc execution on Windows (uses `shell = true`)

--- a/packages/nodejs-utils/src/commandRunner.ts
+++ b/packages/nodejs-utils/src/commandRunner.ts
@@ -15,7 +15,9 @@ export class CommandRunner {
     run(cmd: string, args: string[] = []): Promise<string | void> {
         return new Promise((resolve, reject) => {
             const stack: any = [];
-            const spawnedCmd = spawn(cmd, args, {});
+            const spawnOpts = process.platform === 'win32' ? { shell: true } : {};
+
+            const spawnedCmd = spawn(cmd, args, spawnOpts);
             spawnedCmd.stdout.setEncoding('utf8');
             let response: string;
             spawnedCmd.stdout.on('data', (data: Buffer) => {

--- a/packages/nodejs-utils/test/unit/commandRunner.test.ts
+++ b/packages/nodejs-utils/test/unit/commandRunner.test.ts
@@ -29,7 +29,12 @@ describe('CommandRunner', () => {
         const response = await commandRunner.run(cmd, args);
 
         expect(response).toBe(expectedResponse);
-        expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+
+        if (process.platform === 'win32') {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, { shell: true });
+        } else {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+        }
     });
 
     it('should handle command errors', async () => {
@@ -39,7 +44,12 @@ describe('CommandRunner', () => {
         spawnMock.setDefault(spawnMock.simple(1, 'npm install'));
 
         await expect(commandRunner.run(cmd, args)).rejects.toContain(expectedError);
-        expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+
+        if (process.platform === 'win32') {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, { shell: true });
+        } else {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+        }
     });
 
     it('should handle command failures', async () => {
@@ -49,6 +59,11 @@ describe('CommandRunner', () => {
         spawnMock.setDefault(spawnMock.simple(1, 'npm install', 'npm ERR! missing script: install'));
 
         await expect(commandRunner.run(cmd, args)).rejects.toContain(expectedError);
-        expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+
+        if (process.platform === 'win32') {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, { shell: true });
+        } else {
+            expect(spawnSpy).toHaveBeenCalledWith(cmd, args, {});
+        }
     });
 });


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2433

CommandRunner was executing `npm -g root` without the option `shell = true` on Windows resulting in extension generator packages not being found.

<img width="1580" alt="image" src="https://github.com/user-attachments/assets/384bba17-0fd1-4e1a-bc9b-4e9cce4f33de">

<img width="845" alt="image" src="https://github.com/user-attachments/assets/9ae314bd-b6a8-4a3d-bd38-e52b7c8785f4">

