### PR TITLE
Feature: Adds entity related prompting

### DIFF
--- a/packages/fiori-elements-writer/src/data/manifestSettings.ts
+++ b/packages/fiori-elements-writer/src/data/manifestSettings.ts
@@ -28,12 +28,12 @@ export function extendManifestJson<T>(
     // FEOP and ALP v4 are variants of LROP and so we use the same template and settings
     if (
         feApp.service.version === OdataVersion.v4 &&
-        [
+        ([
             TemplateType.FormEntryObjectPage,
             TemplateType.AnalyticalListPage,
             TemplateType.ListReportObjectPage,
             TemplateType.Worklist
-        ].includes(feApp.template.type)
+        ] as TemplateType[]).includes(feApp.template.type)
     ) {
         templatePath = TemplateType.ListReportObjectPage;
 

--- a/packages/fiori-elements-writer/src/types.ts
+++ b/packages/fiori-elements-writer/src/types.ts
@@ -1,14 +1,16 @@
 import type { Ui5App, App, AppOptions } from '@sap-ux/ui5-application-writer';
 import type { OdataService } from '@sap-ux/odata-service-writer';
 
-export enum TemplateType {
-    Worklist = 'worklist',
-    ListReportObjectPage = 'lrop',
-    AnalyticalListPage = 'alp',
-    OverviewPage = 'ovp',
-    FormEntryObjectPage = 'feop',
-    FlexibleProgrammingModel = 'fpm'
-}
+export const TemplateType = {
+    Worklist: 'worklist',
+    ListReportObjectPage: 'lrop',
+    AnalyticalListPage: 'alp',
+    OverviewPage: 'ovp',
+    FormEntryObjectPage: 'feop',
+    FlexibleProgrammingModel: 'fpm'
+} as const;
+
+export type TemplateType = (typeof TemplateType)[keyof typeof TemplateType];
 
 /**
  * General validation error thrown if app config options contain invalid combinations
@@ -33,19 +35,24 @@ export interface EntityConfig {
     };
 }
 
-export enum TableType {
-    GRID = 'GridTable',
-    ANALYTICAL = 'AnalyticalTable',
-    RESPONSIVE = 'ResponsiveTable',
-    TREE = 'TreeTable'
-}
+export const TableType = {
+    GRID: 'GridTable',
+    ANALYTICAL: 'AnalyticalTable',
+    RESPONSIVE: 'ResponsiveTable',
+    TREE: 'TreeTable'
+} as const;
 
-export enum TableSelectionMode {
-    NONE = 'None',
-    AUTO = 'Auto',
-    MULTI = 'Multi',
-    SINGLE = 'Single'
-}
+export type TableType = (typeof TableType)[keyof typeof TableType];
+
+export const TableSelectionMode = {
+    NONE: 'None',
+    AUTO: 'Auto',
+    MULTI: 'Multi',
+    SINGLE: 'Single'
+} as const;
+export type TableSelectionMode = (typeof TableSelectionMode)[keyof typeof TableSelectionMode];
+
+
 export interface TableSettings {
     tableType?: TableType;
     qualifier?: string;

--- a/packages/fiori-freestyle-writer/src/types.ts
+++ b/packages/fiori-freestyle-writer/src/types.ts
@@ -1,11 +1,13 @@
 import type { Ui5App, App } from '@sap-ux/ui5-application-writer';
 import type { OdataService } from '@sap-ux/odata-service-writer';
 
-export enum TemplateType {
-    Basic = 'basic',
-    Worklist = 'worklist',
-    ListDetail = 'listdetail'
-}
+export const TemplateType = {
+    Basic: 'basic',
+    Worklist: 'worklist',
+    ListDetail: 'listdetail'
+} as const;
+
+export type TemplateType = (typeof TemplateType)[keyof typeof TemplateType];
 
 interface Entity {
     name: string;

--- a/packages/inquirer-common/src/prompts/utility.ts
+++ b/packages/inquirer-common/src/prompts/utility.ts
@@ -21,7 +21,7 @@ export function getUI5ThemesChoices(ui5Version?: string): ListChoiceOptions[] {
 }
 
 /**
- * Finds the search value in the provided list using `fuzzy` search.
+ * Finds the search value in the provided list using `fuzzy` search to match the choice name.
  *
  * @param searchVal - the string to search for
  * @param searchList - the list in which to search by fuzzy matching the choice name

--- a/packages/odata-service-inquirer/README.md
+++ b/packages/odata-service-inquirer/README.md
@@ -1,6 +1,6 @@
 # @sap-ux/odata-service-inquirer
 
-Provides Inquirer based end-user prompting to allow selection of a service from multiple data source types. This involves acquiring a connection to backend systems and retrieving edmx metadata for services provided by the catalog, from a local file or CAP project.
+Provides Inquirer based end-user prompting to allow selection of a service from multiple data source types. This involves acquiring a connection to backend systems and retrieving edmx metadata for services provided by the catalog, from a local file or CAP project. This module also provides prompts that may be used to gather user selections to define the main and navigation entities and related prompts relating to application layout and annotation generation when creating a UI5 application using the `@sap-ux/fiori-freestyle-writer` and `@sap-ux/fiori-elements-writer` modules.
 
 **Note:**
 Current implementation is limited to metadata file and Local Cap projects as datasources only.

--- a/packages/odata-service-inquirer/package.json
+++ b/packages/odata-service-inquirer/package.json
@@ -31,8 +31,10 @@
     ],
     "dependencies": {
         "@sap/cf-tools": "3.2.2",
+        "@sap-ux/annotation-converter": "0.10.0",
         "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/btp-utils": "workspace:*",
+        "@sap-ux/edmx-parser": "0.9.0",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/guided-answers-helper": "workspace:*",
         "@sap-ux/telemetry": "workspace:*",
@@ -50,8 +52,11 @@
     },
     "devDependencies": {
         "@sap-ux/fiori-generator-shared": "workspace:*",
+        "@sap-ux/fiori-elements-writer": "workspace:*",
+        "@sap-ux/fiori-freestyle-writer": "workspace:*",
         "@sap-ux/feature-toggle": "workspace:*",
         "@sap-ux/odata-service-writer": "workspace:*",
+        "@sap-ux/vocabularies-types": "0.12.1",
         "@sap-devx/yeoman-ui-types": "1.14.4",
         "@types/inquirer-autocomplete-prompt": "2.0.1",
         "@types/inquirer": "8.2.6",

--- a/packages/odata-service-inquirer/src/index.ts
+++ b/packages/odata-service-inquirer/src/index.ts
@@ -1,33 +1,37 @@
-import { type InquirerAdapter } from '@sap-ux/inquirer-common';
-import type { Question } from 'inquirer';
+import { type InquirerAdapter, ERROR_TYPE, ErrorHandler, setTelemetryClient } from '@sap-ux/inquirer-common';
 import { type Logger } from '@sap-ux/logger';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import { type ToolsSuiteTelemetryClient } from '@sap-ux/telemetry';
+import type { Question } from 'inquirer';
 import autocomplete from 'inquirer-autocomplete-prompt';
-import { ERROR_TYPE, ErrorHandler, setTelemetryClient } from '@sap-ux/inquirer-common';
 import { initI18nOdataServiceInquirer } from './i18n';
 import { getQuestions } from './prompts';
+import type { ServiceAnswer } from './prompts/datasources/sap-system/service-selection';
 import {
     type SystemSelectionAnswers,
-    SystemSelectionAnswerType,
-    getSystemSelectionQuestions as getSystemSelectionQuestionsBase
+    getSystemSelectionQuestions as getSystemSelectionQuestionsBase,
+    SystemSelectionAnswerType
 } from './prompts/datasources/sap-system/system-selection';
-import type { ServiceAnswer } from './prompts/datasources/sap-system/service-selection';
 import type {
-    NewSystemChoice,
-    CfAbapEnvServiceChoice
+    CfAbapEnvServiceChoice,
+    NewSystemChoice
 } from './prompts/datasources/sap-system/system-selection/prompt-helpers';
 
+import type { Annotations } from '@sap-ux/axios-extension';
+import type { TemplateType } from '@sap-ux/fiori-elements-writer';
+import { getEntitySelectionQuestions } from './prompts/edmx/questions';
 import LoggerHelper from './prompts/logger-helper';
+import type { EntityPromptOptions } from './types';
 import {
-    DatasourceType,
-    promptNames,
     type CapRuntime,
     type CapService,
     type OdataServiceAnswers,
     type OdataServicePromptOptions,
     type OdataServiceQuestion,
-    type SapSystemType
+    type SapSystemType,
+    DatasourceType,
+    EntityRelatedAnswers,
+    promptNames
 } from './types';
 import { getPromptHostEnvironment, PromptState } from './utils';
 
@@ -85,6 +89,35 @@ async function getSystemSelectionQuestions(
 }
 
 /**
+ * Get the questions that may be used to prompt for entity selection, table configuration, annotation generation, and ALP specific table configuration.
+ * Since these are releated to service metadata processing and entity selection, they are grouped together.
+ *
+ * @param metadata
+ * @param templateType
+ * @param isCapService
+ * @param annotations
+ * @param promptOptions - options that can control some of the prompt behavior. See {@link EntityPromptOptions} for details
+ * @param logger
+ * @param isYUI
+ * @returns the prompts
+ */
+function getEntityRelatedPrompts(
+    metadata: string,
+    templateType: TemplateType,
+    isCapService = false,
+    annotations?: Annotations,
+    promptOptions?: EntityPromptOptions,
+    logger?: Logger,
+    isYUI = false
+): Question<EntityRelatedAnswers>[] {
+    if (logger) {
+        LoggerHelper.logger = logger;
+    }
+    PromptState.isYUI = isYUI;
+    return getEntitySelectionQuestions(metadata, templateType, isCapService, annotations, promptOptions);
+}
+
+/**
  * Prompt for odata service writer inputs.
  *
  * @param adapter - optionally provide references to a calling inquirer instance, this supports integration to Yeoman generators, for example
@@ -116,13 +149,18 @@ async function prompt(
 }
 
 export {
+    CfAbapEnvServiceChoice,
     // @derecated - temp export to support to support open source migration
     DatasourceType,
+    EntityRelatedAnswers,
     // @deprecated - temp export to support to support open source migration
     ERROR_TYPE,
     // @deprecated - temp export to support to support open source migration
     ErrorHandler,
+    getEntityRelatedPrompts,
     getPrompts,
+    getSystemSelectionQuestions,
+    NewSystemChoice,
     // @deprecated - temp export to support to support open source migration
     OdataVersion,
     prompt,
@@ -135,8 +173,5 @@ export {
     type OdataServiceAnswers,
     type OdataServicePromptOptions,
     // @deprecated - temp export to support to support open source migration
-    type SapSystemType,
-    NewSystemChoice,
-    CfAbapEnvServiceChoice,
-    getSystemSelectionQuestions
+    type SapSystemType
 };

--- a/packages/odata-service-inquirer/src/prompts/edmx/alp-questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/alp-questions.ts
@@ -1,0 +1,149 @@
+import type { Annotations } from '@sap-ux/axios-extension';
+import type { TableSelectionMode } from '@sap-ux/fiori-elements-writer';
+import type { ConfirmQuestion, ListQuestion } from '@sap-ux/inquirer-common';
+import { OdataVersion } from '@sap-ux/odata-service-writer';
+import type { ChoiceOptions, Question } from 'inquirer';
+import { t } from '../../i18n';
+import type { AlpTableConfigAnswers, EntitySelectionAnswers } from '../../types';
+import { EntityPromptNames } from '../../types';
+import { xmlToJson } from '../../utils';
+
+/**
+ * Return the annotation `selectionPresentationVariant.qualifier` properties as prompt choices for the specified annotations and entityType.
+ *
+ * @param annotations
+ * @param entityType
+ * @returns
+ */
+function getQualifierChoices(annotations: Annotations, entityType: string): ChoiceOptions[] {
+    const qualifierChoices: ChoiceOptions[] = [{ name: t('texts.choiceNameNone'), value: undefined }];
+
+    const parsedDefinitions: any = xmlToJson(annotations?.Definitions) || {};
+    const parsedAnnotations = parsedDefinitions.Edmx.DataServices.Schema?.Annotations;
+
+    let filteredAnnotations = [];
+    if (Array.isArray(parsedAnnotations)) {
+        filteredAnnotations = parsedAnnotations;
+    } else if (typeof parsedAnnotations === 'object') {
+        filteredAnnotations.push(parsedAnnotations);
+    }
+    filteredAnnotations = filteredAnnotations.filter((a) => {
+        return a.Target === entityType;
+    });
+
+    if (filteredAnnotations.length > 0) {
+        const selectionPresentationTerm = 'UI.SelectionPresentationVariant';
+        let filterQualifiers = filteredAnnotations[0]?.Annotation;
+        if (Array.isArray(filterQualifiers)) {
+            filterQualifiers = filterQualifiers
+                .filter((a) => a.Term === selectionPresentationTerm)
+                .map((a) => {
+                    if (a.Qualifier) {
+                        qualifierChoices.push({ name: a.Qualifier, value: a.Qualifier });
+                    }
+                });
+        } else if (filterQualifiers.Term === selectionPresentationTerm) {
+            filterQualifiers = [];
+            qualifierChoices.push({ name: filterQualifiers.Qualifier, value: filterQualifiers.Qualifier });
+        }
+    }
+    return qualifierChoices;
+}
+
+/**
+ * Get questions that related to generation of Analytical List Page type applications.
+ *
+ * @param odataVersion
+ * @param annotations
+ * @param hideTableLayoutPrompts
+ * @returns
+ */
+export function getAnalyticListPageQuestions(
+    odataVersion: OdataVersion,
+    annotations?: Annotations,
+    hideTableLayoutPrompts = false
+): Question<AlpTableConfigAnswers>[] {
+    const alpQuestions: Question<AlpTableConfigAnswers>[] = [];
+
+    if (annotations && odataVersion === OdataVersion.v2) {
+        const qualifierChoices: ChoiceOptions[] = [];
+
+        alpQuestions.push({
+            when: (answers: EntitySelectionAnswers) => {
+                if (answers.mainEntity) {
+                    qualifierChoices.push(...getQualifierChoices(annotations, answers.mainEntity?.entitySetType));
+                }
+                return qualifierChoices.length > 1;
+            },
+            type: 'list',
+            name: EntityPromptNames.presentationQualifier,
+            message: t('prompts.presentationQualifier.message'),
+            guiOptions: {
+                hint: t('prompts.presentationQualifier.hint'),
+                breadcrumb: true
+            },
+            choices: () => qualifierChoices,
+            default: 0
+        } as ListQuestion<AlpTableConfigAnswers>);
+    }
+
+    // Layout prompts
+    if (!hideTableLayoutPrompts) {
+        // v4 specific options
+        if (odataVersion === OdataVersion.v4) {
+            alpQuestions.push({
+                when: (prevAnswers: EntitySelectionAnswers) => {
+                    return !!prevAnswers.mainEntity;
+                },
+                type: 'list',
+                name: EntityPromptNames.tableSelectionMode,
+                message: t('prompts.tableSelectionMode.message'),
+                guiOptions: {
+                    hint: t('prompts.tableSelectionMode.hint'),
+                    breadcrumb: true
+                },
+                choices: (): { name: string; value: TableSelectionMode }[] => [
+                    { name: t('prompts.tableSelectionMode.choiceNone'), value: 'None' },
+                    { name: t('prompts.tableSelectionMode.choiceAuto'), value: 'Auto' },
+                    { name: t('prompts.tableSelectionMode.choiceMulti'), value: 'Multi' },
+                    { name: t('prompts.tableSelectionMode.choiceSingle'), value: 'Single' }
+                ]
+            } as ListQuestion<AlpTableConfigAnswers>);
+        } else {
+            // v2 specific options
+            alpQuestions.push(
+                {
+                    type: 'confirm',
+                    name: EntityPromptNames.tableMultiSelect,
+                    message: t('prompts.tableMultiSelect.message'),
+                    guiOptions: {
+                        hint: t('prompts.tableMultiSelect.hint'),
+                        breadcrumb: true
+                    },
+                    default: false
+                } as ConfirmQuestion<AlpTableConfigAnswers>,
+                {
+                    type: 'confirm',
+                    name: EntityPromptNames.tableAutoHide,
+                    message: t('prompts.tableAutoHide.message'),
+                    guiOptions: {
+                        hint: t('prompts.tableAutoHide.hint'),
+                        breadcrumb: true
+                    },
+                    default: true
+                } as ConfirmQuestion<AlpTableConfigAnswers>,
+                {
+                    type: 'confirm',
+                    name: EntityPromptNames.smartVariantManagement,
+                    message: t('prompts.smartVariantManagement.message'),
+                    guiOptions: {
+                        hint: t('prompts.smartVariantManagement.hint'),
+                        breadcrumb: true
+                    },
+                    default: false
+                } as ConfirmQuestion<AlpTableConfigAnswers>
+            );
+        }
+    }
+    return alpQuestions;
+}

--- a/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
@@ -1,0 +1,217 @@
+import { convert } from '@sap-ux/annotation-converter';
+import { parse } from '@sap-ux/edmx-parser';
+import { OdataVersion } from '@sap-ux/odata-service-writer';
+import type { ConvertedMetadata, EntitySet, NavigationProperty } from '@sap-ux/vocabularies-types';
+import type { ListChoiceOptions } from 'inquirer';
+import { t } from '../../i18n';
+import LoggerHelper from '../logger-helper';
+
+export type EntityAnswer = {
+    entitySetName: string;
+    entitySetType: string;
+};
+
+export type NavigationEntityAnswer = {
+    navigationPropertyName: string;
+    entitySetName: string;
+};
+
+interface EntityChoiceOptions {
+    choices: ListChoiceOptions<EntityAnswer>[];
+    draftRootIndex?: number;
+    defaultMainEntityIndex?: number;
+    convertedMetadata?: ConvertedMetadata;
+    odataVersion?: OdataVersion;
+}
+
+/**
+ * Filters entities that have a type property of 'HasDraftEnabled'.
+ *
+ * @param entitySets
+ * @returns
+ */
+function filterDraftEnabledEntities(entitySets: EntitySet[]): EntitySet[] | undefined {
+    return entitySets.filter((entitySet) => {
+        const entitySetTypeProperties = entitySet.entityType.entityProperties;
+        return !!entitySetTypeProperties.find((property) => property.name === 'HasDraftEntity');
+    });
+}
+
+/**
+ * If any of the draft root annotated entity sets have the share action property, then collaborative draft is enabled.
+ *
+ * @param draftEnabledEntitySets ]
+ * @returns
+ */
+function hasCollaborativeDraft(draftEnabledEntitySets: EntitySet[]): boolean {
+    const entitySetWithDraftRootAndShareAction = draftEnabledEntitySets.find((entitySet) =>
+        entitySet.annotations?.Common?.DraftRoot ? !!entitySet.annotations.Common.DraftRoot.ShareAction : false
+    );
+    return !!entitySetWithDraftRootAndShareAction;
+}
+
+/**
+ * Determines if the collaborative draft warning should be shown.
+ *
+ * @param edmx metadata string
+ * @returns true if the warning should be shown
+ */
+export function showCollabDraftWarning(edmx: string): boolean {
+    let showWarning = false;
+    const convertedMetadata = convert(parse(edmx));
+    const draftEnabledEntitySets = filterDraftEnabledEntities(convertedMetadata.entitySets);
+
+    if (Array.isArray(draftEnabledEntitySets) && draftEnabledEntitySets.length > 0) {
+        showWarning = !hasCollaborativeDraft(draftEnabledEntitySets);
+    }
+    return showWarning;
+}
+
+/**
+ * Returns the entity choice options for use in a list inquirer prompt.
+ *
+ * @param edmx metadata string
+ * @param options
+ * @param options.useEntityTypeAsName Choice options will use the non-namepspaced entity set type as the choice name (label) when true, otherwise the entity set name will be used
+ * @param options.filterDraftEnabledOnly Only draft enabled entities wil be returned when true, useful for Form Object Page app generation
+ * @param options.defaultMainEntityName The default selected entity set name
+ * @param options.filterAggregateTransformationsOnly Only return entity choices that have an aggregate annotation (Aggregation.ApplySupported) with the `Transformations` property set, specifically used for ALP V4 app generation
+ * @returns entity options
+ */
+export function getEntityChoiceOptions(
+    edmx: string,
+    {
+        useEntityTypeAsName = false,
+        filterDraftEnabledOnly = false,
+        defaultMainEntityName,
+        filterAggregateTransformationsOnly = false
+    }: {
+        useEntityTypeAsName?: boolean;
+        filterDraftEnabledOnly?: boolean;
+        defaultMainEntityName?: string;
+        filterAggregateTransformationsOnly?: boolean;
+    } = {}
+): EntityChoiceOptions {
+    const choices: ListChoiceOptions<EntityAnswer>[] = [];
+    let draftRootIndex: number | undefined;
+    let defaultMainEntityIndex: number | undefined;
+    let convertedMetadata: ConvertedMetadata | undefined;
+    let odataVersion: OdataVersion | undefined;
+    try {
+        convertedMetadata = convert(parse(edmx));
+        const parsedOdataVersion = parseInt(convertedMetadata?.version, 10);
+        if (Number.isNaN(parsedOdataVersion)) {
+            LoggerHelper.logger.error(t('errors.unparseableOdataVersion'));
+            throw new Error(t('errors.unparseableOdataVersion'));
+        }
+        // Note that odata version > `4` e.g. `4.1`, is not currently supported by `@sap-ux/edmx-converter`
+        odataVersion = parsedOdataVersion === 4 ? OdataVersion.v4 : OdataVersion.v2;
+        let entitySets: EntitySet[] = [];
+
+        if (filterDraftEnabledOnly) {
+            entitySets = filterDraftEnabledEntities(convertedMetadata.entitySets) ?? [];
+        } else if (filterAggregateTransformationsOnly && odataVersion === OdataVersion.v4) {
+            entitySets = filterAggregateTransformations(convertedMetadata.entitySets);
+        } else {
+            entitySets = convertedMetadata.entitySets;
+        }
+
+        entitySets.forEach((entitySet, index) => {
+            // Determine whether to use the entity set type name or the entity set name as the choice name.
+            // Note that in the case of the entity type name, the namespace will be removed.
+            const entitySetChoiceName = useEntityTypeAsName
+                ? entitySet.entityTypeName.substring(entitySet.entityTypeName.lastIndexOf('.') + 1)
+                : entitySet.name;
+            const choice: ListChoiceOptions<EntityAnswer> = {
+                name: entitySetChoiceName,
+                value: {
+                    entitySetName: entitySetChoiceName,
+                    entitySetType: entitySet.entityTypeName // Fully qualified entity type name
+                }
+            };
+            choices.push(choice);
+            // Select the first found draft root index
+            if (!draftRootIndex && entitySet.annotations?.Common?.DraftRoot) {
+                draftRootIndex = index;
+            }
+
+            if (defaultMainEntityName && entitySet.name === defaultMainEntityName) {
+                defaultMainEntityIndex = index;
+            }
+        });
+    } catch (err) {
+        LoggerHelper.logger.log(t('errors.unparseableMetadata', { error: err.message }));
+    }
+
+    return {
+        choices,
+        draftRootIndex,
+        defaultMainEntityIndex,
+        convertedMetadata,
+        odataVersion
+    };
+}
+
+/**
+ * Get the entity set name from its type name.
+ *
+ * @param entitySets
+ * @param entityType
+ * @returns
+ */
+function findEntitySetName(entitySets: EntitySet[], entityType: string): string | undefined {
+    const foundEntitySet = entitySets.find((entitySet) => {
+        return entitySet.entityTypeName === entityType;
+    });
+    return foundEntitySet ? foundEntitySet.name : undefined;
+}
+
+/**
+ *
+ * @param metadata
+ * @param odataVersion
+ * @param mainEntityName
+ * @returns
+ */
+export function getNavigationEntityChoices(
+    metadata: ConvertedMetadata,
+    odataVersion: OdataVersion,
+    mainEntityName: string
+): ListChoiceOptions<NavigationEntityAnswer>[] {
+    const choices: ListChoiceOptions[] = [];
+    const mainEntitySet = metadata.entitySets.find((entitySet) => entitySet.name === mainEntityName);
+
+    let navProps: NavigationProperty[] = [];
+    if (odataVersion === OdataVersion.v4) {
+        navProps = mainEntitySet?.entityType.navigationProperties.filter((navProp) => navProp.isCollection) ?? [];
+    } else {
+        navProps = mainEntitySet?.entityType.navigationProperties ?? [];
+    }
+
+    navProps.forEach((navProp) => {
+        choices.push({
+            name: navProp.name,
+            value: {
+                navigationPropertyName: navProp.name,
+                entitySetName: findEntitySetName(metadata.entitySets, navProp.targetTypeName)
+            } as NavigationEntityAnswer
+        });
+    });
+
+    if (choices.length > 0) {
+        choices.unshift({ name: t('prompts.navigationEntitySelection.choiceNone'), value: {} });
+    }
+    return choices;
+}
+
+/**
+ * Filter entity sets that have the `Aggregation.ApplySupported` annotation term with the `Transformations` property.
+ *
+ * @param entitySets
+ * @returns
+ */
+function filterAggregateTransformations(entitySets: EntitySet[]): EntitySet[] {
+    return entitySets.filter((entitySet) => {
+        return !!entitySet.annotations?.Aggregation?.ApplySupported?.Transformations;
+    });
+}

--- a/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
@@ -1,0 +1,313 @@
+import { Severity } from '@sap-devx/yeoman-ui-types';
+import type { Annotations } from '@sap-ux/axios-extension';
+import type { TableType, TemplateType } from '@sap-ux/fiori-elements-writer';
+import type { ConfirmQuestion, InputQuestion, ListQuestion } from '@sap-ux/inquirer-common';
+import { searchChoices } from '@sap-ux/inquirer-common';
+import { OdataVersion } from '@sap-ux/odata-service-writer';
+import type { ListChoiceOptions, Question } from 'inquirer';
+import { t } from '../../i18n';
+import type {
+    AlpTableConfigAnswers,
+    AnnotationGenerationAnswers,
+    EntityPromptOptions,
+    EntitySelectionAnswers,
+    TableConfigAnswers
+} from '../../types';
+import { EntityPromptNames } from '../../types';
+import { PromptState } from '../../utils';
+import LoggerHelper from '../logger-helper';
+import { getAnalyticListPageQuestions } from './alp-questions';
+import {
+    type EntityAnswer,
+    type NavigationEntityAnswer,
+    getEntityChoiceOptions,
+    getNavigationEntityChoices
+} from './entity-helper';
+
+/**
+ *
+ * @param entityChoiceOptions
+ * @param templateType
+ * @param odataVersion
+ * @param isCapService
+ */
+function validateEntitySelection(
+    entityChoiceOptions: ListChoiceOptions<EntityAnswer>[],
+    templateType: TemplateType,
+    odataVersion: OdataVersion,
+    isCapService: boolean
+): string | void {
+    let validationMsg;
+    if (entityChoiceOptions.length === 0) {
+        if (templateType === 'feop' && isCapService) {
+            validationMsg = t('prompts.mainEntitySelection.noDraftEnabledEntitiesError');
+        }
+        validationMsg =
+            templateType === 'alp' && odataVersion === OdataVersion.v4
+                ? t('prompts.mainEntitySelection.noEntitiesAlpV4Error')
+                : t('prompts.mainEntitySelection.noEntitiesError');
+    }
+
+    if (PromptState.isYUI && validationMsg) {
+        LoggerHelper.logger.debug(`Exiting due to validation error: ${validationMsg}`);
+        throw new Error(t('errors.exitingGeneration', { exitReason: validationMsg }));
+    }
+}
+
+/**
+ * Get the questions that may be used to prompt for entity selection.
+ *
+ * @param metadata
+ * @param templateType
+ * @param isCapService
+ * @param annotations
+ * @param promptOptions - options that can control some of the prompt behavior. See {@link EntityPromptOptions} for details
+ * @returns the prompts used to provide input for system selection and a reference to the answers object which will be populated with the user's responses once `inquirer.prompt` returns
+ */
+export function getEntitySelectionQuestions(
+    metadata: string,
+    templateType: TemplateType,
+    isCapService: boolean,
+    annotations?: Annotations,
+    promptOptions?: EntityPromptOptions
+): Question<EntitySelectionAnswers & TableConfigAnswers & AnnotationGenerationAnswers & AlpTableConfigAnswers>[] {
+    const entityChoices = getEntityChoiceOptions(metadata, {
+        useEntityTypeAsName: templateType === 'ovp',
+        defaultMainEntityName: promptOptions?.defaultMainEntityName,
+        filterDraftEnabledOnly: templateType === 'feop' && !!isCapService,
+        filterAggregateTransformationsOnly: templateType === 'alp'
+    });
+
+    if (!entityChoices.convertedMetadata || !entityChoices.odataVersion) {
+        // getEntityChoiceOptions will log an error if the metadata or its odata version are unparseable
+        return [];
+    }
+    const odataVersion = entityChoices.odataVersion;
+
+    const entityQuestions: Question<
+        EntitySelectionAnswers & TableConfigAnswers & AnnotationGenerationAnswers & AlpTableConfigAnswers
+    >[] = [];
+
+    // OVP only has filter entity, does not use tables and we do not add annotations
+    if (templateType === 'ovp') {
+        entityQuestions.push({
+            type: promptOptions?.useAutoComplete ? 'autocomplete' : 'list',
+            name: EntityPromptNames.filterEntityType,
+            message: t('prompts.filterEntityType.message'),
+            guiOptions: {
+                breadcrumb: true
+            },
+            choices: () => entityChoices.choices,
+            source: (preAnswers: EntitySelectionAnswers, input: string) =>
+                searchChoices(input, entityChoices.choices as ListChoiceOptions[]),
+            validate: () =>
+                entityChoices.choices.length === 0 ? t('prompts.mainEntitySelection.noEntitiesError') : true
+        } as ListQuestion<EntitySelectionAnswers>);
+    } else {
+        entityQuestions.push({
+            type: promptOptions?.useAutoComplete ? 'autocomplete' : 'list',
+            name: EntityPromptNames.mainEntity,
+            message: t('prompts.mainEntitySelection.message'),
+            guiOptions: {
+                breadcrumb: true
+            },
+            choices: entityChoices.choices,
+            source: (prevAnswers: unknown, input: string) =>
+                searchChoices(input, entityChoices.choices as ListChoiceOptions[]),
+            default: entityChoices.defaultMainEntityIndex ?? entityChoices.draftRootIndex ?? 0,
+            validate: validateEntitySelection(entityChoices.choices, templateType, odataVersion, isCapService),
+            additionalMessages: () => {
+                if (promptOptions?.defaultMainEntityName && entityChoices.defaultMainEntityIndex === undefined) {
+                    return {
+                        message: t('prompts.mainEntitySelection.defaultEntityNameNotFoundWarning'),
+                        severity: Severity.warning
+                    };
+                }
+            }
+        } as ListQuestion<EntitySelectionAnswers>);
+
+        const convertedMetadata = entityChoices.convertedMetadata;
+        // No nav entity for FPM
+        if (templateType !== 'fpm') {
+            let navigationEntityChoices: ListChoiceOptions<NavigationEntityAnswer>[];
+            entityQuestions.push({
+                when: (answers: EntitySelectionAnswers) => {
+                    if (answers.mainEntity) {
+                        navigationEntityChoices = getNavigationEntityChoices(
+                            convertedMetadata,
+                            odataVersion,
+                            answers.mainEntity.entitySetName
+                        );
+                        return navigationEntityChoices.length > 0;
+                    }
+                    return false;
+                },
+                type: promptOptions?.useAutoComplete ? 'autocomplete' : 'list',
+                name: EntityPromptNames.navigationEntity,
+                message: t('prompts.navigationEntitySelection.message'),
+                guiOptions: {
+                    applyDefaultWhenDirty: true, // Selected nav entity may no longer be present if main entity changes
+                    breadcrumb: true
+                },
+                choices: () => navigationEntityChoices,
+                source: (preAnswers: EntitySelectionAnswers, input: string) =>
+                    searchChoices(input, navigationEntityChoices as ListChoiceOptions[]),
+                default: 0
+            } as ListQuestion<EntitySelectionAnswers>);
+        }
+
+        entityQuestions.push(...getAddAnnotationQuestions(metadata, templateType, odataVersion, isCapService));
+
+        if (!promptOptions?.hideTableLayoutPrompts) {
+            entityQuestions.push(...getTableLayoutQuestions(templateType, odataVersion, isCapService));
+        }
+
+        if (templateType === 'alp') {
+            entityQuestions.push(
+                ...getAnalyticListPageQuestions(odataVersion, annotations, promptOptions?.hideTableLayoutPrompts)
+            );
+        }
+    }
+    return entityQuestions;
+}
+
+/**
+ *
+ * @param templateType
+ * @param odataVersion
+ * @param isCapService
+ * @returns
+ */
+function getTableLayoutQuestions(
+    templateType: TemplateType,
+    odataVersion: OdataVersion,
+    isCapService: boolean
+): Question<TableConfigAnswers>[] {
+    const tableTypeChoices: { name: string; value: TableType }[] = [
+        { name: t('prompts.tableType.choiceAnalytical'), value: 'AnalyticalTable' },
+        { name: t('prompts.tableType.choiceGrid'), value: 'GridTable' },
+        { name: t('prompts.tableType.choiceResponsive'), value: 'ResponsiveTable' }
+    ];
+
+    if (templateType !== 'alp' && !isCapService) {
+        tableTypeChoices.push({ name: t('prompts.tableType.choiceTree'), value: 'TreeTable' });
+    }
+    const tableLayoutQuestions: Question<TableConfigAnswers>[] = [];
+
+    if (templateType === 'lrop' || templateType === 'worklist' || templateType === 'alp') {
+        const tableTypeDefault: TableType = templateType === 'alp' ? 'AnalyticalTable' : 'ResponsiveTable';
+        tableLayoutQuestions.push({
+            when: (prevAnswers: EntitySelectionAnswers) => !!prevAnswers.mainEntity,
+            type: 'list',
+            name: EntityPromptNames.tableType,
+            message: t('prompts.tableType.message'),
+            guiOptions: {
+                hint: t('prompts.tableType.hint'),
+                breadcrumb: true
+            },
+            choices: (): ListChoiceOptions[] => tableTypeChoices,
+            default: tableTypeDefault
+        } as ListQuestion<TableConfigAnswers>);
+
+        tableLayoutQuestions.push({
+            when: (prevAnswers: TableConfigAnswers) =>
+                prevAnswers?.tableType === 'TreeTable' && odataVersion === OdataVersion.v4,
+            type: 'input',
+            name: EntityPromptNames.hierarchyQualifier,
+            message: t('prompts.hierarchyQualifier.message'),
+            guiOptions: {
+                hint: t('prompts.hierarchyQualifier.hint'),
+                breadcrumb: true,
+                mandatory: true
+            },
+            default: '',
+            validate: (input: string) => {
+                if (!input) {
+                    return t('prompts.hierarchyQualifier.qualifierRequiredForV4Warning');
+                }
+                return true;
+            }
+        } as InputQuestion<TableConfigAnswers>);
+    }
+    return tableLayoutQuestions;
+}
+
+/**
+ * Returns the size of an EDMX string in kilobytes.
+ *
+ * @param {string} edmx - The EDMX string to measure.
+ * @returns {number} The size of the EDMX string in kilobytes. Returns 0 if the input is null, undefined, or an empty string.
+ */
+function getEdmxSizeInKb(edmx: string): number {
+    if (edmx) {
+        const sizeInBytes = Buffer.byteLength(edmx);
+        return sizeInBytes / 1024;
+    }
+    return 0;
+}
+
+/**
+ *
+ * @param metadata
+ * @param templateType
+ * @param odataVersion
+ * @param isCapService
+ * @returns
+ */
+function getAddAnnotationQuestions(
+    metadata: string,
+    templateType: TemplateType,
+    odataVersion: OdataVersion,
+    isCapService: boolean
+): ConfirmQuestion<AnnotationGenerationAnswers>[] {
+    const metadataSizeWarningLimitKb = 1000;
+    const largeEdmxDataset = getEdmxSizeInKb(metadata) > metadataSizeWarningLimitKb;
+    const annotationQuestions: ConfirmQuestion<AnnotationGenerationAnswers>[] = [];
+
+    if (templateType === 'feop') {
+        annotationQuestions.push({
+            type: 'confirm',
+            name: EntityPromptNames.generateFEOPAnnotations,
+            guiOptions: {
+                breadcrumb: t('prompts.addFEOPAnnotations.breadcrumb')
+            },
+            message: t('prompts.addFEOPAnnotations.message'),
+            additionalMessages: (addFEOPAnnotations: boolean) => {
+                if (addFEOPAnnotations && largeEdmxDataset) {
+                    return {
+                        message: t('warnings.largeMetadataDocument'),
+                        severity: Severity.warning
+                    };
+                }
+            },
+            default: !largeEdmxDataset
+        } as ConfirmQuestion<AnnotationGenerationAnswers>);
+    }
+    if ((templateType === 'lrop' || templateType === 'worklist') && odataVersion === OdataVersion.v4) {
+        annotationQuestions.push({
+            type: 'confirm',
+            name: EntityPromptNames.generateLROPAnnotations,
+            guiOptions: {
+                breadcrumb: t('prompts.addLROPAnnotations.breadcrumb')
+            },
+            message: t('prompts.addLROPAnnotations.message'),
+            additionalMessages: (answer: boolean) => {
+                if (answer) {
+                    if (largeEdmxDataset) {
+                        return {
+                            message: t('warnings.largeMetadataDocument'),
+                            severity: Severity.warning
+                        };
+                    } else if (isCapService) {
+                        return {
+                            message: t('prompts.addLROPAnnotations.valueHelpsAnnotationsInfoMessage'),
+                            severity: Severity.information
+                        };
+                    }
+                }
+            },
+            default: !largeEdmxDataset
+        } as ConfirmQuestion<AnnotationGenerationAnswers>);
+    }
+    return annotationQuestions;
+}

--- a/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
@@ -31,7 +31,7 @@ export function getDatasourceTypeChoices({
     choices.push({ name: t('prompts.datasourceType.metadataFileChoiceText'), value: DatasourceType.metadataFile });
 
     if (includeNone) {
-        choices.unshift({ name: t('prompts.datasourceType.noneName'), value: DatasourceType.none });
+        choices.unshift({ name: t('prompts.datasourceType.choiceNone'), value: DatasourceType.none });
     }
 
     return choices;

--- a/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
+++ b/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
@@ -8,7 +8,7 @@
             "odataServiceUrlName": "OData Service",
             "capProjectName": "Local CAP Project",
             "metadataFileName": "Metadata Document",
-            "noneName": "None",
+            "choiceNone": "$t(texts.choiceNameNone)",
             "projectSpecificDestChoiceText": "Connect to a $t(prompts.datasourceType.projectSpecificDestName)",
             "businessHubChoiceText": "Connect to $t(prompts.datasourceType.businessHubName)",
             "sapSystemChoiceText": "Connect to a $t(prompts.datasourceType.sapSystemName)",
@@ -101,7 +101,7 @@
         },
         "systemSelection": {
             "newSystemChoiceLabel": "New system",
-            "hint": "Select a system configuration",
+            "hint": "Select a system configuration.",
             "message": "System",
             "authenticationFailedUpdateCredentials": "Authentication failed. Please try updating the credentials."
         },
@@ -113,18 +113,81 @@
         },
         "serviceKey": {
             "message": "Service key file path",
-            "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform",
+            "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
             "incompleteServiceKeyInfo": "Service keys file does not contain the required information",
             "unparseableServiceKey": "Service keys file contents are not a valid JSON format"
         },
         "cloudFoundryAbapSystem": {
             "message": "ABAP environment",
-            "hint": "Enter the name of the Cloud Foundry service that contains the ABAP Environment instance"
+            "hint": "Enter the name of the Cloud Foundry service that contains the ABAP Environment instance."
         },
         "destinationServicePath": {
             "message": "Service path",
-            "hint": "Enter the path to the OData service, relative to the selected destination URL",
+            "hint": "Enter the path to the OData service, relative to the selected destination URL.",
             "invalidServicePathWarning": "Please enter a valid service path"
+        },
+        "mainEntitySelection": {
+            "message": "Main entity",
+            "defaultEntityNameNotFoundWarning": "The supplied entity cannot be found in the service. Please choose from the list above.",
+            "noDraftEnabledEntitiesError": "The CAP service you have chosen does not have any entities that are draft enabled. In order to generate a V4 Fiori application using this floor plan for a CAP project, the entity selected must be draft enabled.",
+            "noEntitiesError": "The template and service selected have no relevant entities that you can use.",
+            "noEntitiesAlpV4Error": "The OData V4 service you have provided is not suitable for use in an Analytical List Page application. The service must contain aggregate based entity sets for this template."
+        },
+        "navigationEntitySelection": {
+            "message": "Navigation entity",
+            "choiceNone": "$t(texts.choiceNameNone)"
+        },
+        "filterEntityType": {
+            "message": "Filter entity"
+        },
+        "tableType": {
+            "message": "Table type",
+            "hint": "Defines the table type for the List Report Page.",
+            "choiceNone": "$t(texts.choiceNameNone)",
+            "choiceGrid": "Grid",
+            "choiceAnalytical": "Analytical",
+            "choiceResponsive": "Responsive",
+            "choiceTree": "Tree"
+        },
+        "hierarchyQualifier": {
+            "message": "Hierarchy qualifier",
+            "hint": "Leading property that decides between either a recursive hierarchy or data aggregation.",
+            "qualifierRequiredForV4Warning": "Hierarchy qualifier is required for V4 OData services"
+        },
+        "addFEOPAnnotations": {
+            "message": "Automatically add a form to the generated application if none already exists?",
+            "hint": "Choose the annotation generation method.",
+            "breadcrumb": "Generate Annotations"
+        },
+        "addLROPAnnotations": {
+            "message": "Automatically add table columns to the list page and a section to the object page if none already exists?",
+            "hint": "Choose the annotation generation method.",
+            "breadcrumb": "Generate Annotations",
+            "valueHelpsAnnotationsInfoMessage": "Basic value helps will also be created."
+        },
+        "presentationQualifier": {
+            "message": "Qualifier",
+            "hint": "Represents the qualifier of the SelectionPresentationVariant. Analytical List Page looks for SelectionPresentationVariant with this qualifier and if not found, it looks for PresentationVariant with this qualifier."
+        },
+        "tableSelectionMode": {
+            "message": "Selection mode",
+            "hint": "Defines different selection modes for the SmartTable in Analytical List Page.",
+            "choiceNone":"$t(texts.choiceNameNone)",
+            "choiceSingle": "Single",
+            "choiceAuto": "Auto",
+            "choiceMulti": "Multi"
+        },
+        "tableMultiSelect": {
+            "message": "Allow multi select",
+            "hint": "Allows you to show a checkbox for selecting multiple items in a table. This setting comes into effect only if there are actions defined either through annotation or manifest."
+        },
+        "tableAutoHide":{
+            "message": "Auto hide",
+            "hint": "Determines chart/table interaction. If set to true, the chart acts as a filter for the table. If set to false, the matching table rows are highlighted but the table is not filtered."
+        },
+        "smartVariantManagement": {
+            "message": "Enable smart variant management",
+            "hint": "Enables page level variant."
         }
     },
     "errors": {
@@ -153,7 +216,13 @@
         "serviceCatalogRequest": "An error occurred requesting services from: {{- catalogRequestUri }} and entity set: {{entitySet}}. {{error}}",
         "storedSystemConnectionError": "An error occurred while validating the stored system connection info. System name: {{-systemName}}, error: {{- error}}",
         "noCatalogOrServiceAvailable": "No active system or OData service endpoint connection available to retrieve service(s).",
-        "allCatalogServiceRequestsFailed": "All catalog service requests failed for the selected system. OData version(s): V{{version}}."
+        "allCatalogServiceRequestsFailed": "All catalog service requests failed for the selected system. OData version(s): V{{version}}.",
+        "unparseableMetadata": "Unable to parse entities from metadata document. {{-error}}",
+        "unparseableOdataVersion": "Unable to parse the odata version from the metadata.",
+        "unparseableXML": "Unparseable XML was specified: {{-error}}"
+    },
+    "warnings": {
+        "largeMetadataDocument": "The metadata for this OData service is significantly large. It may take some time before this operation completes.",
     },
     "texts": {
         "suggestedSystemNameClient": ", client {{client}}",
@@ -162,6 +231,7 @@
         "systemTypeBTP": "BTP",
         "systemTypeS4HC": "S4HC",
         "httpStatus": "http status {{httpStatus}}",
-        "checkDestinationAuthConfig": "Please check the SAP BTP destination authentication configuration."
+        "checkDestinationAuthConfig": "Please check the SAP BTP destination authentication configuration.",
+        "choiceNameNone": "None"
     }
 }

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -5,6 +5,8 @@ import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { CdsVersionInfo } from '@sap-ux/project-access';
 import type { BackendSystem } from '@sap-ux/store';
 import type { ListChoiceOptions } from 'inquirer';
