### PR TITLE
UICombobox: Added new property 'searchByKeyEnabled' to allow searching by the option's "key" in addition to "text".

### DIFF
--- a/.changeset/lazy-planets-accept.md
+++ b/.changeset/lazy-planets-accept.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': minor
+---
+
+UICombobox: Added new property 'searchByKeyEnabled' to allow searching by the option's "key" in addition to "text".

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -66,6 +66,13 @@ export interface UIComboBoxProps extends IComboBoxProps, UIMessagesExtendedProps
     isForceEnabled?: boolean;
     readOnly?: boolean;
     calloutCollisionTransformation?: boolean;
+    /**
+     * Determines whether the `key` property should be considered during search.
+     * By default, only the `text` property of an option is considered.
+     *
+     * @default false
+     */
+    searchByKeyEnabled?: boolean;
 }
 export interface UIComboBoxState {
     minWidth?: number;
@@ -174,7 +181,11 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                 isGroupVisible = false;
             } else {
                 // Handle selectable item
-                const isHidden = option.text.toLowerCase().indexOf(this.query) === -1;
+                let isHidden = !option.text.toLowerCase().includes(this.query);
+                // Consider 'key' of option if property 'searchByKeyEnabled' is enabled
+                if (this.props.searchByKeyEnabled && isHidden) {
+                    isHidden = !option.key.toString().toLowerCase().includes(this.query);
+                }
                 option.hidden = isHidden;
                 if (this.isListHidden && !option.hidden) {
                     this.isListHidden = false;

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -427,3 +427,50 @@ export const customRender = () => {
         />
     );
 };
+
+const searchKeysData = [
+    { 'key': 'test1', 'text': 'test1' },
+    { 'key': 'dummy', 'text': 'dummy' },
+    { 'key': 'customer', 'text': 'customer' },
+    { 'key': 'name', 'text': 'name' },
+    { 'key': 'employee', 'text': 'employee' },
+    { 'key': 'ID', 'text': 'ID' },
+    { 'key': 'tripEndDate', 'text': 'tripEndDate' },
+    { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Divider },
+    { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Header },
+    { 'key': 'bookings/airlines', 'text': 'airlines' },
+    { 'key': 'bookings/bookingDate', 'text': 'bookingDate' },
+    { 'key': 'bookings/DateOnBookings', 'text': 'DateOnBookings' },
+    { 'key': 'bookings/employee', 'text': 'employee' },
+    { 'key': 'bookings/flightDate', 'text': 'flightDate' },
+    { 'key': 'bookings/ID', 'text': 'ID' },
+    { 'key': 'bookings/priceUSD', 'text': 'priceUSD' },
+    { 'key': 'bookings/travel_ID', 'text': 'travel_ID' },
+    { 'key': 'bookings/usedString5', 'text': 'usedString5' },
+    { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Divider },
+    { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Header },
+    { 'key': 'notes/comment', 'text': 'comment' },
+    { 'key': 'notes/description', 'text': 'description' }
+];
+
+export const SearchIncludeKeys = (): JSX.Element => (
+    <div style={{ width: '300px' }}>
+        <UIComboBox
+            options={searchKeysData}
+            highlight={true}
+            allowFreeform={true}
+            useComboBoxAsMenuMinWidth={true}
+            autoComplete="on"
+            searchByKeyEnabled={true}
+        />
+        <UIComboBox
+            options={searchKeysData}
+            highlight={true}
+            allowFreeform={true}
+            useComboBoxAsMenuMinWidth={true}
+            autoComplete="on"
+            disabled={true}
+            searchByKeyEnabled={true}
+        />
+    </div>
+);

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as Enzyme from 'enzyme';
 import type { UIComboBoxOption, UIComboBoxProps, UIComboBoxState } from '../../../src/components/UIComboBox';
-import { UIComboBox, UIComboBoxLoaderType } from '../../../src/components/UIComboBox';
+import { UIComboBox, UIComboBoxLoaderType, UISelectableOptionMenuItemType } from '../../../src/components/UIComboBox';
 import { data as originalData, groupsData as originalGroupsData } from '../../__mock__/select-data';
 import { initIcons } from '../../../src/components/Icons';
 import type { IComboBox, IComboBoxOption } from '@fluentui/react';
@@ -872,5 +872,64 @@ describe('<UIComboBox />', () => {
         });
         openDropdown();
         expect(wrapper.find('div.dummy').length).toEqual(1);
+    });
+
+    describe('Test "searchByKeyEnabled" property', () => {
+        const searchKeysData = [
+            { 'key': 'test1', 'text': 'test1' },
+            { 'key': 'dummy', 'text': 'dummy' },
+            { 'key': 'customer', 'text': 'customer' },
+            { 'key': 'name', 'text': 'name' },
+            { 'key': 'employee', 'text': 'employee' },
+            { 'key': 'ID', 'text': 'ID' },
+            { 'key': 'tripEndDate', 'text': 'tripEndDate' },
+            { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Divider },
+            { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Header },
+            { 'key': 'bookings/airlines', 'text': 'airlines' },
+            { 'key': 'bookings/bookingDate', 'text': 'bookingDate' },
+            { 'key': 'bookings/DateOnBookings', 'text': 'DateOnBookings' },
+            { 'key': 'bookings/employee', 'text': 'employee' },
+            { 'key': 'bookings/flightDate', 'text': 'flightDate' },
+            { 'key': 'bookings/ID', 'text': 'ID' },
+            { 'key': 'bookings/priceUSD', 'text': 'priceUSD' },
+            { 'key': 'bookings/travel_ID', 'text': 'travel_ID' },
+            { 'key': 'bookings/usedString5', 'text': 'usedString5' },
+            { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Divider },
+            { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Header },
+            { 'key': 'notes/comment', 'text': 'comment' },
+            { 'key': 'notes/description', 'text': 'description' }
+        ];
+        const testCases = [
+            {
+                name: '"searchByKeyEnabled" is undefined',
+                searchByKeyEnabled: undefined,
+                expectedCount: 2
+            },
+            {
+                name: '"searchByKeyEnabled" is false',
+                searchByKeyEnabled: false,
+                expectedCount: 2
+            },
+            {
+                name: '"searchByKeyEnabled" is true',
+                searchByKeyEnabled: true,
+                expectedCount: 10
+            }
+        ];
+        for (const testCase of testCases) {
+            const { name, searchByKeyEnabled, expectedCount } = testCase;
+            it(name, () => {
+                const query = 'bookings';
+                wrapper.setProps({
+                    highlight: true,
+                    options: searchKeysData,
+                    searchByKeyEnabled
+                });
+                openDropdown();
+                wrapper.find('input').simulate('keyDown', {});
+                triggerSearch(query);
+                expect(wrapper.find('.ms-Button').length).toEqual(expectedCount);
+            });
+        }
     });
 });


