### PR TITLE
fix(ui-components): #2140 - fix dropdown vertical align input field

### DIFF
--- a/.changeset/fresh-hotels-tap.md
+++ b/.changeset/fresh-hotels-tap.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/ui-components": patch
+---
+
+fix(ui-components): #2140 - fix dropdown vertical align input field

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -19,7 +19,7 @@
         .ms-Dropdown-title {
             background: transparent;
             height: $dropdown-input-height;
-            line-height: $dropdown-input-height;
+            line-height: $dropdown-line-height;
             border: $dropdown-input-border-width solid transparent;
             padding: $dropdown-input-text-padding;
             @include base-font;

--- a/packages/ui-components/src/styles/_variables.scss
+++ b/packages/ui-components/src/styles/_variables.scss
@@ -5,6 +5,7 @@ $font-size-base: var(--vscode-font-size);
 $font-weight-base: var(--vscode-font-weight);
 
 $base-element-height: 26px;
+$base-element-line-height: 24px;
 $button-font-size: $font-size-base;
 
 // Box shadows
@@ -15,6 +16,7 @@ $box-shadow-large: 0 10px 20px 0 var(--vscode-widget-shadow);
 // Dropdowns
 // colors
 $dropdown-input-height: $base-element-height;
+$dropdown-line-height: $base-element-line-height;
 $dropdown-input-color: var(--vscode-foreground);
 $dropdown-input-placeholder-color: var(--vscode-input-placeholderForeground);
 $dropdown-input-background: var(--vscode-input-background);


### PR DESCRIPTION
BUG - Values in the UI.Dropdown control is not centered aligned (vertically)

issue #2140 

- [x] remove the border top and bottom from the total height to get the line-height which should the full height - 2px