### PR TITLE
Replace Keytar with alternative Secure Store Implementations

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -26,6 +26,7 @@
         "unlink": "pnpm unlink --global"
     },
     "dependencies": {
+        "@napi-rs/keyring": "1.1.6",
         "@sap-ux/logger": "workspace:*",
         "i18next": "20.6.1",
         "i18next-fs-backend": "1.2.0",
@@ -40,9 +41,9 @@
         "@types/pluralize": "0.0.30",
         "@types/qs": "6.9.1",
         "fast-check": "2.19.0",
+        "jest": ">=29.7.0",
         "jest-extended": "4.0.2",
         "memfs": "3.3.0",
-        "jest": ">=29.7.0",
         "typescript": "5.6.2",
         "unionfs": "4.4.0"
     },

--- a/packages/store/src/secure-store/cli-wrapper/cli-key-store.ts
+++ b/packages/store/src/secure-store/cli-wrapper/cli-key-store.ts
@@ -1,0 +1,239 @@
+import type { SecureStore } from '../types';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { type Logger } from '@sap-ux/logger';
+import { errorString } from '../../utils';
+import { getAccountsFromSystemsFile } from '../systems-file-utils';
+import { type SupportedPlatform, getPlatformCommands } from './commands';
+const execAsync = promisify(exec);
+
+type Entities<T> = {
+    [key: string]: T;
+};
+
+/**
+ * Helper function to check if the platform is supported.
+ * @param platform - The platform of the operating system (e.g., 'darwin', 'win32', etc.).
+ * @returns True if the platform is supported, otherwise false.
+ */
+function isValidPlatform(platform: NodeJS.Platform): platform is SupportedPlatform {
+    return ['darwin', 'win32'].includes(platform);
+}
+
+/**
+ * Wrapper class for storing and retrieving credentials securely using OS specific cli commands:
+ * - macOS: `security` command.
+ * - Windows: `cmdkey` command.
+ * - Linux: `secret-tool` command.
+ */
+export class CredentialStoreWrapper implements SecureStore {
+    private readonly log: Logger;
+
+    constructor(log: Logger) {
+        this.log = log;
+    }
+
+    /**
+     * Helper function to execute PowerShell commands for storing credentials
+     * on Windows using New-StoredCredential and Get-StoredCredential.
+     */
+    private async executePowerShellCommand(command: string): Promise<string> {
+        try {
+            const { stdout, stderr } = await execAsync(`powershell -Command "${command}"`);
+            if (stderr) {
+                throw new Error(stderr);
+            }
+            return stdout;
+        } catch (e) {
+            this.log.error(`Error executing PowerShell command: ${command}`);
+            this.log.error(errorString(e));
+            throw e;
+        }
+    }
+
+    /**
+     * Saves a credential to the secure store.
+     * @param service - The service name associated with the credential.
+     * @param key - The key/username for the credential.
+     * @param value - The value/password to store, serialized as a string.
+     * @returns True if the credential was saved successfully, otherwise false.
+     */
+    public async save<T>(service: string, key: string, value: T): Promise<boolean> {
+        const platform = process.platform;
+
+        if (!isValidPlatform(platform)) {
+            this.log.error(`Unsupported platform for saving credentials: ${platform}`);
+            return false;
+        }
+
+        try {
+            const serializedValue = Buffer.from(JSON.stringify(value)).toString('base64');
+            if (platform === 'win32') {
+                // Use PowerShell cmdlets for Windows (New-StoredCredential)
+                const uniqueKey = `${service}/${key}`;
+                const command = `New-StoredCredential -Target '${uniqueKey}' -UserName '${key}' -Password '${serializedValue}' -Persist LocalMachine`;
+                await this.executePowerShellCommand(command);
+            } else {
+                const commands = getPlatformCommands(platform);
+                await execAsync(commands.saveCommand(service, key, serializedValue));
+            }
+            return true;
+        } catch (e) {
+            this.log.error(`Error saving credential: Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieves a credential from the secure store.
+     * @param service - The service name associated with the credential.
+     * @param key - The key/username for the credential.
+     * @returns The stored value as an object or undefined if not found.
+     */
+    public async retrieve<T>(service: string, key: string): Promise<T | undefined> {
+        const platform = process.platform;
+
+        if (!isValidPlatform(platform)) {
+            this.log.error(`Unsupported platform for retrieving credentials: ${platform}`);
+            return undefined;
+        }
+
+        try {
+            let serializedValue: string | undefined;
+            if (platform === 'win32') {
+                // Use PowerShell cmdlets to retrieve credentials from the Windows Credential Manager
+                const psScriptFile = "./win32-get-credential-script.ps1"; 
+                const uniqueKey = `${service}/${key}`;
+                const { stdout, stderr } = await execAsync(`powershell -ExecutionPolicy RemoteSigned -NoProfile -File "${psScriptFile}" ${uniqueKey}`);
+        
+                if (stderr) {
+                    this.log.error(`Error retrieving credential from Credential Manager: ${stderr}`);
+                    return undefined;
+                }
+                const password = stdout.trim();
+                if (password && password !== 'Credential not found') {
+                    this.log.info(`Credential retrieved: Service: [${service}], Key: [${key}]`);
+                    return JSON.parse(password);
+                } else {
+                    this.log.warn(`Credential not found: Service: [${service}], Key: [${key}]`);
+                    return undefined;
+                }
+            } else {
+                const commands = getPlatformCommands(platform);
+                const { stdout } = await execAsync(commands.retrieveCommand(service, key));
+                serializedValue = stdout ? Buffer.from(stdout.trim(), 'base64').toString('utf-8') : undefined;
+            }
+            if (serializedValue) {
+                this.log.info(`Credential retrieved successfully: Service: [${service}], Key: [${key}]`);
+                return JSON.parse(serializedValue);
+            }
+            return undefined;
+        } catch (e) {
+            this.log.error(`Error retrieving credential: Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return undefined;
+        }
+    }
+
+    /**
+     * Deletes a credential from the secure store.
+     * @param service - The service name associated with the credential.
+     * @param key - The key/username for the credential.
+     * @returns True if the credential was deleted successfully, otherwise false.
+     */
+    public async delete(service: string, key: string): Promise<boolean> {
+        const platform = process.platform;
+
+        if (!isValidPlatform(platform)) {
+            this.log.error(`Unsupported platform for deleting credentials: ${platform}`);
+            return false;
+        }
+
+        try {
+            if (platform === 'win32') {
+                const uniqueKey = `${service}/${key}`;
+                const command = `Remove-StoredCredential -Target '${uniqueKey}'`;
+                await this.executePowerShellCommand(command);
+            } else {
+                const commands = getPlatformCommands(platform);
+                await execAsync(commands.deleteCommand(service, key));
+                // if (platform === 'darwin') {
+                //     await execAsync(`security delete-generic-password -a "${key}" -s "${service}"`);
+                // } else if (platform === 'win32') {
+                //     await execAsync(`cmdkey /delete:${service}`);
+                // } else if (platform === 'linux') {
+                //     // Secret-tool doesn't directly delete, so we use a workaround:
+                //     const { stdout } = await execAsync(`secret-tool lookup service "${service}" account "${key}"`);
+                //     if (stdout) {
+                //         await execAsync(`secret-tool clear service "${service}" account "${key}"`);
+                //     }
+                // }
+            }
+            this.log.info(`Credential deleted successfully: Service: [${service}], Key: [${key}]`);
+            return true;
+        } catch (e) {
+            this.log.error(`Error deleting credential: Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieves all credentials for a given service.
+     * Only supported on macOS due to limitations with `cmdkey` on Windows.
+     * @param service - The service name to retrieve credentials for.
+     * @returns An object containing all key-value pairs for the service.
+     */
+    public async getAll<T>(service: string): Promise<Entities<T>> {
+        const platform = process.platform;
+
+        if (platform === 'darwin') {
+            try {
+                const result: Entities<T> = {};
+                const accounts = getAccountsFromSystemsFile(this.log);
+                //const accounts = ['test-key1', 'test-key2'];
+    
+                for (const account of accounts) {
+                    try {
+                        const password = await this.retrieve<string>(service, account);
+                        if (password) {
+                            result[account] = JSON.parse(password);
+                        }
+                    } catch (e) {
+                        this.log.warn(`Failed to parse value for account: [${account}]`);
+                    }
+                }
+                this.log.info(`Successfully retrieved all credentials for service: [${service}]`);
+                return result;
+            } catch (e) {
+                this.log.error(`Error retrieving all credentials for service: [${service}]`);
+                this.log.error(errorString(e));
+                return {};
+            }
+        } else {
+            try {
+                const result: Entities<T> = {};
+                const accounts = ['test-key1', 'test-key2'];
+                // const accounts = getAccountsFromSystemsFile(this.log);
+        
+                for (const account of accounts) {
+                    try {
+                        const password = await this.retrieve<string>(service, account);
+                        if (password) {
+                            result[account] = JSON.parse(password);
+                        }
+                    } catch (e) {
+                        this.log.warn(`Failed to parse value for account: [${account}]`);
+                    }
+                }
+                this.log.info(`Successfully retrieved all credentials for service: [${service}]`);
+                return result;
+            } catch (e) {
+                this.log.error(`Error retrieving all credentials for service: [${service}]`);
+                this.log.error(errorString(e));
+                return {};
+            }
+        } 
+    }
+}

--- a/packages/store/src/secure-store/cli-wrapper/commands.ts
+++ b/packages/store/src/secure-store/cli-wrapper/commands.ts
@@ -1,0 +1,53 @@
+export type SupportedPlatform = 'darwin' | 'win32' | 'linux';
+
+type PlatformCommands = {
+    saveCommand: (service: string, key: string, value: string) => string;
+    retrieveCommand: (service: string, key: string) => string;
+    deleteCommand: (service: string, key: string) => string;
+    getAllCommand?: (service: string) => string;
+};
+
+/**
+ * Returns the platform-specific commands for credential management.
+ * @param platform - The platform type (darwin, win32, or linux).
+ * @returns The commands for each operation (save, retrieve, delete, getAll).
+ */
+export function getPlatformCommands(platform: SupportedPlatform): PlatformCommands {
+    switch (platform) {
+        case 'darwin':
+            return {
+                saveCommand: (service: string, key: string, value: string) =>
+                    `security add-generic-password -a "${key}" -s "${service}" -w "${value}" -D "${key}" -U`,
+                retrieveCommand: (service: string, key: string) =>
+                    `security find-generic-password -a "${key}" -s "${service}" -w`,
+                deleteCommand: (service: string, key: string) =>
+                    `security delete-generic-password -a "${key}" -s "${service}"`
+            };
+
+        case 'win32':
+            return {
+                saveCommand: (service: string, key: string, value: string) =>
+                    `cmdkey /add:${service} /user:${key} /pass:${value}`,
+                retrieveCommand: (service: string, key: string) =>
+                    `cmdkey /list:${service}`,
+                deleteCommand: (service: string, key: string) =>
+                    `cmdkey /delete:${service}`,
+                getAllCommand: (service: string) =>
+                    `cmdkey /list:${service}`
+            };
+
+        case 'linux':
+            return {
+                saveCommand: (service: string, key: string, value: string) =>
+                    `secret-tool store --label="${service}" service "${service}" account "${key}" <<< "${value}"`,
+                retrieveCommand: (service: string, key: string) =>
+                    `secret-tool lookup service "${service}" account "${key}"`, 
+                deleteCommand: (service: string, key: string) =>
+                    `secret-tool clear service "${service}" account "${key}"`
+            };
+
+        default:
+            throw new Error(`Unsupported platform: ${platform}`);
+    }
+}
+

--- a/packages/store/src/secure-store/cli-wrapper/test-credential-store-wrapper.ts
+++ b/packages/store/src/secure-store/cli-wrapper/test-credential-store-wrapper.ts
@@ -1,0 +1,38 @@
+import { ToolsLogger } from '@sap-ux/logger';
+import { CredentialStoreWrapper } from './cli-key-store';
+
+const log = new ToolsLogger();
+const store = new CredentialStoreWrapper(log);
+
+(async () => {
+    const service = 'test-service';
+    const key1 = 'test-key1';
+    const value1 = { username: 'user1', password: 'pass1' };
+    const key2 = 'test-key2';
+    const value2 = { username: 'user2', password: 'pass2' };
+
+    // Save
+    const saveResult1 = await store.save(service, key1, value1);
+    console.log('Save Result:', saveResult1 ? 'Success' : 'Failed');
+
+    const saveResult2 = await store.save(service, key2, value2);
+    console.log('Save Result:', saveResult2 ? 'Success' : 'Failed');
+
+    // Retrieve
+    const retrievedValue1 = await store.retrieve(service, key1);
+    console.log('Retrieved Value:', retrievedValue1);
+
+    const retrievedValue2 = await store.retrieve(service, key2);
+    console.log('Retrieved Value:', retrievedValue2);
+
+    // Get All
+    const allCredentials = await store.getAll(service);
+    console.log('All Credentials:', JSON.stringify(allCredentials, null, 2));
+
+    // Delete
+    const deleteResult1 = await store.delete(service, key1);
+    console.log('Delete Result:', deleteResult1 ? 'Success' : 'Failed');
+
+    const deleteResult2 = await store.delete(service, key2);
+    console.log('Delete Result:', deleteResult2 ? 'Success' : 'Failed');
+})();

--- a/packages/store/src/secure-store/cli-wrapper/win32-get-credential-script.ps1
+++ b/packages/store/src/secure-store/cli-wrapper/win32-get-credential-script.ps1
@@ -1,0 +1,55 @@
+# Import the CredentialManager module
+Import-Module CredentialManager
+
+# Access the first argument passed to the script
+$uniqueKey = $args[0]
+
+if (-not $uniqueKey) {
+    Write-Host "No service name provided."
+    exit 1
+}
+# Example usage with the passed $uniqueKey
+Write-Host "Service: $uniqueKey"
+
+# Retrieve the credential
+$retrievedCreds = Get-StoredCredential -Target $uniqueKey
+
+if ($retrievedCreds) {
+    # Convert the SecureString password to plain text
+    $securePassword = $retrievedCreds.Password
+    $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePassword)
+    $plainPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($ptr)
+
+    # Trim any surrounding whitespace (in case it was added)
+    $plainPassword = $plainPassword.Trim()
+
+    # Check if the password is a valid Base64 string
+    if ($plainPassword -match '^[a-zA-Z0-9\+/=]+$' -and $plainPassword.Length % 4 -eq 0) {
+        try {
+            # Decode the Base64 string
+            $decodedBytes = [System.Convert]::FromBase64String($plainPassword)
+            $decodedJson = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
+
+            # Convert JSON to a PowerShell object
+            $passwordObject = $decodedJson | ConvertFrom-Json
+
+            # Prepare output as a JSON object
+            $outputObject = @{
+                username = $passwordObject.username
+                password = $passwordObject.password
+            }
+
+            # Convert to JSON format for easy consumption
+            $jsonOutput = $outputObject | ConvertTo-Json
+
+            Write-Output $jsonOutput  # This is the output in the desired format
+        
+        } catch {
+            Write-Output "Error decoding Base64 password: $_"
+        }
+    } else {
+        Write-Output "Stored password is not a valid Base64 string."
+    }
+} else {
+    Write-Output "No credentials found for $uniqueKey."
+}

--- a/packages/store/src/secure-store/index.ts
+++ b/packages/store/src/secure-store/index.ts
@@ -7,6 +7,9 @@ import type { SecureStore } from './types';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { default as fs } from 'fs';
+//import { SecureKeyStoreManager } from './zowe-sdk/zowe-sdk-store';
+import { SecureKeyStoreManager } from './napi-rs-keyring-store/keyring-store';
+
 // __non_webpack_require__ is used to ensure the require is not bundled by webpack and resolved at runtime
 declare function __non_webpack_require__(m: string): any;
 
@@ -89,8 +92,11 @@ export const getSecureStore = (log: Logger): SecureStore => {
     if (isAppStudio() || process.env.FIORI_TOOLS_DISABLE_SECURE_STORE) {
         return new DummyStore(log);
     } else {
-        const keytar = getKeytar(log);
-        return keytar ? new KeytarStore(log, keytar) : new DummyStore(log);
+        // const keytar = getKeytar(log);
+        // return keytar ? new KeytarStore(log, keytar) : new DummyStore(log);
+
+        const keyStoreManager = new SecureKeyStoreManager(log);
+        return keyStoreManager ?? new DummyStore(log);
     }
 };
 

--- a/packages/store/src/secure-store/napi-rs-keyring-store/keyring-store.ts
+++ b/packages/store/src/secure-store/napi-rs-keyring-store/keyring-store.ts
@@ -1,0 +1,151 @@
+/**
+ * Uses @napi-rs/keyring to store and retrieve credentials.
+ * Please install @napi-rs/keyring package before using this store & remove path from tsconfig.json to include it in the build.
+ */
+import type { SecureStore } from '../types';
+import { Entry } from "@napi-rs/keyring";
+import { type Logger } from '@sap-ux/logger';
+import { errorString } from '../../utils';
+import { getAccountsFromSystemsFile } from '../systems-file-utils';
+
+/**
+ * Implements a secure key store manager that interacts with the system's secure storage.
+ */
+export class SecureKeyStoreManager implements SecureStore {
+    private readonly log: Logger;
+    private readonly entryCache: Map<string, Entry>;
+
+    constructor(log: Logger) {
+        this.log = log;
+        this.entryCache = new Map<string, Entry>();
+        this.log.info("napi keyring SecureKeyStoreManager initialized.");
+    }
+
+    /**
+     * Get or initialize an Entry object for a given service and key.
+     * Uses a cache to prevent multiple initializations for the same service-key pair.
+     * @param service - The service name/identifier.
+     * @param key - The unique key.
+     * @returns An Entry instance.
+     */
+    private getEntry(service: string, key: string): Entry | null {
+        const cacheKey = `${service}:${key}`;
+        if (this.entryCache.has(cacheKey)) {
+            return this.entryCache.get(cacheKey) || null;
+        }
+
+        try {
+            const entry = new Entry(service, key);
+            this.entryCache.set(cacheKey, entry);
+            return entry;
+        } catch (e) {
+            this.log.error(`Error initializing Entry for service: [${service}], key: [${key}]`);
+            this.log.error(errorString(e));
+            return null;
+        }
+    }
+
+    /**
+     * Save a key-value pair in the secure storage.
+     * @param service - The service name/identifier.
+     * @param key - The unique key.
+     * @param value - The value to be saved.
+     * @returns A Promise resolving to `true` if the operation is successful, `false` otherwise.
+     */
+    public async save<T>(service: string, key: string, value: T): Promise<boolean> {
+        const entry = this.getEntry(service, key);
+        if (!entry) return false;
+
+        try {
+            const serialized = JSON.stringify(value);
+            entry.setPassword(serialized);
+            this.log.info(`Saved to secure store. Service: [${service}], Key: [${key}]`);
+            return true;
+        } catch (e) {
+            this.log.error(`Error saving to secure store. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieve a value from the secure storage.
+     * @param service - The service name/identifier.
+     * @param key - The unique key.
+     * @returns A Promise resolving to the retrieved value or `undefined` if not found.
+     */
+    public async retrieve<T>(service: string, key: string): Promise<T | undefined> {
+        const entry = this.getEntry(service, key);
+        if (!entry) return undefined;
+
+        try {
+            const serializedValue = entry.getPassword();
+            this.log.info(`Retrieved value from secure store. Service: [${service}], Key: [${key}]`);
+            return serializedValue ? JSON.parse(serializedValue) : undefined;
+        } catch (e) {
+            this.log.error(`Error retrieving from secure store. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return undefined;
+        }
+    }
+
+    /**
+     * Delete a key-value pair from the secure storage.
+     * @param service - The service name/identifier.
+     * @param key - The unique key.
+     * @returns A Promise resolving to `true` if deletion is successful, `false` otherwise.
+     */
+    public async delete(service: string, key: string): Promise<boolean> {
+        const entry = this.getEntry(service, key);
+        if (!entry) return false;
+
+        try {
+            const deleted = entry.deletePassword();
+            if (deleted) {
+                const cacheKey = `${service}:${key}`;
+                this.entryCache.delete(cacheKey);
+            }
+            this.log.info(`Deleted from secure store. Service: [${service}], Key: [${key}]`);
+            return deleted;
+        } catch (e) {
+            this.log.error(`Error deleting from secure store. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieve all key-value pairs for a given service.
+     * @param service - The service name/identifier.
+     * @returns A Promise resolving to an object mapping keys to values.
+     */
+    public async getAll<T>(service: string): Promise<Record<string, T>> {
+        const result: Record<string, T> = {};
+
+        try {
+
+            const accounts = getAccountsFromSystemsFile(this.log);
+
+            for (const account of accounts) {
+                const entry = this.getEntry(service, account);
+                if (!entry) continue;
+
+                try {
+                    const serializedValue = entry.getPassword();
+                    if (serializedValue) {
+                        result[account] = JSON.parse(serializedValue);
+                    }
+                } catch (e) {
+                    this.log.warn(`Failed to parse value for account: [${account}]`);
+                }
+            }
+
+            this.log.info(`Retrieved all values for service: [${service}]`);
+            return result;
+        } catch (e) {
+            this.log.error(`Error retrieving all values for service: [${service}]`);
+            this.log.error(errorString(e));
+            return {};
+        }
+    }
+}

--- a/packages/store/src/secure-store/napi-rs-keyring-store/test-keyring-store.ts
+++ b/packages/store/src/secure-store/napi-rs-keyring-store/test-keyring-store.ts
@@ -1,0 +1,25 @@
+import { ToolsLogger } from "@sap-ux/logger";
+import { SecureKeyStoreManager } from "./keyring-store";
+
+(async () => {
+    const log = new ToolsLogger();
+    const keyStore = new SecureKeyStoreManager(log);
+
+    const service = 'exampleService';
+    const key = 'exampleKey';
+    const value = { foo: 'bar' };
+
+    // Save a value
+    await keyStore.save(service, key, value);
+
+    // Retrieve the value
+    const retrievedValue = await keyStore.retrieve(service, key);
+    console.log('Retrieved:', retrievedValue);
+
+    // Retrieve all values for the service
+    const allValues = await keyStore.getAll(service);
+    console.log('All values:', allValues);
+
+    // Delete the value
+    await keyStore.delete(service, key);
+})();

--- a/packages/store/src/secure-store/systems-file-utils.ts
+++ b/packages/store/src/secure-store/systems-file-utils.ts
@@ -1,0 +1,32 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync, readFileSync } from 'fs';
+import { type Logger } from '@sap-ux/logger';
+
+/**
+ * Reads the systems.json file from the user's .fioritools directory and extracts the accounts.
+ * @param log - Logger instance for logging warnings and errors.
+ * @returns An array of account keys or an empty array if the file doesn't exist or is invalid.
+ */
+export function getAccountsFromSystemsFile(log: Logger): string[] {
+    const systemsFilePath = join(homedir(), '.fioritools', 'systems.json');
+
+    try {
+        // Check if the systems file exists
+        if (!existsSync(systemsFilePath)) {
+            log.warn(`Systems file not found at path: ${systemsFilePath}`);
+            return [];
+        }
+
+        // Read and parse the systems.json file
+        const systemsFileContent = readFileSync(systemsFilePath, 'utf-8');
+        const systemsData = JSON.parse(systemsFileContent);
+
+        // Extract and return the account keys
+        return Object.keys(systemsData?.systems || {});
+    } catch (error) {
+        log.error(`Error reading or parsing systems file at path: ${systemsFilePath}`);
+        log.error(error.message);
+        return [];
+    }
+}

--- a/packages/store/src/secure-store/zowe-sdk/test-zowe-sdk-store.ts
+++ b/packages/store/src/secure-store/zowe-sdk/test-zowe-sdk-store.ts
@@ -1,0 +1,27 @@
+import { ToolsLogger } from "@sap-ux/logger";
+import { SecureKeyStoreManager } from "./zowe-sdk-store";
+
+(async () => {
+    const logger = new ToolsLogger();
+    const keyStore = new SecureKeyStoreManager(logger);
+
+    const service = "testService";
+    const account = "testAccount";
+    const value = { username: "user123", password: "pass123" };
+
+    // Save value
+    const saveSuccess = await keyStore.save(service, account, value);
+    console.log("Save successful:", saveSuccess);
+
+    // Retrieve value
+    const retrievedValue = await keyStore.retrieve(service, account);
+    console.log("Retrieved value:", retrievedValue);
+
+    // GetAll operation
+    const allValues = await keyStore.getAll(service);
+    console.log("All values:", allValues);
+
+    // Delete value
+    const deleteSuccess = await keyStore.delete(service, account);
+    console.log("Delete successful:", deleteSuccess);
+})();

--- a/packages/store/src/secure-store/zowe-sdk/zowe-sdk-store.ts
+++ b/packages/store/src/secure-store/zowe-sdk/zowe-sdk-store.ts
@@ -1,0 +1,129 @@
+/**
+ * Uses @zowe/secrets-for-zowe-sdk to store and retrieve credentials.
+ * Please install @zowe/secrets-for-zowe-sdk package before using this store & remove path from tsconfig.json to include it in the build.
+ */
+import type { SecureStore } from '../types';
+import { keyring } from "@zowe/secrets-for-zowe-sdk";
+import { type Logger } from '@sap-ux/logger';
+import { errorString } from '../../utils';
+
+/**
+ * SecureKeyStoreManager is responsible for securely managing credentials using
+ * a keyring implementation. It provides methods to save, retrieve, delete, 
+ * and fetch all credentials for a given service.
+ */
+export class SecureKeyStoreManager implements SecureStore {
+    private readonly log: Logger;
+    private readonly keyring: typeof keyring;
+
+    /**
+     * Constructor initializes the SecureKeyStoreManager.
+     * 
+     * @param log - Logger instance for logging messages.
+     */
+    constructor(log: Logger) {
+        this.log = log;
+        this.keyring = keyring;
+        this.log.info("zowe sdk SecureKeyStoreManager initialized.");
+    }
+
+    /**
+     * Saves a value to the secure store under the specified service and key.
+     *
+     * @param service - The service name associated with the credential.
+     * @param key - The key or account name.
+     * @param value - The value to be saved (e.g., a password or object).
+     * @returns Promise resolving to `true` if saved successfully, otherwise `false`.
+     */
+    public async save<T>(service: string, key: string, value: T): Promise<boolean> {
+        try {
+            const serialized = JSON.stringify(value);
+            await this.keyring.setPassword(service, key, serialized);
+            this.log.info(`Successfully saved to secure store. Service: [${service}], Key: [${key}]`);
+            return true;
+        } catch (e) {
+            this.log.error(`Failed to save to secure store. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieves a value from the secure store for the specified service and key.
+     *
+     * @param service - The service name associated with the credential.
+     * @param key - The key or account name.
+     * @returns Promise resolving to the retrieved value or `undefined` if not found or on error.
+     */
+    public async retrieve<T>(service: string, key: string): Promise<T | undefined> {
+        try {
+            const serializedValue = await this.keyring.getPassword(service, key);
+            if (serializedValue) {
+                const parsedValue = JSON.parse(serializedValue);
+                this.log.info(`Successfully retrieved value for Service: [${service}], Key: [${key}]`);
+                return parsedValue;
+            } else {
+                this.log.warn(`No value found for Service: [${service}], Key: [${key}]`);
+                return undefined;
+            }
+        } catch (e) {
+            this.log.error(`Failed to retrieve value. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return undefined;
+        }
+    }
+
+    /**
+     * Deletes a value from the secure store for the specified service and key.
+     *
+     * @param service - The service name associated with the credential.
+     * @param key - The key or account name.
+     * @returns Promise resolving to `true` if deleted successfully, otherwise `false`.
+     */
+    public async delete(service: string, key: string): Promise<boolean> {
+        try {
+            const deleted = await this.keyring.deletePassword(service, key);
+            if (deleted) {
+                this.log.info(`Successfully deleted entry. Service: [${service}], Key: [${key}]`);
+            } else {
+                this.log.warn(`No entry found to delete. Service: [${service}], Key: [${key}]`);
+            }
+            return deleted;
+        } catch (e) {
+            this.log.error(`Failed to delete entry. Service: [${service}], Key: [${key}]`);
+            this.log.error(errorString(e));
+            return false;
+        }
+    }
+
+    /**
+     * Retrieves all credentials associated with the specified service.
+     *
+     * @param service - The service name for which to retrieve all credentials.
+     * @returns Promise resolving to an object where keys are accounts and values are the parsed credentials.
+     */
+    public async getAll<T>(service: string): Promise<Record<string, T>> {
+        try {
+            const entries = await this.keyring.findCredentials(service);
+            const results: Record<string, T> = {};
+
+            entries.forEach(({ account, password }: { account: string; password: string }) => {
+                try {
+                    if (account) {
+                        results[account] = JSON.parse(password) as T;
+                    }
+                } catch (e) {
+                    this.log.error(`Error parsing credential for Account: [${account}] ${e}`);
+                }
+            });
+
+            this.log.info(`Successfully retrieved all credentials for Service: [${service}]`);
+            return results;
+        } catch (e) {
+            this.log.error(`Failed to retrieve all credentials. Service: [${service}]`);
+            this.log.error(errorString(e));
+            return {};
+        }
+    }
+}
+

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -5,5 +5,9 @@
         "rootDir": "src",
         "outDir": "dist"
     },
-    "references": [{ "path": "../logger" }]
+    "references": [{ "path": "../logger" }],
+    "exclude": [
+        "./src/secure-store/zowe-sdk",
+        //"./src/secure-store/napi-rs-keyring-store"
+    ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2449,6 +2449,9 @@ importers:
 
   packages/store:
     dependencies:
+      '@napi-rs/keyring':
+        specifier: 1.1.6
+        version: 1.1.6
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
@@ -2483,7 +2486,7 @@ importers:
         version: 2.19.0
       jest:
         specifier: '>=29.7.0'
-        version: 29.7.0(@types/node@18.11.9)(ts-node@10.9.2)
+        version: 29.7.0
       jest-extended:
         specifier: 4.0.2
         version: 4.0.2(jest@29.7.0)
@@ -6939,6 +6942,49 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /@jest/core@29.7.0:
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 18.11.9
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@18.11.9)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.7
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /@jest/core@29.7.0(ts-node@10.9.2):
     resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7222,6 +7268,132 @@ packages:
 
   /@microsoft/load-themed-styles@1.10.295:
     resolution: {integrity: sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==}
+
+  /@napi-rs/keyring-darwin-arm64@1.1.6:
+    resolution: {integrity: sha512-8N+qvM+O6OSU59BTgDP/PvqYhoqfOcD2HGy1NgRFo1B0DRmkTp4U/DGZrV4Pk/nOP6Uf0PLqznfx3a/M8O5sjQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-darwin-x64@1.1.6:
+    resolution: {integrity: sha512-r3Jgc5/ubfaao6Lmk/USA13IwU/GEVLP8NDfg5gYXjPVllU6bWnAaEDHVg7q4vl51kViwj9ELo6XTmOeJFut6A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-freebsd-x64@1.1.6:
+    resolution: {integrity: sha512-ayG396jZAt7j820gsEyW/LJKn+rf9KtgSPq1NKpvu84Y5GXopoFLyjMIP7wYZ1RLBL6SGKy27/f8S4f6YZ4DuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm-gnueabihf@1.1.6:
+    resolution: {integrity: sha512-8nXavgxcaUTUxyFHR+PEQF7eC8rITlYZNUmlf5amTb36y5bkNKrc3QLvCxjtbFSR/+KYzMi3vydoqNmFpF616w==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm64-gnu@1.1.6:
+    resolution: {integrity: sha512-qsI2NTAxGD3mBhZvdyYGL+N0n1D/NAjV0zCpTsFKKSzdpIrQJ0nM5Y0HxlLi6TsHm61dMyXHkdHb0ut8AzTcGA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-arm64-musl@1.1.6:
+    resolution: {integrity: sha512-SB/2A4LtL+SrS2aZXl3rWBtyCVB2aG2zAU56kOGFDGwRZM2tqaITuQoM1QLOAMwu0eksN/Xedy95Yn2rkRH0nQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-riscv64-gnu@1.1.6:
+    resolution: {integrity: sha512-BcjXf33T2CoVgS87SvZ62Y6xxkbenNIeldy0r8O5nz6zFgN+wYB0scz5ulvowEYBQnhi4fmbxfneeqM/0HUOeA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-x64-gnu@1.1.6:
+    resolution: {integrity: sha512-eK0OxCBI6Wl8rFHYynrtEID6pxOwhPfnpIIpul7UPeqCCMJSyZpFN4lFP3oZ4vqX/6FnWjwMrR7IGbPgivdMjA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-linux-x64-musl@1.1.6:
+    resolution: {integrity: sha512-Qb3NP98KFq4jXmk9PUQlcYrHjbzsBTtG+OOxX4YxUNKTGuUaIOGP79lB0w7jhns2oHdq8DwkW2ugzlmGSUaRSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-arm64-msvc@1.1.6:
+    resolution: {integrity: sha512-e794gO2CLD0P7JN2DVPT5CC60k3WmNWTWU5BVoQM8Hj0NYebx7j6LyxMIpdb2cztOHHiv7iltEHekgutf0TMlA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-ia32-msvc@1.1.6:
+    resolution: {integrity: sha512-SUPafl6vKRMQBKZoSwIeBFZ+c7AGEKUy6mpAD9fVHDKHOBWP3VpHKda4YIlgGtQd3SxH0bjfqJ078Z5SYsDYZQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring-win32-x64-msvc@1.1.6:
+    resolution: {integrity: sha512-FkNhM1x5ijFzGSrRcshRxUxQSrrjxl4wCmvRcXnimWreOHyzNotT+/1EZtSfM/k8yhdK0HEkkVIMQl0UqfioRw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/keyring@1.1.6:
+    resolution: {integrity: sha512-e6xoYELSMyaxcXv4MmEHhf0oOGsMnfWMmeu84CD91ICMgMH1I1vrLSMFpiPEQz03xD+pNQgAkQ7DwwBDozCuvw==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.1.6
+      '@napi-rs/keyring-darwin-x64': 1.1.6
+      '@napi-rs/keyring-freebsd-x64': 1.1.6
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.1.6
+      '@napi-rs/keyring-linux-arm64-gnu': 1.1.6
+      '@napi-rs/keyring-linux-arm64-musl': 1.1.6
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.1.6
+      '@napi-rs/keyring-linux-x64-gnu': 1.1.6
+      '@napi-rs/keyring-linux-x64-musl': 1.1.6
+      '@napi-rs/keyring-win32-arm64-msvc': 1.1.6
+      '@napi-rs/keyring-win32-ia32-msvc': 1.1.6
+      '@napi-rs/keyring-win32-x64-msvc': 1.1.6
+    dev: false
 
   /@ndelangen/get-tarball@3.0.9:
     resolution: {integrity: sha512-9JKTEik4vq+yGosHYhZ1tiH/3WpUS0Nh0kej4Agndhox8pAdWhEx5knFVRcb/ya9knCRCs1rPxNrSXTDdfVqpA==}
@@ -11084,6 +11256,7 @@ packages:
 
   /aproba@1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
+    requiresBuild: true
 
   /archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
@@ -11684,6 +11857,7 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    requiresBuild: true
 
   /basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
@@ -11737,6 +11911,7 @@ packages:
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    requiresBuild: true
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
@@ -11880,6 +12055,7 @@ packages:
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    requiresBuild: true
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -12190,6 +12366,7 @@ packages:
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    requiresBuild: true
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -12568,6 +12745,7 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+    requiresBuild: true
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
@@ -12634,6 +12812,7 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+    requiresBuild: true
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -12665,6 +12844,24 @@ packages:
       crc-32: 1.2.2
       readable-stream: 4.5.2
     dev: false
+
+  /create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@18.11.9)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
 
   /create-jest@29.7.0(@types/node@18.11.9)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -12946,6 +13143,7 @@ packages:
   /decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
+    requiresBuild: true
     dependencies:
       mimic-response: 3.1.0
 
@@ -12989,6 +13187,7 @@ packages:
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+    requiresBuild: true
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -13076,6 +13275,7 @@ packages:
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+    requiresBuild: true
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -13418,6 +13618,7 @@ packages:
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    requiresBuild: true
     dependencies:
       once: 1.4.0
 
@@ -15025,6 +15226,7 @@ packages:
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    requiresBuild: true
 
   /fs-exists-sync@0.1.0:
     resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
@@ -15577,6 +15779,7 @@ packages:
 
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+    requiresBuild: true
 
   /has-yarn@3.0.0:
     resolution: {integrity: sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==}
@@ -15944,6 +16147,7 @@ packages:
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    requiresBuild: true
 
   /ignore-case@0.1.0:
     resolution: {integrity: sha512-tQS9ucNf134w040JaMWzQ0WXfDR8Vdelk8E6ITviSzE6cOY2K12kNU04lLa8yy9WtcRrKWh3sdv0Xn8uLbMjUA==}
@@ -16045,6 +16249,7 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    requiresBuild: true
 
   /ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
@@ -16571,6 +16776,7 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+    requiresBuild: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -16721,6 +16927,34 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@18.11.9)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-cli@29.7.0(@types/node@18.11.9)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -16747,6 +16981,46 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config@29.7.0(@types/node@18.11.9):
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.20
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 18.11.9
+      babel-jest: 29.7.0(@babel/core@7.22.20)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.7
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
     dev: true
 
   /jest-config@29.7.0(@types/node@18.11.9)(ts-node@10.9.2):
@@ -16891,7 +17165,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      jest: 29.7.0(@types/node@18.11.9)(ts-node@10.9.2)
+      jest: 29.7.0
       jest-diff: 29.7.0
       jest-get-type: 29.4.3
     dev: true
@@ -17173,6 +17447,27 @@ packages:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
+
+  /jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
     dev: true
 
   /jest@29.7.0(@types/node@18.11.9)(ts-node@10.9.2):
@@ -17781,6 +18076,7 @@ packages:
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+    requiresBuild: true
     dependencies:
       yallist: 4.0.0
 
@@ -18200,6 +18496,7 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    requiresBuild: true
 
   /minipass-collect@1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -18295,6 +18592,7 @@ packages:
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    requiresBuild: true
 
   /mkdirp-infer-owner@2.0.0:
     resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
@@ -18968,6 +19266,7 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
 
   /object-inspect@1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -19973,6 +20272,7 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+    requiresBuild: true
 
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -20091,6 +20391,7 @@ packages:
 
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    requiresBuild: true
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
@@ -20232,6 +20533,7 @@ packages:
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    requiresBuild: true
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
@@ -20611,6 +20913,7 @@ packages:
 
   /readable-stream@2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+    requiresBuild: true
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -20623,6 +20926,7 @@ packages:
   /readable-stream@3.6.0:
     resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
     engines: {node: '>= 6'}
+    requiresBuild: true
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
@@ -21107,6 +21411,7 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    requiresBuild: true
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -21301,6 +21606,7 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    requiresBuild: true
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -21897,11 +22203,13 @@ packages:
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+    requiresBuild: true
     dependencies:
       safe-buffer: 5.1.2
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
 
@@ -22089,6 +22397,7 @@ packages:
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+    requiresBuild: true
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -22108,6 +22417,7 @@ packages:
   /tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+    requiresBuild: true
     dependencies:
       bl: 4.1.0
       end-of-stream: 1.4.4
@@ -23040,6 +23350,7 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    requiresBuild: true
 
   /util.inherits@1.0.3:
     resolution: {integrity: sha512-gMirHcfcq5D87nXDwbZqf5vl65S0mpMZBsHXJsXOO3Hc3G+JoQLwgaJa1h+PL7h3WhocnuLqoe8CuvMlztkyCA==}
@@ -23420,6 +23731,7 @@ packages:
 
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+    requiresBuild: true
     dependencies:
       string-width: 4.2.3
 
@@ -23644,6 +23956,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    requiresBuild: true
 
   /yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}


### PR DESCRIPTION

This PR introduces three potential replacements for `keytar`. 

#### 1.  CLI-Based Secure Store 
`open-ux-tools/packages/store/src/secure-store/cli-wrapper/cli-key-store.ts`

- Uses OS-specific CLI commands to manage credentials.
- Windows: Uses PowerShell cmdlets (`Set-StoredCredential` and `Get-StoredCredential`) to store and retrieve credentials. Requires PowerShell 5+ and a script to be executed.
- macOS: `security` CLI.
- Linux: `secret-tool`.
- Note: Windows requires explicit handling for unique `service/account` combinations, also `cmdkey` cannot retrieve passwords.

#### 2.  KeyringSecure Store
`open-ux-tools/packages/store/src/secure-store/napi-rs-keyring-store/keyring-store.ts`

- Utilizes the `@napi-rs/keyring` package to store and retrieve credentials.
- Note: Explicit handling of unique `service/account` combinations is required.

#### 3.  Zowe SDK Secure Store 
`open-ux-tools/packages/store/src/secure-store/zowe-sdk/zowe-sdk-store.ts`
- Utilizes the `@zowe/secrets-for-zowe-sdk` package for credential management.
- Note: Requires separate installation of Cargo on Linux systems

Also each potential replacement logic has its own test node scripts which can be run.
This PR provides initial groundwork for replacing `keytar`. Feedback and further grooming are welcome.
