### PR TITLE
fix(cf-deploy-config-writer): allow underscore as a supported character

### DIFF
--- a/.changeset/chatty-chefs-smile.md
+++ b/.changeset/chatty-chefs-smile.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+ensure underscore is a supported character when writing configuration

--- a/packages/cf-deploy-config-writer/src/mta-config/index.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/index.ts
@@ -81,7 +81,7 @@ export async function addMtaBuildParams(mtaInstance: MtaConfig): Promise<void> {
 }
 
 /**
- * Add the deploy parameters to the MTA configuration.
+ * Add the deployment parameters to the MTA configuration.
  *
  * @param mtaInstance MTA instance
  */

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -52,7 +52,7 @@ export function getTemplatePath(relativeTemplatePath: string = ''): string {
  * @returns Name that's acceptable in an mta.yaml
  */
 export function toMtaModuleName(id: string): string {
-    return id.replace(/[`~!@#$%^&*£()|+=?;:'",.<>]/gi, '').slice(0, 128);
+    return id.replace(/[`~!@#$%^&*£()|+=?;:'",.<>]/gi, '');
 }
 
 /**

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -52,7 +52,7 @@ export function getTemplatePath(relativeTemplatePath: string = ''): string {
  * @returns Name that's acceptable in an mta.yaml
  */
 export function toMtaModuleName(id: string): string {
-    return id.replace(/[`~!@#$%^&*()_|+=?;:'",.<>]/gi, '');
+    return id.replace(/[`~!@#$%^&*£()|+=?;:'",.<>]/gi, '').slice(0, 128);
 }
 
 /**

--- a/packages/cf-deploy-config-writer/test/unit/utils.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { validateVersion } from '../../src/utils';
+import { validateVersion, toMtaModuleName } from '../../src/utils';
 import { MTAVersion } from '../../src/constants';
 
 describe('CF utils', () => {
@@ -17,6 +17,14 @@ describe('CF utils', () => {
             expect(() => validateVersion()).not.toThrowError();
             expect(validateVersion(MTAVersion)).toBeTruthy();
             expect(validateVersion('1')).toBeTruthy();
+        });
+
+        test('Validate - toMtaModuleName', () => {
+            expect(toMtaModuleName('0.0.0')).toEqual('000');
+            expect(toMtaModuleName('cf_mta_id')).toEqual('cf_mta_id');
+            expect(toMtaModuleName('cf.mta.00')).toEqual('cfmta00');
+            expect(toMtaModuleName('cf_mta.!£$%^&*,()')).toEqual('cf_mta');
+            expect(toMtaModuleName('c'.repeat(130))).toEqual('c'.repeat(128));
         });
     });
 });

--- a/packages/cf-deploy-config-writer/test/unit/utils.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/utils.test.ts
@@ -24,7 +24,6 @@ describe('CF utils', () => {
             expect(toMtaModuleName('cf_mta_id')).toEqual('cf_mta_id');
             expect(toMtaModuleName('cf.mta.00')).toEqual('cfmta00');
             expect(toMtaModuleName('cf_mta.!£$%^&*,()')).toEqual('cf_mta');
-            expect(toMtaModuleName('c'.repeat(130))).toEqual('c'.repeat(128));
         });
     });
 });


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2007

- allow `_` to be written to mta configuration