### PR TITLE
add quick action for create new annotation

### DIFF
--- a/packages/adp-tooling/package.json
+++ b/packages/adp-tooling/package.json
@@ -43,6 +43,7 @@
         "@sap-ux/project-input-validator": "workspace:*",
         "@sap-ux/system-access": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
+        "@sap-ux/odata-service-writer": "workspace:*",
         "adm-zip": "0.5.10",
         "ejs": "3.1.10",
         "i18next": "23.11.2",

--- a/packages/adp-tooling/src/base/change-utils.ts
+++ b/packages/adp-tooling/src/base/change-utils.ts
@@ -269,7 +269,7 @@ export function getChange(
     changeType: ChangeType
 ): ManifestChangeProperties {
     return {
-        fileName: `id_${timestamp}`,
+        fileName: `id_${timestamp}_addAnnotationsToOData`,
         namespace: path.posix.join(namespace, DirName.Changes),
         layer,
         fileType: 'change',

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -21,7 +21,8 @@ declare global {
 export const enum ApiRoutes {
     FRAGMENT = '/adp/api/fragment',
     CONTROLLER = '/adp/api/controller',
-    CODE_EXT = '/adp/api/code_ext/:controllerName'
+    CODE_EXT = '/adp/api/code_ext/:controllerName',
+    ANNOTATION_FILE = '/adp/api/annotation'
 }
 
 /**
@@ -198,6 +199,11 @@ export class AdpPreview {
         router.post(ApiRoutes.CONTROLLER, this.routesHandler.handleWriteControllerExt as RequestHandler);
 
         router.get(ApiRoutes.CODE_EXT, this.routesHandler.handleGetControllerExtensionData as RequestHandler);
+        router.post(ApiRoutes.ANNOTATION_FILE, this.routesHandler.handleCreateAnnoationFile as RequestHandler);
+        router.get(
+            ApiRoutes.ANNOTATION_FILE,
+            this.routesHandler.handleGetAllAnnotationFilesMappedByDataSource as RequestHandler
+        );
     }
 
     /**

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -200,6 +200,22 @@ export interface CodeExtChange extends CommonChangeProperties {
     };
 }
 
+export interface AnnotationFileChange extends CommonChangeProperties {
+    changeType: 'appdescr_app_addAnnotationsToOData';
+    creation: string;
+    content: {
+        dataSourceId: string;
+        annotations: string[];
+        annotationsInsertPosition: 'END';
+        dataSource: {
+            [fileName: string]: {
+                uri: string;
+                type: 'ODataAnnotation';
+            };
+        };
+    };
+}
+
 export const enum TemplateFileName {
     Fragment = 'fragment.xml',
     Controller = 'controller.ejs',

--- a/packages/adp-tooling/tsconfig.json
+++ b/packages/adp-tooling/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../logger"
     },
     {
+      "path": "../odata-service-writer"
+    },
+    {
       "path": "../project-access"
     },
     {

--- a/packages/preview-middleware-client/src/adp/api-handler.ts
+++ b/packages/preview-middleware-client/src/adp/api-handler.ts
@@ -6,6 +6,7 @@ export const enum ApiEndpoints {
     FRAGMENT = '/adp/api/fragment',
     CONTROLLER = '/adp/api/controller',
     CODE_EXT = '/adp/api/code_ext',
+    ANNOTATION_FILE = '/adp/api/annotation',
     MANIFEST_APP_DESCRIPTOR = '/manifest.appdescr_variant'
 }
 
@@ -30,6 +31,14 @@ export interface CodeExtResponse {
     controllerExists: boolean;
     controllerPath: string;
     controllerPathFromRoot: string;
+    isRunningInBAS: boolean;
+}
+
+export interface AnnotationFileResponse {
+    annotationExists: boolean;
+    annotationPath: string;
+    serviceUrl: string;
+    annotationPathFromRoot: string;
     isRunningInBAS: boolean;
 }
 
@@ -137,6 +146,31 @@ export async function readControllers<T>(): Promise<T> {
  */
 export async function writeController<T>(data: T): Promise<T> {
     return request<T>(ApiEndpoints.CONTROLLER, RequestMethod.POST, data);
+}
+
+/**
+ * Writes a new annotation file to the project's workspace
+ *
+ * @param data Data to be send to the server
+ * @returns Generic Promise<T>
+ */
+export async function writeAnnotationFile<T>(data: T): Promise<T> {
+    return request<T>(ApiEndpoints.ANNOTATION_FILE, RequestMethod.POST, data);
+}
+
+/**
+ * Writes a new annotation file to the project's workspace
+ *
+ * @param data Data to be send to the server
+ * @returns Generic Promise<T>
+ */
+export async function getDataSourceAnnotationFileMap(): Promise<{
+    [key: string]: { serviceUrl: string; annotationFiles: AnnotationFileResponse[] };
+}> {
+    return request<{ [key: string]: { serviceUrl: string; annotationFiles: AnnotationFileResponse[] } }>(
+        ApiEndpoints.ANNOTATION_FILE,
+        RequestMethod.GET
+    );
 }
 
 /**

--- a/packages/preview-middleware-client/src/adp/controllers/ShowFileExistDialog.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ShowFileExistDialog.controller.ts
@@ -1,0 +1,81 @@
+import JSONModel from 'sap/ui/model/json/JSONModel';
+import type Dialog from 'sap/m/Dialog';
+
+import type Event from 'sap/ui/base/Event';
+
+import type SimpleForm from 'sap/ui/layout/form/SimpleForm';
+
+export interface ShowFileExist {
+    title: string;
+    fileName: string;
+    filePath: string;
+    isRunningInBAS: boolean;
+}
+
+/**
+ * @namespace open.ux.preview.client.adp.controllers
+ */
+export default class ShowFileExistDialog {
+    private options: ShowFileExist;
+    private model: JSONModel;
+    private dialog: Dialog;
+    private _name: string;
+    constructor(name: string, options: ShowFileExist) {
+        this._name = name;
+        this.model = new JSONModel();
+        this.options = options;
+    }
+
+    /**
+     * Setups the Dialog and the JSON Model
+     *
+     * @param {Dialog} dialog - Dialog instance
+     */
+    async setup(dialog: Dialog): Promise<void> {
+        this.dialog = dialog;
+
+        this.model.setProperty('/filePath', this.options.filePath);
+        this.model.setProperty('/filePathFromRoot', this.options.fileName);
+        this.model.setProperty('/isRunningInBAS', this.options.isRunningInBAS);
+        await this.buildDialogData();
+
+        this.dialog.setModel(this.model);
+
+        this.dialog.open();
+    }
+
+    /**
+     * Handles create button press
+     *
+     * @param _event Event
+     */
+    async onShowFileInVscodeBtn(_event: Event) {
+        const annotationPath = this.model.getProperty('/filePath');
+        window.open(`vscode://file${annotationPath}`);
+
+        this.handleDialogClose();
+    }
+
+    async handleDialogClose() {
+        this.dialog.close();
+        this.dialog.destroy();
+    }
+
+    /**
+     * Builds data that is used in the dialog.
+     */
+    async buildDialogData(): Promise<void> {
+        const content = this.dialog.getContent();
+
+        const messageForm = content[0] as SimpleForm;
+        messageForm.setVisible(true);
+
+        const isRunningInBAS = this.model.getProperty('/isRunningInBAS');
+        if (isRunningInBAS) {
+            this.dialog.getBeginButton().setVisible(false);
+        } else {
+            this.dialog.getBeginButton().setText('Open in VS Code').setEnabled(true);
+        }
+        this.dialog.getEndButton().setText('Close');
+    }
+}

--- a/packages/preview-middleware-client/src/adp/init-dialogs.ts
+++ b/packages/preview-middleware-client/src/adp/init-dialogs.ts
@@ -18,6 +18,7 @@ import AddFragment, { AddFragmentOptions } from './controllers/AddFragment.contr
 import ControllerExtension from './controllers/ControllerExtension.controller';
 import { ExtensionPointData } from './extension-point';
 import ExtensionPoint from './controllers/ExtensionPoint.controller';
+import ShowFileExistDialog, { ShowFileExist } from './controllers/ShowFileExistDialog.controller';
 import ManagedObject from 'sap/ui/base/ManagedObject';
 import { isReuseComponent } from '../cpe/utils';
 import { Ui5VersionInfo } from '../utils/version';
@@ -28,10 +29,11 @@ export const enum DialogNames {
     ADD_FRAGMENT = 'AddFragment',
     ADD_TABLE_COLUMN_FRAGMENTS = 'AddTableColumnFragments',
     CONTROLLER_EXTENSION = 'ControllerExtension',
-    ADD_FRAGMENT_AT_EXTENSION_POINT = 'ExtensionPoint'
+    ADD_FRAGMENT_AT_EXTENSION_POINT = 'ExtensionPoint',
+    SHOW_FILE_EXIST_DIALOG = 'ShowFileExist'
 }
 
-type Controller = AddFragment | AddTableColumnFragments | ControllerExtension | ExtensionPoint;
+type Controller = AddFragment | AddTableColumnFragments | ControllerExtension | ExtensionPoint | ShowFileExistDialog;
 
 /**
  * Handler for enablement of Extend With Controller context menu entry
@@ -128,7 +130,7 @@ export async function handler(
     rta: RuntimeAuthoring,
     dialogName: DialogNames,
     extensionPointData?: ExtensionPointData,
-    options: Partial<AddFragmentOptions> = {}
+    options: Partial<AddFragmentOptions> | Partial<ShowFileExist> = {}
 ): Promise<void> {
     let controller: Controller;
     const resources = await getTextBundle();
@@ -136,15 +138,20 @@ export async function handler(
     switch (dialogName) {
         case DialogNames.ADD_FRAGMENT:
             controller = new AddFragment(`open.ux.preview.client.adp.controllers.${dialogName}`, overlay, rta, {
-                aggregation: options.aggregation,
+                ...('aggregation' in options && { aggregation: options.aggregation }),
                 title: resources.getText(options.title ?? 'ADP_ADD_FRAGMENT_DIALOG_TITLE')
             });
             break;
         case DialogNames.ADD_TABLE_COLUMN_FRAGMENTS:
-            controller = new AddTableColumnFragments(`open.ux.preview.client.adp.controllers.${dialogName}`, overlay, rta, {
-                aggregation: options.aggregation,
-                title: resources.getText(options.title ?? 'ADP_ADD_FRAGMENT_DIALOG_TITLE')
-            });
+            controller = new AddTableColumnFragments(
+                `open.ux.preview.client.adp.controllers.${dialogName}`,
+                overlay,
+                rta,
+                {
+                    ...('aggregation' in options && { aggregation: options.aggregation }),
+                    title: resources.getText(options.title ?? 'ADP_ADD_FRAGMENT_DIALOG_TITLE')
+                }
+            );
             break;
         case DialogNames.CONTROLLER_EXTENSION:
             controller = new ControllerExtension(`open.ux.preview.client.adp.controllers.${dialogName}`, overlay, rta);
@@ -155,6 +162,12 @@ export async function handler(
                 overlay,
                 rta,
                 extensionPointData!
+            );
+            break;
+        case DialogNames.SHOW_FILE_EXIST_DIALOG:
+            controller = new ShowFileExistDialog(
+                `open.ux.preview.client.adp.controllers.${dialogName}`,
+                options as ShowFileExist
             );
             break;
     }

--- a/packages/preview-middleware-client/src/adp/quick-actions/common/add-new-annotation-file.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/common/add-new-annotation-file.ts
@@ -1,0 +1,97 @@
+import FlexCommand from 'sap/ui/rta/command/FlexCommand';
+
+import { QuickActionContext, NestedQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
+import { getDataSourceAnnotationFileMap, writeAnnotationFile } from '../../api-handler';
+import {
+    NESTED_QUICK_ACTION_KIND,
+    NestedQuickAction,
+    NestedQuickActionChild
+} from '@sap-ux-private/control-property-editor-common';
+import { DialogNames, handler } from '../../init-dialogs';
+import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
+
+export const ADD_NEW_ANNOTATION_FILE = 'add-new-annotation-file';
+
+/**
+ * Add New Annotation File.
+ */
+export class AddNewAnnotationFile implements NestedQuickActionDefinition {
+    public children: NestedQuickActionChild[] = [];
+    readonly kind = NESTED_QUICK_ACTION_KIND;
+    readonly type = ADD_NEW_ANNOTATION_FILE;
+    readonly forceRefreshAfterExecution = true;
+    public get id(): string {
+        return `${this.context.key}-${this.type}`;
+    }
+
+    constructor(protected readonly context: QuickActionContext) {}
+
+    public get isActive(): boolean {
+        return true;
+    }
+
+    async initialize(): Promise<void> {
+        const dataSourceAnnotationFileMap = await getDataSourceAnnotationFileMap();
+        if (!dataSourceAnnotationFileMap) {
+            throw new Error('No data sources found in the manifest');
+        }
+        for (const key in dataSourceAnnotationFileMap) {
+            const source = dataSourceAnnotationFileMap[key];
+            this.children.push({
+                label: source.annotationFiles.length
+                    ? this.context.resourceBundle.getText('SHOW_ANNOTATION_FILE', [key])
+                    : this.context.resourceBundle.getText('ODATA_SORUCE', [key]),
+                children: []
+            });
+        }
+    }
+    async execute(path: string): Promise<FlexCommand[]> {
+        const index = Number(path);
+        if (index >= 0) {
+            // Do not cache the result of getDataSourceAnnotationFileMap api , as annotation file or datasource can be added outside using create command/So refresh would be required for the cache to be updated.
+            const dataSourceAnnotationFileMap = await getDataSourceAnnotationFileMap();
+            const dataSourceId = Object.keys(dataSourceAnnotationFileMap)[index];
+            // Create annotation file only, if no file exists already for datasource id or if the change file exist and but no annotation file exists in file system.
+            if (
+                dataSourceAnnotationFileMap[dataSourceId] &&
+                (!dataSourceAnnotationFileMap[dataSourceId].annotationFiles.length ||
+                    dataSourceAnnotationFileMap[dataSourceId].annotationFiles.every((item) => !item.annotationExists))
+            ) {
+                await writeAnnotationFile({
+                    dataSource: dataSourceId,
+                    serviceUrl: dataSourceAnnotationFileMap[dataSourceId].serviceUrl
+                });
+            } else {
+                const annotationFiles = dataSourceAnnotationFileMap[dataSourceId].annotationFiles;
+                const { annotationPath, annotationPathFromRoot, isRunningInBAS } =
+                    annotationFiles[annotationFiles.length - 1];
+                handler(
+                    OverlayRegistry.getOverlay(this.context.view), // this passed only because, for method param is required.
+                    this.context.rta, // same as above
+                    DialogNames.SHOW_FILE_EXIST_DIALOG,
+                    undefined,
+                    {
+                        fileName: annotationPathFromRoot,
+                        filePath: annotationPath,
+                        isRunningInBAS
+                    }
+                );
+            }
+        }
+        return [];
+    }
+
+    /**
+     * Prepares nested quick action object
+     * @returns action instance
+     */
+    getActionObject(): NestedQuickAction {
+        return {
+            kind: NESTED_QUICK_ACTION_KIND,
+            id: this.id,
+            enabled: this.isActive,
+            title: this.context.resourceBundle.getText('QUICK_ACTION_ADD_NEW_ANNOTATION_FILE'),
+            children: this.children
+        };
+    }
+}

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/registry.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/registry.ts
@@ -18,6 +18,7 @@ import { AddTableActionQuickAction } from '../fe-v2/create-table-action';
 import { AddTableCustomColumnQuickAction } from './create-table-custom-column';
 import { AddPageActionQuickAction } from '../common/create-page-action';
 import { ToggleSemanticDateRangeFilterBar } from './lr-enable-semantic-date-range-filter-bar';
+import { AddNewAnnotationFile } from '../common/add-new-annotation-file';
 type PageName = 'listReport' | 'objectPage' | 'analyticalListPage';
 
 const OBJECT_PAGE_TYPE = 'sap.suite.ui.generic.template.ObjectPage.view.Details';
@@ -48,7 +49,8 @@ export default class FEV2QuickActionRegistry extends QuickActionDefinitionRegist
                         ToggleSemanticDateRangeFilterBar,
                         ChangeTableColumnsQuickAction,
                         AddTableActionQuickAction,
-                        AddTableCustomColumnQuickAction
+                        AddTableCustomColumnQuickAction,
+                        AddNewAnnotationFile
                     ],
                     view,
                     key: name + index
@@ -63,7 +65,8 @@ export default class FEV2QuickActionRegistry extends QuickActionDefinitionRegist
                         AddCustomSectionQuickAction,
                         ChangeTableColumnsQuickAction,
                         AddTableActionQuickAction,
-                        AddTableCustomColumnQuickAction
+                        AddTableCustomColumnQuickAction,
+                        AddNewAnnotationFile
                     ],
                     view,
                     key: name + index

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/registry.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/registry.ts
@@ -13,6 +13,7 @@ import { AddTableCustomColumnQuickAction } from './create-table-custom-column';
 import { AddPageActionQuickAction } from '../common/create-page-action';
 import { AddTableActionQuickAction } from './create-table-action';
 import { ToggleSemanticDateRangeFilterBar } from './lr-enable-semantic-date-range-filter-bar';
+import { AddNewAnnotationFile } from '../common/add-new-annotation-file';
 
 type PageName = 'listReport' | 'objectPage';
 
@@ -43,7 +44,8 @@ export default class FEV4QuickActionRegistry extends QuickActionDefinitionRegist
                         ToggleSemanticDateRangeFilterBar,
                         ChangeTableColumnsQuickAction,
                         AddTableActionQuickAction,
-                        AddTableCustomColumnQuickAction
+                        AddTableCustomColumnQuickAction,
+                        AddNewAnnotationFile
                     ],
                     view,
                     key: name + index
