### PR TITLE
fix(ui-components): UIComboBox, UIDropdown: Allow extending 'calloutProps' instead of overwriting.

### DIFF
--- a/.changeset/witty-carrots-give.md
+++ b/.changeset/witty-carrots-give.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIComboBox, UIDropdown: Allow extending 'calloutProps' instead of overwriting.

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -717,26 +717,6 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                         },
                         onRenderIcon: this.onRenderIcon
                     }}
-                    calloutProps={{
-                        calloutMaxHeight: 200,
-                        popupProps: {
-                            ref: this.menuDomRef
-                        },
-                        className: 'ts-Callout ts-Callout-Dropdown',
-                        styles: {
-                            ...(this.props.useComboBoxAsMenuMinWidth && {
-                                calloutMain: {
-                                    minWidth: this.state.minWidth,
-                                    display: this.state.isListHidden ? 'none' : undefined
-                                }
-                            })
-                        },
-                        ...getCalloutCollisionTransformationProps(
-                            this.calloutCollisionTransform,
-                            this.props.multiSelect,
-                            this.props.calloutCollisionTransformation
-                        )
-                    }}
                     styles={{
                         label: {
                             ...labelGlobalStyle,
@@ -757,6 +737,27 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                         errorMessage: [messageInfo.style]
                     }}
                     {...this.props}
+                    calloutProps={{
+                        calloutMaxHeight: 200,
+                        popupProps: {
+                            ref: this.menuDomRef
+                        },
+                        className: 'ts-Callout ts-Callout-Dropdown',
+                        styles: {
+                            ...(this.props.useComboBoxAsMenuMinWidth && {
+                                calloutMain: {
+                                    minWidth: this.state.minWidth,
+                                    display: this.state.isListHidden ? 'none' : undefined
+                                }
+                            })
+                        },
+                        ...getCalloutCollisionTransformationProps(
+                            this.calloutCollisionTransform,
+                            this.props.multiSelect,
+                            this.props.calloutCollisionTransformation
+                        ),
+                        ...this.props.calloutProps
+                    }}
                     {...(this.props.highlight && {
                         onInput: this.onInput,
                         onMenuDismissed: this.reserQuery,

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -313,6 +313,15 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
         return (
             <Dropdown
                 ref={this.dropdownDomRef}
+                onRenderCaretDown={this.onRenderCaretDown}
+                onClick={this.onClick}
+                onChange={this.onChange}
+                onRenderTitle={this.onRenderTitle}
+                // Use default responsiveMode as xxxLarge, which does not enter mobile mode.
+                responsiveMode={ResponsiveMode.xxxLarge}
+                disabled={this.props.readOnly}
+                {...additionalProps}
+                {...this.props}
                 calloutProps={{
                     calloutMaxHeight: 200,
                     styles: this.props.useDropdownAsMenuMinWidth ? this.getCalloutStylesForUseAsMinWidth : undefined,
@@ -324,17 +333,9 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
                         this.calloutCollisionTransform,
                         this.props.multiSelect,
                         this.props.calloutCollisionTransformation
-                    )
+                    ),
+                    ...this.props.calloutProps
                 }}
-                onRenderCaretDown={this.onRenderCaretDown}
-                onClick={this.onClick}
-                onChange={this.onChange}
-                onRenderTitle={this.onRenderTitle}
-                // Use default responsiveMode as xxxLarge, which does not enter mobile mode.
-                responsiveMode={ResponsiveMode.xxxLarge}
-                disabled={this.props.readOnly}
-                {...additionalProps}
-                {...this.props}
                 onRenderOption={this.onRenderOption.bind(this)}
                 onRenderItem={this.onRenderItem.bind(this)}
                 styles={dropdownStyles}

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -863,4 +863,14 @@ describe('<UIComboBox />', () => {
         expect(wrapper.find('.custom-render-item').length).toBeGreaterThan(0);
         expect(wrapper.find('.ts-ComboBox--selected').length).toBeGreaterThan(0);
     });
+
+    it('Test "calloutProps"', () => {
+        wrapper.setProps({
+            calloutProps: {
+                className: 'dummy'
+            }
+        });
+        openDropdown();
+        expect(wrapper.find('div.dummy').length).toEqual(1);
+    });
 });

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -395,6 +395,16 @@ describe('<UIDropdown />', () => {
         openDropdown();
         expect(wrapper.find('.custom-render-item').length).toBeGreaterThan(0);
     });
+
+    it('Test "calloutProps"', () => {
+        wrapper.setProps({
+            calloutProps: {
+                className: 'dummy'
+            }
+        });
+        openDropdown();
+        expect(wrapper.find('div.dummy').length).toEqual(1);
+    });
 });
 
 describe('Utils/getCalloutCollisionTransformationProps', () => {


### PR DESCRIPTION
We noticed problem with `UIComboBox`, `UIDropdown` - if we pass callout props to them, then all `calloutProperties` are overwritten instead of merging it with properties defined within `UIComboBox`, `UIDropdown` components