+import type { EntityAnswer, NavigationEntityAnswer } from './prompts/edmx/entity-helper';
+import type { TableSelectionMode, TableType } from '@sap-ux/fiori-elements-writer';
 
 /**
  * This file contains types that are exported by the module and are needed for consumers using the APIs `prompt` and `getPrompts`.
@@ -142,6 +144,56 @@ export enum promptNames {
      */
     systemSelection = 'systemSelection'
 }
+
+export const EntityPromptNames = {
+    mainEntity: 'mainEntity',
+    navigationEntity: 'navigationEntity',
+    filterEntityType: 'filterEntityType',
+    tableType: 'tableType',
+    hierarchyQualifier: 'hierarchyQualifier',
+    generateFEOPAnnotations: 'generateFEOPAnnotations',
+    generateLROPAnnotations: 'generateLROPAnnotations',
+    presentationQualifier: 'presentationQualifier',
+    tableSelectionMode: 'tableSelectionMode',
+    tableMultiSelect: 'tableMultiSelect',
+    tableAutoHide: 'tableAutoHide',
+    smartVariantManagement: 'smartVariantManagement'
+} as const;
+export type EntityPromptNames = (typeof EntityPromptNames)[keyof typeof EntityPromptNames];
+
+export interface EntitySelectionAnswers {
+    mainEntity?: EntityAnswer;
+    navigationEntity?: NavigationEntityAnswer;
+    filterEntityType?: EntityAnswer;
+}
+
+export interface TableConfigAnswers {
+    tableType: TableType;
+    hierarchyQualifier: string;
+}
+
+export interface AnnotationGenerationAnswers {
+    // todo: consolidate, it cant be both
+    addFEOPAnnotations?: boolean;
+    addLROPAnnotations?: boolean;
+}
+
+export interface AlpTableConfigAnswers {
+    qualifier: string;
+    multiSelect: boolean;
+    autoHide: boolean;
+    smartVariantManagement: boolean;
+    selectionMode: TableSelectionMode;
+}
+
+/**
+ * Convienience type for the entity related answers
+ *
+ */
+export type EntityRelatedAnswers = EntitySelectionAnswers &
+    TableConfigAnswers &
+    AnnotationGenerationAnswers &
+    AlpTableConfigAnswers;
 
 export type CapRuntime = 'Node.js' | 'Java';
 
