### PR TITLE
fix: Modify existing services

### DIFF
--- a/.changeset/pretty-ghosts-cough.md
+++ b/.changeset/pretty-ghosts-cough.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Update existing services in a way that is required for multiple services support - service files in their respective folders.

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -255,7 +255,7 @@ async function generate(basePath: string, service: OdataService, fs?: Editor): P
     // Prepare template folder for manifest and xml updates
     const templateRoot = join(__dirname, '../templates');
     // Update manifest.json
-    updateManifest(basePath, service, fs, templateRoot);
+    await updateManifest(basePath, service, fs, templateRoot);
     // Dont extend backend and mockserver middlewares if service type is CDS
     if (isServiceTypeEdmx) {
         await writeEDMXServiceFiles(fs, basePath, paths, templateRoot, service as EdmxOdataService);

--- a/packages/odata-service-writer/src/updates.ts
+++ b/packages/odata-service-writer/src/updates.ts
@@ -1,11 +1,69 @@
 import { render } from 'ejs';
 import type { Editor } from 'mem-fs-editor';
-import { join, normalize, posix } from 'path';
+import { join, normalize, posix, sep } from 'path';
 import { t } from './i18n';
 import type { OdataService, CdsAnnotationsInfo, EdmxAnnotationsInfo } from './types';
 import semVer from 'semver';
 import prettifyXml from 'prettify-xml';
-import { getMinimumUI5Version, type Manifest, hasUI5CliV3 } from '@sap-ux/project-access';
+import type { Manifest, ManifestNamespace } from '@sap-ux/project-access';
+import { DirName, getMinimumUI5Version, getWebappPath, hasUI5CliV3 } from '@sap-ux/project-access';
+
+/**
+ * Modifies service in manifest.json and service files in a way that is supported by multiple services.
+ * If service files are defined in 'localService' folder then those files are moved to respective service folder and service configuration URI are modified in manifest.json.
+ *
+ * @param {string} webappPath - the webapp path of an existing UI5 application
+ * @param {string} dataSourceKey - dataSource key in manifest.json
+ * @param {Manifest} dataSource - dataSource configuration from manifest.json
+ * @param {Editor} fs - the memfs editor instance
+ */
+function updateExistingService(
+    webappPath: string,
+    dataSourceKey: string,
+    dataSource: ManifestNamespace.DataSource,
+    fs: Editor
+): void {
+    const settings = dataSource.settings;
+    if (settings) {
+        // "localService/metadata.xml"
+        const localUri = settings.localUri;
+        // -> ["localService", "metadata.xml"]
+        const localUriParts = localUri ? localUri.split('/') : undefined;
+        if (localUriParts && localUriParts.length === 2) {
+            const localFileName = localUriParts[localUriParts.length - 1];
+            settings.localUri = `localService/${dataSourceKey}/${localFileName}`;
+            // move related files to service folder
+            const fromFilePath = join(webappPath, localUriParts.join(sep));
+            const toFilePath = join(webappPath, DirName.LocalService, dataSourceKey, localFileName);
+            fs.copy(fromFilePath, toFilePath);
+        }
+    }
+}
+
+/**
+ * Modifies services in manifest.json and services files in a way that is supported by multiple services.
+ *
+ * @param {string} webappPath - the webapp path of an existing UI5 application
+ * @param {Manifest} manifest - the manifest.json of the application
+ * @param {Editor} fs - the memfs editor instance
+ */
+async function updateExistingServices(webappPath: string, manifest: Manifest, fs: Editor): Promise<void> {
+    const dataSources = manifest?.['sap.app']?.dataSources;
+    for (const dataSourceKey in dataSources) {
+        const dataSource = dataSources[dataSourceKey];
+        if (dataSource.type === 'OData') {
+            updateExistingService(webappPath, dataSourceKey, dataSource, fs);
+            const annotations = dataSource.settings?.annotations;
+            if (annotations) {
+                annotations.forEach((annotationName) => {
+                    const annotationDataSource = dataSources[annotationName];
+                    updateExistingService(webappPath, dataSourceKey, annotationDataSource, fs);
+                });
+            }
+        }
+    }
+    fs.writeJSON(join(webappPath, 'manifest.json'), manifest);
+}
 
 /**
  * Internal function that updates the manifest.json based on the given service configuration.
@@ -15,12 +73,20 @@ import { getMinimumUI5Version, type Manifest, hasUI5CliV3 } from '@sap-ux/projec
  * @param fs - the memfs editor instance
  * @param templateRoot - root folder contain the ejs templates
  */
-export function updateManifest(basePath: string, service: OdataService, fs: Editor, templateRoot: string): void {
-    const manifestPath = join(basePath, 'webapp', 'manifest.json');
+export async function updateManifest(
+    basePath: string,
+    service: OdataService,
+    fs: Editor,
+    templateRoot: string
+): Promise<void> {
+    const webappPath = await getWebappPath(basePath, fs);
+    const manifestPath = join(webappPath, 'manifest.json');
     // Get component app id
     const manifest = fs.readJSON(manifestPath) as unknown as Manifest;
     const appProp = 'sap.app';
     const appid = manifest?.[appProp]?.id;
+    // Check and update existing services
+    await updateExistingServices(webappPath, manifest, fs);
     // Throw if required property is not found manifest.json
     if (!appid) {
         throw new Error(

--- a/packages/odata-service-writer/src/updates.ts
+++ b/packages/odata-service-writer/src/updates.ts
@@ -29,9 +29,9 @@ function updateExistingService(
         const localUri = settings.localUri;
         // -> ["localService", "metadata.xml"]
         const localUriParts = localUri ? localUri.split('/') : undefined;
-        if (localUriParts && localUriParts.length === 2) {
+        if (localUriParts && localUriParts[0] === DirName.LocalService && localUriParts.length === 2) {
             const localFileName = localUriParts[localUriParts.length - 1];
-            settings.localUri = `localService/${dataSourceKey}/${localFileName}`;
+            settings.localUri = `${DirName.LocalService}/${dataSourceKey}/${localFileName}`;
             // move related files to service folder
             const fromFilePath = join(webappPath, localUriParts.join(sep));
             const toFilePath = join(webappPath, DirName.LocalService, dataSourceKey, localFileName);

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -165,6 +165,10 @@ describe('generate', () => {
             expect(manifest['sap.app'].dataSources.SEPMRA_PROD_MAN.settings.localUri).toBe(
                 'localService/mainService/SEPMRA_PROD_MAN.xml'
             );
+            // No service file in localService
+            expect(fs.exists(join(root, 'webapp', 'localService', 'metadata.xml'))).toBe(false);
+            expect(fs.exists(join(root, 'webapp', 'localService', 'SEPMRA_PROD_MAN.xml'))).toBe(false);
+            // Services files are moved to localService/mainService
             expect(fs.exists(join(root, 'webapp', 'localService', 'mainService', 'metadata.xml'))).toBe(true);
             expect(fs.exists(join(root, 'webapp', 'localService', 'mainService', 'SEPMRA_PROD_MAN.xml'))).toBe(true);
             // Check if new service is added

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -24,7 +24,7 @@ describe('updates', () => {
     });
 
     describe('updateManifest', () => {
-        test('Ensure OdataService properties are not interpretted as ejs render options', () => {
+        test('Ensure OdataService properties are not interpretted as ejs render options', async () => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest'
@@ -41,7 +41,7 @@ describe('updates', () => {
 
             fs.writeJSON('./webapp/manifest.json', testManifest);
             const ejsMock = jest.spyOn(ejs, 'render');
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             // Passing empty options prevents ejs interpretting OdataService properties as ejs options
             expect(ejsMock).toHaveBeenCalledWith(expect.anything(), service, {});
         });
@@ -52,7 +52,7 @@ describe('updates', () => {
             ['1.105.0', false],
             [undefined, false],
             [['1.120.10', '2.0.0'], true]
-        ])('Ensure synchronizationMode is correctly set for minUI5Version %s', (minUI5Version, syncMode) => {
+        ])('Ensure synchronizationMode is correctly set for minUI5Version %s', async (minUI5Version, syncMode) => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest'
@@ -77,7 +77,7 @@ describe('updates', () => {
             const ejsMock = jest.spyOn(ejs, 'render');
 
             // Call updateManifest
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
 
             expect(ejsMock).toHaveBeenCalledWith(
                 expect.anything(),
@@ -85,7 +85,7 @@ describe('updates', () => {
                 {}
             );
         });
-        test('Ensure manifest updates are updated as expected as in edmx projects', () => {
+        test('Ensure manifest updates are updated as expected as in edmx projects', async () => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest'
@@ -108,12 +108,12 @@ describe('updates', () => {
 
             fs.writeJSON('./webapp/manifest.json', testManifest);
             // Call updateManifest
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifest);
         });
 
-        test('Ensure manifest updates are updated as expected as in edmx projects with multiple annotations', () => {
+        test('Ensure manifest updates are updated as expected as in edmx projects with multiple annotations', async () => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest'
@@ -143,12 +143,12 @@ describe('updates', () => {
 
             fs.writeJSON('./webapp/manifest.json', testManifest);
             // Call updateManifest
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifestMultipleAnnotations);
         });
 
-        test('Ensure manifest updates are updated as expected as in edmx projects with multiple services', () => {
+        test('Ensure manifest updates are updated as expected as in edmx projects with multiple services', async () => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest',
@@ -185,12 +185,12 @@ describe('updates', () => {
 
             fs.writeJSON('./webapp/manifest.json', testManifest);
             // Call updateManifest
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifestMultipleServices);
         });
 
-        test('Ensure manifest updates are updated as expected as in cds projects', () => {
+        test('Ensure manifest updates are updated as expected as in cds projects', async () => {
             const testManifest = {
                 'sap.app': {
                     id: 'test.update.manifest'
@@ -212,7 +212,7 @@ describe('updates', () => {
             };
             fs.writeJSON('./webapp/manifest.json', testManifest);
             // Call updateManifest
-            updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedCdsManifest);
         });


### PR DESCRIPTION
After introduction of multiple services for `odata-service-writer` (https://github.com/SAP/open-ux-tools/pull/2499), existing services for previously generated applications should be checked and adapted if necessary.

Previously whenever service was generated, service files were always generated in localService folder. Currently multiple services are supported so each service should have its own folder.

For example:
>       "mainService": {
>         "uri": "/sap/opu/odata4/dmo/sb_travel_mdsk_o4/srvd/dmo/sd_travel_mdsk/0001/",
>         "type": "OData",
>         "settings": {
>           "annotations": [
>             "annotation"
>           ],
>           "localUri": "localService/metadata.xml",
>           "odataVersion": "4.0"
>         }
>       }

`localUri` of the existing OData dataSource should be modified to `localService/mainService/metadata.xml` and respective service files moved to service folder, like:
`project/webapp/localService/metadata.xml` -> `project/webapp/localService/mainService/metadata.xml`
`project/webapp/localService/service-annotation.xml` -> `project/webapp/localService/mainService/service-annotation.xml`.

**Summary of changes:**
Added one step before manifest.json template is generated for service:
`await updateExistingServices(webappPath, manifest, fs);` which goes through existing services, modifies `localUri` and moves related files to service folder.