@@ -58,7 +60,8 @@ export default class FEV4QuickActionRegistry extends QuickActionDefinitionRegist
                         AddCustomSectionQuickAction,
                         ChangeTableColumnsQuickAction,
                         AddTableActionQuickAction,
-                        AddTableCustomColumnQuickAction
+                        AddTableCustomColumnQuickAction,
+                        AddNewAnnotationFile
                     ],
                     view,
                     key: name + index

--- a/packages/preview-middleware-client/src/adp/ui/ShowFileExist.fragment.xml
+++ b/packages/preview-middleware-client/src/adp/ui/ShowFileExist.fragment.xml
@@ -1,0 +1,37 @@
+<Dialog id="showFileExistDialog"  
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns="sap.m"
+    xmlns:core="sap.ui.core"
+    xmlns:f="sap.ui.layout.form" 
+    title="Annotation File Exists" 
+    contentWidth="450px" 
+    class="sapUiRTABorder">
+    <content>
+        <f:SimpleForm
+            editable="true"
+            layout="ResponsiveGridLayout"
+            labelSpanS="12"
+            visible="true"
+            singleContainerFullSize="true">
+            <f:content>
+                <Label text="An Annotation file has been found." />
+                <Text text="{/filePathFromRoot}" />
+            </f:content>
+        </f:SimpleForm>
+    </content>
+    <beginButton>
+        <Button 
+            id="showFileInVscodeBtn" 
+            text="Show File in VSCode"
+            press="onShowFileInVscodeBtn"
+            enabled="true"
+            type="Emphasized" />
+    </beginButton>
+    <endButton>
+        <Button 
+            id="closeShowFileInVsCodeBtn" 
+            text="Cancel"
+            press="handleDialogClose"
+            type="Reject" />
+    </endButton>
+</Dialog>

