### PR TITLE
TBI - Allow filtering folder(s) to compile CAP model from

### DIFF
--- a/.changeset/many-carrots-notice.md
+++ b/.changeset/many-carrots-notice.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/project-access": patch
+---
+
+TBI - Optionally allow filtering CAP folder(s) to compile CAP model from

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -138,24 +138,28 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
  * @returns {Promise<{ model: csn; services: ServiceInfo[]; cdsVersionInfo: CdsVersionInfo }>} - CAP Model and Services
  */
 export async function getCapModelAndServices(
-    projectRoot: string | { projectRoot: string; logger?: Logger }
+    projectRoot: string | { projectRoot: string; logger?: Logger; pathSelection?: Set<'app' | 'srv' | 'db'> }
 ): Promise<{ model: csn; services: ServiceInfo[]; cdsVersionInfo: CdsVersionInfo }> {
     let _projectRoot;
     let _logger;
+    let _pathSelection;
+    const defaultPathSelection = new Set(['app', 'srv', 'db']);
     if (typeof projectRoot === 'object') {
         _projectRoot = projectRoot.projectRoot;
         _logger = projectRoot.logger;
+        _pathSelection = projectRoot.pathSelection ? projectRoot.pathSelection : defaultPathSelection;
     } else {
+        _pathSelection = defaultPathSelection;
         _projectRoot = projectRoot;
     }
 
     const cds = await loadCdsModuleFromProject(_projectRoot, true);
     const capProjectPaths = await getCapCustomPaths(_projectRoot);
-    const modelPaths = [
-        join(_projectRoot, capProjectPaths.app),
-        join(_projectRoot, capProjectPaths.srv),
-        join(_projectRoot, capProjectPaths.db)
-    ];
+    const modelPaths: string[] = [];
+    _pathSelection?.forEach((path: string) => {
+        modelPaths.push(join(_projectRoot, capProjectPaths[path as keyof CapCustomPaths]));
+    });
+
     const model = await cds.load(modelPaths, { root: _projectRoot });
 
     _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'cds.home': ${cds.home}`);

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -409,6 +409,41 @@ describe('Test getCapModelAndServices()', () => {
         expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: 'ROOT_PATH' });
     });
 
+    test('Get model and services filtered by db, but services are empty', async () => {
+        // Mock setup
+        const cdsMock = {
+            env: {
+                'for': () => ({
+                    folders: {
+                        app: 'APP',
+                        db: 'DB',
+                        srv: 'SRV'
+                    }
+                })
+            },
+            load: jest.fn().mockImplementation(() => Promise.resolve('MODEL_NO_SERVICES')),
+            compile: {
+                to: {
+                    serviceinfo: jest.fn().mockImplementation(() => null)
+                }
+            }
+        };
+        jest.spyOn(projectModuleMock, 'loadModuleFromProject').mockImplementation(() => Promise.resolve(cdsMock));
+
+        // Test execution
+        const capMS = await getCapModelAndServices('ROOT_PATH');
+
+        // Check results
+        expect(capMS.model).toEqual('MODEL_NO_SERVICES');
+        expect(capMS.services).toEqual([]);
+        expect(capMS.cdsVersionInfo).toEqual({
+            home: undefined,
+            version: undefined,
+            root: undefined
+        });
+        expect(cdsMock.compile.to.serviceinfo).toBeCalledWith('MODEL_NO_SERVICES', { root: 'ROOT_PATH' });
+    });
+
     test('Get model and service', async () => {
         // Mock setup
         const cdsMock = {


### PR DESCRIPTION
In some cases such as Data Editor it is only expected to compile the db model and not the full CAP model. 
Updating `getCapModelAndServices` to optionally pass `pathSelection`