### PR TITLE
fix(flp-inquirer): fix hiding flp prompts

### DIFF
--- a/.changeset/long-lions-cheat.md
+++ b/.changeset/long-lions-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/flp-config-inquirer': patch
+---
+
+fix hiding prompts with prompt options

--- a/packages/flp-config-inquirer/src/prompts/prompts.ts
+++ b/packages/flp-config-inquirer/src/prompts/prompts.ts
@@ -58,33 +58,12 @@ export function getQuestions(
         [promptNames.createAnotherInbound]: getCreateAnotherInboundPrompt(isCLI)
     };
 
-    const questions: FLPConfigQuestion[] = [];
-
-    if (promptOptions?.[promptNames.inboundId]?.hide !== true) {
-        questions.push(keyedPrompts[promptNames.inboundId]);
-    }
-
-    if (promptOptions?.[promptNames.emptyInboundsInfo]?.hide !== true) {
-        questions.push(keyedPrompts[promptNames.emptyInboundsInfo]);
-    }
-
-    questions.push(
-        ...[
-            keyedPrompts[promptNames.semanticObject],
-            keyedPrompts[promptNames.action],
-            keyedPrompts[promptNames.overwrite],
-            keyedPrompts[promptNames.title],
-            keyedPrompts[promptNames.subTitle]
-        ]
-    );
-
-    if (promptOptions?.[promptNames.additionalParameters]?.hide !== true) {
-        questions.push(keyedPrompts[promptNames.additionalParameters]);
-    }
-
-    if (promptOptions?.[promptNames.createAnotherInbound]?.hide !== true) {
-        questions.push(keyedPrompts[promptNames.createAnotherInbound]);
-    }
+    const questions: FLPConfigQuestion[] = Object.entries(keyedPrompts)
+        .filter(([promptName]) => {
+            const option = promptOptions?.[promptName as promptNames];
+            return option && 'hide' in option ? !option.hide : true;
+        })
+        .map(([_, prompt]) => prompt);
 
     return questions;
 }

