### PR TITLE
feat: add support for external HTTP calls

### DIFF
--- a/.changeset/three-olives-brake.md
+++ b/.changeset/three-olives-brake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/jest-environment-ui5': patch
+---
+
+feat: add the possibility to refer to external services, and load application CSS for further component testing using mockserver

--- a/packages/jest-environment-ui5/package.json
+++ b/packages/jest-environment-ui5/package.json
@@ -43,8 +43,8 @@
         "@ui5/project": "^3.9.0 || ^4.0.0"
     },
     "devDependencies": {
-        "@ui5/project": "^3.9.0",
         "@ui5/cli": "^3",
+        "@ui5/project": "^3.9.0",
         "cross-env": "^7.0.3",
         "jest": "^29.7.0"
     }

--- a/packages/jest-environment-ui5/src/env/mockXHR.js
+++ b/packages/jest-environment-ui5/src/env/mockXHR.js
@@ -13,6 +13,11 @@ const fs = require('fs');
 function createMockXHR(globalWindow, pathMappingFn, shimmedFilePath, mockData, XHR) {
     let realXhr = new XHR();
 
+    /**
+     * Handles the real XHR send.
+     * @param mockXHR The mock XHR object.
+     * @param data The data to send.
+     */
     function handleRealXHRSend(mockXHR, data) {
         realXhr.addEventListener('load', function () {
             mockXHR.responseText = realXhr.responseText;

--- a/packages/jest-environment-ui5/src/env/ui5Environment.js
+++ b/packages/jest-environment-ui5/src/env/ui5Environment.js
@@ -13,8 +13,9 @@ function initUI5Environment(globalWindow, pathMappingFn, isV2, ui5Version) {
 
     globalWindow.jestSetup = true;
 
+    const XHR = globalWindow.XMLHttpRequest;
     globalWindow.XMLHttpRequest = function () {
-        return mockXHR(globalWindow, pathMappingFn, shimmedFilePath, mockData);
+        return mockXHR(globalWindow, pathMappingFn, shimmedFilePath, mockData, XHR);
     };
     globalWindow.performance.timing = {
         fetchStart: Date.now(),

--- a/packages/jest-environment-ui5/test/unit/mockXHR.test.js
+++ b/packages/jest-environment-ui5/test/unit/mockXHR.test.js
@@ -1,0 +1,60 @@
+const createMockXHR = require('../../src/env/mockXHR');
+describe('Mock XHR', () => {
+    let mockXHR;
+    let XHR;
+    const openMock = jest.fn();
+    const sendMock = jest.fn();
+    let callback;
+    const addEventMock = jest.fn().mockImplementation((event, outCallback) => {
+        callback = outCallback;
+    });
+    const setRequestHeaderMock = jest.fn();
+    const getResponseHeaderMock = jest.fn();
+    const getAllResponseHeadersMock = jest.fn();
+
+    beforeEach(() => {
+        const pathMappingFn = jest.fn();
+        const fakeWindow = jest.fn();
+        const shimmedFilePath = {};
+
+        const mockData = { 'mockedPath': 'mockedData' };
+        XHR = jest.fn().mockImplementation(() => {
+            return {
+                open: openMock,
+                send: sendMock,
+                addEventListener: addEventMock,
+                setRequestHeader: setRequestHeaderMock,
+                getResponseHeader: getResponseHeaderMock,
+                getAllResponseHeaders: getAllResponseHeadersMock
+            };
+        });
+        mockXHR = createMockXHR(fakeWindow, pathMappingFn, shimmedFilePath, mockData, XHR);
+    });
+
+    it('Can be used to query mockedData', (done) => {
+        mockXHR.open('GET', 'mockedPath');
+        mockXHR.addEventListener('load', () => {
+            expect(mockXHR.responseText).toBe('mockedData');
+            done();
+        });
+        mockXHR.send();
+    });
+    it('Can be used to query data from the backend', (done) => {
+        mockXHR.onload = jest.fn();
+        mockXHR.open('PUT', 'http://localhost:8080/xxxc');
+        expect(openMock).toHaveBeenCalledWith('PUT', 'http://localhost:8080/xxxc');
+        mockXHR.setRequestHeader('Content-Type', 'application/json');
+        expect(setRequestHeaderMock).toHaveBeenCalledWith('Content-Type', 'application/json');
+
+        mockXHR.send('Hello');
+        expect(sendMock).toHaveBeenCalledWith('Hello');
+        expect(addEventMock).toHaveBeenCalled();
+        expect(callback).toBeDefined();
+        callback();
+        mockXHR.getResponseHeader('Content-Type');
+        expect(getResponseHeaderMock).toHaveBeenCalledWith('Content-Type');
+        mockXHR.getAllResponseHeaders();
+        expect(getAllResponseHeadersMock).toHaveBeenCalled();
+        done();
+    });
+});

--- a/packages/jest-environment-ui5/test/unit/mockXHR.test.js
+++ b/packages/jest-environment-ui5/test/unit/mockXHR.test.js
@@ -17,7 +17,7 @@ describe('Mock XHR', () => {
         const fakeWindow = jest.fn();
         const shimmedFilePath = {};
 
-        const mockData = { 'mockedPath': 'mockedData' };
+        const mockData = { 'mockedPath.xml': 'mockedData' };
         XHR = jest.fn().mockImplementation(() => {
             return {
                 open: openMock,
@@ -32,11 +32,12 @@ describe('Mock XHR', () => {
     });
 
     it('Can be used to query mockedData', (done) => {
-        mockXHR.open('GET', 'mockedPath');
+        mockXHR.open('GET', 'mockedPath.xml');
         mockXHR.addEventListener('load', () => {
             expect(mockXHR.responseText).toBe('mockedData');
             done();
         });
+        expect( mockXHR.getResponseHeader('Content-Type')).toBe("application/xml");
         mockXHR.send();
     });
     it('Can be used to query data from the backend', (done) => {
@@ -55,6 +56,8 @@ describe('Mock XHR', () => {
         expect(getResponseHeaderMock).toHaveBeenCalledWith('Content-Type');
         mockXHR.getAllResponseHeaders();
         expect(getAllResponseHeadersMock).toHaveBeenCalled();
+        mockXHR.onload();
+        expect(mockXHR.onload).toHaveBeenCalled();
         done();
     });
 });

--- a/packages/jest-environment-ui5/test/unit/mockXHR.test.js
+++ b/packages/jest-environment-ui5/test/unit/mockXHR.test.js
@@ -11,7 +11,7 @@ describe('Mock XHR', () => {
     const setRequestHeaderMock = jest.fn();
     const getResponseHeaderMock = jest.fn();
     const getAllResponseHeadersMock = jest.fn();
-
+    let currentRealXHR;
     beforeEach(() => {
         const pathMappingFn = jest.fn();
         const fakeWindow = jest.fn();
@@ -19,7 +19,7 @@ describe('Mock XHR', () => {
 
         const mockData = { 'mockedPath.xml': 'mockedData' };
         XHR = jest.fn().mockImplementation(() => {
-            return {
+            currentRealXHR = {
                 open: openMock,
                 send: sendMock,
                 addEventListener: addEventMock,
@@ -27,6 +27,7 @@ describe('Mock XHR', () => {
                 getResponseHeader: getResponseHeaderMock,
                 getAllResponseHeaders: getAllResponseHeadersMock
             };
+            return currentRealXHR;
         });
         mockXHR = createMockXHR(fakeWindow, pathMappingFn, shimmedFilePath, mockData, XHR);
     });
@@ -37,7 +38,7 @@ describe('Mock XHR', () => {
             expect(mockXHR.responseText).toBe('mockedData');
             done();
         });
-        expect( mockXHR.getResponseHeader('Content-Type')).toBe("application/xml");
+        expect(mockXHR.getResponseHeader('Content-Type')).toBe('application/xml');
         mockXHR.send();
     });
     it('Can be used to query data from the backend', (done) => {
@@ -57,7 +58,9 @@ describe('Mock XHR', () => {
         mockXHR.getAllResponseHeaders();
         expect(getAllResponseHeadersMock).toHaveBeenCalled();
         mockXHR.onload();
-        expect(mockXHR.onload).toHaveBeenCalled();
+        expect(mockXHR.onload).toHaveBeenCalledTimes(2);
+        currentRealXHR.onload();
+        expect(mockXHR.onload).toHaveBeenCalledTimes(3);
         done();
     });
 });


### PR DESCRIPTION
When doing component based testing it might be useful to refer to an actual mockserver. 

Furthermore if we want to leverage more complex snapshot (including screenshots), being able to load CSS is desired, so an option was added for that.