### PR TITLE
fix: Sass warning about deprecate usage of '/' for division outside of calc

### DIFF
--- a/.changeset/chilly-dragons-call.md
+++ b/.changeset/chilly-dragons-call.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Sass warning about depricate usage of '/' for devision outside of calc

--- a/.changeset/chilly-dragons-call.md
+++ b/.changeset/chilly-dragons-call.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-components': patch
 ---
 
-Sass warning about depricate usage of '/' for devision outside of calc
+Sass warning about deprecate usage of '/' for division outside of calc

--- a/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.scss
+++ b/packages/ui-components/src/components/UIContextualMenu/UIContextualMenu.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import './_variables.scss';
 
 $layout-dropdown-menu-border-color: $menu-border-color;
@@ -136,8 +137,8 @@ $layout-contextual-menu-item-focus-color: $layout-contextual-menu-item-hover-col
 
         > .ms-ContextualMenu-link {
             &.is-checked  .ms-ContextualMenu-checkmarkIcon {
-                margin-right: $menu-item-horizontal-padding/2;
-                margin-left: -$menu-item-horizontal-padding/2;
+                margin-right: math.div($menu-item-horizontal-padding, 2);
+                margin-left: math.div(-$menu-item-horizontal-padding, 2);
             }
         }
 


### PR DESCRIPTION
Fix for Sass warning about deprecate usage of '/' for division outside of calc:

![image](https://github.com/user-attachments/assets/1b4052b9-979e-4d2a-bf72-f965286ab065)
