### PR TITLE
feat(ui-components): add multiple missing exports

### DIFF
--- a/.changeset/fifty-nails-search.md
+++ b/.changeset/fifty-nails-search.md
@@ -1,0 +1,10 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Add missing exports:
+- `UIChoiceGroup` - export interface `IChoiceGroup`
+- `UIList` - export interfaces `UIGroup`, `UIGroupedListProps`, `UIGroupHeaderProps`, `UIGroupRenderProps`
+- `UILoader` - export enum `UISpinnerSize `
+- `UIStack` - export component `UIStack`
+- focus utility functions - export method `isElementTabbable`

--- a/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
+++ b/packages/ui-components/src/components/UIChoiceGroup/UIChoiceGroup.tsx
@@ -3,7 +3,8 @@ import type {
     IChoiceGroupOption,
     IChoiceGroupProps,
     IChoiceGroupStyles,
-    IChoiceGroupOptionProps
+    IChoiceGroupOptionProps,
+    IChoiceGroup
 } from '@fluentui/react';
 import { ChoiceGroup } from '@fluentui/react';
 import { labelGlobalStyle } from '../UILabel';
@@ -11,6 +12,8 @@ import { REQUIRED_LABEL_INDICATOR } from '../types';
 
 export type ChoiceGroupOption = IChoiceGroupOption;
 export type ChoiceGroupOptionProps = IChoiceGroupOptionProps;
+
+export { IChoiceGroup };
 
 export interface ChoiceGroupProps extends IChoiceGroupProps {
     // Render each radio option

--- a/packages/ui-components/src/components/UIList/UIList.tsx
+++ b/packages/ui-components/src/components/UIList/UIList.tsx
@@ -14,6 +14,8 @@ import { UiIcons } from '../Icons';
 
 import './UIList.scss';
 
+export { IGroup as UIGroup, IGroupedListProps as UIGroupedListProps };
+
 export interface ListProps extends IGroupedListProps {
     groups: IGroup[];
     groupProps?: IGroupRenderProps;

--- a/packages/ui-components/src/components/UIList/UIList.tsx
+++ b/packages/ui-components/src/components/UIList/UIList.tsx
@@ -14,7 +14,12 @@ import { UiIcons } from '../Icons';
 
 import './UIList.scss';
 
-export { IGroup as UIGroup, IGroupedListProps as UIGroupedListProps };
+export {
+    IGroup as UIGroup,
+    IGroupedListProps as UIGroupedListProps,
+    IGroupHeaderProps as UIGroupHeaderProps,
+    IGroupRenderProps as UIGroupRenderProps
+};
 
 export interface ListProps extends IGroupedListProps {
     groups: IGroup[];

--- a/packages/ui-components/src/components/UILoader/UILoader.tsx
+++ b/packages/ui-components/src/components/UILoader/UILoader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import type { ISpinnerProps, ISpinnerStyles, IOverlayStyles } from '@fluentui/react';
-import { Spinner, Overlay } from '@fluentui/react';
+import { Spinner, Overlay, SpinnerSize } from '@fluentui/react';
 
 import './UILoader.scss';
+
+export { SpinnerSize as UISpinnerSize };
 
 export interface UILoaderProps extends ISpinnerProps {
     blockDOM?: boolean;

--- a/packages/ui-components/src/components/index.tsx
+++ b/packages/ui-components/src/components/index.tsx
@@ -1,3 +1,4 @@
+export { Stack as UIStack } from '@fluentui/react';
 export * from './Icons';
 export * from './UIButton';
 export * from './UIBreadcrumb';

--- a/packages/ui-components/src/utilities/Focus.ts
+++ b/packages/ui-components/src/utilities/Focus.ts
@@ -4,7 +4,8 @@ import {
     setFocusVisibility,
     getNextElement,
     getPreviousElement,
-    getDocument
+    getDocument,
+    isElementTabbable
 } from '@fluentui/react';
 
 export { getFirstFocusable as getUIFirstFocusable };
@@ -12,6 +13,7 @@ export { getLastFocusable as getUILastFocusable };
 export { setFocusVisibility as setUIFocusVisibility };
 export { getNextElement };
 export { getPreviousElement };
+export { isElementTabbable };
 
 /**
  * Method redirects focus to next or previous element based on source element in stack/sequence in DOM.


### PR DESCRIPTION
Add missing exports:
- `UIChoiceGroup` - export interface `IChoiceGroup`
- `UIList` - export interfaces `UIGroup`, `UIGroupedListProps`, `UIGroupHeaderProps`, `UIGroupRenderProps`
- `UILoader` - export enum `UISpinnerSize `
- `UIStack` - export component `UIStack`
- focus utility functions - export method `isElementTabbable`