### PR TITLE
feat(ui-components): allow to pass custom filter function for combobox search

### DIFF
--- a/.changeset/cold-pumas-hear.md
+++ b/.changeset/cold-pumas-hear.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': minor
+---
+
+UIComboBox: New property "customSearchFilter" allows passing a custom filter function to apply additional filtering logic on top of the default search.

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -188,30 +188,42 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
                 isGroupVisible = false;
             } else {
                 // Handle selectable item
-                let isHidden: boolean | undefined;
-                if (this.props.customSearchFilter) {
-                    // Apply external custom search
-                    const isVisibleByExternalFilter = this.props.customSearchFilter(this.query, option);
-                    isHidden = isVisibleByExternalFilter !== undefined ? !isVisibleByExternalFilter : undefined;
-                }
-                if (isHidden === undefined) {
-                    // Apply internal search
-                    isHidden = !option.text.toLowerCase().includes(this.query);
-                    // Consider 'key' of option if property 'searchByKeyEnabled' is enabled
-                    if (this.props.searchByKeyEnabled && isHidden) {
-                        isHidden = !option.key.toString().toLowerCase().includes(this.query);
-                    }
-                }
-
-                option.hidden = isHidden;
+                const isVisible = this.isOptionVisibleByQuery(option, this.query);
+                option.hidden = !isVisible;
                 if (this.isListHidden && !option.hidden) {
                     this.isListHidden = false;
                 }
                 // Groups should be visible if at least one item is visible within group
-                isGroupVisible = !isHidden || isGroupVisible;
+                isGroupVisible = isVisible || isGroupVisible;
             }
         }
         updateGroupVisibility();
