### PR TITLE
feat: enable quick actions

### DIFF
--- a/.changeset/witty-seas-battle.md
+++ b/.changeset/witty-seas-battle.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Enable quick actions by default

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/change-table-columns.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/change-table-columns.ts
@@ -1,10 +1,11 @@
 import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import type Table from 'sap/m/Table';
 import type SmartTable from 'sap/ui/comp/smarttable/SmartTable';
+import ManagedObject from 'sap/ui/base/ManagedObject';
 
+import { FeatureService } from '../../../cpe/feature-service';
 import { QuickActionContext, NestedQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { getControlById, isA } from '../../../utils/core';
-import ManagedObject from 'sap/ui/base/ManagedObject';
 import { TableQuickActionDefinitionBase } from './table-quick-action-base';
 
 export const CHANGE_TABLE_COLUMNS = 'change-table-columns';
@@ -21,6 +22,13 @@ export class ChangeTableColumnsQuickAction
         super(CHANGE_TABLE_COLUMNS, CONTROL_TYPES, 'V2_QUICK_ACTION_CHANGE_TABLE_COLUMNS', context, true);
     }
 
+    initialize(): Promise<void> {
+        if (FeatureService.isFeatureEnabled('cpe.beta.quick-actions') === false) {
+            return Promise.resolve();
+        }
+        return super.initialize();
+    }
+    
     async execute(path: string): Promise<FlexCommand[]> {
         const { table, iconTabBarFilterKey, changeColumnActionId, sectionInfo } = this.tableMap[path];
         if (!table) {

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-page-action.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-page-action.ts
@@ -1,6 +1,7 @@
 import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
 import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 
+import { FeatureService } from '../../../cpe/feature-service';
 import { DialogNames, handler } from '../../init-dialogs';
 import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
@@ -14,6 +15,13 @@ const CONTROL_TYPES = ['sap.f.DynamicPageTitle', 'sap.uxap.ObjectPageHeader', 's
 export class AddPageActionQuickAction extends SimpleQuickActionDefinitionBase implements SimpleQuickActionDefinition {
     constructor(context: QuickActionContext) {
         super(ADD_PAGE_ACTION, CONTROL_TYPES, 'QUICK_ACTION_ADD_CUSTOM_PAGE_ACTION', context);
+    }
+
+    initialize(): void {
+        if (FeatureService.isFeatureEnabled('cpe.beta.quick-actions') === false) {
+            return;
+        }
+        return super.initialize();
     }
 
     async execute(): Promise<FlexCommand[]> {

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-table-action.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-table-action.ts
@@ -1,14 +1,15 @@
 import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import type Table from 'sap/m/Table';
 import type SmartTable from 'sap/ui/comp/smarttable/SmartTable';
+import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
+import ManagedObject from 'sap/ui/base/ManagedObject';
+import UI5Element from 'sap/ui/core/Element';
 
 import { QuickActionContext, NestedQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { getControlById, isA } from '../../../utils/core';
-import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
 import { DialogNames, handler } from '../../init-dialogs';
+import { FeatureService } from '../../../cpe/feature-service';
 import { TableQuickActionDefinitionBase } from './table-quick-action-base';
-import ManagedObject from 'sap/ui/base/ManagedObject';
-import UI5Element from 'sap/ui/core/Element';
 
 export const CREATE_TABLE_ACTION = 'create-table-action';
 const SMART_TABLE_TYPE = 'sap.ui.comp.smarttable.SmartTable';
@@ -20,6 +21,13 @@ const CONTROL_TYPES = [SMART_TABLE_TYPE, M_TABLE_TYPE, 'sap.ui.table.TreeTable',
 export class AddTableActionQuickAction extends TableQuickActionDefinitionBase implements NestedQuickActionDefinition {
     constructor(context: QuickActionContext) {
         super(CREATE_TABLE_ACTION, CONTROL_TYPES, 'QUICK_ACTION_ADD_CUSTOM_TABLE_ACTION', context);
+    }
+
+    initialize(): Promise<void> {
+        if (FeatureService.isFeatureEnabled('cpe.beta.quick-actions') === false) {
+            return Promise.resolve();
+        }
+        return super.initialize();
     }
 
     async execute(path: string): Promise<FlexCommand[]> {

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/change-table-columns.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/change-table-columns.ts
@@ -8,6 +8,7 @@ import { NESTED_QUICK_ACTION_KIND } from '@sap-ux-private/control-property-edito
 
 import { QuickActionContext, NestedQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { getRelevantControlFromActivePage } from '../../../cpe/quick-actions/utils';
+import { FeatureService } from '../../../cpe/feature-service';
 import { getControlById } from '../../../utils/core';
 
 export const CHANGE_TABLE_COLUMNS = 'change-table-columns';
@@ -31,6 +32,9 @@ export class ChangeTableColumnsQuickAction implements NestedQuickActionDefinitio
     constructor(private context: QuickActionContext) {}
 
     async initialize(): Promise<void> {
+        if (FeatureService.isFeatureEnabled('cpe.beta.quick-actions') === false) {
+            return;
+        }
         let index = 0;
         for (const smartTable of getRelevantControlFromActivePage(this.context.controlIndex, this.context.view, [
             CONTROL_TYPE

--- a/packages/preview-middleware-client/src/adp/quick-actions/load.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/load.ts
@@ -9,9 +9,6 @@ import type { ApplicationType } from '../../utils/application';
  * @returns Quick Action registries.
  */
 export async function loadDefinitions(appType: ApplicationType): Promise<QuickActionDefinitionRegistry<string>[]> {
-    if (FeatureService.isFeatureEnabled('cpe.beta.quick-actions') === false) {
-        return [];
-    }
     if (appType === 'fe-v2') {
         const FEV2QuickActionRegistry = (await import('open/ux/preview/client/adp/quick-actions/fe-v2/registry'))
             .default;

--- a/packages/preview-middleware-client/src/adp/quick-actions/load.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/load.ts
@@ -1,4 +1,3 @@
-import { FeatureService } from '../../cpe/feature-service';
 import type { QuickActionDefinitionRegistry } from '../../cpe/quick-actions/registry';
 import type { ApplicationType } from '../../utils/application';
 

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -13,6 +13,7 @@ jest.mock('../../../../src/adp/init-dialogs', () => {
 
 import { QuickActionService } from '../../../../src/cpe/quick-actions/quick-action-service';
 import { OutlineService } from '../../../../src/cpe/outline/service';
+import { FeatureService } from '../../../../src/cpe/feature-service';
 
 import FEV2QuickActionRegistry from '../../../../src/adp/quick-actions/fe-v2/registry';
 import { sapCoreMock } from 'mock/window';
@@ -258,6 +259,15 @@ describe('FE V2 quick actions', () => {
         });
 
         describe('change table columns', () => {
+            beforeEach(() => {
+                jest.spyOn(FeatureService, 'isFeatureEnabled').mockImplementation((feature: string) => {
+                    if (feature === 'cpe.beta.quick-actions') {
+                        return true;
+                    }
+                    return false;
+                });
+                FeatureService.isFeatureEnabled;
+            });
             test('initialize and execute', async () => {
                 const pageView = new XMLView();
 
@@ -394,6 +404,15 @@ describe('FE V2 quick actions', () => {
         });
 
         describe('create table action', () => {
+            beforeEach(() => {
+                jest.spyOn(FeatureService, 'isFeatureEnabled').mockImplementation((feature: string) => {
+                    if (feature === 'cpe.beta.quick-actions') {
+                        return true;
+                    }
+                    return false;
+                });
+                FeatureService.isFeatureEnabled;
+            });
             test('initialize and execute', async () => {
                 const pageView = new XMLView();
 
@@ -508,6 +527,15 @@ describe('FE V2 quick actions', () => {
             });
         });
         describe('add page action', () => {
+            beforeEach(() => {
+                jest.spyOn(FeatureService, 'isFeatureEnabled').mockImplementation((feature: string) => {
+                    if (feature === 'cpe.beta.quick-actions') {
+                        return true;
+                    }
+                    return false;
+                });
+                FeatureService.isFeatureEnabled;
+            });
             test('initialize and execute action', async () => {
                 const pageView = new XMLView();
                 FlexUtils.getViewForControl.mockImplementation(() => {
@@ -766,6 +794,15 @@ describe('FE V2 quick actions', () => {
             });
         });
         describe('add custom section', () => {
+            beforeEach(() => {
+                jest.spyOn(FeatureService, 'isFeatureEnabled').mockImplementation((feature: string) => {
+                    if (feature === 'cpe.beta.quick-actions') {
+                        return true;
+                    }
+                    return false;
+                });
+                FeatureService.isFeatureEnabled;
+            });
             test('initialize and execute action', async () => {
                 const pageView = new XMLView();
                 FlexUtils.getViewForControl.mockImplementation(() => {

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../../../src/adp/init-dialogs', () => {
 });
 import { QuickActionService } from '../../../../src/cpe/quick-actions/quick-action-service';
 import { OutlineService } from '../../../../src/cpe/outline/service';
+import { FeatureService } from '../../../../src/cpe/feature-service';
 
 import FEV4QuickActionRegistry from 'open/ux/preview/client/adp/quick-actions/fe-v4/registry';
 import { sapCoreMock } from 'mock/window';
@@ -270,6 +271,15 @@ describe('FE V2 quick actions', () => {
         });
 
         describe('change table columns', () => {
+            beforeEach(() => {
+                jest.spyOn(FeatureService, 'isFeatureEnabled').mockImplementation((feature: string) => {
+                    if (feature === 'cpe.beta.quick-actions') {
+                        return true;
+                    }
+                    return false;
+                });
+                FeatureService.isFeatureEnabled;
+            });
             test('initialize and execute action', async () => {
                 const pageView = new XMLView();
                 jest.spyOn(FlexRuntimeInfoAPI, 'hasVariantManagement').mockReturnValue(true);


### PR DESCRIPTION
Enables quick actions by default. The following quick actions are still behind feature flag:
- Custom Action
- Custom Table Columns