### PR DESCRIPTION
We noticed that we can have keys in combobox option different than text, and we need allow to find such entries by searching by key.
LIke options:
```
[
            { 'key': 'test1', 'text': 'test1' },
            { 'key': 'dummy', 'text': 'dummy' },
            { 'key': 'customer', 'text': 'customer' },
            { 'key': 'name', 'text': 'name' },
            { 'key': 'employee', 'text': 'employee' },
            { 'key': 'ID', 'text': 'ID' },
            { 'key': 'tripEndDate', 'text': 'tripEndDate' },
            { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Divider },
            { 'key': 'bookings', 'text': 'bookings', 'itemType': UISelectableOptionMenuItemType.Header },
            { 'key': 'bookings/airlines', 'text': 'airlines' },
            { 'key': 'bookings/bookingDate', 'text': 'bookingDate' },
            { 'key': 'bookings/DateOnBookings', 'text': 'DateOnBookings' },
            { 'key': 'bookings/employee', 'text': 'employee' },
            { 'key': 'bookings/flightDate', 'text': 'flightDate' },
            { 'key': 'bookings/ID', 'text': 'ID' },
            { 'key': 'bookings/priceUSD', 'text': 'priceUSD' },
            { 'key': 'bookings/travel_ID', 'text': 'travel_ID' },
            { 'key': 'bookings/usedString5', 'text': 'usedString5' },
            { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Divider },
            { 'key': 'notes', 'text': 'notes', 'itemType': UISelectableOptionMenuItemType.Header },
            { 'key': 'notes/comment', 'text': 'comment' },
            { 'key': 'notes/description', 'text': 'description' }
        ]
```

we need to allow search by `booking` to find all options.

As solution - new property added `searchByKeyEnabled`, which allows to search by key.
Before:
![image](https://github.com/user-attachments/assets/139f639e-e4ff-4e0d-a6d7-caa9f9f6044b)


With change and when `searchByKeyEnabled` is set to true:
![image](https://github.com/user-attachments/assets/79f106a0-321c-4574-8fd5-e798236972f4)


