### PR TITLE
fix(ui-components): `calloutCollisionTransformation` gets overwritten when external listeners are passed(calloutProps.preventDismissOnEvent, calloutProps.layerProps.onLayerDidMount, calloutProps.layerProps.onLayerWillUnmount)

### DIFF
--- a/.changeset/curly-dogs-smash.md
+++ b/.changeset/curly-dogs-smash.md
@@ -1,0 +1,9 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIComboBox/UIDropdown:
+Fixed an issue where `calloutCollisionTransformation` gets overwritten when external listeners are passed for the following props:
+- calloutProps.preventDismissOnEvent
+- calloutProps.layerProps.onLayerDidMount
+- calloutProps.layerProps.onLayerWillUnmount

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { IComboBoxProps, IComboBoxState, IAutofillProps, IButtonProps, ICalloutProps } from '@fluentui/react';
+import type { IComboBoxProps, IComboBoxState, IAutofillProps, IButtonProps } from '@fluentui/react';
 import {
     ComboBox,
     IComboBox,
@@ -18,7 +18,7 @@ import { UiIcons } from '../Icons';
 import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo, MESSAGE_TYPES_CLASSNAME_MAP } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
-import { isDropdownEmpty, getCalloutCollisionTransformationProps } from '../UIDropdown';
+import { isDropdownEmpty, getCalloutCollisionTransformationPropsForDropdown } from '../UIDropdown';
 import { CalloutCollisionTransform } from '../UICallout';
 import { isHTMLInputElement } from '../../utilities';
 
@@ -116,7 +116,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
     private query = '';
     private ignoreOpenKeys: Array<string> = ['Meta', 'Control', 'Shift', 'Tab', 'Alt', 'CapsLock'];
     private isListHidden = false;
