### PR TITLE
chore: only run component build from preview middleware

### DIFF
--- a/.changeset/swift-kids-laugh.md
+++ b/.changeset/swift-kids-laugh.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux-private/control-property-editor-common': patch
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/control-property-editor': patch
+'@sap-ux/preview-middleware': patch
+---
+Fixed Adaptation Editor crash when project contains Personalization change.

--- a/packages/control-property-editor-common/CHANGELOG.md
+++ b/packages/control-property-editor-common/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @sap-ux-private/control-property-editor-common
 
-## 0.5.7
-
-### Patch Changes
-
--   8c0ba5c: Fixed Adaptation Editor crash when project contains Personalization change.
-
 ## 0.5.6
 
 ### Patch Changes

--- a/packages/control-property-editor-common/package.json
+++ b/packages/control-property-editor-common/package.json
@@ -3,7 +3,7 @@
     "displayName": "Control Property Editor Common",
     "description": "A common module for Control Property Editor react app and ui5",
     "license": "Apache-2.0",
-    "version": "0.5.7",
+    "version": "0.5.6",
     "main": "dist/index.js",
     "repository": {
         "type": "git",

--- a/packages/control-property-editor/CHANGELOG.md
+++ b/packages/control-property-editor/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @sap-ux/control-property-editor
 
-## 0.5.26
-
-### Patch Changes
-
--   8c0ba5c: Fixed Adaptation Editor crash when project contains Personalization change.
-
 ## 0.5.25
 
 ### Patch Changes

--- a/packages/control-property-editor/package.json
+++ b/packages/control-property-editor/package.json
@@ -3,7 +3,7 @@
     "displayName": "Control Property Editor",
     "description": "Control Property Editor",
     "license": "Apache-2.0",
-    "version": "0.5.26",
+    "version": "0.5.25",
     "main": "dist/app.js",
     "repository": {
         "type": "git",

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @sap-ux/create
 
-## 0.8.75
-
-### Patch Changes
-
--   Updated dependencies [8c0ba5c]
-    -   @sap-ux/preview-middleware@0.16.115
-    -   @sap-ux/app-config-writer@0.4.52
-
 ## 0.8.74
 
 ### Patch Changes

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/create",
     "description": "SAP Fiori tools module to add or remove features",
-    "version": "0.8.75",
+    "version": "0.8.74",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/preview-middleware-client/CHANGELOG.md
+++ b/packages/preview-middleware-client/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @sap-ux-private/preview-middleware-client
 
-## 0.11.29
-
-### Patch Changes
-
--   8c0ba5c: Fixed Adaptation Editor crash when project contains Personalization change.
-
 ## 0.11.28
 
 ### Patch Changes

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux-private/preview-middleware-client",
-    "version": "0.11.29",
+    "version": "0.11.28",
     "description": "Client-side coding hosted by the preview middleware",
     "repository": {
         "type": "git",

--- a/packages/preview-middleware/CHANGELOG.md
+++ b/packages/preview-middleware/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @sap-ux/preview-middleware
 
-## 0.16.115
-
-### Patch Changes
-
--   8c0ba5c: Fixed Adaptation Editor crash when project contains Personalization change.
-
 ## 0.16.114
 
 ### Patch Changes

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Apreview-middleware"
     },
-    "version": "0.16.115",
+    "version": "0.16.114",
     "license": "Apache-2.0",
     "author": "@SAP/ux-tools-team",
     "main": "dist/index.js",

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -17,7 +17,7 @@
         "start:fixture": "ui5 serve --config test/fixtures/simple-app/ui5.yaml",
         "build": "npm-run-all -l -p build:middleware build:client",
         "build:middleware": "tsc --build",
-        "build:client": "pnpm -C ../preview-middleware-client run build && copyfiles --exclude **/*-dbg.js --up 4 \"./node_modules/@private/preview-middleware-client/dist/**/*\" \"./dist/client\"",
+        "build:client": "pnpm -C ../preview-middleware-client run build:component && copyfiles --exclude **/*-dbg.js --up 4 \"./node_modules/@private/preview-middleware-client/dist/**/*\" \"./dist/client\"",
         "watch": "tsc --watch",
         "clean": "rimraf --glob dist test/test-output coverage *.tsbuildinfo playwright-report",
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",


### PR DESCRIPTION
After 8906662ef7005c75b32069bad9ac820b0b853e66 build is failing because references from `@sap-ux-private/control-property-editor-common` could not be resolved. We do not actually need to run type checking from `preview-middleware` as we only need to copy the artefacts over, so we can run only component build and relay on type checking being done by `preview-middleware-client` build.

Included changeset from the failed release build.