### PR TITLE
chore: Improved service updates in manifest

### DIFF
--- a/.changeset/empty-turtles-complain.md
+++ b/.changeset/empty-turtles-complain.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Improved update function for manifest by reducing JSON write calls for manifest file.

--- a/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-older-services.ts
+++ b/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-older-services.ts
@@ -1,0 +1,39 @@
+export const expectedEdmxManifestOlderServices = {
+    'sap.app': {
+        id: 'test.update.manifest',
+        dataSources: {
+            mainService: {
+                type: 'OData',
+                settings: {
+                    annotations: ['SEPMRA_OVW_ANNO_MDL']
+                }
+            },
+            SEPMRA_OVW_ANNO_MDL: {
+                type: 'ODataAnnotation',
+                settings: {
+                    localUri: 'localService/mainService/SEPMRA_OVW_ANNO_MDL.xml'
+                }
+            },
+            aname: {
+                uri: '/a/path',
+                type: 'OData',
+                settings: {
+                    annotations: [],
+                    odataVersion: '2.0'
+                }
+            }
+        }
+    },
+    'sap.ui5': {
+        models: {
+            '': {
+                dataSource: 'mainService'
+            },
+            amodel: {
+                dataSource: 'aname',
+                preload: true,
+                settings: {}
+            }
+        }
+    }
+};

--- a/packages/odata-service-writer/test/unit/updates.test.ts
+++ b/packages/odata-service-writer/test/unit/updates.test.ts
@@ -8,6 +8,7 @@ import { OdataVersion, ServiceType } from '../../src';
 import { expectedEdmxManifest } from '../test-data/manifest-json/edmx-manifest';
 import { expectedEdmxManifestMultipleAnnotations } from '../test-data/manifest-json/edmx-manifest-multiple-annotations';
 import { expectedEdmxManifestMultipleServices } from '../test-data/manifest-json/edmx-manifest-multiple-services';
+import { expectedEdmxManifestOlderServices } from '../test-data/manifest-json/edmx-manifest-older-services';
 import { expectedCdsManifest } from '../test-data/manifest-json/cap-manifest';
 import { expectedEdmxManifestLocalAnnotation } from '../test-data/manifest-json/edmx-manifest-local-annotation'; // single local annotation
 import { expectedEdmxManifestLocalAnnotations } from '../test-data/manifest-json/edmx-manifest-local-annotations'; // multiple local annotations
@@ -303,6 +304,51 @@ describe('updates', () => {
             await updateManifest('./', service, fs);
             const manifestJson = fs.readJSON('./webapp/manifest.json');
             expect(manifestJson).toEqual(expectedEdmxManifestMultipleServices);
+        });
+
+        test('Ensure manifest updates are updated as expected as in edmx projects with older services', async () => {
+            // Test to basically check whether existing service definitions are updated (localUri attribute is modified)
+            const testManifest = {
+                'sap.app': {
+                    id: 'test.update.manifest',
+                    dataSources: {
+                        mainService: {
+                            type: 'OData',
+                            settings: {
+                                annotations: ['SEPMRA_OVW_ANNO_MDL']
+                            }
+                        },
+                        SEPMRA_OVW_ANNO_MDL: {
+                            type: 'ODataAnnotation',
+                            settings: {
+                                localUri: 'localService/SEPMRA_OVW_ANNO_MDL.xml' // localUri defined in localService folder - should be updated
+                            }
+                        }
+                    }
+                },
+                'sap.ui5': {
+                    models: {
+                        '': {
+                            dataSource: 'mainService'
+                        }
+                    }
+                }
+            };
+            const service: OdataService = {
+                version: OdataVersion.v2,
+                client: '123',
+                model: 'amodel',
+                name: 'aname',
+                path: '/a/path',
+                type: ServiceType.EDMX,
+                annotations: []
+            };
+
+            fs.writeJSON('./webapp/manifest.json', testManifest);
+            // Call updateManifest
+            await updateManifest('./', service, fs);
+            const manifestJson = fs.readJSON('./webapp/manifest.json');
+            expect(manifestJson).toEqual(expectedEdmxManifestOlderServices);
         });
 
         test('Ensure manifest updates are updated as expected as in cds projects', async () => {


### PR DESCRIPTION
Instead of updating existing services in manifest and then reading manifest file again to enhance with new service, now it will only write changes to manifest after existing services are modified and new services added.
In summary, writeJSON calls reduced by one.