### PR TITLE
feat(axios-ext): add entry for s4 hana cloud urls with .lab

### DIFF
--- a/.changeset/rich-horses-mix.md
+++ b/.changeset/rich-horses-mix.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+add entry for s4 hana cloud urls with .lab

--- a/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
+++ b/packages/axios-extension/src/abap/ui5-abap-repository-service.ts
@@ -76,7 +76,8 @@ export interface AppInfo {
 export const abapUrlReplaceMap = new Map([
     [/\.abap\./, '.abap-web.'],
     [/-api\.s4hana\.ondemand\.com/, '.s4hana.ondemand.com'],
-    [/-api\.saps4hanacloud\.cn/, '.saps4hanacloud.cn']
+    [/-api\.saps4hanacloud\.cn/, '.saps4hanacloud.cn'],
+    [/-api\.lab\.s4hana\.cloud\.sap/, '.lab.s4hana.cloud.sap']
 ]);
 
 const xmlReplaceMap = {

--- a/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
+++ b/packages/axios-extension/test/abap/ui5-abap-repository-service.test.ts
@@ -408,6 +408,10 @@ describe('Ui5AbapRepositoryService', () => {
             expect(xmlPayload).toContain(`<id>${publicUrl}/Repositories('special&amp;name')</id>`);
             // ABAP frontend reflects
             expect(service.getAbapFrontendUrl()).toEqual(publicUrl);
+
+            const publicS4HanaCloudUrl = 'https://my12345-api.lab.s4hana.cloud.sap';
+            const s4HanaCloudService = new ServiceForTesting({ publicUrl: publicS4HanaCloudUrl });
+            expect(s4HanaCloudService.getAbapFrontendUrl()).toEqual('https://my12345.lab.s4hana.cloud.sap');
         });
     });
 });


### PR DESCRIPTION
#2776 

Adds entry to `abapUrlReplaceMap` to accomodate s4 hana cloud systems with `.lab`