### PR TITLE
fix: hide quick action if the application has old manifest structure

### DIFF
--- a/.changeset/light-crabs-camp.md
+++ b/.changeset/light-crabs-camp.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+CPE - Hide Quick Actions in V2 application, if the application has old manifest structure.

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
@@ -4,7 +4,7 @@ import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/qu
 import { pageHasControlId } from '../../../cpe/quick-actions/utils';
 import { getControlById, isA } from '../../../utils/core';
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
-import { areManifestChangesSupported, prepareManifestChange } from './utils';
+import { areManifestChangesNotSupported, prepareManifestChange } from './utils';
 import SmartFilterBar from 'sap/ui/comp/smartfilterbar/SmartFilterBar';
 
 export const ENABLE_SEMANTIC_DATE_RANGE_FILTER_BAR = 'enable-semantic-daterange-filterbar';
@@ -24,9 +24,8 @@ export class ToggleSemanticDateRangeFilterBar
     private isUseDateRangeTypeEnabled = false;
 
     async initialize(): Promise<void> {
-        const isUI5VersionNotSupported = await areManifestChangesSupported();
-        const pagesStructureInManifest = this.context.manifest['sap.ui.generic.app'].pages;
-        if (isUI5VersionNotSupported || Array.isArray(pagesStructureInManifest)) {
+        const manifestChangesNotSupported = await areManifestChangesNotSupported(this.context.manifest);
+        if (manifestChangesNotSupported) {
             return;
         }
         const controls = this.context.controlIndex[CONTROL_TYPE] ?? [];

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
@@ -4,7 +4,7 @@ import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/qu
 import { pageHasControlId } from '../../../cpe/quick-actions/utils';
 import { getControlById, isA } from '../../../utils/core';
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
-import { areManifestChangesNotSupported, prepareManifestChange } from './utils';
+import { areManifestChangesSupported, prepareManifestChange } from './utils';
 import SmartFilterBar from 'sap/ui/comp/smartfilterbar/SmartFilterBar';
 
 export const ENABLE_SEMANTIC_DATE_RANGE_FILTER_BAR = 'enable-semantic-daterange-filterbar';
@@ -24,8 +24,8 @@ export class ToggleSemanticDateRangeFilterBar
     private isUseDateRangeTypeEnabled = false;
 
     async initialize(): Promise<void> {
-        const manifestChangesNotSupported = await areManifestChangesNotSupported(this.context.manifest);
-        if (manifestChangesNotSupported) {
+        const manifestChangesSupported = await areManifestChangesSupported(this.context.manifest);
+        if (!manifestChangesSupported) {
             return;
         }
         const controls = this.context.controlIndex[CONTROL_TYPE] ?? [];

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
@@ -25,7 +25,8 @@ export class ToggleSemanticDateRangeFilterBar
 
     async initialize(): Promise<void> {
         const isUI5VersionNotSupported = await areManifestChangesSupported();
-        if (isUI5VersionNotSupported) {
+        const pagesStructureInManifest = this.context.manifest['sap.ui.generic.app'].pages;
+        if (isUI5VersionNotSupported || Array.isArray(pagesStructureInManifest)) {
             return;
         }
         const controls = this.context.controlIndex[CONTROL_TYPE] ?? [];

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
@@ -32,7 +32,8 @@ export class EnableTableFilteringQuickAction
 
     async initialize(): Promise<void> {
         const isUI5VersionNotSupported = await areManifestChangesSupported();
-        if (isUI5VersionNotSupported) {
+        const pagesStructureInManifest = this.context.manifest['sap.ui.generic.app'].pages;
+        if (isUI5VersionNotSupported || Array.isArray(pagesStructureInManifest)) {
             return;
         }
 

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
@@ -2,7 +2,7 @@ import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { getRelevantControlFromActivePage, pageHasControlId } from '../../../cpe/quick-actions/utils';
 import { GRID_TABLE_TYPE, M_TABLE_TYPE, SMART_TABLE_TYPE, TREE_TABLE_TYPE } from '../table-quick-action-base';
-import { areManifestChangesSupported, prepareManifestChange } from './utils';
+import { areManifestChangesNotSupported, prepareManifestChange } from './utils';
 
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
 import { isA } from '../../../utils/core';
@@ -31,12 +31,10 @@ export class EnableTableFilteringQuickAction
     }
 
     async initialize(): Promise<void> {
-        const isUI5VersionNotSupported = await areManifestChangesSupported();
-        const pagesStructureInManifest = this.context.manifest['sap.ui.generic.app'].pages;
-        if (isUI5VersionNotSupported || Array.isArray(pagesStructureInManifest)) {
+        const manifestChangesNotSupported = await areManifestChangesNotSupported(this.context.manifest);
+        if (manifestChangesNotSupported) {
             return;
         }
-
         for (const table of getRelevantControlFromActivePage(
             this.context.controlIndex,
             this.context.view,

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-table-filtering.ts
@@ -2,7 +2,7 @@ import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import { getRelevantControlFromActivePage, pageHasControlId } from '../../../cpe/quick-actions/utils';
 import { GRID_TABLE_TYPE, M_TABLE_TYPE, SMART_TABLE_TYPE, TREE_TABLE_TYPE } from '../table-quick-action-base';
-import { areManifestChangesNotSupported, prepareManifestChange } from './utils';
+import { areManifestChangesSupported, prepareManifestChange } from './utils';
 
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
 import { isA } from '../../../utils/core';
@@ -31,8 +31,8 @@ export class EnableTableFilteringQuickAction
     }
 
     async initialize(): Promise<void> {
-        const manifestChangesNotSupported = await areManifestChangesNotSupported(this.context.manifest);
-        if (manifestChangesNotSupported) {
+        const manifestChangesSupported = await areManifestChangesSupported(this.context.manifest);
+        if (!manifestChangesSupported) {
             return;
         }
         for (const table of getRelevantControlFromActivePage(

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -55,29 +55,28 @@ export async function prepareManifestChange(
 
 /**
  * Checks if the current UI5 version and manifest structure is supported in v2 applications.
- * 
+ *
  * @param manifest - manifest changes of the current application.
  *
- * Returns `true` 
- * 
- *  - If the manifest is structured as an array 
+ * Returns `false`
+ *
+ *  - If the manifest is structured is an array
  *  - If the UI5 version is not supported
- * Otherwise, returns `false`.
+ * Otherwise, returns `true`.
  *
  */
-export async function areManifestChangesNotSupported(manifest: Manifest): Promise<boolean> {
+export async function areManifestChangesSupported(manifest: Manifest): Promise<boolean> {
     const pagesStructureInManifest = manifest['sap.ui.generic.app'].pages;
-    if( Array.isArray(pagesStructureInManifest)) {
-        return true;
+    if (Array.isArray(pagesStructureInManifest)) {
+        return false;
     }
-    
+
     const version = await getUi5Version();
-    return (
-        isLowerThanMinimalUi5Version(version, { major: 1, minor: 128 }) &&
-        !(
-            isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 96, patch: 37 }) ||
-            isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 108, patch: 38 }) ||
-            isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 120, patch: 23 })
-        )
-    );
+    const isAboveOrEqualMinimalVersion = !isLowerThanMinimalUi5Version(version, { major: 1, minor: 128 });
+    const isSupportedPatchVersion =
+        isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 96, patch: 37 }) ||
+        isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 108, patch: 38 }) ||
+        isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 120, patch: 23 });
+
+    return isAboveOrEqualMinimalVersion || isSupportedPatchVersion;
 }

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -4,6 +4,7 @@ import CommandFactory from 'sap/ui/rta/command/CommandFactory';
 
 import { QuickActionContext } from '../../../cpe/quick-actions/quick-action-definition';
 import { getUi5Version, isLowerThanMinimalUi5Version, isVersionEqualOrHasNewerPatch } from '../../../utils/version';
+import { Manifest } from 'sap/ui/rta/RuntimeAuthoring';
 
 /**
  * Prepares the change for the manifest setting.
@@ -53,13 +54,23 @@ export async function prepareManifestChange(
 }
 
 /**
- * Checks if the current UI5 version supports manifest changes in v2 applications.
+ * Checks if the current UI5 version and manifest structure is supported in v2 applications.
+ * 
+ * @param manifest - manifest changes of the current application.
  *
- * Returns `true` if the UI5 version is supported.
+ * Returns `true` 
+ * 
+ *  - If the manifest is structured as an array 
+ *  - If the UI5 version is not supported
  * Otherwise, returns `false`.
  *
  */
-export async function areManifestChangesSupported(): Promise<boolean> {
+export async function areManifestChangesNotSupported(manifest: Manifest): Promise<boolean> {
+    const pagesStructureInManifest = manifest['sap.ui.generic.app'].pages;
+    if( Array.isArray(pagesStructureInManifest)) {
+        return true;
+    }
+    
     const version = await getUi5Version();
     return (
         isLowerThanMinimalUi5Version(version, { major: 1, minor: 128 }) &&

--- a/packages/preview-middleware-client/types/sap.ui.rta.d.ts
+++ b/packages/preview-middleware-client/types/sap.ui.rta.d.ts
@@ -179,6 +179,10 @@ declare module 'sap/ui/rta/RuntimeAuthoring' {
             };
             flexEnabled?: boolean;
         };
+        'sap.ui.generic.app': {
+            [key: string]: string;
+            pages?: object | Array;
+        };
     };
 
     export type SelectionChangeEvent = Event<SelectionChangeParams>;


### PR DESCRIPTION
 hide the manifest change actions from the quick action list, if the manifest of the underlying app has array structure.