-    private calloutCollisionTransform = new CalloutCollisionTransform(this.comboboxDomRef, this.menuDomRef);
+    public readonly calloutCollisionTransform = new CalloutCollisionTransform(this.comboboxDomRef, this.menuDomRef);
 
     /**
      * Initializes component properties.
@@ -139,9 +139,6 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
         this.onScrollToItem = this.onScrollToItem.bind(this);
         this.setFocus = this.setFocus.bind(this);
         this.onRenderIcon = this.onRenderIcon.bind(this);
-        this.preventDismissOnEvent = this.preventDismissOnEvent.bind(this);
-        this.onLayerDidMount = this.onLayerDidMount.bind(this);
-        this.onLayerWillUnmount = this.onLayerWillUnmount.bind(this);
 
         initializeComponentRef(this);
 
@@ -711,69 +708,6 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
     }
 
     /**
-     * Method returns additional callout props for callout collision transformation if feature is enabled.
-     *
-     * @returns Callout props to enable callout collision transformation.
-     */
-    private getCalloutCollisionTransformationProps(): ICalloutProps {
-        return (
-            getCalloutCollisionTransformationProps(
-                this.calloutCollisionTransform,
-                this.props.multiSelect,
-                this.props.calloutCollisionTransformation
-            ) ?? {}
-        );
-    }
-
-    /**
-     * Method prevents callout dismiss/close if focus/click on target elements.
-     *
-     * @param event Triggered event to check.
-     * @returns Returns true if callout should not be closed.
-     */
-    private preventDismissOnEvent(
-        event: Event | React.FocusEvent<Element> | React.KeyboardEvent<Element> | React.MouseEvent<Element, MouseEvent>
-    ): boolean {
-        let preventDismiss = false;
-        if (this.props.calloutProps?.preventDismissOnEvent) {
-            preventDismiss = this.props.calloutProps.preventDismissOnEvent(event);
-        }
-        if (!preventDismiss) {
-            const { preventDismissOnEvent } = this.getCalloutCollisionTransformationProps();
-            if (preventDismissOnEvent) {
-                return preventDismissOnEvent(event);
-            }
-        }
-        return preventDismiss;
-    }
-
-    /**
-     * Callback for when the callout layer is mounted.
-     */
-    private onLayerDidMount(): void {
-        const { layerProps } = this.getCalloutCollisionTransformationProps();
-        if (this.props.calloutProps?.layerProps?.onLayerDidMount) {
-            this.props.calloutProps?.layerProps?.onLayerDidMount();
-        }
-        if (layerProps?.onLayerDidMount) {
-            layerProps.onLayerDidMount();
-        }
-    }
-
-    /**
-     * Callback for when the callout layer is unmounted.
-     */
-    private onLayerWillUnmount(): void {
-        const { layerProps } = this.getCalloutCollisionTransformationProps();
-        if (this.props.calloutProps?.layerProps?.onLayerWillUnmount) {
-            this.props.calloutProps?.layerProps?.onLayerWillUnmount();
-        }
-        if (layerProps?.onLayerWillUnmount) {
-            layerProps.onLayerWillUnmount();
-        }
-    }
-
-    /**
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
@@ -830,12 +764,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                         },
 
                         ...this.props.calloutProps,
-                        preventDismissOnEvent: this.preventDismissOnEvent,
-                        layerProps: {
-                            ...this.props.calloutProps?.layerProps,
-                            onLayerDidMount: this.onLayerDidMount,
-                            onLayerWillUnmount: this.onLayerWillUnmount
-                        }
+                        ...getCalloutCollisionTransformationPropsForDropdown(this)
                     }}
                     {...(this.props.highlight && {
                         onInput: this.onInput,

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -116,7 +116,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
     private query = '';
     private ignoreOpenKeys: Array<string> = ['Meta', 'Control', 'Shift', 'Tab', 'Alt', 'CapsLock'];
     private isListHidden = false;
-    public readonly calloutCollisionTransform = new CalloutCollisionTransform(this.comboboxDomRef, this.menuDomRef);
+    private calloutCollisionTransform = new CalloutCollisionTransform(this.comboboxDomRef, this.menuDomRef);
 
     /**
      * Initializes component properties.
@@ -764,7 +764,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                         },
 
                         ...this.props.calloutProps,
-                        ...getCalloutCollisionTransformationPropsForDropdown(this)
+                        ...getCalloutCollisionTransformationPropsForDropdown(this, this.calloutCollisionTransform)
                     }}
                     {...(this.props.highlight && {
                         onInput: this.onInput,

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -63,7 +63,7 @@ const ERROR_BORDER_COLOR = 'var(--vscode-inputValidation-errorBorder)';
 export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState> {
     private dropdownDomRef = React.createRef<HTMLDivElement>();
     private menuDomRef = React.createRef<HTMLDivElement>();
-    public readonly calloutCollisionTransform = new CalloutCollisionTransform(this.dropdownDomRef, this.menuDomRef);
+    private calloutCollisionTransform = new CalloutCollisionTransform(this.dropdownDomRef, this.menuDomRef);
 
     /**
      * Initializes component properties.
@@ -330,7 +330,7 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
                         ref: this.menuDomRef
                     },
                     ...this.props.calloutProps,
-                    ...getCalloutCollisionTransformationPropsForDropdown(this)
+                    ...getCalloutCollisionTransformationPropsForDropdown(this, this.calloutCollisionTransform)
                 }}
                 onRenderOption={this.onRenderOption.bind(this)}
                 onRenderItem={this.onRenderItem.bind(this)}

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -3,8 +3,7 @@ import type {
     IDropdownProps,
     IDropdownStyles,
     ICalloutContentStyleProps,
-    ICalloutContentStyles,
-    ICalloutProps
+    ICalloutContentStyles
 } from '@fluentui/react';
 import { Dropdown, DropdownMenuItemType, IDropdownOption, ResponsiveMode } from '@fluentui/react';
 
@@ -12,7 +11,7 @@ import { UIIcon } from '../UIIcon';
 import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo, MESSAGE_TYPES_CLASSNAME_MAP } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
-import { isDropdownEmpty, getCalloutCollisionTransformationProps } from './utils';
+import { isDropdownEmpty, getCalloutCollisionTransformationPropsForDropdown } from './utils';
 import { CalloutCollisionTransform } from '../UICallout';
 
 import './UIDropdown.scss';
@@ -64,7 +63,7 @@ const ERROR_BORDER_COLOR = 'var(--vscode-inputValidation-errorBorder)';
 export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState> {
     private dropdownDomRef = React.createRef<HTMLDivElement>();
     private menuDomRef = React.createRef<HTMLDivElement>();
-    private calloutCollisionTransform = new CalloutCollisionTransform(this.dropdownDomRef, this.menuDomRef);
+    public readonly calloutCollisionTransform = new CalloutCollisionTransform(this.dropdownDomRef, this.menuDomRef);
 
     /**
      * Initializes component properties.
@@ -78,9 +77,6 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
             options: [],
             isOpen: false
         };
-        this.preventDismissOnEvent = this.preventDismissOnEvent.bind(this);
-        this.onLayerDidMount = this.onLayerDidMount.bind(this);
-        this.onLayerWillUnmount = this.onLayerWillUnmount.bind(this);
     }
 
     onRenderCaretDown = (): JSX.Element => {
@@ -287,69 +283,6 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
     }
 
     /**
-     * Method returns additional callout props for callout collision transformation if feature is enabled.
-     *
-     * @returns Callout props to enable callout collision transformation.
-     */
-    private getCalloutCollisionTransformationProps(): ICalloutProps {
-        return (
-            getCalloutCollisionTransformationProps(
-                this.calloutCollisionTransform,
-                this.props.multiSelect,
-                this.props.calloutCollisionTransformation
-            ) ?? {}
-        );
-    }
-
-    /**
-     * Method prevents callout dismiss/close if focus/click on target elements.
-     *
-     * @param event Triggered event to check.
-     * @returns Returns true if callout should not be closed.
-     */
-    private preventDismissOnEvent(
-        event: Event | React.FocusEvent<Element> | React.KeyboardEvent<Element> | React.MouseEvent<Element, MouseEvent>
-    ): boolean {
-        let preventDismiss = false;
-        if (this.props.calloutProps?.preventDismissOnEvent) {
-            preventDismiss = this.props.calloutProps.preventDismissOnEvent(event);
-        }
-        if (!preventDismiss) {
-            const { preventDismissOnEvent } = this.getCalloutCollisionTransformationProps();
-            if (preventDismissOnEvent) {
-                return preventDismissOnEvent(event);
-            }
-        }
-        return preventDismiss;
-    }
-
-    /**
-     * Callback for when the callout layer is mounted.
-     */
-    private onLayerDidMount(): void {
-        const { layerProps } = this.getCalloutCollisionTransformationProps();
-        if (this.props.calloutProps?.layerProps?.onLayerDidMount) {
-            this.props.calloutProps?.layerProps?.onLayerDidMount();
-        }
-        if (layerProps?.onLayerDidMount) {
-            layerProps.onLayerDidMount();
-        }
-    }
-
-    /**
-     * Callback for when the callout layer is unmounted.
-     */
-    private onLayerWillUnmount(): void {
-        const { layerProps } = this.getCalloutCollisionTransformationProps();
-        if (this.props.calloutProps?.layerProps?.onLayerWillUnmount) {
-            this.props.calloutProps?.layerProps?.onLayerWillUnmount();
-        }
-        if (layerProps?.onLayerWillUnmount) {
-            layerProps.onLayerWillUnmount();
-        }
-    }
-
-    /**
      * @returns {JSX.Element}
      */
     render(): JSX.Element {
@@ -397,12 +330,7 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
                         ref: this.menuDomRef
                     },
                     ...this.props.calloutProps,
