### PR TITLE
Pass Optional `mem-fs` editor to get project type while generating annotations

### DIFF
--- a/.changeset/rude-zebras-return.md
+++ b/.changeset/rude-zebras-return.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-generator': patch
+---
+
+Pass optional mem-fs editor to get project information in annotation generator

--- a/packages/annotation-generator/src/generation.ts
+++ b/packages/annotation-generator/src/generation.ts
@@ -141,12 +141,12 @@ interface Context {
     ignoreChangedFileInitialContent: boolean;
 }
 
-async function adaptProject(projectOrRoot: string | Project): Promise<Project> {
+async function adaptProject(projectOrRoot: string | Project, fs?: Editor): Promise<Project> {
     if (typeof projectOrRoot === 'string') {
         // On Windows platform when called from the Application Wizard the root path may contain lowercase drive letter
         // This causes annotation generation error in Fiori annotation API, thus needs adaptation
         const root = adaptFilePath(projectOrRoot);
-        return await getProject(root);
+        return await getProject(root, fs);
     } else {
         return projectOrRoot;
     }
@@ -159,7 +159,7 @@ async function getContext(
     annotationServiceParams: AnnotationServiceParameters
 ): Promise<Context> {
     const { project, serviceName, appName, writeSapAnnotations = false } = annotationServiceParams;
-    const projectInstance = await adaptProject(project);
+    const projectInstance = await adaptProject(project, fs);
     const annotationService = await FioriAnnotationService.createService(
         projectInstance,
         serviceName,


### PR DESCRIPTION

Pass Optional `mem-fs` editor to get project type while generating annotations. 
`getProjectType` now accepts reference to in memory fs based in [tbi](https://github.com/SAP/open-ux-tools/issues/2762).