### PR TITLE
fix(@sap-ux/jest-environment-ui5): Do not reassign global.navigator

### DIFF
--- a/.changeset/loud-mangos-love.md
+++ b/.changeset/loud-mangos-love.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/jest-environment-ui5': patch
+---
+
+Do not reassign global.navigator

--- a/packages/jest-environment-ui5/src/index.js
+++ b/packages/jest-environment-ui5/src/index.js
@@ -56,7 +56,6 @@ class UI5DOMEnvironment extends JSDOMEnvironment {
         window.NewObject = Object;
         [
             'sap',
-            'navigator',
             'location',
             'top',
             'self',


### PR DESCRIPTION
Node.js introduced a readonly global.navigator property with Node.js 21. That is, attempting to (re-)assign the property now breaks.

It turns out that the global.navigator object is not used in the Jest environment. window.navigator is, but that property is unaffected by this change.

Replaces #2748 