--- a/packages/flp-config-inquirer/src/prompts/prompts.ts
+++ b/packages/flp-config-inquirer/src/prompts/prompts.ts
@@ -38,12 +38,8 @@ export function getQuestions(
     const silentOverwrite = promptOptions?.silentOverwrite ?? false;
 
     const keyedPrompts: Record<promptNames, FLPConfigQuestion> = {
-        [promptNames.inboundId]: getInboundIdsPrompt(inboundKeys, promptOptions?.[promptNames.inboundId]),
-        [promptNames.emptyInboundsInfo]: getEmptyInboundsLabelPrompt(
-            inboundKeys,
-            appId,
-            promptOptions?.[promptNames.emptyInboundsInfo]
-        ),
+        [promptNames.inboundId]: getInboundIdsPrompt(inboundKeys),
+        [promptNames.emptyInboundsInfo]: getEmptyInboundsLabelPrompt(inboundKeys, appId),
         [promptNames.semanticObject]: getSemanticObjectPrompt(isCLI, promptOptions?.[promptNames.semanticObject]),
         [promptNames.action]: getActionPrompt(isCLI, promptOptions?.[promptNames.action]),
         [promptNames.overwrite]: getOverwritePrompt(
@@ -58,27 +54,37 @@ export function getQuestions(
             silentOverwrite,
             promptOptions?.[promptNames.subTitle]
         ),
-        [promptNames.additionalParameters]: getParameterStringPrompt(
-            inboundKeys,
-            promptOptions?.[promptNames.additionalParameters]
-        ),
-        [promptNames.createAnotherInbound]: getCreateAnotherInboundPrompt(
-            isCLI,
-            promptOptions?.[promptNames.createAnotherInbound]
-        )
+        [promptNames.additionalParameters]: getParameterStringPrompt(inboundKeys),
+        [promptNames.createAnotherInbound]: getCreateAnotherInboundPrompt(isCLI)
     };
 
-    const questions: FLPConfigQuestion[] = [
-        keyedPrompts[promptNames.inboundId],
-        keyedPrompts[promptNames.emptyInboundsInfo],
-        keyedPrompts[promptNames.semanticObject],
-        keyedPrompts[promptNames.action],
-        keyedPrompts[promptNames.overwrite],
-        keyedPrompts[promptNames.title],
-        keyedPrompts[promptNames.subTitle],
-        keyedPrompts[promptNames.additionalParameters],
-        keyedPrompts[promptNames.createAnotherInbound]
-    ];
+    const questions: FLPConfigQuestion[] = [];
+
+    if (promptOptions?.[promptNames.inboundId]?.hide !== true) {
+        questions.push(keyedPrompts[promptNames.inboundId]);
+    }
+
+    if (promptOptions?.[promptNames.emptyInboundsInfo]?.hide !== true) {
+        questions.push(keyedPrompts[promptNames.emptyInboundsInfo]);
+    }
+
+    questions.push(
+        ...[
+            keyedPrompts[promptNames.semanticObject],
+            keyedPrompts[promptNames.action],
+            keyedPrompts[promptNames.overwrite],
+            keyedPrompts[promptNames.title],
+            keyedPrompts[promptNames.subTitle]
+        ]
+    );
+
+    if (promptOptions?.[promptNames.additionalParameters]?.hide !== true) {
+        questions.push(keyedPrompts[promptNames.additionalParameters]);
+    }
+
+    if (promptOptions?.[promptNames.createAnotherInbound]?.hide !== true) {
+        questions.push(keyedPrompts[promptNames.createAnotherInbound]);
+    }
 
     return questions;
 }

--- a/packages/flp-config-inquirer/src/prompts/questions/advanced.ts
+++ b/packages/flp-config-inquirer/src/prompts/questions/advanced.ts
@@ -1,25 +1,16 @@
 import { parseParameters } from '@sap-ux/adp-tooling';
 import { validateEmptyString } from '@sap-ux/project-input-validator';
-
-import type {
-    FLPConfigQuestion,
-    FLPConfigAnswers,
-    InboundIdPromptOptions,
-    CreateAnotherInboundPromptOptions,
-    ParameterStringPromptOptions,
-    EmptyInboundsLabelOptions
-} from '../../types';
 import { t } from '../../i18n';
 import { promptNames } from '../../types';
+import type { FLPConfigQuestion, FLPConfigAnswers } from '../../types';
 
 /**
  * Creates the 'inboundId' prompt for FLP configuration.
  *
  * @param {string[]} inboundIds - List of existing inbound IDs to populate the prompt choices.
- * @param {InboundIdPromptOptions} [options] - Optional configuration for the inbound ID prompt, including defaults.
  * @returns {FLPConfigQuestion} The prompt configuration for selecting an inbound ID.
  */
-export function getInboundIdsPrompt(inboundIds: string[], options?: InboundIdPromptOptions): FLPConfigQuestion {
+export function getInboundIdsPrompt(inboundIds: string[]): FLPConfigQuestion {
     return {
         type: 'list',
         name: promptNames.inboundId,
@@ -27,7 +18,7 @@ export function getInboundIdsPrompt(inboundIds: string[], options?: InboundIdPro
         choices: inboundIds,
         default: inboundIds[0],
         validate: validateEmptyString,
-        when: options?.hide ? false : inboundIds?.length > 0,
+        when: inboundIds?.length > 0,
         guiOptions: {
             hint: t('tooltips.inboundId'),
             breadcrumb: t('prompts.inboundIds'),
@@ -41,14 +32,9 @@ export function getInboundIdsPrompt(inboundIds: string[], options?: InboundIdPro
  *
  * @param {string[]} inboundIds - List of existing inbound IDs to determine whether to display this label.
  * @param {string} [appId] - Application ID to generate a link for the Fiori application library.
- * @param {EmptyInboundsLabelOptions} [options] - Optional configuration for the label prompt.
  * @returns {FLPConfigQuestion} The prompt configuration for displaying an information label when no inbounds exist.
  */
-export function getEmptyInboundsLabelPrompt(
-    inboundIds: string[],
-    appId?: string,
-    options?: EmptyInboundsLabelOptions
-): FLPConfigQuestion {
+export function getEmptyInboundsLabelPrompt(inboundIds: string[], appId?: string): FLPConfigQuestion {
     return {
         type: 'input',
         name: promptNames.emptyInboundsInfo,
@@ -63,7 +49,7 @@ export function getEmptyInboundsLabelPrompt(
                 }`
             }
         },
-        when: options?.hide ? false : inboundIds.length === 0
+        when: inboundIds.length === 0
     };
 }
 
@@ -71,13 +57,9 @@ export function getEmptyInboundsLabelPrompt(
  * Creates the 'additionalParameters' prompt for specifying parameters in JSON format.
  *
  * @param {string[]} inboundIds - List of existing inbound IDs to conditionally display this prompt.
- * @param {ParameterStringPromptOptions} [options] - Optional configuration for the additional parameter string prompt, including defaults.
  * @returns {FLPConfigQuestion} The prompt configuration for specifying a parameter string.
  */
-export function getParameterStringPrompt(
-    inboundIds: string[],
-    options?: ParameterStringPromptOptions
-): FLPConfigQuestion {
+export function getParameterStringPrompt(inboundIds: string[]): FLPConfigQuestion {
     return {
         type: 'editor',
         name: promptNames.additionalParameters,
@@ -92,10 +74,9 @@ export function getParameterStringPrompt(
             } catch (error) {
                 return error.message;
             }
-
             return true;
         },
-        when: options?.hide ? false : inboundIds?.length === 0,
+        when: inboundIds?.length === 0,
         guiOptions: {
             hint: t('tooltips.additionalParameters'),
             mandatory: false
@@ -107,19 +88,15 @@ export function getParameterStringPrompt(
  * Creates the 'createAnotherInbound' confirmation prompt for adding additional inbounds.
  *
  * @param {boolean} isCLI - Indicates if the platform is CLI.
- * @param {CreateAnotherInboundPromptOptions} [options] - Optional configuration for the confirmation prompt, including defaults.
  * @returns {FLPConfigQuestion} The prompt configuration for confirming whether to create another inbound.
  */
-export function getCreateAnotherInboundPrompt(
-    isCLI: boolean,
-    options?: CreateAnotherInboundPromptOptions
-): FLPConfigQuestion {
+export function getCreateAnotherInboundPrompt(isCLI: boolean): FLPConfigQuestion {
     return {
         type: 'confirm',
         name: promptNames.createAnotherInbound,
         message: t('prompts.createAnotherInbound'),
         default: false,
-        when: options?.hide ? false : (answers: FLPConfigAnswers) => !isCLI && !!answers?.inboundId,
+        when: (answers: FLPConfigAnswers) => !isCLI && !!answers?.inboundId,
         guiOptions: {
             hint: t('tooltips.inboundId'),
             breadcrumb: t('prompts.inboundIds')

--- a/packages/flp-config-inquirer/src/prompts/questions/basic.ts
+++ b/packages/flp-config-inquirer/src/prompts/questions/basic.ts
@@ -90,13 +90,11 @@ export function getOverwritePrompt(
             applyDefaultWhenDirty: true
         },
         default: options?.default ?? ((): boolean => !existingKeyRef.value),
-        when: options?.hide
-            ? false
-            : (previousAnswers: FLPConfigAnswers): boolean => {
-                  existingKeyRef.value =
-                      inboundKeys.indexOf(`${previousAnswers.semanticObject}-${previousAnswers.action}`) > -1;
-                  return existingKeyRef.value;
-              },
+        when: (previousAnswers: FLPConfigAnswers): boolean => {
+            existingKeyRef.value =
+                inboundKeys.indexOf(`${previousAnswers.semanticObject}-${previousAnswers.action}`) > -1;
+            return existingKeyRef.value;
+        },
         additionalMessages: (_, previousAnswers) => ({
             message: t('validators.inboundConfigKeyExists', {
                 inboundKey: `${(previousAnswers as FLPConfigAnswers).semanticObject}-${

--- a/packages/flp-config-inquirer/test/index.test.ts
+++ b/packages/flp-config-inquirer/test/index.test.ts
@@ -1,5 +1,4 @@
 import { isAppStudio } from '@sap-ux/btp-utils';
-
 import { getPrompts, prompt } from '../src';
 import type { FLPConfigAnswers } from '../src';
 
@@ -16,6 +15,18 @@ describe('index', () => {
 
             expect(prompts).toBeDefined();
             expect(prompts.length).toBe(9);
+        });
+
+        it('should return selected prompts from getPrompts prompt options', async () => {
+            const prompts = await getPrompts(undefined, undefined, {
+                inboundId: { hide: true },
+                emptyInboundsInfo: { hide: true },
+                additionalParameters: { hide: true },
+                createAnotherInbound: { hide: true }
+            });
+
+            expect(prompts).toBeDefined();
+            expect(prompts.length).toBe(5);
         });
     });
 

--- a/packages/flp-config-inquirer/test/prompts/questions/advanced.test.ts
+++ b/packages/flp-config-inquirer/test/prompts/questions/advanced.test.ts
@@ -41,12 +41,6 @@ describe('advanced prompts', () => {
             });
         });
 
-        it('should set "when" to false when options.hide is true', () => {
-            const prompt = getInboundIdsPrompt(inboundIds, { hide: true });
-
-            expect(prompt.when).toBe(false);
-        });
-
         it('should return a warning message when inboundIds are empty', () => {
             const emptyInboundIds: string[] = [];
             const prompt = getInboundIdsPrompt(emptyInboundIds);
@@ -115,12 +109,6 @@ describe('advanced prompts', () => {
             expect(prompt.when).toBe(false);
         });
 
-        it('should not display the prompt when options.hide is true', () => {
-            const prompt = getEmptyInboundsLabelPrompt([], 'app.variant1', { hide: true });
-
-            expect(prompt.when).toBe(false);
-        });
-
         it('should generate the correct link URL based on appId', () => {
             const appId = 'app.variant1';
             const prompt = getEmptyInboundsLabelPrompt([], appId);
@@ -156,12 +144,6 @@ describe('advanced prompts', () => {
                     mandatory: false
                 }
             });
-        });
-
-        it('should set "when" to false if options.hide is true', () => {
-            const prompt = getParameterStringPrompt(inboundIds, { hide: true });
-
-            expect(prompt.when).toBe(false);
         });
 
         it('should set "when" to true if inboundIds is empty', () => {
@@ -217,12 +199,6 @@ describe('advanced prompts', () => {
                     breadcrumb: t('prompts.inboundIds')
                 }
             });
-        });
-
-        it('should set "when" to false if options.hide is true', () => {
-            const prompt = getCreateAnotherInboundPrompt(false, { hide: true });
-
-            expect(prompt.when).toBe(false);
         });
 
         it('should set "when" to a function if options.hide is not true', () => {

--- a/packages/flp-config-inquirer/test/prompts/questions/basic.test.ts
+++ b/packages/flp-config-inquirer/test/prompts/questions/basic.test.ts
@@ -224,15 +224,6 @@ describe('basic prompts', () => {
             expect(result).toBe(true);
         });
 
-        it('should return false for "when" if options.hide is true', () => {
-            const options = { hide: true };
-
-            const prompt = getOverwritePrompt([], false, existingKeyRef, options);
-            const whenFn = prompt.when as boolean;
-
-            expect(whenFn).toBe(false);
-        });
-
         it('should provide additionalMessages with correct severity and message', () => {
             const prompt = getOverwritePrompt([], false, existingKeyRef);
             const additionalMessagesFn = prompt.additionalMessages as (val: any, previousAnswers: any) => any;


### PR DESCRIPTION
Related to https://github.com/SAP/open-ux-tools/issues/2756

To prevent default methods being ran, and answers automatically populated, if the `hide` prompt option is set for a specific prompt it should not be returned from `getPrompts`

This will also enhance performance in YUI so that conditions e.g `when` `default` are not ran everytime