--- a/packages/preview-middleware-client/src/messagebundle.properties
+++ b/packages/preview-middleware-client/src/messagebundle.properties
@@ -5,6 +5,7 @@ QUICK_ACTION_OP_ADD_CUSTOM_SECTION=Add Custom Section
 QUICK_ACTION_ADD_CUSTOM_PAGE_ACTION=Add Custom Page Action
 QUICK_ACTION_ADD_CUSTOM_TABLE_ACTION=Add Custom Table Action
 QUICK_ACTION_ADD_CUSTOM_TABLE_COLUMN=Add Custom Table Column
+QUICK_ACTION_ADD_NEW_ANNOTATION_FILE=Add New Annotation File
 
 V2_QUICK_ACTION_CHANGE_TABLE_COLUMNS=Change Table Columns
 
@@ -39,3 +40,5 @@ CPE_CHANGES_VISIBLE_AFTER_SAVE_AND_RELOAD_MESSAGE = Note: The change will be vis
 TABLE_ROWS_NEEDED_TO_CREATE_CUSTOM_COLUMN=At least one table row is required to create new custom column. Make sure the table data is loaded and try again.
 
 HIGHER_LAYER_CHANGES_INFO_MESSAGE=The preview of the project was reloaded due to detected changes in higher layer than the one used in your project.