+    }
+
+    /**
+     * Determines whether an option should be hidden based on the current search query.
+     * Applies a custom filter if `customSearchFilter` is provided, otherwise uses the default
+     * search logic to match the `text` property (and `key` if `searchByKeyEnabled` is enabled).
+     *
+     * @param option - The option to evaluate for visibility.
+     * @param query - The current search query string.
+     * @returns `true` if the option should be hidden, `false` if it should be visible.
+     */
+    private isOptionVisibleByQuery(option: IComboBoxOption, query: string): boolean {
+        let isVisible: boolean | undefined;
+        if (this.props.customSearchFilter) {
+            // Apply external custom search
+            isVisible = this.props.customSearchFilter(query, option);
+        }
+        if (isVisible === undefined) {
+            // Apply internal search
+            isVisible = option.text.toLowerCase().includes(query);
+            // Consider 'key' of option if property 'searchByKeyEnabled' is enabled
+            if (this.props.searchByKeyEnabled && !isVisible) {
+                isVisible = option.key.toString().toLowerCase().includes(this.query);
+            }
+        }
+        return isVisible;
     }
 
     /**

--- a/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
+++ b/packages/ui-components/src/components/UIComboBox/UIComboBox.tsx
@@ -220,7 +220,7 @@ export class UIComboBox extends React.Component<UIComboBoxProps, UIComboBoxState
             isVisible = option.text.toLowerCase().includes(query);
             // Consider 'key' of option if property 'searchByKeyEnabled' is enabled
             if (this.props.searchByKeyEnabled && !isVisible) {
-                isVisible = option.key.toString().toLowerCase().includes(this.query);
+                isVisible = option.key.toString().toLowerCase().includes(query);
             }
         }
         return isVisible;

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -474,3 +474,37 @@ export const SearchIncludeKeys = (): JSX.Element => (
         />
     </div>
 );
+
+const dataForCustomSearch = [
+    ...data,
+    {
+        key: 'A1',
+        text: 'Do not hide',
+        customMark: true
+    },
+    {
+        key: 'A2',
+        text: 'Always visible',
+        customMark: true
+    }
+];
+
+export const AdditionalCustomSearch = (): JSX.Element => (
+    <div style={{ width: '300px' }}>
+        <UIComboBox
+            options={dataForCustomSearch}
+            highlight={true}
+            allowFreeform={true}
+            useComboBoxAsMenuMinWidth={true}
+            autoComplete="on"
+            customSearchFilter={(searchTerm: string, option: UIComboBoxOption) => {
+                // console.log('customSearchFilter');
+                if ('customMark' in option && option.customMark) {
+                    // console.log('always visible');
+                    return true;
+                }
+                return undefined;
+            }}
+        />
+    </div>
+);

--- a/packages/ui-components/stories/UICombobox.story.tsx
+++ b/packages/ui-components/stories/UICombobox.story.tsx
@@ -498,9 +498,7 @@ export const AdditionalCustomSearch = (): JSX.Element => (
             useComboBoxAsMenuMinWidth={true}
             autoComplete="on"
             customSearchFilter={(searchTerm: string, option: UIComboBoxOption) => {
-                // console.log('customSearchFilter');
                 if ('customMark' in option && option.customMark) {
-                    // console.log('always visible');
                     return true;
                 }
                 return undefined;

--- a/packages/ui-components/test/unit/components/UICombobox.test.tsx
+++ b/packages/ui-components/test/unit/components/UICombobox.test.tsx
@@ -1022,4 +1022,74 @@ describe('<UIComboBox />', () => {
             });
         }
     });
+
+    describe('Test "customSearchFilter" property', () => {
+        const dataForCustomSearch = [
+            ...data,
+            {
+                key: 'A1',
+                text: 'Do not hide',
+                customMark: true
+            },
+            {
+                key: 'A2',
+                text: 'Always visible',
+                customMark: true
+            }
+        ];
+        const testCases = [
+            {
+                name: 'Test "true" and "undefined" result from custom filter',
+                options: dataForCustomSearch,
+                query: 'Australia',
+                expectedCountBefore: 1,
+                expectedCountAfter: 3
+            },
+            {
+                name: 'Test "true" result from custom filter when no default matches',
+                options: dataForCustomSearch,
+                query: '404',
+                expectedCountBefore: 0,
+                expectedCountAfter: 2
+            },
+            {
+                name: 'Test "false" result from custom filter',
+                options: data,
+                query: 'Lorem ipsum dolor sit amet',
+                expectedCountBefore: 1,
+                expectedCountAfter: 0
+            }
+        ];
+        for (const testCase of testCases) {
+            const { name, query, expectedCountBefore, expectedCountAfter, options } = testCase;
+            it(name, () => {
+                // Default state before custom filter
+                wrapper.setProps({
+                    highlight: true,
+                    options: options
+                });
+                openDropdown();
+                wrapper.find('input').simulate('keyDown', {});
+                triggerSearch(query);
+                expect(wrapper.find('.ms-Button--action').length).toEqual(expectedCountBefore);
+                // Apply custom filter and check result for same query
+                wrapper.setProps({
+                    customSearchFilter: (searchTerm: string, option: UIComboBoxOption) => {
+                        if ('customMark' in option && option.customMark) {
+                            return true;
+                        }
+                        if (option.key === 'BC') {
+                            // Hide 'Lorem ipsum dolor sit amet' when searching
+                            return false;
+                        }
+                        return undefined;
+                    }
+                });
+                openDropdown();
+                wrapper.find('input').simulate('keyDown', {});
+                triggerSearch(query);
+                expect(wrapper.find('.ms-Button--action').length).toEqual(expectedCountAfter);
+            });
+        }
+    });
 });


### PR DESCRIPTION
We have a requirement to display certain custom ComboBox items that do not match the current search query. To accomplish this, we need to extend the UIComboBox interface by adding a new property, `customSearchFilter`, which allows passing a custom filter function to apply additional filtering logic on top of the default search.

Screenshots from storybook based on filter -> https://github.com/SAP/open-ux-tools/blob/feat/allowPassCustomFilterForCombobox/packages/ui-components/stories/UICombobox.story.tsx#L500
![image](https://github.com/user-attachments/assets/c773d67d-0697-4b2c-bec4-b0c182117f6a)
![image](https://github.com/user-attachments/assets/bf9a4c81-14f9-479a-ae54-dbfbbdf72bed)