-                    preventDismissOnEvent: this.preventDismissOnEvent,
-                    layerProps: {
-                        ...this.props.calloutProps?.layerProps,
-                        onLayerDidMount: this.onLayerDidMount,
-                        onLayerWillUnmount: this.onLayerWillUnmount
-                    }
+                    ...getCalloutCollisionTransformationPropsForDropdown(this)
                 }}
                 onRenderOption={this.onRenderOption.bind(this)}
                 onRenderItem={this.onRenderItem.bind(this)}

--- a/packages/ui-components/src/components/UIDropdown/utils.ts
+++ b/packages/ui-components/src/components/UIDropdown/utils.ts
@@ -1,5 +1,7 @@
 import type { IDropdownProps, IComboBoxProps, ICalloutProps } from '@fluentui/react';
 import type { CalloutCollisionTransform } from '../UICallout';
+import type { UIDropdown } from './UIDropdown';
+import type { UIComboBox } from '../UIComboBox';
 
 /**
  * Method checks if drodpown or combobox is empty or any value is selected.
@@ -39,6 +41,106 @@ export function getCalloutCollisionTransformationProps(
             layerProps: {
                 onLayerDidMount: calloutCollisionTransform.applyTransformation,
                 onLayerWillUnmount: calloutCollisionTransform.resetTransformation
+            }
+        };
+    }
+    return undefined;
+}
+
+/**
+ * Method returns callback function to 'onLayerDidMount' property of dropdown 'callout'.
+ *
+ * @param dropdown Instance of dropdown.
+ * @returns Returns callback function to 'onLayerDidMount' property of dropdown 'callout'.
+ */
+function getOnLayerDidMount(dropdown: UIDropdown | UIComboBox): () => void {
+    return () => {
+        const { layerProps } =
+            getCalloutCollisionTransformationProps(
+                dropdown.calloutCollisionTransform,
+                dropdown.props.multiSelect,
+                dropdown.props.calloutCollisionTransformation
+            ) ?? {};
+        if (dropdown.props.calloutProps?.layerProps?.onLayerDidMount) {
+            dropdown.props.calloutProps?.layerProps?.onLayerDidMount();
+        }
+        if (layerProps?.onLayerDidMount) {
+            layerProps.onLayerDidMount();
+        }
+    };
+}
+
+/**
+ * Method returns callback function to 'onLayerWillUnmount' property of dropdown 'callout'.
+ *
+ * @param dropdown Instance of dropdown.
+ * @returns Returns callback function to 'onLayerWillUnmount' property of dropdown 'callout'.
+ */
+function getOnLayerWillUnmount(dropdown: UIDropdown | UIComboBox): () => void {
+    return () => {
+        const { layerProps } =
+            getCalloutCollisionTransformationProps(
+                dropdown.calloutCollisionTransform,
+                dropdown.props.multiSelect,
+                dropdown.props.calloutCollisionTransformation
+            ) ?? {};
+        if (dropdown.props.calloutProps?.layerProps?.onLayerWillUnmount) {
+            dropdown.props.calloutProps?.layerProps?.onLayerWillUnmount();
+        }
+        if (layerProps?.onLayerWillUnmount) {
+            layerProps.onLayerWillUnmount();
+        }
+    };
+}
+
+/**
+ * Method returns callback function to 'preventDismissOnEvent' property of dropdown 'callout', which prevents callout dismiss/close if focus/click on target elements.
+ *
+ * @param dropdown Instance of dropdown.
+ * @returns Returns callback function to 'preventDismissOnEvent' property of dropdown 'callout'.
+ */
+function getPreventDismissOnEvent(
+    dropdown: UIDropdown | UIComboBox
+): (
+    event: Event | React.FocusEvent<Element> | React.KeyboardEvent<Element> | React.MouseEvent<Element, MouseEvent>
+) => boolean {
+    return (event) => {
+        let preventDismiss = false;
+        if (dropdown.props.calloutProps?.preventDismissOnEvent) {
+            preventDismiss = dropdown.props.calloutProps.preventDismissOnEvent(event);
+        }
+        if (!preventDismiss) {
+            const { preventDismissOnEvent } =
+                getCalloutCollisionTransformationProps(
+                    dropdown.calloutCollisionTransform,
+                    dropdown.props.multiSelect,
+                    dropdown.props.calloutCollisionTransformation
+                ) ?? {};
+            if (preventDismissOnEvent) {
+                return preventDismissOnEvent(event);
+            }
+        }
+        return preventDismiss;
+    };
+}
+
+/**
+ * Method returns additional callout props for callout collision transformation if feature is enabled.
+ * Callout collision transformation checks if dropdown menu overlaps with dialog action/submit buttons
+ *  and if overlap happens, then additional offset is applied to make action buttons visible.
+ *
+ * @param dropdown Instance of dropdown.
+ * @returns Callout props to enable callout collision transformation.
+ */
+export function getCalloutCollisionTransformationPropsForDropdown(
+    dropdown: UIDropdown | UIComboBox
+): ICalloutProps | undefined {
+    if (dropdown.props.multiSelect && dropdown.props.calloutCollisionTransformation) {
+        return {
+            preventDismissOnEvent: getPreventDismissOnEvent(dropdown),
+            layerProps: {
+                onLayerDidMount: getOnLayerDidMount(dropdown),
+                onLayerWillUnmount: getOnLayerWillUnmount(dropdown)
             }
         };
     }

--- a/packages/ui-components/src/components/UIDropdown/utils.ts
+++ b/packages/ui-components/src/components/UIDropdown/utils.ts
@@ -51,13 +51,17 @@ export function getCalloutCollisionTransformationProps(
  * Method returns callback function to 'onLayerDidMount' property of dropdown 'callout'.
  *
  * @param dropdown Instance of dropdown.
+ * @param calloutCollisionTransform of callout collision transformation.
  * @returns Returns callback function to 'onLayerDidMount' property of dropdown 'callout'.
  */
-function getOnLayerDidMount(dropdown: UIDropdown | UIComboBox): () => void {
+function getOnLayerDidMount(
+    dropdown: UIDropdown | UIComboBox,
+    calloutCollisionTransform: CalloutCollisionTransform
+): () => void {
     return () => {
         const { layerProps } =
             getCalloutCollisionTransformationProps(
-                dropdown.calloutCollisionTransform,
+                calloutCollisionTransform,
                 dropdown.props.multiSelect,
                 dropdown.props.calloutCollisionTransformation
             ) ?? {};
@@ -74,13 +78,17 @@ function getOnLayerDidMount(dropdown: UIDropdown | UIComboBox): () => void {
  * Method returns callback function to 'onLayerWillUnmount' property of dropdown 'callout'.
  *
  * @param dropdown Instance of dropdown.
+ * @param calloutCollisionTransform of callout collision transformation.
  * @returns Returns callback function to 'onLayerWillUnmount' property of dropdown 'callout'.
  */
-function getOnLayerWillUnmount(dropdown: UIDropdown | UIComboBox): () => void {
+function getOnLayerWillUnmount(
+    dropdown: UIDropdown | UIComboBox,
+    calloutCollisionTransform: CalloutCollisionTransform
+): () => void {
     return () => {
         const { layerProps } =
             getCalloutCollisionTransformationProps(
-                dropdown.calloutCollisionTransform,
+                calloutCollisionTransform,
                 dropdown.props.multiSelect,
                 dropdown.props.calloutCollisionTransformation
             ) ?? {};
@@ -97,10 +105,12 @@ function getOnLayerWillUnmount(dropdown: UIDropdown | UIComboBox): () => void {
  * Method returns callback function to 'preventDismissOnEvent' property of dropdown 'callout', which prevents callout dismiss/close if focus/click on target elements.
  *
  * @param dropdown Instance of dropdown.
+ * @param calloutCollisionTransform of callout collision transformation.
  * @returns Returns callback function to 'preventDismissOnEvent' property of dropdown 'callout'.
  */
 function getPreventDismissOnEvent(
-    dropdown: UIDropdown | UIComboBox
+    dropdown: UIDropdown | UIComboBox,
+    calloutCollisionTransform: CalloutCollisionTransform
 ): (
     event: Event | React.FocusEvent<Element> | React.KeyboardEvent<Element> | React.MouseEvent<Element, MouseEvent>
 ) => boolean {
@@ -112,7 +122,7 @@ function getPreventDismissOnEvent(
         if (!preventDismiss) {
             const { preventDismissOnEvent } =
                 getCalloutCollisionTransformationProps(
-                    dropdown.calloutCollisionTransform,
+                    calloutCollisionTransform,
                     dropdown.props.multiSelect,
                     dropdown.props.calloutCollisionTransformation
                 ) ?? {};
@@ -130,17 +140,19 @@ function getPreventDismissOnEvent(
  *  and if overlap happens, then additional offset is applied to make action buttons visible.
  *
  * @param dropdown Instance of dropdown.
+ * @param calloutCollisionTransform of callout collision transformation.
  * @returns Callout props to enable callout collision transformation.
  */
 export function getCalloutCollisionTransformationPropsForDropdown(
-    dropdown: UIDropdown | UIComboBox
+    dropdown: UIDropdown | UIComboBox,
+    calloutCollisionTransform: CalloutCollisionTransform
 ): ICalloutProps | undefined {
     if (dropdown.props.multiSelect && dropdown.props.calloutCollisionTransformation) {
         return {
-            preventDismissOnEvent: getPreventDismissOnEvent(dropdown),
+            preventDismissOnEvent: getPreventDismissOnEvent(dropdown, calloutCollisionTransform),
             layerProps: {
-                onLayerDidMount: getOnLayerDidMount(dropdown),
-                onLayerWillUnmount: getOnLayerWillUnmount(dropdown)
+                onLayerDidMount: getOnLayerDidMount(dropdown, calloutCollisionTransform),
+                onLayerWillUnmount: getOnLayerWillUnmount(dropdown, calloutCollisionTransform)
             }
         };
     }

--- a/packages/ui-components/stories/UICalloutCollisionTransform.story.tsx
+++ b/packages/ui-components/stories/UICalloutCollisionTransform.story.tsx
@@ -10,7 +10,9 @@ import {
     UITextInput,
     UICallout,
     UICheckbox,
-    CalloutCollisionTransform
+    CalloutCollisionTransform,
+    UIComboBoxProps,
+    UIDropdownProps
 } from '../src/components';
 import { data } from '../test/__mock__/select-data';
 
@@ -61,7 +63,57 @@ const CustomCallout = (props: { id: string }) => {
     );
 };
 
-const getContent = (controlType: ControlTypes, enabled: boolean) => {
+const ComboBoxOverwritter = (props: UIComboBoxProps) => {
+    return (
+        <UIComboBox
+            {...props}
+            ref={undefined}
+            calloutProps={{
+                preventDismissOnEvent: () => {
+                    console.log('custom preventDismissOnEvent');
+                    return false;
+                },
+                layerProps: {
+                    onLayerDidMount: () => {
+                        console.log('custom onLayerDidMount');
+                        return false;
+                    },
+                    onLayerWillUnmount: () => {
+                        console.log('custom onLayerWillUnmount');
+                        return false;
+                    }
+                }
+            }}
+        />
+    );
+};
+
+const DropdownOverwritter = (props: UIDropdownProps) => {
+    return (
+        <UIDropdown
+            {...props}
+            ref={undefined}
+            calloutProps={{
+                preventDismissOnEvent: () => {
+                    console.log('custom preventDismissOnEvent');
+                    return false;
+                },
+                layerProps: {
+                    onLayerDidMount: () => {
+                        console.log('custom onLayerDidMount');
+                        return false;
+                    },
+                    onLayerWillUnmount: () => {
+                        console.log('custom onLayerWillUnmount');
+                        return false;
+                    }
+                }
+            }}
+        />
+    );
+};
+
+const getContent = (controlType: ControlTypes, enabled: boolean, overwrittenComponent = false) => {
     const content: React.ReactElement[] = [];
 
     for (let i = 0; i < 6; i++) {
@@ -69,7 +121,16 @@ const getContent = (controlType: ControlTypes, enabled: boolean) => {
         if (controlType === ControlTypes.Callout) {
             element = <CustomCallout key={i} id={`Dummy-${i}`} />;
         } else {
-            const Control = controlType === ControlTypes.ComboBox ? UIComboBox : UIDropdown;
+            let Control:
+                | typeof UIComboBox
+                | typeof UIDropdown
+                | typeof ComboBoxOverwritter
+                | typeof DropdownOverwritter;
+            if (!overwrittenComponent) {
+                Control = controlType === ControlTypes.ComboBox ? UIComboBox : UIDropdown;
+            } else {
+                Control = controlType === ControlTypes.ComboBox ? ComboBoxOverwritter : DropdownOverwritter;
+            }
             element = (
                 <Control
                     key={i}
@@ -91,6 +152,7 @@ export const collisionTransformInDialog = () => {
     const [isOpen, setIsOpen] = useState(false);
     const [enabled, setEnabled] = useState(true);
     const [selectedType, setSelectedType] = useState<string>(ControlTypes.ComboBox);
+    const [overwrittenComponents, setOverwrittenComponents] = useState<boolean>(false);
     const onToggle = () => {
         setIsOpen(!isOpen);
     };
@@ -129,6 +191,18 @@ export const collisionTransformInDialog = () => {
                         }
                     }}
                 />
+                <UICheckbox
+                    label={'Use overwritten components'}
+                    checked={overwrittenComponents}
+                    onChange={() => {
+                        setOverwrittenComponents(!overwrittenComponents);
+                    }}
+                    styles={{
+                        label: {
+                            alignItems: 'center'
+                        }
+                    }}
+                />
             </div>
             <UIDefaultButton onClick={onToggle} primary>
                 Open Dialog
@@ -150,7 +224,7 @@ export const collisionTransformInDialog = () => {
                 }}
                 onCancel={onToggle}
                 onDismiss={onToggle}>
-                {getContent(ControlTypes[selectedType], enabled)}
+                {getContent(ControlTypes[selectedType], enabled, overwrittenComponents)}
             </UIDialog>
         </>
     );

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -6,6 +6,7 @@ import { data as originalData, groupsData as originalGroupsData } from '../../__
 import { initIcons } from '../../../src/components/Icons';
 import type { IComboBox, IComboBoxOption } from '@fluentui/react';
 import { KeyCodes, ComboBox, Autofill } from '@fluentui/react';
+import { CalloutCollisionTransform } from '../../../src/components/UICallout/CalloutCollisionTransform';
 
 const data = JSON.parse(JSON.stringify(originalData));
 const groupsData = JSON.parse(JSON.stringify(originalGroupsData));
@@ -32,8 +33,18 @@ describe('<UIComboBox />', () => {
             target: getInputTarget(query)
         });
     };
+    let CalloutCollisionTransformSpy: {
+        preventDismissOnEvent: jest.SpyInstance;
+        applyTransformation: jest.SpyInstance;
+        resetTransformation: jest.SpyInstance;
+    };
 
     beforeEach(() => {
+        CalloutCollisionTransformSpy = {
+            preventDismissOnEvent: jest.spyOn(CalloutCollisionTransform.prototype, 'preventDismissOnEvent'),
+            applyTransformation: jest.spyOn(CalloutCollisionTransform.prototype, 'applyTransformation'),
+            resetTransformation: jest.spyOn(CalloutCollisionTransform.prototype, 'resetTransformation')
+        };
         wrapper = Enzyme.mount(<UIComboBox options={data} highlight={false} allowFreeform={true} autoComplete="on" />);
     });
 
@@ -781,17 +792,52 @@ describe('<UIComboBox />', () => {
                 const dropdown = wrapper.find(ComboBox);
                 expect(dropdown.length).toEqual(1);
                 const calloutProps = dropdown.prop('calloutProps');
-                if (expected) {
-                    expect(calloutProps?.preventDismissOnEvent).toBeDefined();
-                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
-                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
-                } else {
-                    expect(calloutProps?.preventDismissOnEvent).toBeUndefined();
-                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeUndefined();
-                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeUndefined();
-                }
+                expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+                expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+                expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+
+                calloutProps?.preventDismissOnEvent?.({} as Event);
+                calloutProps?.layerProps?.onLayerDidMount?.();
+                calloutProps?.layerProps?.onLayerWillUnmount?.();
+                expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(expected ? 1 : 0);
+                expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(expected ? 1 : 0);
+                expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(expected ? 1 : 0);
             });
         }
+
+        it(`Pass external listeners`, () => {
+            const externalListeners = {
+                calloutProps: {
+                    preventDismissOnEvent: jest.fn(),
+                    layerProps: {
+                        onLayerDidMount: jest.fn(),
+                        onLayerWillUnmount: jest.fn()
+                    }
+                }
+            };
+            wrapper.setProps({
+                multiSelect: true,
+                calloutCollisionTransformation: true,
+                ...externalListeners
+            });
+            const dropdown = wrapper.find(ComboBox);
+            expect(dropdown.length).toEqual(1);
+            const calloutProps = dropdown.prop('calloutProps');
+            // if (expected) {
+            expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+            expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+            expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+
+            calloutProps?.preventDismissOnEvent?.({} as Event);
+            calloutProps?.layerProps?.onLayerDidMount?.();
+            calloutProps?.layerProps?.onLayerWillUnmount?.();
+            expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(1);
+            expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(1);
+            expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.preventDismissOnEvent).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.layerProps.onLayerDidMount).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.layerProps.onLayerWillUnmount).toBeCalledTimes(1);
+        });
     });
 
     describe('Test "isLoading" property', () => {

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -792,16 +792,22 @@ describe('<UIComboBox />', () => {
                 const dropdown = wrapper.find(ComboBox);
                 expect(dropdown.length).toEqual(1);
                 const calloutProps = dropdown.prop('calloutProps');
-                expect(calloutProps?.preventDismissOnEvent).toBeDefined();
-                expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
-                expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+                if (expected) {
+                    expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
 
-                calloutProps?.preventDismissOnEvent?.({} as Event);
-                calloutProps?.layerProps?.onLayerDidMount?.();
-                calloutProps?.layerProps?.onLayerWillUnmount?.();
-                expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(expected ? 1 : 0);
-                expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(expected ? 1 : 0);
-                expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(expected ? 1 : 0);
+                    calloutProps?.preventDismissOnEvent?.({} as Event);
+                    calloutProps?.layerProps?.onLayerDidMount?.();
+                    calloutProps?.layerProps?.onLayerWillUnmount?.();
+                    expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(expected ? 1 : 0);
+                    expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(expected ? 1 : 0);
+                    expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(expected ? 1 : 0);
+                } else {
+                    expect(calloutProps?.preventDismissOnEvent).toBeUndefined();
+                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeUndefined();
+                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeUndefined();
+                }
             });
         }
 
@@ -823,10 +829,6 @@ describe('<UIComboBox />', () => {
             const dropdown = wrapper.find(ComboBox);
             expect(dropdown.length).toEqual(1);
             const calloutProps = dropdown.prop('calloutProps');
-            // if (expected) {
-            expect(calloutProps?.preventDismissOnEvent).toBeDefined();
-            expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
-            expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
 
             calloutProps?.preventDismissOnEvent?.({} as Event);
             calloutProps?.layerProps?.onLayerDidMount?.();

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -20,11 +20,23 @@ describe('<UIDropdown />', () => {
         wrapper.find('.ms-Dropdown .ms-Dropdown-caretDownWrapper').simulate('click', document.createEvent('Events'));
     };
 
+    let CalloutCollisionTransformSpy: {
+        preventDismissOnEvent: jest.SpyInstance;
+        applyTransformation: jest.SpyInstance;
+        resetTransformation: jest.SpyInstance;
+    };
+
     beforeEach(() => {
+        CalloutCollisionTransformSpy = {
+            preventDismissOnEvent: jest.spyOn(CalloutCollisionTransform.prototype, 'preventDismissOnEvent'),
+            applyTransformation: jest.spyOn(CalloutCollisionTransform.prototype, 'applyTransformation'),
+            resetTransformation: jest.spyOn(CalloutCollisionTransform.prototype, 'resetTransformation')
+        };
         wrapper = Enzyme.mount(<UIDropdown options={data} selectedKey="EE" />);
     });
 
     afterEach(() => {
+        jest.clearAllMocks();
         wrapper.unmount();
     });
 
@@ -356,17 +368,51 @@ describe('<UIDropdown />', () => {
                 const dropdown = wrapper.find(Dropdown);
                 expect(dropdown.length).toEqual(1);
                 const calloutProps = dropdown.prop('calloutProps');
-                if (expected) {
-                    expect(calloutProps?.preventDismissOnEvent).toBeDefined();
-                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
-                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
-                } else {
-                    expect(calloutProps?.preventDismissOnEvent).toBeUndefined();
-                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeUndefined();
-                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeUndefined();
-                }
+                expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+                expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+                expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+
+                calloutProps?.preventDismissOnEvent?.({} as Event);
+                calloutProps?.layerProps?.onLayerDidMount?.();
+                calloutProps?.layerProps?.onLayerWillUnmount?.();
+                expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(expected ? 1 : 0);
+                expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(expected ? 1 : 0);
+                expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(expected ? 1 : 0);
             });
         }
+
+        it(`Pass external listeners`, () => {
+            const externalListeners = {
+                calloutProps: {
+                    preventDismissOnEvent: jest.fn(),
+                    layerProps: {
+                        onLayerDidMount: jest.fn(),
+                        onLayerWillUnmount: jest.fn()
+                    }
+                }
+            };
+            wrapper.setProps({
+                multiSelect: true,
+                calloutCollisionTransformation: true,
+                ...externalListeners
+            });
+            const dropdown = wrapper.find(Dropdown);
+            expect(dropdown.length).toEqual(1);
+            const calloutProps = dropdown.prop('calloutProps');
+            expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+            expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+            expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+
+            calloutProps?.preventDismissOnEvent?.({} as Event);
+            calloutProps?.layerProps?.onLayerDidMount?.();
+            calloutProps?.layerProps?.onLayerWillUnmount?.();
+            expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(1);
+            expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(1);
+            expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.preventDismissOnEvent).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.layerProps.onLayerDidMount).toBeCalledTimes(1);
+            expect(externalListeners.calloutProps.layerProps.onLayerWillUnmount).toBeCalledTimes(1);
+        });
     });
 
     it('Custom renderers for "onRenderOption"', () => {

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -368,16 +368,23 @@ describe('<UIDropdown />', () => {
                 const dropdown = wrapper.find(Dropdown);
                 expect(dropdown.length).toEqual(1);
                 const calloutProps = dropdown.prop('calloutProps');
-                expect(calloutProps?.preventDismissOnEvent).toBeDefined();
-                expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
-                expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
 
-                calloutProps?.preventDismissOnEvent?.({} as Event);
-                calloutProps?.layerProps?.onLayerDidMount?.();
-                calloutProps?.layerProps?.onLayerWillUnmount?.();
-                expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(expected ? 1 : 0);
-                expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(expected ? 1 : 0);
-                expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(expected ? 1 : 0);
+                if (expected) {
+                    expect(calloutProps?.preventDismissOnEvent).toBeDefined();
+                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeDefined();
+                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeDefined();
+
+                    calloutProps?.preventDismissOnEvent?.({} as Event);
+                    calloutProps?.layerProps?.onLayerDidMount?.();
+                    calloutProps?.layerProps?.onLayerWillUnmount?.();
+                    expect(CalloutCollisionTransformSpy.preventDismissOnEvent).toBeCalledTimes(1);
+                    expect(CalloutCollisionTransformSpy.applyTransformation).toBeCalledTimes(1);
+                    expect(CalloutCollisionTransformSpy.resetTransformation).toBeCalledTimes(1);
+                } else {
+                    expect(calloutProps?.preventDismissOnEvent).toBeUndefined();
+                    expect(calloutProps?.layerProps?.onLayerDidMount).toBeUndefined();
+                    expect(calloutProps?.layerProps?.onLayerWillUnmount).toBeUndefined();
+                }
             });
         }
 


### PR DESCRIPTION
UIComboBox/UIDropdown:
Fixed an issue where `calloutCollisionTransformation` gets overwritten when external listeners are passed for the following props:
- calloutProps.preventDismissOnEvent
- calloutProps.layerProps.onLayerDidMount
- calloutProps.layerProps.onLayerWillUnmount

Scenario was:
1. enable `calloutCollisionTransformation` feature;
2. pass properties -> `calloutProps.preventDismissOnEvent`, `calloutProps.layerProps.onLayerDidMount`, `calloutProps.layerProps.onLayerWillUnmount`