### PR TITLE
fix(abap-deploy): fix support for library deployment

### DIFF
--- a/.changeset/silly-zoos-lick.md
+++ b/.changeset/silly-zoos-lick.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/abap-deploy-config-sub-generator': patch
+'@sap-ux/abap-deploy-config-writer': patch
+---
+
+fix issues for library deployment

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -113,15 +113,19 @@ export default class extends DeploymentGenerator {
     }
 
     private async _processIndexHtmlConfig(): Promise<void> {
-        const htmlIndexExists = await indexHtmlExists(this.fs, this.destinationPath());
-        if (htmlIndexExists) {
+        if (this.projectType === DeployProjectType.Library) {
             this.indexGenerationAllowed = false;
-            if (this.options.index) {
-                DeploymentGenerator.logger?.debug(t('debug.indexExists'));
-            }
-            delete this.options.index;
         } else {
-            this.indexGenerationAllowed = true;
+            const htmlIndexExists = await indexHtmlExists(this.fs, this.destinationPath());
+            if (htmlIndexExists) {
+                this.indexGenerationAllowed = false;
+                if (this.options.index) {
+                    DeploymentGenerator.logger?.debug(t('debug.indexExists'));
+                }
+                delete this.options.index;
+            } else {
+                this.indexGenerationAllowed = true;
+            }
         }
     }
 
@@ -138,8 +142,8 @@ export default class extends DeploymentGenerator {
         this._initDestinationRoot();
         try {
             this._processProjectConfig();
-            await this._processIndexHtmlConfig();
             await this._initBackendConfig();
+            await this._processIndexHtmlConfig();
         } catch (e) {
             if (e === ERROR_TYPE.ABORT_SIGNAL) {
                 DeploymentGenerator.logger?.debug(

--- a/packages/abap-deploy-config-sub-generator/test/fixtures/samplelib/package.json
+++ b/packages/abap-deploy-config-sub-generator/test/fixtures/samplelib/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "library1",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@ui5/cli": "^3.9.1",
+    "karma": "6.3.17",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-cli": "^2.0.0",
+    "karma-ui5": "^3.0.3",
+    "@sap/ux-ui5-tooling": "1"
+  },
+  "scripts": {
+    "build": "ui5 build --clean-dest",
+    "start": "fiori run --open test-resources/com/sap/library1/Example.html",
+    "testsuite": "fiori run --open test-resources/com/sap/library1/qunit/testsuite.qunit.html",
+    "test": "karma start --browsers=ChromeHeadless --singleRun=true"
+  }
+}

--- a/packages/abap-deploy-config-sub-generator/test/fixtures/samplelib/ui5.yaml
+++ b/packages/abap-deploy-config-sub-generator/test/fixtures/samplelib/ui5.yaml
@@ -1,0 +1,19 @@
+specVersion: '2.2'
+metadata:
+  name: "library1"
+type: library
+framework:
+  name: SAPUI5
+  version: 1.108.0
+  libraries:
+    - name: sap.ui.core
+    - name: themelib_sap_belize
+    - name: themelib_sap_fiori_3
+server:
+  customMiddleware:
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        path: test
+        port: 35729
+        delay: 300

--- a/packages/abap-deploy-config-writer/src/config.ts
+++ b/packages/abap-deploy-config-writer/src/config.ts
@@ -13,7 +13,7 @@ import type { AbapDeployConfig, AbapTarget, CustomTask, NodeComment } from '@sap
  */
 export function updateBaseConfig(isLib: boolean, basePath: string, baseConfig: UI5Config, fs: Editor) {
     if (isLib) {
-        if (baseConfig.findCustomTask(UI5_TASK_FLATTEN_LIB) === undefined) {
+        if (!baseConfig.findCustomTask(UI5_TASK_FLATTEN_LIB)) {
             const customTask = {
                 name: UI5_TASK_FLATTEN_LIB,
                 afterTask: 'generateResourcesJson'

--- a/packages/abap-deploy-config-writer/src/config.ts
+++ b/packages/abap-deploy-config-writer/src/config.ts
@@ -13,11 +13,13 @@ import type { AbapDeployConfig, AbapTarget, CustomTask, NodeComment } from '@sap
  */
 export function updateBaseConfig(isLib: boolean, basePath: string, baseConfig: UI5Config, fs: Editor) {
     if (isLib) {
-        const customTask = {
-            name: UI5_TASK_FLATTEN_LIB,
-            afterTask: 'generateResourcesJson'
-        };
-        baseConfig.addCustomTasks([customTask]);
+        if (baseConfig.findCustomTask(UI5_TASK_FLATTEN_LIB) === undefined) {
+            const customTask = {
+                name: UI5_TASK_FLATTEN_LIB,
+                afterTask: 'generateResourcesJson'
+            };
+            baseConfig.addCustomTasks([customTask]);
+        }
         fs.write(basePath, baseConfig.toString());
         baseConfig.removeConfig('builder');
     }

--- a/packages/abap-deploy-config-writer/test/sample/test.ui5.lib/base-config.yaml
+++ b/packages/abap-deploy-config-writer/test/sample/test.ui5.lib/base-config.yaml
@@ -17,3 +17,7 @@ server:
               path: test
               port: 35729
               delay: 300
+builder:
+    customTasks:
+        - name: ui5-task-flatten-library
+          afterTask: generateResourcesJson


### PR DESCRIPTION
- Removes prompting for the generation of index.html during deployment for libraries
     - Also adds library test (there is a tests for libs in the writer)
- Checks the custom task `ui5-task-flatten-library` is not already present in base config (ui5.yaml) before adding it