### PR TITLE
fix(abap-deploy-config): fix backend target choices check

### DIFF
--- a/.changeset/rotten-dolls-try.md
+++ b/.changeset/rotten-dolls-try.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+bug fix

--- a/packages/abap-deploy-config-inquirer/src/prompts/helpers.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/helpers.ts
@@ -93,9 +93,9 @@ async function getBackendTargetChoices(
     const systemChoices: AbapSystemChoice[] = Object.values(backendSystems)
         .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, caseFirst: 'lower' }))
         .map((system) => {
-            if (!targetExists) {
+            if (!targetExists && target?.url) {
                 targetExists =
-                    system.url.replace(/\/$/, '') === target?.url.replace(/\/$/, '') &&
+                    system.url.replace(/\/$/, '') === target.url.replace(/\/$/, '') &&
                     (system.client ?? '') === (target?.client ?? '');
             }
             return {

--- a/packages/abap-deploy-config-inquirer/src/prompts/index.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/index.ts
@@ -24,7 +24,7 @@ export async function getAbapDeployConfigQuestions(
     const questions = [...targetPrompts, ...authPrompts];
 
     if (options.ui5AbapRepo?.hide !== true) {
-        questions.push(getAppConfigPrompts(options));
+        questions.push(...getAppConfigPrompts(options));
     }
 
     const packagePrompts = getPackagePrompts(options);

--- a/packages/abap-deploy-config-inquirer/test/index.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/index.test.ts
@@ -16,7 +16,7 @@ describe('index', () => {
         });
         const prompts = await getPrompts({}, undefined, false);
         expect(prompts.answers).toBeDefined();
-        expect(prompts.prompts.length).toBe(22);
+        expect(prompts.prompts.length).toBe(23);
     });
 
     it('should prompt with inquirer adapter', async () => {

--- a/packages/abap-deploy-config-inquirer/test/prompts/helpers.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/helpers.test.ts
@@ -65,6 +65,34 @@ describe('helpers', () => {
                 ]
             `);
         });
+
+        it('should return backend target choices (no backend target / default)', async () => {
+            const systemChoices = await getAbapSystemChoices(undefined, undefined, mockTargetSystems);
+            expect(systemChoices).toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "name": "Enter Target System URL",
+                    "value": "Url",
+                  },
+                  Object {
+                    "client": "000",
+                    "isDefault": false,
+                    "isS4HC": false,
+                    "name": "target1 [mockUser]",
+                    "scp": false,
+                    "value": "https://mock.url.target1.com",
+                  },
+                  Object {
+                    "client": "001",
+                    "isDefault": false,
+                    "isS4HC": true,
+                    "name": "target2 (S4HC) [mockUser2]",
+                    "scp": false,
+                    "value": "https://mock.url.target2.com",
+                  },
+                ]
+            `);
+        });
     });
 
     describe('updatePromptStateUrl', () => {


### PR DESCRIPTION
Introduced in https://github.com/SAP/open-ux-tools/pull/2449 .. when no backend target exists an error is thrown trying to replace trailing slash