### PR TITLE
fix: writing collections with string values

### DIFF
--- a/.changeset/nice-brooms-grab.md
+++ b/.changeset/nice-brooms-grab.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-annotation-api': patch
+---
+
+Fixed writing collections with string values

--- a/packages/fiori-annotation-api/src/avt/to-internal.ts
+++ b/packages/fiori-annotation-api/src/avt/to-internal.ts
@@ -121,6 +121,8 @@ export function convertCollectionElement(
     } else if (typeof entry === 'boolean') {
         // obvious extension of annotation.record definition
         return createElementNode({ name: Edm.Bool, content: [createTextNode(entry ? 'true' : 'false')] });
+    } else if (typeof entry === 'string') {
+        return createElementNode({ name: Edm.String, content: [createTextNode(entry)] });
     }
     return undefined;
 }

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -759,6 +759,48 @@ exports[`fiori annotation service insert collection item EDMXBackend xml-start v
 "
 `;
 
+exports[`fiori annotation service insert collection of strings CAPNodejs cap-start v4 1`] = `
+"using IncidentService as service from '../../srv/incidentservice';
+
+annotate service.test with @(
+    Common.SideEffects : {
+        $Type : 'Common.SideEffectsType',
+        TargetProperties : [
+            '_it/dummyTargetPropertyPath',
+        ],
+    }
+);
+
+"
+`;
+
+exports[`fiori annotation service insert collection of strings EDMXBackend xml-start v4 1`] = `
+"<edmx:Edmx xmlns:edmx=\\"http://docs.oasis-open.org/odata/ns/edmx\\" Version=\\"4.0\\">
+    <edmx:Reference Uri=\\"https://sap.github.io/odata-vocabularies/vocabularies/Common.xml\\">
+        <edmx:Include Namespace=\\"com.sap.vocabularies.Common.v1\\" Alias=\\"Common\\"/>
+    </edmx:Reference>
+    <edmx:Reference Uri=\\"/incident/$metadata\\">
+        <edmx:Include Namespace=\\"IncidentService\\"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns=\\"http://docs.oasis-open.org/odata/ns/edm\\" Namespace=\\"sap.fe.demo\\">
+            <Annotations Target=\\"IncidentService.test\\">
+                <Annotation Term=\\"Common.SideEffects\\">
+                    <Record Type=\\"Common.SideEffectsType\\">
+                        <PropertyValue Property=\\"TargetProperties\\">
+                            <Collection>
+                                <String>_it/dummyTargetPropertyPath</String>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>
+"
+`;
+
 exports[`fiori annotation service insert embedded annotation and update collection CAPNodejs cap-start v4 1`] = `
 "using IncidentService as service from '../../srv/incidentservice';
 

--- a/packages/fiori-annotation-api/test/unit/avt/__snapshots__/to-internal.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/avt/__snapshots__/to-internal.test.ts.snap
@@ -60,6 +60,55 @@ Object {
 }
 `;
 
+exports[`avt to internal convertExpressionToInternal Collection with string values 1`] = `
+Object {
+  "attributes": Object {},
+  "content": Array [
+    Object {
+      "attributes": Object {},
+      "content": Array [
+        Object {
+          "text": "test",
+          "type": "text",
+        },
+      ],
+      "name": "String",
+      "type": "element",
+    },
+  ],
+  "name": "Collection",
+  "type": "element",
+}
+`;
+
+exports[`avt to internal convertExpressionToInternal Collection with string values 2`] = `
+Object {
+  "attributes": Object {},
+  "content": Array [
+    Object {
+      "attributes": Object {},
+      "content": Array [
+        Object {
+          "attributes": Object {},
+          "content": Array [
+            Object {
+              "text": "test",
+              "type": "text",
+            },
+          ],
+          "name": "String",
+          "type": "element",
+        },
+      ],
+      "name": "Collection",
+      "type": "element",
+    },
+  ],
+  "name": "Annotation",
+  "type": "element",
+}
+`;
+
 exports[`avt to internal convertExpressionToInternal If 1`] = `
 Object {
   "attributes": Object {},

--- a/packages/fiori-annotation-api/test/unit/avt/to-internal.test.ts
+++ b/packages/fiori-annotation-api/test/unit/avt/to-internal.test.ts
@@ -1,4 +1,4 @@
-import type { Expression } from '@sap-ux/vocabularies-types';
+import type { Expression, StringExpression } from '@sap-ux/vocabularies-types';
 import { createElementNode, type AliasInformation } from '@sap-ux/odata-annotation-core-types';
 
 import { convertExpressionToInternal } from '../../../src/avt/to-internal';
@@ -21,6 +21,9 @@ describe('avt to internal', () => {
         }
         test('Collection', () => {
             testConversion({ type: 'Collection', Collection: [] });
+        });
+        test('Collection with string values', () => {
+            testConversion({ type: 'Collection', Collection: ['test'] as unknown as StringExpression[] });
         });
         test('Record', () => {
             testConversion({

--- a/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
+++ b/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
@@ -12,7 +12,8 @@ import type {
     Collection,
     PropertyPathExpression,
     PropertyValue,
-    RawAnnotation
+    RawAnnotation,
+    StringExpression
 } from '@sap-ux/vocabularies-types';
 import { getProject } from '@sap-ux/project-access';
 
@@ -1557,6 +1558,40 @@ describe('fiori annotation service', () => {
                                 Collection: []
                             }
                         }
+                    }
+                ]
+            });
+
+            createEditTestCase({
+                name: 'of strings',
+                projectTestModels: TEST_TARGETS,
+                getChanges: (files) => [
+                    {
+                        kind: ChangeType.InsertAnnotation,
+                        content: {
+                            target: targetName,
+                            type: 'annotation',
+                            value: {
+                                term: `${COMMON}.SideEffects`,
+                                record: {
+                                    type: `${COMMON}.SideEffectsType`,
+                                    propertyValues: [
+                                        {
+                                            name: 'TargetProperties',
+                                            value: {
+                                                type: 'Collection',
+                                                // AVT also allows plain string values even though it doesn't match types
+                                                // https://github.com/SAP/open-ux-odata/blob/c499009b388d2fe8d94762f619a33998491b4e68/packages/edmx-parser/src/parser.ts#L708-L710
+                                                Collection: [
+                                                    '_it/dummyTargetPropertyPath'
+                                                ] as unknown as StringExpression[]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        uri: files.annotations
                     }
                 ]
             });


### PR DESCRIPTION
#2530 contains inaccurate type update for collection values which does not match the parser and converter implementation. `StringExpression` is expected, but parser and converter only create regular string values. So we need to make sure that this case is also correctly handled.