### PR TITLE
fix: Manifest change for enabling semantic date range has no effect on running app with UI5 latest snapshot (=>1.132)

### DIFF
--- a/.changeset/spicy-lizards-juggle.md
+++ b/.changeset/spicy-lizards-juggle.md
@@ -1,5 +1,4 @@
 ---
-'@sap-ux-private/preview-middleware-client': patch
 '@sap-ux/reload-middleware': patch
 '@sap-ux/preview-middleware': patch
 ---

--- a/.changeset/spicy-lizards-juggle.md
+++ b/.changeset/spicy-lizards-juggle.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/reload-middleware': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: Manifest change for enabling semantic date range has no effect on running app with UI5 latest snapshot (=>1.132)

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -438,6 +438,7 @@ export class ChangeService extends EventTarget {
                     (sum, change) =>
                         change.kind === CONFIGURATION_CHANGE_KIND ||
                         change.changeType === 'appdescr_ui_generic_app_changePageConfiguration' ||
+                        change.changeType === 'appdescr_ui_gen_app_changePageConfig' ||
                         change.changeType === 'appdescr_app_addAnnotationsToOData'
                             ? sum + 1
                             : sum,
@@ -635,9 +636,7 @@ export class ChangeService extends EventTarget {
             return undefined;
         }
 
-        const { fileName } = change.getDefinition
-            ? change.getDefinition()
-            : (change.getJson() as { fileName: string });
+        const { fileName } = change.getDefinition ? change.getDefinition() : (change.getJson() as { fileName: string });
         if ((changeType === 'propertyChange' || changeType === 'propertyBindingChange') && selectorId) {
             let value = '';
             switch (changeType) {
@@ -666,7 +665,10 @@ export class ChangeService extends EventTarget {
                 command.getProperty('parameters') as { entityPropertyChange: { propertyValue: ConfigurationValue } }
             ).entityPropertyChange.propertyValue;
             return this.prepareV4ConfigurationChange(command, value, fileName, index, inactiveCommandCount);
-        } else if (changeType === 'appdescr_ui_generic_app_changePageConfiguration') {
+        } else if (
+            changeType === 'appdescr_ui_generic_app_changePageConfiguration' ||
+            changeType === 'appdescr_ui_gen_app_changePageConfig'
+        ) {
             return this.prepareV2ConfigurationChange(command, fileName, index, inactiveCommandCount);
         } else {
             const title = TITLE_MAP[changeType] ?? '';

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -438,7 +438,6 @@ export class ChangeService extends EventTarget {
                     (sum, change) =>
                         change.kind === CONFIGURATION_CHANGE_KIND ||
                         change.changeType === 'appdescr_ui_generic_app_changePageConfiguration' ||
-                        change.changeType === 'appdescr_ui_gen_app_changePageConfig' ||
                         change.changeType === 'appdescr_app_addAnnotationsToOData'
                             ? sum + 1
                             : sum,
@@ -665,10 +664,7 @@ export class ChangeService extends EventTarget {
                 command.getProperty('parameters') as { entityPropertyChange: { propertyValue: ConfigurationValue } }
             ).entityPropertyChange.propertyValue;
             return this.prepareV4ConfigurationChange(command, value, fileName, index, inactiveCommandCount);
-        } else if (
-            changeType === 'appdescr_ui_generic_app_changePageConfiguration' ||
-            changeType === 'appdescr_ui_gen_app_changePageConfig'
-        ) {
+        } else if (changeType === 'appdescr_ui_generic_app_changePageConfiguration') {
             return this.prepareV2ConfigurationChange(command, fileName, index, inactiveCommandCount);
         } else {
             const title = TITLE_MAP[changeType] ?? '';

--- a/packages/preview-middleware-client/src/cpe/connector-service.ts
+++ b/packages/preview-middleware-client/src/cpe/connector-service.ts
@@ -45,11 +45,9 @@ export class WorkspaceConnectorService {
         };
         if (
             (changeType &&
-                ![
-                    'appdescr_fe_changePageConfiguration',
-                    'appdescr_ui_generic_app_changePageConfiguration',
-                    'appdescr_ui_gen_app_changePageConfig'
-                ].includes(changeType)) ||
+                !['appdescr_fe_changePageConfiguration', 'appdescr_ui_generic_app_changePageConfiguration'].includes(
+                    changeType
+                )) ||
             kind === 'delete' ||
             this.isReloadPending
         ) {

--- a/packages/preview-middleware-client/src/cpe/connector-service.ts
+++ b/packages/preview-middleware-client/src/cpe/connector-service.ts
@@ -45,9 +45,11 @@ export class WorkspaceConnectorService {
         };
         if (
             (changeType &&
-                !['appdescr_fe_changePageConfiguration', 'appdescr_ui_generic_app_changePageConfiguration'].includes(
-                    changeType
-                )) ||
+                ![
+                    'appdescr_fe_changePageConfiguration',
+                    'appdescr_ui_generic_app_changePageConfiguration',
+                    'appdescr_ui_gen_app_changePageConfig'
+                ].includes(changeType)) ||
             kind === 'delete' ||
             this.isReloadPending
         ) {

--- a/packages/reload-middleware/src/base/livereload.ts
+++ b/packages/reload-middleware/src/base/livereload.ts
@@ -76,6 +76,7 @@ export function watchManifestChanges(livereload: LiveReloadServer): void {
             if (
                 path.endsWith('appdescr_fe_changePageConfiguration.change') ||
                 path.endsWith('appdescr_ui_generic_app_changePageConfiguration.change') ||
+                path.endsWith('appdescr_ui_gen_app_changePageConfig.change') ||
                 path.endsWith('appdescr_app_addAnnotationsToOData.change')
             ) {
                 global.__SAP_UX_MANIFEST_SYNC_REQUIRED__ = true;

--- a/packages/reload-middleware/test/unit/base/livereload.test.ts
+++ b/packages/reload-middleware/test/unit/base/livereload.test.ts
@@ -160,4 +160,14 @@ describe('adp backend sync', () => {
 
         expect(global.__SAP_UX_MANIFEST_SYNC_REQUIRED__).toBe(true);
     });
+
+    test('sync on manifest change', async () => {
+        const server = await getLivereloadServer({});
+
+        watchManifestChanges(server);
+
+        onSpy.mock.calls[0][1]('add', '123_appdescr_ui_gen_app_changePageConfig.change');
+
+        expect(global.__SAP_UX_MANIFEST_SYNC_REQUIRED__).toBe(true);
+    });
 });


### PR DESCRIPTION
Fix for #2763.
- Adds the change type `appdescr_ui_gen_app_changePageConfig.change` for the reload middleware to set the `__SAP_UX_MANIFEST_SYNC_REQUIRED__` to true to then sync the merged manifest.