+ODATA_SORUCE=''{0}'' datasource
+SHOW_ANNOTATION_FILE=Show ''{0}'' annotation file

--- a/packages/preview-middleware/src/base/flex.ts
+++ b/packages/preview-middleware/src/base/flex.ts
@@ -1,8 +1,8 @@
 import type { Logger } from '@sap-ux/logger';
 import type { ReaderCollection } from '@ui5/fs';
 import type { Editor } from 'mem-fs-editor';
-import { existsSync, readdirSync, unlinkSync } from 'fs';
-import { join, parse } from 'path';
+import { existsSync, readdirSync, statSync, unlinkSync } from 'fs';
+import { join, parse, sep } from 'path';
 import type { CommonChangeProperties } from '@sap-ux/adp-tooling';
 
 /**
@@ -17,7 +17,7 @@ export async function readChanges(
     logger: Logger
 ): Promise<Record<string, CommonChangeProperties>> {
     const changes: Record<string, CommonChangeProperties> = {};
-    const files = await project.byGlob('/**/changes/*.*');
+    const files = await project.byGlob('/**/changes/**/*.*');
     for (const file of files) {
         try {
             const change = JSON.parse(await file.getString()) as CommonChangeProperties;
@@ -78,15 +78,37 @@ export function deleteChange(
     if (fileName) {
         const path = join(webappPath, 'changes');
         if (existsSync(path)) {
-            const files = readdirSync(path);
-            const file = files.find((element) => element.includes(fileName));
-            if (file) {
-                logger.debug(`Write change ${file}`);
-                const filePath = join(path, file);
+            // Changes can be in subfolders of changes directory. For eg: New Annotation File Change
+            const files: string[] = [];
+            readDirectoriesRecursively(path, files);
+            const filePath = files.find((element) => element.includes(fileName));
+            if (filePath) {
+                const fileNameWithExt = filePath.split(sep).pop();
+                logger.debug(`Write change ${fileNameWithExt}`);
                 unlinkSync(filePath);
-                return { success: true, message: `FILE_DELETED ${file}` };
+                return { success: true, message: `FILE_DELETED ${fileNameWithExt}` };
             }
         }
     }
     return { success: false };
+}
+
+/**
+ * Recursively find all files in the given folder.
+ *
+ * @param path path to the folder.
+ * @param files all files in the given folder and subfolders.
+ */
+
+function readDirectoriesRecursively(path: string, files: string[] = []): void {
+    const items = readdirSync(path);
+    items.forEach((item) => {
+        const fullPath = join(path, item);
+        const stats = statSync(fullPath);
+        if (stats.isDirectory()) {
+            readDirectoriesRecursively(fullPath, files);
+        } else if (stats.isFile()) {
+            files.push(fullPath);
+        }
+    });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
+      '@sap-ux/odata-service-writer':
+        specifier: workspace:*
+        version: link:../odata-service-writer
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access


### PR DESCRIPTION
- Add New quick action for V2 and V4 app for creation of new annotation file.
- Update middleware glob pattern to read subdirectories from changes folder as well handling of deletion when changes are in subfolder
- Api for reading and writing annotation file