### PR TITLE
feat(odata-service-inq): fetch credentials after system has been selected

### DIFF
--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -31,7 +31,7 @@ export type CfAbapEnvServiceChoice = typeof CfAbapEnvServiceChoice;
  * Connects to the specified backend system and validates the connection.
  * Note this will return true in the case of basic auth validation failure to defer validation to the credentials prompt.
  *
- * @param backend the backend system to connect to
+ * @param backendSystem the backend system to connect to
  * @param connectionValidator the connection validator to use for the connection
  * @param requiredOdataVersion the required OData version for the service, this will be used to narrow the catalog service connections
  * @returns the validation result of the backend system connection

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -239,6 +239,7 @@ export async function createSystemChoices(
             };
         }
     } else {
+        // Fetch backend systems from systems.json file, credential are fetched once the system is selected
         const fileSystemStore = getFilesystemStore<BackendSystem>(LoggerHelper.logger);
         const backendSystems = await fileSystemStore.getAll({ entityName: 'system' });
         systemChoices = backendSystems.map((system) => {

--- a/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
+++ b/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
@@ -151,6 +151,7 @@
         "serviceTypeRequestError": "Error retrieving service type: {{- error}}",
         "abapServiceAuthenticationFailed": "ABAP environment authentication using UAA failed.",
         "serviceCatalogRequest": "An error occurred requesting services from: {{- catalogRequestUri }} and entity set: {{entitySet}}. {{error}}",
+        "storeSystemReadingError": "An error occurred while reading the stored system credentials. System name: {{-systemName}}, error: {{- error}}",
         "storedSystemConnectionError": "An error occurred while validating the stored system connection info. System name: {{-systemName}}, error: {{- error}}",
         "noCatalogOrServiceAvailable": "No active system or OData service endpoint connection available to retrieve service(s).",
         "allCatalogServiceRequestsFailed": "All catalog service requests failed for the selected system. OData version(s): V{{version}}."

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -44,6 +44,7 @@ export * from './entities/api-hub';
 // @todo: change notification needs to be more generic and not tied to filesystems
 // Support any filesystem watchers
 export { getFilesystemWatcherFor } from './data-access';
+export { getFilesystemStore } from './data-access/filesystem';
 export { ServiceOptions };
 export { Entity };
 


### PR DESCRIPTION
**POC** 

Rather than using the 'hybrid' approach which fetch both the system details from `.fioritools/systems.json` & the credentials from the store

We would split up these calls, i.e
 1. Fetch the systems from the file using `getFilesystemStore(). getAll()` to be used in system selection prompt
 2. Use the `SystemService` API to and read the credentials of specific system