### PR TITLE
fix(ui-components): ignore asterisk for screen readers

### DIFF
--- a/.changeset/cyan-eggs-swim.md
+++ b/.changeset/cyan-eggs-swim.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UITextInput, UIComboBox, UIDropdown, and UIChoiceGroup: Do not announce 'asterisk' on screen readers for required labels

--- a/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
+++ b/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@fluentui/react';
 import { ChoiceGroup } from '@fluentui/react';
 import { labelGlobalStyle } from '../UILabel';
+import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 export type ChoiceGroupOption = IChoiceGroupOption;
 export type ChoiceGroupOptionProps = IChoiceGroupOptionProps;
@@ -162,7 +163,7 @@ export class UIChoiceGroup extends React.Component<ChoiceGroupProps, {}> {
                 ...(this.props.required && {
                     selectors: {
                         '::after': {
-                            content: `' *'`,
+                            content: REQUIRED_LABEL_INDICATOR,
                             color: 'var(--vscode-inputValidation-errorBorder)',
                             paddingRight: 12
                         }

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -21,6 +21,7 @@ import { labelGlobalStyle } from '../UILabel';
 import { isDropdownEmpty, getCalloutCollisionTransformationPropsForDropdown } from '../UIDropdown';
 import { CalloutCollisionTransform } from '../UICallout';
 import { isHTMLInputElement } from '../../utilities';
+import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 export {
     IComboBoxOption as UIComboBoxOption,
@@ -737,7 +738,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                             ...(this.props.required && {
                                 selectors: {
                                     '::after': {
-                                        content: `' *'`,
+                                        content: REQUIRED_LABEL_INDICATOR,
                                         color: 'var(--vscode-inputValidation-errorBorder)',
                                         paddingRight: 12
                                     }

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.tsx
@@ -13,6 +13,7 @@ import { getMessageInfo, MESSAGE_TYPES_CLASSNAME_MAP } from '../../helper/Valida
 import { labelGlobalStyle } from '../UILabel';
 import { isDropdownEmpty, getCalloutCollisionTransformationPropsForDropdown } from './utils';
 import { CalloutCollisionTransform } from '../UICallout';
+import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 import './UIDropdown.scss';
 
@@ -298,7 +299,7 @@ export class UIDropdown extends React.Component<UIDropdownProps, UIDropdownState
                     ...(this.props.required && {
                         selectors: {
                             '::after': {
-                                content: `' *'`,
+                                content: REQUIRED_LABEL_INDICATOR,
                                 color: ERROR_BORDER_COLOR,
                                 paddingRight: 12
                             }

--- a/packages/ui-components/src/components/UIInput/UITextInput.tsx
+++ b/packages/ui-components/src/components/UIInput/UITextInput.tsx
@@ -5,6 +5,7 @@ import { TextField } from '@fluentui/react';
 import type { UIMessagesExtendedProps, InputValidationMessageInfo } from '../../helper/ValidationMessage';
 import { getMessageInfo } from '../../helper/ValidationMessage';
 import { labelGlobalStyle } from '../UILabel';
+import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 export { ITextField, ITextFieldProps } from '@fluentui/react';
 
@@ -206,7 +207,7 @@ export class UITextInput extends React.Component<UITextInputProps> {
                             props.required && {
                                 selectors: {
                                     '::after': {
-                                        content: `' *'`,
+                                        content: REQUIRED_LABEL_INDICATOR,
                                         color: 'var(--vscode-inputValidation-errorBorder)',
                                         paddingRight: 12
                                     }

--- a/packages/ui-components/src/components/UILabel/UILabel.tsx
+++ b/packages/ui-components/src/components/UILabel/UILabel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { ILabelProps, ILabelStyleProps, ILabelStyles } from '@fluentui/react';
 import { Label } from '@fluentui/react';
+import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 export type UILabelProps = ILabelProps;
 
@@ -49,7 +50,7 @@ export class UILabel extends React.Component<UILabelProps> {
                         props.required && {
                             selectors: {
                                 '::after': {
-                                    content: `' *'`,
+                                    content: REQUIRED_LABEL_INDICATOR,
                                     color: 'var(--vscode-inputValidation-errorBorder)',
                                     paddingRight: 12
                                 }

--- a/packages/ui-components/src/components/types.ts
+++ b/packages/ui-components/src/components/types.ts
@@ -1,0 +1,2 @@
+// Asterisk for visible UI and empty for screen readers
+export const REQUIRED_LABEL_INDICATOR = `' *' / ''`;

--- a/packages/ui-components/stories/UITextInput.story.tsx
+++ b/packages/ui-components/stories/UITextInput.story.tsx
@@ -37,6 +37,10 @@ export const defaultUsage = () => {
                 </Text>
                 <UITextInput label="Enter your name" disabled></UITextInput>
             </Stack>
+
+            <Stack tokens={{ childrenGap: 16 }}>
+                <UITextInput label="Required" required={true}></UITextInput>
+            </Stack>
         </Stack>
     );
 };

--- a/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
+++ b/packages/ui-components/test/__snapshots__/UITextfield.test.tsx.snap
@@ -1327,3 +1327,110 @@ Object {
   },
 }
 `;
+
+exports[`<UIToggle /> Styles - required 1`] = `
+Object {
+  "errorMessage": Array [
+    Object {
+      "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+      "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderColor": "var(--vscode-inputValidation-errorBorder)",
+      "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+      "color": "var(--vscode-input-foreground)",
+      "margin": 0,
+      "paddingBottom": 5,
+      "paddingLeft": 8,
+      "paddingTop": 4,
+    },
+  ],
+  "field": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderRadius": 2,
+      "boxSizing": "border-box",
+      "color": "var(--vscode-input-foreground)",
+      "fontFamily": "var(--vscode-font-family)",
+      "fontSize": "13px",
+      "fontWeight": "normal",
+      "selectors": Object {
+        "::placeholder": Object {
+          "color": "var(--vscode-input-placeholderForeground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": 13,
+        },
+      },
+    },
+    Object {
+      "lineHeight": "normal",
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "fieldGroup": Array [
+    Object {
+      "backgroundColor": "var(--vscode-input-background)",
+      "borderColor": "var(--vscode-editorWidget-border)",
+      "borderRadius": 2,
+      "borderStyle": "solid",
+      "borderWidth": 1,
+      "boxSizing": "initial",
+      "color": "var(--vscode-input-foreground)",
+    },
+    Object {
+      "height": 24,
+      "maxHeight": 24,
+      "minHeight": 24,
+    },
+    Object {
+      "selectors": Object {
+        "&:hover": Object {
+          "borderColor": "var(--vscode-focusBorder)",
+        },
+      },
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ],
+  "icon": Array [
+    Object {
+      "bottom": 2,
+    },
+  ],
+  "root": Object {
+    "fontFamily": "var(--vscode-font-family)",
+    "height": "auto",
+  },
+  "subComponentStyles": Object {
+    "label": Object {
+      "root": Array [
+        Object {
+          "color": "var(--vscode-input-foreground)",
+          "fontFamily": "var(--vscode-font-family)",
+          "fontSize": "13px",
+          "fontWeight": "bold",
+          "marginTop": 25,
+          "padding": "4px 0",
+        },
+        undefined,
+        Object {
+          "selectors": Object {
+            "::after": Object {
+              "color": "var(--vscode-inputValidation-errorBorder)",
+              "content": "' *' / ''",
+              "paddingRight": 12,
+            },
+          },
+        },
+      ],
+    },
+  },
+  "suffix": Object {
+    "backgroundColor": "var(--vscode-input-background)",
+  },
+}
+`;

--- a/packages/ui-components/test/unit/components/UIChoiceGroup.test.tsx
+++ b/packages/ui-components/test/unit/components/UIChoiceGroup.test.tsx
@@ -232,7 +232,7 @@ describe('<UIToggle />', () => {
                 "selectors": Object {
                   "::after": Object {
                     "color": "var(--vscode-inputValidation-errorBorder)",
-                    "content": "' *'",
+                    "content": "' *' / ''",
                     "paddingRight": 12,
                   },
                 },

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -98,6 +98,48 @@ describe('<UIComboBox />', () => {
         );
     });
 
+    it('Styles - required', () => {
+        wrapper.setProps({
+            required: true
+        });
+        const styles = wrapper.find(ComboBox).props().styles;
+        expect(styles).toMatchInlineSnapshot(
+            {},
+            `
+            Object {
+              "errorMessage": Array [
+                Object {
+                  "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+                  "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "borderColor": "var(--vscode-inputValidation-errorBorder)",
+                  "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "color": "var(--vscode-input-foreground)",
+                  "margin": 0,
+                  "paddingBottom": 5,
+                  "paddingLeft": 8,
+                  "paddingTop": 4,
+                },
+              ],
+              "label": Object {
+                "color": "var(--vscode-input-foreground)",
+                "fontFamily": "var(--vscode-font-family)",
+                "fontSize": "13px",
+                "fontWeight": "bold",
+                "padding": "4px 0",
+                "selectors": Object {
+                  "::after": Object {
+                    "color": "var(--vscode-inputValidation-errorBorder)",
+                    "content": "' *' / ''",
+                    "paddingRight": 12,
+                  },
+                },
+              },
+            }
+        `
+        );
+    });
+
     describe('Test highlight', () => {
         beforeEach(() => {
             wrapper.setProps({

--- a/packages/ui-components/test/unit/components/UIDropdown.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDropdown.test.tsx
@@ -77,6 +77,45 @@ describe('<UIDropdown />', () => {
         );
     });
 
+    it('Styles - required', () => {
+        wrapper.setProps({
+            required: true
+        });
+        const styles = (wrapper.find(Dropdown).props().styles as IStyleFunction<{}, {}>)({}) as IDropdownStyleProps;
+        expect(styles).toMatchInlineSnapshot(`
+            Object {
+              "errorMessage": Array [
+                Object {
+                  "backgroundColor": "var(--vscode-inputValidation-errorBackground)",
+                  "borderBottom": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "borderColor": "var(--vscode-inputValidation-errorBorder)",
+                  "borderLeft": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "borderRight": "1px solid var(--vscode-inputValidation-errorBorder)",
+                  "color": "var(--vscode-input-foreground)",
+                  "margin": 0,
+                  "paddingBottom": 5,
+                  "paddingLeft": 8,
+                  "paddingTop": 4,
+                },
+              ],
+              "label": Object {
+                "color": "var(--vscode-input-foreground)",
+                "fontFamily": "var(--vscode-font-family)",
+                "fontSize": "13px",
+                "fontWeight": "bold",
+                "padding": "4px 0",
+                "selectors": Object {
+                  "::after": Object {
+                    "color": "var(--vscode-inputValidation-errorBorder)",
+                    "content": "' *' / ''",
+                    "paddingRight": 12,
+                  },
+                },
+              },
+            }
+        `);
+    });
+
     it('Test responsive mode - custom value', () => {
         wrapper.setProps({
             responsiveMode: ResponsiveMode.small

--- a/packages/ui-components/test/unit/components/UITextfield.test.tsx
+++ b/packages/ui-components/test/unit/components/UITextfield.test.tsx
@@ -33,6 +33,13 @@ describe('<UIToggle />', () => {
         expect(getStyles()).toMatchSnapshot();
     });
 
+    it('Styles - required', () => {
+        wrapper.setProps({
+            required: true
+        });
+        expect(getStyles()).toMatchSnapshot();
+    });
+
     const testCases = [
         // Single line
         {


### PR DESCRIPTION
ignore asterisk for screen readers. Speech history when issue appears:
![image](https://github.com/user-attachments/assets/11d95de8-a17f-47b8-a335-e67b8271cd57)

solution -> https://a11ysupport.io/tests/tech__css__css_generated_content_alt
after solution, speech history:
![image](https://github.com/user-attachments/assets/cba3a096-2774-4639-84ab-89ed818d0d88)
