### PR TITLE
fix(odata-service-inquirer): Wrong dest url format in yamls

### DIFF
--- a/.changeset/new-hornets-taste.md
+++ b/.changeset/new-hornets-taste.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for wrong format destination urls returned

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -602,12 +602,15 @@ export class ConnectionValidator {
     ): Promise<{ valResult: ValidationResult; errorType?: ERROR_TYPE }> {
         this.resetConnectionState();
         this.resetValidity();
-        // Get the destination URL in the BAS specific form <protocol>://<destinationName>.dest
-        const destUrl = getDestinationUrlForAppStudio(destination.Name, servicePath);
+        // Get the destination URL in the BAS specific form <protocol>://<destinationName>.dest. This function lowercases the origin.
+        const destUrl = getDestinationUrlForAppStudio(destination.Name, servicePath).toLowerCase();
         // Get the destination URL in the portable form <protocol>://<host>:<port>.
         // We remove trailing slashes (up to 10, infinite would allow DOS attack) from the host to avoid double slashes when appending the service path.
         this._destinationUrl = servicePath
-            ? destUrl.replace(`https://${destination.Name}.dest`, destination.Host.replace(/\/{1,10}$/, ''))
+            ? destUrl.replace(
+                  `https://${destination.Name.toLowerCase()}.dest`,
+                  destination.Host.replace(/\/{1,10}$/, '')
+              )
             : destination.Host;
         this._destination = destination;
         // No need to apply sap-client as this happens automatically (from destination config) when going through the BAS proxy

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -572,7 +572,7 @@ describe('ConnectionValidator', () => {
         const connectValidator = new ConnectionValidator();
         expect(
             await connectValidator.validateDestination({
-                Name: 'dest1',
+                Name: 'DEST1',
                 Host: 'https://system1:12345/path/to/service',
                 Type: 'HTTP',
                 Authentication: 'NoAuthentication',
@@ -594,7 +594,7 @@ describe('ConnectionValidator', () => {
         expect(
             await connectValidator.validateDestination(
                 {
-                    Name: 'dest2',
+                    Name: 'DEST2',
                     Host: 'https://system2:12345/',
                     Type: 'HTTP',
                     Authentication: 'NoAuthentication',


### PR DESCRIPTION
Fix for : https://github.com/SAP/open-ux-tools/issues/2673

- Lowercase dest name before replacing to portable format as `btp-utils.getDestinationUrlForAppStudio` returns inconsistent origin casing (lowercases origin if path passed,  but not otherwise)
- Modify test to cover