### PR TITLE
feat(btp-utils): adds options for list destination api

### DIFF
--- a/.changeset/light-suits-crash.md
+++ b/.changeset/light-suits-crash.md
@@ -1,0 +1,9 @@
+---
+'@sap-ux/btp-utils': minor
+'@sap-ux/abap-deploy-config-inquirer': patch
+'@sap-ux/cf-deploy-config-inquirer': patch
+'@sap-ux/cf-deploy-config-writer': patch
+'@sap-ux/odata-service-inquirer': patch
+---
+
+adds new options for listing destinations api

--- a/packages/abap-deploy-config-inquirer/src/utils.ts
+++ b/packages/abap-deploy-config-inquirer/src/utils.ts
@@ -33,7 +33,9 @@ export async function getAbapSystems(): Promise<{
     let backendSystems;
 
     if (isAppStudio()) {
-        destinations = await listDestinations();
+        destinations = await listDestinations({
+            stripS4HCApiHosts: true
+        });
         cachedDestinations = destinations;
     } else {
         const systemStore = await getService<BackendSystem, BackendSystemKey>({

--- a/packages/btp-utils/src/destination.ts
+++ b/packages/btp-utils/src/destination.ts
@@ -82,6 +82,10 @@ export interface Destination extends Partial<AdditionalDestinationProperties> {
     Host: string;
 }
 
+export interface ListDestinationOpts {
+    stripS4HCApiHosts?: boolean; // strips the `-api` from the S/4 Hana Cloud destination host name
+}
+
 /**
  * Checks whether the provided destination is configured to point to an ABAP system (both cloud and on-premise).
  *

--- a/packages/btp-utils/test/app-studio.test.ts
+++ b/packages/btp-utils/test/app-studio.test.ts
@@ -156,12 +156,22 @@ describe('App Studio', () => {
             destinationList.forEach((destination) => {
                 expect(!!actualDestinations[destination.Name]).toBe(destination.WebIDEEnabled === 'true');
             });
+            // test host remains unchanged when no opts passed to api
+            expect(actualDestinations['S4HC'].Host).toBe('https://s4hc-example-api.sap.example');
         });
 
         test('nothing returned', async () => {
             nock(server).get('/api/listDestinations').reply(200);
             const actualDestinations = await listDestinations();
             expect(Object.values(actualDestinations).length).toBe(0);
+        });
+
+        test('test stripping -api from s4hc destination', async () => {
+            nock(server)
+                .get('/api/listDestinations')
+                .replyWithFile(200, join(__dirname, 'mockResponses/destinations.json'));
+            const destinationsWithOpts = await listDestinations({ stripS4HCApiHosts: true });
+            expect(destinationsWithOpts['S4HC'].Host).toBe('https://s4hc-example.sap.example');
         });
     });
 

--- a/packages/btp-utils/test/mockResponses/destinations.json
+++ b/packages/btp-utils/test/mockResponses/destinations.json
@@ -66,7 +66,7 @@
         "Description": "S4HC for ABAP Cloud Deployment",
         "WebIDEEnabled": "true",
         "WebIDEUsage": "odata_abap,dev_abap",
-        "Host": "https://s4hc-example.sap.example",
+        "Host": "https://s4hc-example-api.sap.example",
         "HTML5.DynamicDestination": "true",
         "audience": "https://s4hc-example.sap.example",
         "authnContextClassRef": "urn:oasis:names:tc:SAML:2.0:ac:classes:PreviousSession"

--- a/packages/cf-deploy-config-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/cf-deploy-config-inquirer/src/prompts/prompt-helpers.ts
@@ -47,7 +47,7 @@ export async function getCfSystemChoices(destinations?: Destinations): Promise<C
  */
 export async function fetchBTPDestinations(): Promise<Destinations | undefined> {
     if (isAppStudio()) {
-        const destinations = await listDestinations();
+        const destinations = await listDestinations({ stripS4HCApiHosts: true });
         return destinations;
     }
     LoggerHelper.logger.warn(t('warning.btpDestinationListWarning'));

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -93,7 +93,7 @@ export async function getDestinationProperties(
  */
 export async function getBTPDestinations(): Promise<Destinations> {
     if (Object.keys(cachedDestinationsList).length === 0) {
-        cachedDestinationsList = await listDestinations();
+        cachedDestinationsList = await listDestinations({ stripS4HCApiHosts: true });
     }
     return cachedDestinationsList;
 }

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -190,7 +190,7 @@ export async function createSystemChoices(
 
     // If this is BAS, return destinations, otherwise return stored backend systems
     if (isAppStudio()) {
-        const destinations = await listDestinations();
+        const destinations = await listDestinations({ stripS4HCApiHosts: true });
         systemChoices = Object.values(destinations)
             .filter((destination) => {
                 return matchesFilters(destination, destinationFilters);


### PR DESCRIPTION
#2555 

Adds options `ListDestinationOpts` for btp-utils API `listDestinations`
- `stripS4HCApiHosts` removes `-api` from host name