### PR TITLE
fix: refactor control id and control type

### DIFF
--- a/.changeset/empty-carpets-stare.md
+++ b/.changeset/empty-carpets-stare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/control-property-editor': major
+---
+
+Added tooltip for value of control id and type and removed controlid popup

--- a/packages/control-property-editor/src/panels/properties/HeaderField.tsx
+++ b/packages/control-property-editor/src/panels/properties/HeaderField.tsx
@@ -81,8 +81,10 @@ export function HeaderField(headerFieldProps: Readonly<HeaderFieldProps>): React
             </UITooltip>
             <TextField
                 id={label}
+                data-testid={label}
                 value={value}
                 readOnly={true}
+                title={value}
                 borderless
                 styles={{
                     field: {

--- a/packages/control-property-editor/src/panels/properties/PropertiesList.tsx
+++ b/packages/control-property-editor/src/panels/properties/PropertiesList.tsx
@@ -41,13 +41,6 @@ export function PropertiesList(): ReactElement {
         (item) => item.name === FilterName.showEditableProperties
     )[0].value as boolean;
     const [filterValue, setFilterValue] = useState('');
-    const doc = {
-        defaultValue: '-',
-        description: 'The unique identifier within a page, either configured or automatically generated.',
-        propertyName: 'id',
-        type: 'sap.ui.core.ID',
-        propertyType: 'ID'
-    };
     if (!control) {
         // Nothing selected, show message
         return <NoControlSelected />;
@@ -124,7 +117,7 @@ export function PropertiesList(): ReactElement {
     return (
         <>
             <div className="property-content">
-                <HeaderField label={t('CONTROL_ID_LABEL')} value={id} documentation={doc} hidden={false} />
+                <HeaderField label={t('CONTROL_ID_LABEL')} value={id} />
                 <HeaderField label={t('CONTROL_TYPE_LABEL')} value={type} />
             </div>
             <Separator


### PR DESCRIPTION
Removed popup for control id and added tooltip for control id and control type values.
![image](https://github.com/user-attachments/assets/4af8fcf2-9f4e-4b57-b401-6583498f785e)
