### PR TITLE
fix(inquirer): adding i18n bundle of common module in consumers

### DIFF
--- a/.changeset/smart-pears-build.md
+++ b/.changeset/smart-pears-build.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+'@sap-ux/ui5-library-inquirer': patch
+'@sap-ux/inquirer-common': patch
+---
+
+add resource bundle for inquirer common in consumers

--- a/packages/inquirer-common/src/i18n.ts
+++ b/packages/inquirer-common/src/i18n.ts
@@ -3,13 +3,20 @@ import i18next from 'i18next';
 import translations from './translations/inquirer-common.i18n.json';
 
 const inquirerCommonI18nNamespace = 'inquirer-common';
+
+/**
+ * Adds the `inquirer-common` resource bundle to i18next.
+ * May be required to load i18n translations after initialising in the consumer module.
+ */
+export function addi18nResourceBundle(): void {
+    i18next.addResourceBundle('en', inquirerCommonI18nNamespace, translations);
+}
+
 /**
  * Initialize i18next with the translations for this module.
  */
 export async function initI18nInquirerCommon(): Promise<void> {
-    await i18next.init({ lng: 'en', fallbackLng: 'en' }, () =>
-        i18next.addResourceBundle('en', inquirerCommonI18nNamespace, translations)
-    );
+    await i18next.init({ lng: 'en', fallbackLng: 'en' }, () => addi18nResourceBundle());
 }
 
 /**

--- a/packages/inquirer-common/src/index.ts
+++ b/packages/inquirer-common/src/index.ts
@@ -1,3 +1,4 @@
 export * from './prompts/utility';
 export * from './types';
 export * from './prompts/helpers';
+export { addi18nResourceBundle } from './i18n';

--- a/packages/ui5-application-inquirer/src/i18n.ts
+++ b/packages/ui5-application-inquirer/src/i18n.ts
@@ -1,6 +1,7 @@
 import type { TOptions } from 'i18next';
 import i18next from 'i18next';
 import translations from './translations/ui5-application-inquirer.i18n.json';
+import { addi18nResourceBundle as addInquirerCommoni18nResourceBundle } from '@sap-ux/inquirer-common';
 
 const ui5AppInquirerNamespace = 'ui5-application-inquirer';
 export const defaultProjectNumber = 1;
@@ -8,18 +9,18 @@ export const defaultProjectNumber = 1;
  * Initialize i18next with the translations for this module.
  */
 export async function initI18nUi5AppInquirer(): Promise<void> {
-    await i18next.init(
-        {
-            lng: 'en',
-            fallbackLng: 'en',
-            interpolation: {
-                defaultVariables: {
-                    defaultProjectNumber
-                }
+    await i18next.init({
+        lng: 'en',
+        fallbackLng: 'en',
+        interpolation: {
+            defaultVariables: {
+                defaultProjectNumber
             }
-        },
-        () => i18next.addResourceBundle('en', ui5AppInquirerNamespace, translations)
-    );
+        }
+    });
+    i18next.addResourceBundle('en', ui5AppInquirerNamespace, translations);
+    // add the inquirer common i18n resource bundle to ensure all translations are available
+    addInquirerCommoni18nResourceBundle();
 }
 
 /**

--- a/packages/ui5-application-inquirer/test/unit/i18n.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/i18n.test.ts
@@ -1,0 +1,26 @@
+import * as mockI18next from 'i18next';
+import { initI18nUi5AppInquirer, t } from '../../src/i18n';
+import * as mockInquirerCommon from '@sap-ux/inquirer-common';
+
+jest.mock('i18next', () => ({
+    ...jest.requireActual('i18next'),
+    init: jest.fn(),
+    addResourceBundle: jest.fn(),
+    t: jest.fn()
+}));
+
+describe('i18n', () => {
+    test('initI18n', async () => {
+        const initSpy = jest.spyOn(mockI18next, 'init');
+        const addi18nResourceBundleSpy = jest.spyOn(mockInquirerCommon, 'addi18nResourceBundle');
+        await initI18nUi5AppInquirer();
+        expect(initSpy).toHaveBeenCalled();
+        expect(addi18nResourceBundleSpy).toHaveBeenCalled();
+    });
+
+    test('t', async () => {
+        const tSpy = jest.spyOn(mockI18next, 't');
+        t('test');
+        expect(tSpy).toHaveBeenCalledWith('test', { ns: 'ui5-application-inquirer' });
+    });
+});

--- a/packages/ui5-library-inquirer/src/i18n.ts
+++ b/packages/ui5-library-inquirer/src/i18n.ts
@@ -1,15 +1,17 @@
 import type { TOptions } from 'i18next';
 import i18next from 'i18next';
 import translations from './translations/ui5-library-inquirer.i18n.json';
+import { addi18nResourceBundle as addInquirerCommoni18nResourceBundle } from '@sap-ux/inquirer-common';
 
 const ui5LibI18nNamespace = 'ui5-library-inquirer';
 /**
  * Initialize i18next with the translations for this module.
  */
 export async function initI18n(): Promise<void> {
-    await i18next.init({ lng: 'en', fallbackLng: 'en' }, () =>
-        i18next.addResourceBundle('en', ui5LibI18nNamespace, translations)
-    );
+    await i18next.init({ lng: 'en', fallbackLng: 'en' });
+    i18next.addResourceBundle('en', ui5LibI18nNamespace, translations);
+    // add the inquirer common i18n resource bundle to ensure all translations are available
+    addInquirerCommoni18nResourceBundle();
 }
 
 /**

--- a/packages/ui5-library-inquirer/test/unit/i18n.test.ts
+++ b/packages/ui5-library-inquirer/test/unit/i18n.test.ts
@@ -1,0 +1,26 @@
+import * as mockI18next from 'i18next';
+import { initI18n, t } from '../../src/i18n';
+import * as mockInquirerCommon from '@sap-ux/inquirer-common';
+
+jest.mock('i18next', () => ({
+    ...jest.requireActual('i18next'),
+    init: jest.fn(),
+    addResourceBundle: jest.fn(),
+    t: jest.fn()
+}));
+
+describe('i18n', () => {
+    test('initI18n', async () => {
+        const initSpy = jest.spyOn(mockI18next, 'init');
+        const addi18nResourceBundleSpy = jest.spyOn(mockInquirerCommon, 'addi18nResourceBundle');
+        await initI18n();
+        expect(initSpy).toHaveBeenCalled();
+        expect(addi18nResourceBundleSpy).toHaveBeenCalled();
+    });
+
+    test('t', async () => {
+        const tSpy = jest.spyOn(mockI18next, 't');
+        t('test');
+        expect(tSpy).toHaveBeenCalledWith('test', { ns: 'ui5-library-inquirer' });
+    });
+});


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2496

Exposes function to add the resource bundle for the `@sap-ux/inquirer-common` module
This allows consuming modules to call this after initialising i18next and ensuring all translations are loaded at the time of prompting