### PR TITLE
fix(ui5-info): fix fallback logic for retrieving maintained versions

### DIFF
--- a/.changeset/fuzzy-toes-talk.md
+++ b/.changeset/fuzzy-toes-talk.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-info': patch
+---
+
+fix fallback logic for retrieving maintained versions

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -372,17 +372,16 @@ export const ui5VersionFallbacks = [
     }
 ] as UI5VersionSupport[];
 
-const supportedUi5VersionFallbacks = ui5VersionFallbacks
-    .filter((supportVersion) => {
-        if (
+const supportedUi5VersionFallbacks: UI5VersionSupport[] = ui5VersionFallbacks
+    .filter(
+        (supportVersion) =>
             supportVersion.support === supportState.maintenance &&
             gte(coerce(supportVersion.version) ?? '0.0.0', defaultMinUi5Version)
-        ) {
-            return true;
-        }
-        return false;
-    })
-    .map((maintainedVersion) => coerce(maintainedVersion.version)?.version ?? '0.0.0');
+    )
+    .map((maintainedVersion) => ({
+        version: coerce(maintainedVersion.version)?.version ?? '0.0.0',
+        support: supportState.maintenance
+    }));
 
-const defaultUi5Versions = [...supportedUi5VersionFallbacks];
+const defaultUi5Versions = [...supportedUi5VersionFallbacks].map((version) => version.version);
 export { defaultUi5Versions, supportedUi5VersionFallbacks };

--- a/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
+++ b/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
@@ -4106,6 +4106,51 @@ exports[`getUI5Versions filterOptions: snapshots included - snapshotVersionsHost
 ]
 `;
 
+exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback for maintained versions, if request fails 1`] = `
+[
+  {
+    "maintained": true,
+    "version": "1.129.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.127.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.126.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.124.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.121.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.120.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.108.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.96.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.84.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.71.0",
+  },
+]
+`;
+
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback for specified min UI5 version, if request fails 1`] = `
 [
   {

--- a/packages/ui5-info/test/ui5-version-info.test.ts
+++ b/packages/ui5-info/test/ui5-version-info.test.ts
@@ -193,6 +193,12 @@ describe('getUI5Versions: Handle error cases while getting UI5 versions: ', () =
         expect(versions).toMatchSnapshot();
         expect(logWarnSpy).toBeCalledTimes(1);
     });
+
+    test('UI5 versions fallback for maintained versions, if request fails', async () => {
+        const versions = await getUI5Versions({ includeMaintained: true });
+        expect(versions).toMatchSnapshot();
+        expect(logWarnSpy).toBeCalledTimes(2);
+    });
 });
 
 describe('getUI5Versions: Handle fatal cases while getting UI5 versions: ', () => {


### PR DESCRIPTION
With changes in https://github.com/SAP/open-ux-tools/pull/2189 to move from using `versionoverview` the try/catch + fallback for offline or errors was removed. 

Updates in this PR : 
- `supportedUi5VersionFallbacks` now also returns property `support` as it is useful for the consumer (for labelling and grouping versions)
-  when the option `includeMaintained` is passed, the call to `retrieveUI5VersionsCache` is wrapped in a try/catch and will fallback to `supportedUi5VersionFallbacks`