@@ -327,5 +379,22 @@ type odataServiceInquirerPromptOptions = Record<promptNames.datasourceType, Data
 export type OdataServiceQuestion = YUIQuestion<OdataServiceAnswers>;
 
 export type OdataServicePromptOptions = Partial<odataServiceInquirerPromptOptions>;
+
+// todo: add implementation
+export type EntityPromptOptions = {
+    /**
+     * Determines if entity related prompts should use auto complete on user input.
+     * Note that the auto-complete module must be registered with the inquirer instance to use this feature.
+     */
+    useAutoComplete?: boolean;
+    /**
+     * Provide an entity name that will be preselected as the default option for the prompt.
+     */
+    defaultMainEntityName?: string;
+    /**
+     * Hides the table layout related prompts when true, default is false.
+     */
+    hideTableLayoutPrompts?: boolean;
+};
 
 export const SAP_CLIENT_KEY = 'sap-client';

--- a/packages/odata-service-inquirer/src/utils/index.ts
+++ b/packages/odata-service-inquirer/src/utils/index.ts
@@ -28,6 +28,23 @@ export function getPromptHostEnvironment(): { name: string; technical: HostEnvir
  * @returns the odata version of the specified metadata, throws an error if the metadata is invalid
  */
 export function parseOdataVersion(metadata: string): OdataVersion {
+    try {
+        const parsed = xmlToJson(metadata);
+        const odataVersion: OdataVersion = parsed['Edmx']['Version'] === 1 ? OdataVersion.v2 : OdataVersion.v4;
+        return odataVersion;
+    } catch (error) {
+        LoggerHelper.logger.error(error);
+        throw new Error(t('prompts.validationMessages.metadataInvalid'));
+    }
+}
+
+/**
+ * Convert specified xml string to JSON.
+ *
+ * @param xml - the schema to parse
+ * @returns parsed object representation of passed XML
+ */
+export function xmlToJson(xml: string): any | void {
     const options = {
         attributeNamePrefix: '',
         ignoreAttributes: false,
@@ -35,14 +52,12 @@ export function parseOdataVersion(metadata: string): OdataVersion {
         parseAttributeValue: true,
         removeNSPrefix: true
     };
-    const parser: XMLParser = new XMLParser(options);
+
     try {
-        const parsed = parser.parse(metadata, true);
-        const odataVersion: OdataVersion = parsed['Edmx']['Version'] === 1 ? OdataVersion.v2 : OdataVersion.v4;
-        return odataVersion;
+        const parser = new XMLParser(options);
+        return parser.parse(xml, true);
     } catch (error) {
-        LoggerHelper.logger.error(error);
-        throw new Error(t('prompts.validationMessages.metadataInvalid'));
+        throw new Error(t('error.unparseableXML', { error }));
     }
 }
 

--- a/packages/odata-service-inquirer/tsconfig.json
+++ b/packages/odata-service-inquirer/tsconfig.json
@@ -19,6 +19,12 @@
       "path": "../feature-toggle"
     },
     {
+      "path": "../fiori-elements-writer"
+    },
+    {
+      "path": "../fiori-freestyle-writer"
+    },
+    {
       "path": "../fiori-generator-shared"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2309,12 +2309,18 @@ importers:
 
   packages/odata-service-inquirer:
     dependencies:
+      '@sap-ux/annotation-converter':
+        specifier: 0.10.0
+        version: 0.10.0
       '@sap-ux/axios-extension':
         specifier: workspace:*
         version: link:../axios-extension
       '@sap-ux/btp-utils':
         specifier: workspace:*
         version: link:../btp-utils
+      '@sap-ux/edmx-parser':
+        specifier: 0.9.0
+        version: 0.9.0
       '@sap-ux/fiori-generator-shared':
         specifier: workspace:*
         version: link:../fiori-generator-shared
@@ -2367,9 +2373,18 @@ importers:
       '@sap-ux/feature-toggle':
         specifier: workspace:*
         version: link:../feature-toggle
+      '@sap-ux/fiori-elements-writer':
+        specifier: workspace:*
+        version: link:../fiori-elements-writer
+      '@sap-ux/fiori-freestyle-writer':
+        specifier: workspace:*
+        version: link:../fiori-freestyle-writer
       '@sap-ux/odata-service-writer':
         specifier: workspace:*
         version: link:../odata-service-writer
+      '@sap-ux/vocabularies-types':
+        specifier: 0.12.1
+        version: 0.12.1
       '@types/inquirer':
         specifier: 8.2.6
         version: 8.2.6
@@ -8172,16 +8187,32 @@ packages:
   /@sap-devx/yeoman-ui-types@1.14.4:
     resolution: {integrity: sha512-HTgMqm3purAJUjirm6m57h8BaoF/Qx6wuXxiB9cy7ZilmriNHVx0aXJV514I1r8GMRdKKHCVixmhZW0/4L02hw==}
 
+  /@sap-ux/annotation-converter@0.10.0:
+    resolution: {integrity: sha512-fBcYuaebQgsV5fMruwbKtUOfEBo9IozLxe4snxjYQpjF+L/lA7WDsAbPt+hymG8YaZxQSHGdukm2SslkUHryaA==}
+    dependencies:
+      '@sap-ux/vocabularies-types': 0.12.1
+    dev: false
+
   /@sap-ux/annotation-converter@0.9.10:
     resolution: {integrity: sha512-lZNcTLMoGUSGooYfKYLNy0SO0Ma6Z7kdGODPkbph6ur83+C6s+rJJ96jzziZT9gjVK8UoVy8qmZyjEZzEJgkeg==}
     dependencies:
       '@sap-ux/vocabularies-types': 0.11.7
     dev: false
 
+  /@sap-ux/edmx-parser@0.9.0:
+    resolution: {integrity: sha512-X7yda14CsUqGhEK5/XYhP0W65ueObQxq6Dv5qmJQBvR73V0gNexrY5sWuzCQPcEVVh0sB9A0qesMU9qgp6R37A==}
+    dependencies:
+      xml-js: 1.6.11
+    dev: false
+
   /@sap-ux/vocabularies-types@0.11.7:
     resolution: {integrity: sha512-rqRhmPW97dQ8K6nYjL1aP0a4THsUSGK6F5LSOOkSkyTQrBOGu5LNdqi90V2EYKSdIARTvgOnaz1mU+nmkzrsOA==}
     engines: {node: '>=18.x'}
     dev: false
+
+  /@sap-ux/vocabularies-types@0.12.1:
+    resolution: {integrity: sha512-9xb+z8IZ/EPLEWdH1IhFcg3KwHP8Anc9dzp9pfNhoBN/WLACfeXugGQ6CxyHNoT6cydVXKDSqhQyd7VtCL1W2Q==}
+    engines: {node: '>=18.x'}
 
   /@sap/bas-sdk@3.8.9:
     resolution: {integrity: sha512-ycYttnSTlEPjDrb0svSv0jBgqEvoekD4bNB4IxuKCu5OKk5FycwsOTgufU8CXYf1ag23wTlurN+N7c4Po6PcJQ==}


### PR DESCRIPTION
Feature: https://github.com/SAP/open-ux-tools/issues/2766

- Adds main, navigation and filter entity prompts
- Adds table type, hierarchy qualifier prompts
- Adds confirm prompts to add annotations for specific template types
- Adds analytical list page template specific prompts for qualifier, multiSelect, autoHide, smartVariantManagement, selectionMode

**todo:**

- Add unit tests to cover
- Add tsdoc (reduce number of  lint warnings)
