### PR TITLE
feat: add hover styles for UIToggle in checked state

### DIFF
--- a/.changeset/flat-readers-buy.md
+++ b/.changeset/flat-readers-buy.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': minor
+---
+
+This update introduces hover styles for the UIToggle component's thumb when in a checked state. It improves the visual feedback for users interacting with the toggle.

--- a/packages/ui-components/src/components/UIToggle/UIToggle.tsx
+++ b/packages/ui-components/src/components/UIToggle/UIToggle.tsx
@@ -246,6 +246,10 @@ export class UIToggle extends React.Component<UIToggleProps, {}> {
                     background: COLORS.pill.checked.background,
                     borderColor: COLORS.pill.checked.borderColor,
                     borderStyle: 'solid',
+                    ':hover .ms-Toggle-thumb': {
+                        background: COLORS.thumb.checked.hover.background,
+                        borderColor: COLORS.thumb.checked.hover.borderColor
+                    },
                     ':hover': {
                         background: COLORS.pill.checked.hover.background,
                         borderColor: COLORS.pill.checked.hover.borderColor

--- a/packages/ui-components/test/unit/components/UIToggle.test.tsx
+++ b/packages/ui-components/test/unit/components/UIToggle.test.tsx
@@ -167,6 +167,10 @@ describe('<UIToggle />', () => {
                     "background": "var(--vscode-editorWidget-background)",
                     "borderColor": "var(--vscode-contrastActiveBorder, var(--vscode-editorWidget-border))",
                   },
+                  ":hover .ms-Toggle-thumb": Object {
+                    "background": "var(--vscode-contrastActiveBorder, var(--vscode-button-hoverBackground))",
+                    "borderColor": "var(--vscode-contrastActiveBorder, var(--vscode-button-border, transparent))",
+                  },
                   "background": "var(--vscode-editorWidget-background)",
                   "borderColor": "var(--vscode-contrastActiveBorder, var(--vscode-editorWidget-border))",
                   "borderStyle": "solid",


### PR DESCRIPTION
This update introduces hover styles for the UIToggle component's thumb when in a checked state. It improves the visual feedback for users interacting with the toggle.