### PR TITLE
fix: enabled missing quick actions on alp v2

### DIFF
--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-enable-semantic-date-range-filter-bar.ts
@@ -7,8 +7,11 @@ import { areManifestChangesSupported, prepareManifestChange } from './utils';
 import SmartFilterBar from 'sap/ui/comp/smartfilterbar/SmartFilterBar';
 
 export const ENABLE_SEMANTIC_DATE_RANGE_FILTER_BAR = 'enable-semantic-daterange-filterbar';
-const CONTROL_TYPE = 'sap.ui.comp.smartfilterbar.SmartFilterBar';
-const COMPONENT = 'sap.suite.ui.generic.template.ListReport';
+const CONTROL_TYPE_LR = 'sap.ui.comp.smartfilterbar.SmartFilterBar';
+const CONTROL_TYPE_ALP = 'sap.suite.ui.generic.template.AnalyticalListPage.control.SmartFilterBarExt';
+const COMPONENT_LR = 'sap.suite.ui.generic.template.ListReport';
+const COMPONENT_ALP = 'sap.suite.ui.generic.template.AnalyticalListPage';
+
 /**
  * Quick Action for toggling the visibility of "semantic date range" for filterbar fields.
  */
@@ -27,7 +30,10 @@ export class ToggleSemanticDateRangeFilterBar
         if (!manifestChangesSupported) {
             return;
         }
