### PR TITLE
(fix): Add Annotation Configuration to ui5-local.yaml

### DIFF
--- a/packages/mockserver-config-writer/src/app-info.ts
+++ b/packages/mockserver-config-writer/src/app-info.ts
@@ -1,4 +1,5 @@
 import type { Manifest, ManifestNamespace } from '@sap-ux/project-access';
+import type { MockserverConfig } from '@sap-ux/ui5-config/dist/types';
 
 /**
  * Get the main service data source entry from manifest.json.
@@ -38,4 +39,19 @@ export function getODataSources(
         }
     }
     return result;
+}
+
+/**
+ * Retrieves the annotation configuration for a mock server by reading and parsing the OData annotations
+ * defined in the application's manifest file.
+ *
+ * @param {Manifest} manifest - The application manifest containing OData annotation sources.
+ * @returns {MockserverConfig['annotations']} - An array of annotation configurations.
+ */
+export function getMockserverAnnotationConfig(manifest: Manifest): MockserverConfig['annotations'] {
+    const annotationSources = Object.values(getODataSources(manifest, 'ODataAnnotation'));
+    return annotationSources.map((annotation) => ({
+        localPath: `./webapp/${annotation.settings?.localUri}`,
+        urlPath: annotation.uri
+    }));
 }

--- a/packages/mockserver-config-writer/src/index.ts
+++ b/packages/mockserver-config-writer/src/index.ts
@@ -1,4 +1,5 @@
 export { generateMockserverConfig, removeMockserverConfig } from './mockserver-config';
 export { getMockserverConfigQuestions } from './prompt';
+export { getMockserverAnnotationConfig } from './app-info';
 export { t } from './i18n';
 export * from './types';

--- a/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
+++ b/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
@@ -5,7 +5,7 @@ import type { CustomMiddleware } from '@sap-ux/ui5-config';
 import type { Manifest } from '@sap-ux/project-access';
 import type { Ui5MockYamlConfig } from '../types';
 import type { MockserverConfig } from '@sap-ux/ui5-config/dist/types';
-import { getMainServiceDataSource, getODataSources } from '../app-info';
+import { getMainServiceDataSource, getMockserverAnnotationConfig } from '../app-info';
 
 /**
  * Enhance or create the ui5-mock.yaml with mockserver config.
@@ -37,12 +37,7 @@ export async function enhanceYaml(
     let mockConfig;
     const manifest = fs.readJSON(join(webappPath, 'manifest.json')) as Partial<Manifest> as Manifest;
     const mockserverPath = config?.path || getMainServiceDataSource(manifest)?.uri;
-    const annotationSource = Object.values(getODataSources(manifest, 'ODataAnnotation'));
-    const annotationsConfig = annotationSource.map((annotation) => ({
-        localPath: `./webapp/${annotation.settings?.localUri}`,
-        urlPath: annotation.uri
-    }));
-
+    const annotationsConfig = getMockserverAnnotationConfig(manifest);
     if (fs.exists(ui5MockYamlPath)) {
         mockConfig = await updateUi5MockYamlConfig(fs, ui5MockYamlPath, mockserverPath, annotationsConfig);
     } else {

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -9,8 +9,8 @@ import prettifyXml from 'prettify-xml';
 import { enhanceData, getAnnotationNamespaces } from './data';
 import { t } from './i18n';
 import { OdataService, OdataVersion, ServiceType, CdsAnnotationsInfo, EdmxAnnotationsInfo } from './types';
-import { getWebappPath } from '@sap-ux/project-access';
-import { generateMockserverConfig } from '@sap-ux/mockserver-config-writer';
+import { getWebappPath, type Manifest } from '@sap-ux/project-access';
+import { generateMockserverConfig, getMockserverAnnotationConfig } from '@sap-ux/mockserver-config-writer';
 
 /**
  * Ensures the existence of the given files in the provided base path. If a file in the provided list does not exit, an error would be thrown.
@@ -129,7 +129,9 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
             await generateMockserverConfig(basePath, config, fs);
             // add mockserver middleware to ui5-local.yaml
             if (ui5LocalConfig) {
-                ui5LocalConfig.addMockServerMiddleware(service.path);
+                const manifest = fs.readJSON(join(webappPath, 'manifest.json')) as Partial<Manifest> as Manifest;
+                const annotationsConfig = getMockserverAnnotationConfig(manifest);
+                ui5LocalConfig.addMockServerMiddleware(service.path, annotationsConfig);
             }
         }
 

--- a/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
@@ -40,7 +40,11 @@ Object {
             metadataPath: ./webapp/localService/metadata.xml
             mockdataPath: ./webapp/localService/data
             generateMockData: true
-        annotations: []
+        annotations:
+          - localPath: ./webapp/localService/sepmra_annotations_tech_name.xml
+            urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='sepmra_annotations_tech_name',Version='0001')/$value/
+          - localPath: ./webapp/annotations/annotations_test.xml
+            urlPath: annotations/annotations_test.xml
 ",
     "state": "modified",
   },
@@ -2820,7 +2824,9 @@ Object {
             metadataPath: ./webapp/localService/metadata.xml
             mockdataPath: ./webapp/localService/data
             generateMockData: true
-        annotations: []
+        annotations:
+          - localPath: ./webapp/localService//SEPM_XYZ/SERVICE.xml
+            urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/
 ",
     "state": "modified",
   },


### PR DESCRIPTION
[#31153 ](https://github.wdf.sap.corp/ux-engineering/tools-suite/issues/31153)

- Addresses a bug where annotation entries in `ui5-local.yaml` were not consistent with those in `ui5-mock.yaml`. The issue is in `@sap-ux/odata-service-eriter`, where annotations were not passed when adding the mockserver middleware to `ui5-local.yaml.`
- unit tests to ensure the above