### PR TITLE
chore: pw reporting checking

### DIFF
--- a/packages/preview-middleware/jest.config.js
+++ b/packages/preview-middleware/jest.config.js
@@ -2,4 +2,5 @@ const config = require('../../jest.base');
 config.modulePathIgnorePatterns.push('<rootDir>/test/test-output');
 config.modulePathIgnorePatterns.push('<rootDir>/.tmp');
 config.testMatch = ['<rootDir>/test/**/*.test.ts'];
+// adding dummy comment
 module.exports = config;

--- a/packages/preview-middleware/test/integration/preview/preview.spec.ts
+++ b/packages/preview-middleware/test/integration/preview/preview.spec.ts
@@ -110,7 +110,7 @@ const check = async (param: { page: Page }) => {
     const { page } = param;
     await page.goto(`${getUrl()}/my/custom/path/preview.html#app-preview`);
     await page.getByRole('button', { name: 'Go', exact: true }).click();
-    await expect(page.getByText('ProductForEdit_0', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('abc', { exact: true })).toBeVisible();
 };
 
 const UI5Versions = JSON.parse(process.env.UI5Versions ?? '[]') as UI5Version[];

--- a/packages/preview-middleware/test/integration/preview/preview.spec.ts
+++ b/packages/preview-middleware/test/integration/preview/preview.spec.ts
@@ -110,7 +110,7 @@ const check = async (param: { page: Page }) => {
     const { page } = param;
     await page.goto(`${getUrl()}/my/custom/path/preview.html#app-preview`);
     await page.getByRole('button', { name: 'Go', exact: true }).click();
-    await expect(page.getByText('ProductForEdit_0', { exact: true })).toBeVisible();
+    await expect(page.getByText('ProductForEdit_0', { exact: true })).not.toBeVisible();
 };
 
 const UI5Versions = JSON.parse(process.env.UI5Versions ?? '[]') as UI5Version[];


### PR DESCRIPTION
With this [PR](https://github.com/SAP/open-ux-tools/pull/2791) ` actions/upload-artifact@v4` was updated. There was a concerned that Playwright reports may not be uploaded on failure. Current PR was a try to check and it playwright reports are uploaded. Check artifacts: https://github.com/SAP/open-ux-tools/actions/runs/12866451957?pr=2797#artifacts