### PR TITLE
fix: Create Custom Table Column quick action bug fix

### DIFF
--- a/.changeset/young-coins-marry.md
+++ b/.changeset/young-coins-marry.md
@@ -3,4 +3,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-Add Custom Table Column quick action bug fix
+Fix: Resolved an issue where Add Custom Table Column quick action didn't work with Analytical/Grid/Tree tables in SAP Fiori Elements for OData V2.

--- a/.changeset/young-coins-marry.md
+++ b/.changeset/young-coins-marry.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Add Custom Table Column quick action bug fix

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-table-custom-column.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/create-table-custom-column.ts
@@ -105,7 +105,10 @@ export class AddTableCustomColumnQuickAction
             return [];
         }
 
-        if ((tableInternal.getAggregation('items') as ManagedObject[]).length === 0) {
+        if (
+            isA(M_TABLE_TYPE, tableInternal) &&
+            (tableInternal.getAggregation('items') as ManagedObject[]).length === 0
+        ) {
             const bundle = await getTextBundle();
             notifyUser(bundle.getText('TABLE_ROWS_NEEDED_TO_CREATE_CUSTOM_COLUMN'), 8000);
             return [];


### PR DESCRIPTION
Fixed bug. Click on quick action doesn't work with Analytical/Grid/Tree tables in v2