### PR TITLE
tbi(ui5-app-inq): update ui5 default version logic

### DIFF
--- a/.changeset/strong-elephants-drum.md
+++ b/.changeset/strong-elephants-drum.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+'@sap-ux/inquirer-common': patch
+---
+
+update ui5 default version logic

--- a/packages/inquirer-common/src/prompts/utility.ts
+++ b/packages/inquirer-common/src/prompts/utility.ts
@@ -1,7 +1,7 @@
 import { getUi5Themes, type UI5Theme, type UI5Version } from '@sap-ux/ui5-info';
 import * as fuzzy from 'fuzzy';
 import type { ListChoiceOptions } from 'inquirer';
-import { coerce, eq, lte } from 'semver';
+import { coerce, eq, lte, type SemVer } from 'semver';
 import { t } from '../i18n';
 import type { UI5VersionChoice } from '../types';
 import { Separator } from './separator';
@@ -44,7 +44,7 @@ export function searchChoices(searchVal: string, searchList: ListChoiceOptions[]
  *
  * @param versions ui5Versions
  * @param includeSeparators Include a separator to visually identify groupings, if false then grouping info is included in each entry as additional name text
- * @param defaultChoice optional, provides an additional version choice entry that is added as the first entry in the version choices and sets as the default
+ * @param defaultChoice optional, provides an additional version choice entry that is added as the first entry in the version choices (if it does not already exist in the version list) and sets as the default
  * @returns Array of ui5 version choices and separators if applicable, grouped by maintenance state
  */
 export function ui5VersionsGrouped(
@@ -95,27 +95,60 @@ export function ui5VersionsGrouped(
 
     const versionChoices = [...maintChoices, ...notMaintChoices];
     if (defaultChoice) {
-        versionChoices.unshift(defaultChoice);
+        // adds or moves default choice to the top of the list
+        const index = versionChoices.findIndex((choice) => choice.value === defaultChoice.value);
+        if (index === -1) {
+            versionChoices.unshift(defaultChoice);
+        }
     }
     return versionChoices;
 }
 
 /**
- * Get the default UI5 version choice that should be selected based on the provided default choice.
- * Note that if the default choice is not found in the provided versions, the closest provided version is returned.
+ * Will either return the UI5 version that is the closest to the default choice version or simply the version that is passed to it.
  *
  * @param ui5Versions - UI5 versions ordered by version descending latest first
- * @param [defaultChoice] - optional default choice to use if found in the provided versions, otherwise the closest provided version is returned
- * @returns The default UI5 version choice that is closest to the provided default choice or the latest provided version
+ * @param useClosestVersion - whether to use the closest available version to the default choice
+ * @param defaultChoiceVersion - default version chosen
+ * @returns - ui5 version to be used as default
+ */
+function getUI5Version(
+    ui5Versions: UI5Version[],
+    useClosestVersion: boolean,
+    defaultChoiceVersion: SemVer
+): UI5Version | undefined {
+    let version;
+    if (useClosestVersion) {
+        version = ui5Versions.find((ui5Ver) => lte(ui5Ver.version, defaultChoiceVersion));
+    } else {
+        version = {
+            version: defaultChoiceVersion.version
+        };
+    }
+    return version;
+}
+
+/**
+ * Get the default UI5 version choice that should be selected based on the provided default choice.
+ * Note, if the provided version is a snapshot version, the closest provided version is returned.
+ * Otherwise if the default choice is not found in the provided versions, it will still be returned.
+ *
+ * @param ui5Versions - UI5 versions ordered by version descending latest first
+ * @param defaultChoice - optional default choice to be used
+ * @returns The default UI5 version choice or the latest provided version
  */
 export function getDefaultUI5VersionChoice(
     ui5Versions: UI5Version[],
     defaultChoice?: UI5VersionChoice
 ): UI5VersionChoice | undefined {
+    let useClosestVersion = false;
     if (defaultChoice) {
+        if (defaultChoice.value.endsWith('SNAPSHOT')) {
+            useClosestVersion = true;
+        }
         const defaultChoiceVersion = coerce(defaultChoice.value);
         if (defaultChoiceVersion !== null) {
-            const version = ui5Versions.find((ui5Ver) => lte(ui5Ver.version, defaultChoiceVersion));
+            const version = getUI5Version(ui5Versions, useClosestVersion, defaultChoiceVersion);
             if (version) {
                 // if the versions are an exact match use the name (UI label) from the default choice as this may use a custom name
                 return {

--- a/packages/inquirer-common/test/unit/prompts/utility.test.ts
+++ b/packages/inquirer-common/test/unit/prompts/utility.test.ts
@@ -105,6 +105,34 @@ describe('utility.ts', () => {
               },
             ]
         `);
+
+        // If version already exists in the list, it should be remain in place
+        const defaultExistingChoice = { name: ui5Vers[1].version, value: ui5Vers[1].version };
+        const ui5VersWithExistingChoice = ui5VersionsGrouped(ui5Vers, true, defaultExistingChoice);
+        expect(ui5VersWithExistingChoice).toMatchInlineSnapshot(`
+            [
+              Separator {
+                "line": "[2mMaintained versions[22m",
+                "type": "separator",
+              },
+              {
+                "name": "1.118.0",
+                "value": "1.118.0",
+              },
+              {
+                "name": "1.117.0",
+                "value": "1.117.0",
+              },
+              Separator {
+                "line": "[2mOut of maintenance versions[22m",
+                "type": "separator",
+              },
+              {
+                "name": "1.116.0",
+                "value": "1.116.0",
+              },
+            ]
+        `);
     });
 
     it('searchChoices', async () => {
@@ -261,11 +289,11 @@ describe('utility.ts', () => {
             'value': '1.117.1'
         });
 
-        // Closest maintained version
+        // Version not in the the list
         testUI5Version = '1.119.1';
         expect(getDefaultUI5VersionChoice(mockUI5Versions, { name: testUI5Version, value: testUI5Version })).toEqual({
-            'name': '1.118.0',
-            'value': '1.118.0'
+            'name': '1.119.1',
+            'value': '1.119.1'
         });
 
         // Not valid semver

--- a/packages/ui5-application-inquirer/src/prompts/prompts.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts.ts
@@ -319,8 +319,8 @@ function getUI5VersionPrompt(
     const defaultChoice = getDefaultUI5VersionChoice(ui5Versions, ui5VersionPromptOptions?.defaultChoice);
     const ui5VersionChoices = ui5VersionsGrouped(
         ui5Versions,
-        ui5VersionPromptOptions?.includeSeparators
-        // defaultChoice - this is added to support systemn versions however currently the middleware preview does not support this
+        ui5VersionPromptOptions?.includeSeparators,
+        defaultChoice
     );
     return {
         when: () => !!ui5VersionChoices,

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -301,7 +301,7 @@ describe('getQuestions', () => {
         // Default version should be used
         expect((ui5VersionPrompt?.default as Function)()).toEqual(expectedUI5VerChoices[0].value);
 
-        // This choice is not a maintained version and so the closest maintained version should be returned
+        // This choice is not a maintained version and so the closest maintained version should be added
         const defaultChoice = {
             'name': '1.120.99',
             'value': '1.120.99'
@@ -313,8 +313,11 @@ describe('getQuestions', () => {
         });
 
         ui5VersionPrompt = questions.find((question) => question.name === promptNames.ui5Version);
-        expect(((ui5VersionPrompt as ListQuestion)?.choices as Function)()).toEqual([...expectedUI5VerChoices]);
-        expect((ui5VersionPrompt?.default as Function)()).toEqual('1.118.0');
+        expect(((ui5VersionPrompt as ListQuestion)?.choices as Function)()).toEqual([
+            defaultChoice,
+            ...expectedUI5VerChoices
+        ]);
+        expect((ui5VersionPrompt?.default as Function)()).toEqual('1.120.99');
     });
 
     test('getQuestions, prompt: `addDeployConfig` conditions and message based on mta.yaml discovery', async () => {


### PR DESCRIPTION
Updates default handling for ui5 version

- If default version is a snapshot, the logic is unchanged, i.e. the closest published version will be returned as the default
- If default version is not found in the version list returned from ui5-info, it will be added to the top of the list (outside of the maintained, out of maintenance seperators)