### PR TITLE
fix: Manifest template for services

### DIFF
--- a/.changeset/tough-poems-smile.md
+++ b/.changeset/tough-poems-smile.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Improved manifest.json template to allow services with empty annotations array.

--- a/.changeset/tough-poems-smile.md
+++ b/.changeset/tough-poems-smile.md
@@ -2,4 +2,4 @@
 '@sap-ux/odata-service-writer': patch
 ---
 
-Improved manifest.json template to allow services with empty annotations array.
+Improved manifest.json template to allow services with empty remote annotations array and added support for multiple local annotations.

--- a/packages/odata-service-writer/src/types.ts
+++ b/packages/odata-service-writer/src/types.ts
@@ -72,7 +72,7 @@ export interface OdataService {
      * Annotations can either be EDMX annotations or CDS annotations.
      */
     annotations?: EdmxAnnotationsInfo | EdmxAnnotationsInfo[] | CdsAnnotationsInfo | CdsAnnotationsInfo[];
-    localAnnotationsName?: string; // The name used in the manifest.json and as the filename for local annotations
+    localAnnotationsName?: string | string[]; // The name or names used in the manifest.json and as the filenames for local annotations
     previewSettings?: Partial<ProxyBackend>;
     /**
      * Indicates whether certificate errors should be ignored.

--- a/packages/odata-service-writer/templates/extend/manifest.json
+++ b/packages/odata-service-writer/templates/extend/manifest.json
@@ -10,14 +10,20 @@
                         <% if (annotations.length) { %>
                             <% annotations.forEach(function(annotation, index) { %>
                                 <% if (annotation.technicalName) { %>
-                                    "<%= annotation.name %>"<% if (index < annotations.length - 1 || locals.localAnnotationsName) { %>,<% } %>
+                                    "<%= annotation.name %>"<% if (index < annotations.length - 1 || locals.localAnnotationsName && (!locals.localAnnotationsName.length || locals.localAnnotationsName.length > 0)) { %>,<% } %>
                                 <% } %>
                             <% }); %>
                         <% } else if (annotations.technicalName) { %>
-                            "<%= annotations.name %>"<% if (locals.localAnnotationsName) {%>,<%}%><% } %>
+                            "<%= annotations.name %>"<% if (locals.localAnnotationsName && (!locals.localAnnotationsName.length || locals.localAnnotationsName.length > 0)) {%>,<%}%><% } %>
                         <% } %>
-                    <% if (locals.localAnnotationsName) { %>
-                        "<%- localAnnotationsName %>"
+                    <% if (locals.localAnnotationsName && typeof localAnnotationsName !== 'undefined') { %>
+                        <% if (Array.isArray(localAnnotationsName)) { %>
+                            <% localAnnotationsName.forEach(function(localAnnotation, index) { %>
+                                "<%- localAnnotation %>"<% if (index < localAnnotationsName.length - 1){ %>,<% } %>
+                            <% }); %>
+                        <% } else if (localAnnotationsName) { %>
+                                "<%- localAnnotationsName %>"
+                        <% } %>
                     <% } %>
                     ]
                     <% if (locals.metadata) { %>,
@@ -49,14 +55,28 @@
                     }
                 <% } %>
             <% } %>
-            <% if (locals.localAnnotationsName) { %>,
-            "<%- localAnnotationsName %>": {
-                "type": "ODataAnnotation",
-                "uri": "annotations/<%- localAnnotationsName %>.xml",
-                "settings": {
-                    "localUri": "annotations/<%- localAnnotationsName %>.xml"
-                }
-            } <% } %>
+            <% if (locals.localAnnotationsName && typeof localAnnotationsName !== 'undefined') { %>,
+                <% if (locals.localAnnotationsName && typeof localAnnotationsName !== 'undefined') { %>
+                    <% if (Array.isArray(localAnnotationsName)) { %>
+                        <% localAnnotationsName.forEach(function(localAnnotation, index) { %>
+                            "<%- localAnnotation %>": {
+                                "type": "ODataAnnotation",
+                                "uri": "annotations/<%- localAnnotation %>.xml",
+                                "settings": {
+                                    "localUri": "annotations/<%- localAnnotation %>.xml"
+                                }
+                            }<% if (index < localAnnotationsName.length - 1){ %>,<% } %>
+                        <% }); %>
+                    <% } else if (localAnnotationsName) { %>
+                        "<%- localAnnotationsName %>": {
+                            "type": "ODataAnnotation",
+                            "uri": "annotations/<%- localAnnotationsName %>.xml",
+                            "settings": {
+                                "localUri": "annotations/<%- localAnnotationsName %>.xml"
+                            }
+                        } <% } %>
+                <% } %>
+            <% } %>
         }
     },
     "sap.ui5": {

--- a/packages/odata-service-writer/templates/extend/manifest.json
+++ b/packages/odata-service-writer/templates/extend/manifest.json
@@ -10,13 +10,12 @@
                         <% if (annotations.length) { %>
                             <% annotations.forEach(function(annotation, index) { %>
                                 <% if (annotation.technicalName) { %>
-                                    "<%= annotation.name %>"<% if (index < annotations.length - 1) { %>,<% } %>
+                                    "<%= annotation.name %>"<% if (index < annotations.length - 1 || locals.localAnnotationsName) { %>,<% } %>
                                 <% } %>
                             <% }); %>
                         <% } else if (annotations.technicalName) { %>
-                            "<%= annotations.name %>"
+                            "<%= annotations.name %>"<% if (locals.localAnnotationsName) {%>,<%}%><% } %>
                         <% } %>
-                    <% if (locals.localAnnotationsName) {%>,<%}%><% } %>
                     <% if (locals.localAnnotationsName) { %>
                         "<%- localAnnotationsName %>"
                     <% } %>

--- a/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-local-annotation.ts
+++ b/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-local-annotation.ts
@@ -1,0 +1,37 @@
+export const expectedEdmxManifestLocalAnnotation = {
+    'sap.app': {
+        id: 'test.update.manifest',
+        dataSources: {
+            mainService: {
+                type: 'OData'
+            },
+            aname: {
+                uri: '/a/path',
+                type: 'OData',
+                settings: {
+                    annotations: ['localTest'],
+                    odataVersion: '2.0'
+                }
+            },
+            localTest: {
+                type: 'ODataAnnotation',
+                uri: 'annotations/localTest.xml',
+                settings: {
+                    localUri: 'annotations/localTest.xml'
+                }
+            }
+        }
+    },
+    'sap.ui5': {
+        models: {
+            '': {
+                dataSource: 'mainService'
+            },
+            amodel: {
+                dataSource: 'aname',
+                preload: true,
+                settings: {}
+            }
+        }
+    }
+};

--- a/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-local-annotations.ts
+++ b/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-local-annotations.ts
@@ -1,0 +1,44 @@
+export const expectedEdmxManifestLocalAnnotations = {
+    'sap.app': {
+        id: 'test.update.manifest',
+        dataSources: {
+            mainService: {
+                type: 'OData'
+            },
+            aname: {
+                uri: '/a/path',
+                type: 'OData',
+                settings: {
+                    annotations: ['localTest0', 'localTest1'],
+                    odataVersion: '2.0'
+                }
+            },
+            localTest0: {
+                uri: 'annotations/localTest0.xml',
+                type: 'ODataAnnotation',
+                settings: {
+                    localUri: 'annotations/localTest0.xml'
+                }
+            },
+            localTest1: {
+                uri: 'annotations/localTest1.xml',
+                type: 'ODataAnnotation',
+                settings: {
+                    localUri: 'annotations/localTest1.xml'
+                }
+            }
+        }
+    },
+    'sap.ui5': {
+        models: {
+            '': {
+                dataSource: 'mainService'
+            },
+            amodel: {
+                dataSource: 'aname',
+                preload: true,
+                settings: {}
+            }
+        }
+    }
+};

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -10,7 +10,8 @@ import { expectedEdmxManifest } from '../test-data/manifest-json/edmx-manifest';
 import { expectedEdmxManifestMultipleAnnotations } from '../test-data/manifest-json/edmx-manifest-multiple-annotations';
 import { expectedEdmxManifestMultipleServices } from '../test-data/manifest-json/edmx-manifest-multiple-services';
 import { expectedCdsManifest } from '../test-data/manifest-json/cap-manifest';
-import { expectedEdmxManifestLocalAnnotation } from '../test-data/manifest-json/edmx-manifest-local-annotation';
+import { expectedEdmxManifestLocalAnnotation } from '../test-data/manifest-json/edmx-manifest-local-annotation'; // single local annotation
+import { expectedEdmxManifestLocalAnnotations } from '../test-data/manifest-json/edmx-manifest-local-annotations'; // multiple local annotations
 import type { Package } from '@sap-ux/project-access';
 
 jest.mock('ejs', () => ({
@@ -147,6 +148,41 @@ describe('updates', () => {
             await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifestLocalAnnotation);
+        });
+
+        test('Ensure manifest updates are updated as expected as in edmx projects with multiple local annotations', async () => {
+            const testManifest = {
+                'sap.app': {
+                    id: 'test.update.manifest',
+                    dataSources: {
+                        'mainService': {
+                            type: 'OData'
+                        }
+                    }
+                },
+                'sap.ui5': {
+                    models: {
+                        '': {
+                            dataSource: 'mainService'
+                        }
+                    }
+                }
+            };
+            const service: OdataService = {
+                version: OdataVersion.v2,
+                client: '123',
+                model: 'amodel',
+                name: 'aname',
+                path: '/a/path',
+                type: ServiceType.EDMX,
+                annotations: [], // No remote annotations
+                localAnnotationsName: ['localTest0', 'localTest1'] // Multiple local annotations
+            };
+            fs.writeJSON('./webapp/manifest.json', testManifest);
+            // Call updateManifest
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            const manifestJson = fs.readJSON('./webapp/manifest.json');
+            expect(manifestJson).toEqual(expectedEdmxManifestLocalAnnotations);
         });
 
         test('Ensure manifest updates are updated as expected as in edmx projects with multiple annotations', async () => {

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -10,6 +10,7 @@ import { expectedEdmxManifest } from '../test-data/manifest-json/edmx-manifest';
 import { expectedEdmxManifestMultipleAnnotations } from '../test-data/manifest-json/edmx-manifest-multiple-annotations';
 import { expectedEdmxManifestMultipleServices } from '../test-data/manifest-json/edmx-manifest-multiple-services';
 import { expectedCdsManifest } from '../test-data/manifest-json/cap-manifest';
+import { expectedEdmxManifestLocalAnnotation } from '../test-data/manifest-json/edmx-manifest-local-annotation';
 import type { Package } from '@sap-ux/project-access';
 
 jest.mock('ejs', () => ({
@@ -111,6 +112,41 @@ describe('updates', () => {
             await updateManifest('./', service, fs, join(__dirname, '../../templates'));
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifest);
+        });
+
+        test('Ensure manifest updates are updated as expected as in edmx projects with local annotation', async () => {
+            const testManifest = {
+                'sap.app': {
+                    id: 'test.update.manifest',
+                    dataSources: {
+                        'mainService': {
+                            type: 'OData'
+                        }
+                    }
+                },
+                'sap.ui5': {
+                    models: {
+                        '': {
+                            dataSource: 'mainService'
+                        }
+                    }
+                }
+            };
+            const service: OdataService = {
+                version: OdataVersion.v2,
+                client: '123',
+                model: 'amodel',
+                name: 'aname',
+                path: '/a/path',
+                type: ServiceType.EDMX,
+                annotations: [], // No remote annotations
+                localAnnotationsName: 'localTest' // Local annotation
+            };
+            fs.writeJSON('./webapp/manifest.json', testManifest);
+            // Call updateManifest
+            await updateManifest('./', service, fs, join(__dirname, '../../templates'));
+            const manifestJson = fs.readJSON('./webapp/manifest.json');
+            expect(manifestJson).toEqual(expectedEdmxManifestLocalAnnotation);
         });
 
         test('Ensure manifest updates are updated as expected as in edmx projects with multiple annotations', async () => {


### PR DESCRIPTION
1. Improved manifest.json template.
JSON parsing error was thrown for case with `annotations: []` and defined `localAnnotationsName`.

2. Updated `localAnnotationsName` type to also allow to use local annotations defined in array.