### PR TITLE
fix: adaptation editor crash

### DIFF
--- a/.changeset/swift-kids-laugh.md
+++ b/.changeset/swift-kids-laugh.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux-private/control-property-editor-common': patch
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/control-property-editor': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Fixed Adaptation Editor crash when project contains Personalization change.

--- a/packages/control-property-editor-common/src/api.ts
+++ b/packages/control-property-editor-common/src/api.ts
@@ -15,6 +15,7 @@ export interface Control {
     properties: ControlProperty[];
 }
 export type PropertyValue = string | boolean | number;
+export type ConfigurationValue = PropertyValue | Record<string, unknown>;
 export type PropertyChangeType = 'propertyChange' | 'propertyBindingChange';
 export interface PropertyChange<T extends PropertyValue = PropertyValue> {
     controlId: string;
@@ -29,7 +30,7 @@ export interface PropertyChanged<T extends PropertyValue = PropertyValue> {
     propertyName: string;
     newValue: T;
 }
-export interface ConfigurationChange<T extends PropertyValue = PropertyValue> {
+export interface ConfigurationChange<T extends ConfigurationValue = ConfigurationValue> {
     propertyPath: string;
     propertyName: string;
     value: T;
@@ -144,7 +145,8 @@ export interface PendingPropertyChange<T extends PropertyValue = PropertyValue> 
     fileName: string;
 }
 
-export interface PendingConfigurationChange<T extends PropertyValue = PropertyValue> extends ConfigurationChange<T> {
+export interface PendingConfigurationChange<T extends ConfigurationValue = ConfigurationValue>
+    extends ConfigurationChange<T> {
     type: typeof PENDING_CHANGE_TYPE;
     controlIds: string[];
     /**

--- a/packages/control-property-editor/src/panels/changes/ConfigChange.tsx
+++ b/packages/control-property-editor/src/panels/changes/ConfigChange.tsx
@@ -38,7 +38,8 @@ export function ConfigChange(configChangeProps: Readonly<ConfigChangeProps>): Re
     const { t } = useTranslation();
     const dispatch = useDispatch();
     const [dialogState, setDialogState] = useState<PropertyChangeDeletionDetails | undefined>(undefined);
-    const valueIcon = getValueIcon(value);
+    const isPrimitiveValue = typeof value !== 'object';
+    const valueIcon = isPrimitiveValue ? getValueIcon(value) : undefined;
     function onConfirmDelete(): void {
         if (dialogState) {
             dispatch(deletePropertyChanges(dialogState));
@@ -70,9 +71,13 @@ export function ConfigChange(configChangeProps: Readonly<ConfigChangeProps>): Re
                             <Text className={styles.text} title={propertyName}>
                                 {convertCamelCaseToPascalCase(propertyName)}
                             </Text>
-                            <UIIcon iconName={IconName.arrow} className={styles.text} />
-                            {valueIcon && <UIIcon className={'ui-cpe-icon-light-theme'} iconName={valueIcon} />}
-                            <Text className={styles.text}>{value}</Text>
+                            {isPrimitiveValue && valueIcon && (
+                                <>
+                                    <UIIcon iconName={IconName.arrow} className={styles.text} />
+                                    <UIIcon className={'ui-cpe-icon-light-theme'} iconName={valueIcon} />
+                                    <Text className={styles.text}>{value}</Text>
+                                </>
+                            )}
                         </Stack.Item>
                         {change.type === SAVED_CHANGE_TYPE && (
                             <Stack.Item className={actionClassName}>

--- a/packages/control-property-editor/src/panels/properties/InputTypeWrapper.tsx
+++ b/packages/control-property-editor/src/panels/properties/InputTypeWrapper.tsx
@@ -116,10 +116,7 @@ export const getInputTypeToggleOptions = (property: ControlProperty, t?: TFuncti
         default:
     }
 
-    if (
-        property.propertyType === PropertyType.ControlProperty ||
-        (property.propertyType === PropertyType.Configuration && type === STRING_VALUE_TYPE && editor != 'dropdown')
-    ) {
+    if (property.propertyType === PropertyType.ControlProperty) {
         inputTypeToggleOptions.push({
             inputType: InputType.expression,
             tooltip: getToolTip('EXPRESSION_TYPE', t),

--- a/packages/control-property-editor/test/unit/panels/changes/ChangesPanel.test.tsx
+++ b/packages/control-property-editor/test/unit/panels/changes/ChangesPanel.test.tsx
@@ -108,6 +108,19 @@ const getChanges = (generateSavedChanges = false, filterByKind = ''): ChangesSli
                   isActive: true,
                   fileName: 'testFile8',
                   propertyPath: '/test/components'
+              },
+              {
+                  kind: 'configuration',
+                  controlIds: ['testId1Exp'],
+                  propertyName: 'Personalization',
+                  type: 'pending',
+                  value: {
+                      a: 'test',
+                      b: 'value'
+                  },
+                  isActive: true,
+                  fileName: 'testFile9',
+                  propertyPath: '/test/components'
               }
           ]
         : [];


### PR DESCRIPTION
After #2458 Adaptation Editor crashes if there are personalisation changes in the project.

Also removed expression change option for configuration changes.