### PR TITLE
fix(app-config-writer): preview config update default configs

### DIFF
--- a/.changeset/two-wasps-sort.md
+++ b/.changeset/two-wasps-sort.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/app-config-writer': patch
+'@sap-ux/create': patch
+---
+
+fix: preview config update default configs

--- a/packages/app-config-writer/src/preview-config/ui5-yaml.ts
+++ b/packages/app-config-writer/src/preview-config/ui5-yaml.ts
@@ -338,8 +338,10 @@ export async function updateDefaultTestConfig(fs: Editor, basePath: string, logg
     const ui5YamlFileNames = await getAllUi5YamlFileNames(basePath, fs);
     for (const ui5Yaml of ui5YamlFileNames.filter((ui5Yaml) => ui5Yaml !== FileName.Ui5Yaml)) {
         const ui5YamlConfig = await readUi5Yaml(basePath, ui5Yaml, fs);
-        const previewMiddleware = (await getPreviewMiddleware(ui5YamlConfig)) as CustomMiddleware<PreviewConfig>;
-        if (previewMiddleware.configuration.test) {
+        const previewMiddleware = (await getPreviewMiddleware(ui5YamlConfig)) as Partial<
+            CustomMiddleware<PreviewConfig>
+        >;
+        if (previewMiddleware?.configuration?.test) {
             return;
         }
     }


### PR DESCRIPTION
prevent crash in case a ui5 yaml config has a preview middleware config without `configuration` property.

🙈 _Thou shall always use the correct type_ 🙈 

```
Cannot read properties of undefined (reading 'configuration')
TypeError: Cannot read properties of undefined (reading 'configuration')
    at updateDefaultTestConfig (<local path here>\npm-cache\_npx\b4bdc7e504f3256c\node_modules\@sap-ux\app-config-writer\dist\preview-config\ui5-yaml.js:273:31)
    at async convertToVirtualPreview (<local path here>\npm-cache\_npx\b4bdc7e504f3256c\node_modules\@sap-ux\app-config-writer\dist\preview-config\index.js:39:9)
    at async convertPreview (<local path here>\npm-cache\_npx\b4bdc7e504f3256c\node_modules\@sap-ux\create\dist\cli\convert\preview.js:37:20)
    at async Command.<anonymous> (<local path here>\npm-cache\_npx\b4bdc7e504f3256c\node_modules\@sap-ux\create\dist\cli\convert\preview.js:20:9)

```