-        const controls = this.context.controlIndex[CONTROL_TYPE] ?? [];
+        const controls = [
+            ...(this.context.controlIndex[CONTROL_TYPE_LR] ?? []),
+            ...(this.context.controlIndex[CONTROL_TYPE_ALP] ?? [])
+        ];
         for (const control of controls) {
             const isActionApplicable = pageHasControlId(this.context.view, control.controlId);
             const modifiedControl = getControlById<SmartFilterBar>(control.controlId);
@@ -52,12 +58,16 @@ export class ToggleSemanticDateRangeFilterBar
     }
 
     async execute(): Promise<FlexCommand[]> {
-        const entitySet = isA<SmartFilterBar>(CONTROL_TYPE, this.control) ? this.control.getEntitySet() : undefined;
+        const entitySet =
+            isA<SmartFilterBar>(CONTROL_TYPE_LR, this.control) || isA<SmartFilterBar>(CONTROL_TYPE_ALP, this.control)
+                ? this.control.getEntitySet()
+                : undefined;
+        const viewName = this.context.view.getViewName();
         const command = await prepareManifestChange(
             this.context,
             'component/settings/filterSettings/dateSettings',
             this.control!,
-            COMPONENT,
+            viewName.includes('AnalyticalListPage') ? COMPONENT_ALP : COMPONENT_LR,
             entitySet,
             {
                 useDateRange: !this.isUseDateRangeTypeEnabled

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-toggle-clear-filter-bar.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/lr-toggle-clear-filter-bar.ts
@@ -9,7 +9,8 @@ import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
 
 export const ENABLE_CLEAR_FILTER_BAR_TYPE = 'enable-clear-filter-bar';
 const PROPERTY_NAME = 'showClearOnFB';
-const CONTROL_TYPE = 'sap.ui.comp.smartfilterbar.SmartFilterBar';
+const CONTROL_TYPE_LR = 'sap.ui.comp.smartfilterbar.SmartFilterBar';
+const CONTROL_TYPE_ALP = 'sap.suite.ui.generic.template.AnalyticalListPage.control.SmartFilterBarExt';
 
 /**
  * Quick Action for toggling the visibility of "clear filter bar" button in List Report page.
@@ -25,7 +26,10 @@ export class ToggleClearFilterBarQuickAction
     private isClearButtonEnabled = false;
 
     initialize(): void {
-        const controls = this.context.controlIndex[CONTROL_TYPE] ?? [];
+        const controls = [
+            ...(this.context.controlIndex[CONTROL_TYPE_LR] ?? []),
+            ...(this.context.controlIndex[CONTROL_TYPE_ALP] ?? [])
+        ];
         for (const control of controls) {
             const isActionApplicable = pageHasControlId(this.context.view, control.controlId);
             const modifiedControl = getControlById<FilterBar>(control.controlId);

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/registry.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/registry.ts
@@ -80,8 +80,14 @@ export default class FEV2QuickActionRegistry extends QuickActionDefinitionRegist
                     title: 'ANALYTICAL LIST PAGE',
                     definitions: [
                         AddControllerToPageQuickAction,
+                        AddPageActionQuickAction,
+                        ToggleClearFilterBarQuickAction,
+                        ToggleSemanticDateRangeFilterBar,
                         ChangeTableColumnsQuickAction,
-                        AddTableCustomColumnQuickAction
+                        AddTableActionQuickAction,
+                        AddTableCustomColumnQuickAction,
+                        EnableTableFilteringQuickAction,
+                        AddNewAnnotationFile
                     ],
                     view,
                     key: name + index

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -879,6 +879,7 @@ describe('FE V2 quick actions', () => {
                 validVersion: boolean;
                 versionInfo: string;
                 isManifestPagesAsArray: boolean;
+                isAlp?: boolean;
             }[] = [
                 {
                     validVersion: true,
@@ -911,6 +912,12 @@ describe('FE V2 quick actions', () => {
                     isManifestPagesAsArray: false
                 },
                 {
+                    validVersion: true,
+                    versionInfo: '1.130',
+                    isManifestPagesAsArray: false,
+                    isAlp: true
+                },
+                {
                     validVersion: false,
                     versionInfo: '1.96.34',
                     isManifestPagesAsArray: false
@@ -926,7 +933,11 @@ describe('FE V2 quick actions', () => {
                 sapCoreMock.byId.mockImplementation((id) => {
                     if (id == 'SmartFilterBar') {
                         return {
-                            isA: (type: string) => type === 'sap.ui.comp.smartfilterbar.SmartFilterBar',
+                            isA: (type: string) =>
+                                type ===
+                                (testCase.isAlp
+                                    ? 'sap.suite.ui.generic.template.AnalyticalListPage.control.SmartFilterBarExt'
+                                    : 'sap.ui.comp.smartfilterbar.SmartFilterBar'),
                             getProperty: jest.fn().mockImplementation((name) => {
                                 if (name === 'persistencyKey') {
                                     return 'filterbar';
@@ -948,8 +959,10 @@ describe('FE V2 quick actions', () => {
                                 contains: () => true
                             };
                         });
-                        pageView.getViewName.mockImplementation(
-                            () => 'sap.suite.ui.generic.template.ListReport.view.ListReport'
+                        pageView.getViewName.mockImplementation(() =>
+                            testCase.isAlp
+                                ? 'sap.suite.ui.generic.template.AnalyticalListPage.view.AnalyticalListPage'
+                                : 'sap.suite.ui.generic.template.ListReport.view.ListReport'
                         );
                         const componentContainer = new ComponentContainer();
                         const spy = jest.spyOn(componentContainer, 'getComponent');
@@ -995,7 +1008,9 @@ describe('FE V2 quick actions', () => {
                 );
                 await service.init(sendActionMock, subscribeMock);
                 await service.reloadQuickActions({
-                    'sap.ui.comp.smartfilterbar.SmartFilterBar': [
+                    [testCase.isAlp
+                        ? 'sap.suite.ui.generic.template.AnalyticalListPage.control.SmartFilterBarExt'
+                        : 'sap.ui.comp.smartfilterbar.SmartFilterBar']: [
                         {
                             controlId: 'SmartFilterBar'
                         } as any
@@ -1009,13 +1024,15 @@ describe('FE V2 quick actions', () => {
                 expect(sendActionMock).toHaveBeenCalledWith(
                     quickActionListChanged([
                         {
-                            title: 'LIST REPORT',
+                            title: testCase.isAlp ? 'ANALYTICAL LIST PAGE' : 'LIST REPORT',
                             actions:
                                 testCase.validVersion && !testCase.isManifestPagesAsArray
                                     ? [
                                           {
                                               'kind': 'simple',
-                                              id: 'listReport0-enable-semantic-daterange-filterbar',
+                                              id: testCase.isAlp
+                                                  ? 'analyticalListPage0-enable-semantic-daterange-filterbar'
+                                                  : 'listReport0-enable-semantic-daterange-filterbar',
                                               title: 'Enable Semantic Date Range in Filter Bar',
                                               enabled: true
                                           }
@@ -1026,7 +1043,12 @@ describe('FE V2 quick actions', () => {
                 );
                 if (testCase.validVersion && !testCase.isManifestPagesAsArray) {
                     await subscribeMock.mock.calls[0][0](
-                        executeQuickAction({ id: 'listReport0-enable-semantic-daterange-filterbar', kind: 'simple' })
+                        executeQuickAction({
+                            id: testCase.isAlp
+                                ? 'analyticalListPage0-enable-semantic-daterange-filterbar'
+                                : 'listReport0-enable-semantic-daterange-filterbar',
+                            kind: 'simple'
+                        })
                     );
                     expect(rtaMock.getCommandStack().pushAndExecute).toHaveBeenCalledWith({
                         'settings': {},
@@ -1042,7 +1064,9 @@ describe('FE V2 quick actions', () => {
                                     }
                                 },
                                 'parentPage': {
-                                    'component': 'sap.suite.ui.generic.template.ListReport',
+                                    'component': testCase.isAlp
+                                        ? 'sap.suite.ui.generic.template.AnalyticalListPage'
+                                        : 'sap.suite.ui.generic.template.ListReport',
                                     'entitySet': 'testEntity'
                                 }
                             },
@@ -1397,12 +1421,12 @@ describe('FE V2 quick actions', () => {
                                         {
                                             children: [],
                                             enabled: true,
-                                            label: 'Add Annotation File for \'\'{0}\'\''
+                                            label: "Add Annotation File for ''{0}''"
                                         },
                                         {
                                             children: [],
                                             enabled: true,
-                                            label: 'Show Annotation File for \'\'{0}\'\''
+                                            label: "Show Annotation File for ''{0}''"
                                         }
                                     ]
                                 }
@@ -2606,6 +2630,20 @@ describe('FE V2 quick actions', () => {
                                         {
                                             'children': [],
                                             enabled: true,
+                                            'label': `'MyTable' table`
+                                        }
+                                    ],
+                                    'enabled': true,
+                                    'id': 'analyticalListPage0-create-table-action',
+                                    'kind': 'nested',
+                                    'title': 'Add Custom Table Action',
+                                    'tooltip': undefined
+                                },
+                                {
+                                    'children': [
+                                        {
+                                            'children': [],
+                                            'enabled': true,
                                             'label': `'MyTable' table`
                                         }
                                     ],


### PR DESCRIPTION
Enabled quick actions available on LRP, but missing on ALP in v2 apps