### PR TITLE
fix:(ui-prompting) Do not show the translation input if the translation props are not provided

### DIFF
--- a/.changeset/mighty-impalas-sit.md
+++ b/.changeset/mighty-impalas-sit.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-prompting': patch
 ---
 
-Do not show translation input if transplation props are not passed(no I18N bundle and translation event handler)
+Do not show the translation input if the translation props are not provided (i.e., no I18N bundle and no translation event handler).

--- a/.changeset/mighty-impalas-sit.md
+++ b/.changeset/mighty-impalas-sit.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-prompting': patch
+---
+
+Do not show translation input if transplation props are not passed(no I18N bundle and translation event handler)

--- a/packages/ui-prompting/src/components/Question/Question.tsx
+++ b/packages/ui-prompting/src/components/Question/Question.tsx
@@ -14,10 +14,11 @@ export interface QuestionProps {
     choices?: PromptListChoices;
     pending?: boolean;
     validation: ValidationResults;
+    isI18nInputSupported?: boolean;
 }
 
 export const Question = (props: QuestionProps) => {
-    const { question, onChange, answers, choices, pending, validation = {}, id } = props;
+    const { question, onChange, answers, choices, pending, validation = {}, id, isI18nInputSupported } = props;
     let questionInput: JSX.Element;
     let errorMessage = '';
     const value: AnswerValue = getAnswer(answers, question.name) as AnswerValue;
@@ -28,7 +29,7 @@ export const Question = (props: QuestionProps) => {
     switch (question?.type) {
         case 'input': {
             const { translatable } = question.guiOptions ?? {};
-            if (translatable) {
+            if (isI18nInputSupported && translatable) {
                 questionInput = (
                     <TranslationInput
                         value={value}

--- a/packages/ui-prompting/src/components/Questions/Questions.tsx
+++ b/packages/ui-prompting/src/components/Questions/Questions.tsx
@@ -140,6 +140,7 @@ export const Questions = (props: QuestionsProps) => {
                     onChange={onAnswerChange}
                     choices={externalChoices}
                     pending={pendingRequests[name]}
+                    isI18nInputSupported={!!props.translationProps}
                 />
             );
         });

--- a/packages/ui-prompting/test/unit/components/Questions.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Questions.test.tsx
@@ -7,7 +7,7 @@ import type { ListPromptQuestion, PromptQuestion } from '../../../src/types';
 import type { QuestionsProps } from '../../../src';
 import { questions } from '../../mock-data/questions';
 import { getDependantQuestions } from '../../../src/utilities';
-import { acceptI18nCallout, clickI18nButton, isI18nLoading } from '../utils';
+import { acceptI18nCallout, clickI18nButton, isI18nLoading, translationInputSelectors } from '../utils';
 
 describe('Questions', () => {
     initIcons();
@@ -358,6 +358,12 @@ describe('Questions', () => {
             );
             // Check result
             expect(isI18nLoading()).toEqual(true);
+        });
+
+        it('Do not show translation input when no translation props passed', async () => {
+            render(<Questions {...props} id="my-prompt" questions={[question]} translationProps={undefined} />);
+            // Check that there no translation input rendered
+            expect(document.querySelectorAll(translationInputSelectors.button).length).toEqual(0);
         });
     });
 });


### PR DESCRIPTION
Do not show the translation input if the translation props are not provided - if there no I18N bundle and no translation event handler