### PR TITLE
fix for refresh token not being used when reconnecting

### DIFF
--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -388,6 +388,7 @@ export class ConnectionValidator {
      * @param connectConfig.serviceInfo the service info
      * @param connectConfig.odataVersion the odata version to restrict the catalog requests if only a specific version is required
      * @param connectConfig.destination the destination to connect with
+     * @param connectConfig.refreshToken
      * @throws an error if the connection attempt fails, callers should handle the error
      */
     private async createSystemConnection({
@@ -395,19 +396,21 @@ export class ConnectionValidator {
         url,
         serviceInfo,
         destination,
-        odataVersion
+        odataVersion,
+        refreshToken
     }: {
         axiosConfig?: AxiosExtensionRequestConfig & ProviderConfiguration;
         url?: URL;
         serviceInfo?: ServiceInfo;
         destination?: Destination;
         odataVersion?: ODataVersion;
+        refreshToken?: string;
     }): Promise<void> {
         this.resetConnectionState();
         this.resetValidity();
 
         if (this.systemAuthType === 'reentranceTicket' || this.systemAuthType === 'serviceKey') {
-            this._serviceProvider = this.getAbapOnCloudServiceProvider(url, serviceInfo);
+            this._serviceProvider = this.getAbapOnCloudServiceProvider(url, serviceInfo, refreshToken);
         } else if (destination) {
             // Assumption: the destination configured URL is a valid URL, will be needed later for basic auth error handling
             this._validatedUrl = getDestinationUrlForAppStudio(destination.Name);
@@ -482,9 +485,14 @@ export class ConnectionValidator {
      *
      * @param url the system url
      * @param serviceInfo the service info
+     * @param refreshToken
      * @returns the service provider
      */
-    private getAbapOnCloudServiceProvider(url?: URL, serviceInfo?: ServiceInfo): AbapServiceProvider {
+    private getAbapOnCloudServiceProvider(
+        url?: URL,
+        serviceInfo?: ServiceInfo,
+        refreshToken?: string
+    ): AbapServiceProvider {
         if (this.systemAuthType === 'reentranceTicket' && url) {
             return createForAbapOnCloud({
                 environment: AbapCloudEnvironment.EmbeddedSteampunk,
@@ -496,6 +504,7 @@ export class ConnectionValidator {
             return createForAbapOnCloud({
                 environment: AbapCloudEnvironment.Standalone,
                 service: serviceInfo,
+                refreshToken,
                 refreshTokenChangedCb: this.refreshTokenChangedCb.bind(this)
             });
         }
@@ -510,15 +519,20 @@ export class ConnectionValidator {
      *
      * @param serviceInfo the service info containing the UAA details
      * @param odataVersion the odata version to restrict the catalog requests if only a specific version is required
+     * @param refreshToken the refresh token for the Abap on Cloud environment, will be used to avoid re-authentication while the token is valid
      * @returns true if the system is reachable and authenticated, if required, false if not, or an error message string
      */
-    public async validateServiceInfo(serviceInfo: ServiceInfo, odataVersion?: ODataVersion): Promise<ValidationResult> {
+    public async validateServiceInfo(
+        serviceInfo: ServiceInfo,
+        odataVersion?: ODataVersion,
+        refreshToken?: string
+    ): Promise<ValidationResult> {
         if (!serviceInfo) {
             return false;
         }
         try {
             this.systemAuthType = 'serviceKey';
-            await this.createSystemConnection({ serviceInfo, odataVersion });
+            await this.createSystemConnection({ serviceInfo, odataVersion, refreshToken });
             // Cache the user info
             this._connectedUserName = await (this.serviceProvider as AbapServiceProvider).user();
             this._serviceInfo = serviceInfo;

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -52,7 +52,11 @@ export async function connectWithBackendSystem(
                 systemAuthType: 'reentranceTicket'
             });
         } else if (backendSystem.serviceKeys) {
-            connectValResult = await connectionValidator.validateServiceInfo(backendSystem.serviceKeys as ServiceInfo);
+            connectValResult = await connectionValidator.validateServiceInfo(
+                backendSystem.serviceKeys as ServiceInfo,
+                convertODataVersionType(requiredOdataVersion),
+                backendSystem.refreshToken
+            );
         } else if (backendSystem.authenticationType === 'basic' || !backendSystem.authenticationType) {
             let errorType;
             ({ valResult: connectValResult, errorType } = await connectionValidator.validateAuth(

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -457,6 +457,19 @@ describe('ConnectionValidator', () => {
         // Ensure the refresh token is updated when it changes
         (connectValidator.serviceProvider as any).refreshTokenChangedCb('newToken1234');
         expect(connectValidator.refreshToken).toEqual('newToken1234');
+
+        // Ensure refresh token is used to create a connection if presented
+        expect(
+            await connectValidator.validateServiceInfo(serviceInfoMock as ServiceInfo, undefined, '123refreshToken456')
+        ).toBe(true);
+        expect(createAbapOnCloudProviderSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                environment: 'Standalone',
+                refreshTokenChangedCb: expect.any(Function),
+                service: serviceInfoMock,
+                refreshToken: '123refreshToken456'
+            })
+        );
     });
 
     test('should attempt to validate auth using v4 catalog where v2 is not available or user is not authorized', async () => {

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/questions.test.ts
@@ -157,6 +157,7 @@ describe('Test system selection prompts', () => {
     beforeEach(() => {
         mockIsAppStudio = false;
         isAuthRequiredMock.mockResolvedValue(false);
+        validateServiceInfoResultMock = true;
     });
 
     test('should return system selection prompts and choices based on development environment, BAS or non-BAS', async () => {
@@ -464,6 +465,29 @@ describe('Test system selection prompts', () => {
             backendSystemServiceKeys,
             connectionValidatorMock,
             undefined
+        );
+    });
+
+    test('getSystemConnectionQuestions: non-BAS (BackendSystem, AuthType: serviceKeys, RefreshToken)', async () => {
+        mockIsAppStudio = false;
+        const connectValidator = new ConnectionValidator();
+        (getPromptHostEnvironment as jest.Mock).mockReturnValue(hostEnvironment.cli);
+        const validateServiceInfoSpy = jest.spyOn(connectValidator, 'validateServiceInfo');
+        const backendSystemServiceKeysClone = { ...backendSystemServiceKeys, refreshToken: '123refreshToken456' };
+        backendSystems.push(backendSystemServiceKeysClone);
+
+        const systemConnectionQuestions = await getSystemConnectionQuestions(connectValidator);
+        const systemSelectionPrompt = systemConnectionQuestions[0] as ListQuestion;
+        expect(
+            await systemSelectionPrompt.validate?.({
+                type: 'backendSystem',
+                system: backendSystemServiceKeysClone
+            } as SystemSelectionAnswerType)
+        ).toBe(true);
+        expect(validateServiceInfoSpy).toHaveBeenCalledWith(
+            backendSystemServiceKeysClone.serviceKeys,
+            undefined,
+            backendSystemServiceKeysClone.refreshToken
         );
     });
 


### PR DESCRIPTION
Fix for : #2625

- Adds passing of refresh token for backend systems that have it defined
- Adds tests to cover 