### PR TITLE
feat(preview-middleware): reroute missing url param viewCache

### DIFF
--- a/.changeset/shy-oranges-tell.md
+++ b/.changeset/shy-oranges-tell.md
@@ -2,4 +2,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-reroute missing url param viewCache
+add url param viewCache in case it is missing

--- a/.changeset/shy-oranges-tell.md
+++ b/.changeset/shy-oranges-tell.md
@@ -1,5 +1,5 @@
 ---
-'@sap-ux/preview-middleware': patch
+'@sap-ux/preview-middleware': minor
 ---
 
 add url param viewCache in case it is missing

--- a/.changeset/shy-oranges-tell.md
+++ b/.changeset/shy-oranges-tell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+reroute missing url param viewCache

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -308,6 +308,7 @@ export class FlpSandbox {
 
         // add route for the sandbox html
         this.router.get(this.config.path, (async (req: EnhancedRequest, res: Response, next: NextFunction) => {
+            // karma (connect API) has no request query property
             if (req.query && !req.query['sap-ui-xx-viewCache']) {
                 // Redirect to the same URL but add the necessary parameter
                 const params = structuredClone(req.query);

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -308,6 +308,13 @@ export class FlpSandbox {
 
         // add route for the sandbox html
         this.router.get(this.config.path, (async (req: EnhancedRequest, res: Response, next: NextFunction) => {
+            if (req.query && !req.query['sap-ui-xx-viewCache']) {
+                // Redirect to the same URL but add the necessary parameter
+                const params = structuredClone(req.query);
+                params['sap-ui-xx-viewCache'] = 'false';
+                res.redirect(302, `${this.config.path}?${new URLSearchParams(params)}`);
+                return;
+            }
             await this.setApplicationDependencies();
             // inform the user if a html file exists on the filesystem
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -1423,6 +1423,83 @@ exports[`FlpSandbox router test/flp.html UI5 2.x 1`] = `
 </html>"
 `;
 
+exports[`FlpSandbox router test/flp.html missing sap-ui-xx-viewCache set to false 1`] = `"Found. Redirecting to /test/flp.html?sap-ui-xx-viewCache=false"`;
+
+exports[`FlpSandbox router test/flp.html sap-ui-xx-viewCache set to true 1`] = `
+"<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+        };
+    </script>
+
+    <script type=\\"text/javascript\\">
+        window[\\"data-open-ux-preview-basePath\\"] = \\"..\\";
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-bindingSyntax=\\"complex\\"
+        data-sap-ui-flexibilityServices='[{\\"connector\\":\\"LrepConnector\\",\\"layers\\":[],\\"url\\":\\"/sap/bc/lrep\\"},{\\"applyConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"writeConnector\\":\\"custom.connectors.WorkspaceConnector\\",\\"custom\\":true},{\\"connector\\":\\"LocalStorageConnector\\",\\"layers\\":[\\"CUSTOMER\\",\\"USER\\"]}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"../preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">
+    </script>
+
+
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>"
+`;
+
 exports[`FlpSandbox router with test suite default with testsuite 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -315,12 +315,22 @@ describe('FlpSandbox', () => {
                 text: jest.fn(),
                 ok: true
             });
-            const response = await server.get('/test/flp.html').expect(200);
+            const response = await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 
         test('test/flp.html', async () => {
-            const response = await server.get('/test/flp.html').expect(200);
+            const response = await server.get('/test/flp.html?sap-ui-xx-viewCache=false#app-preview').expect(200);
+            expect(response.text).toMatchSnapshot();
+        });
+
+        test('test/flp.html sap-ui-xx-viewCache set to true', async () => {
+            const response = await server.get('/test/flp.html?sap-ui-xx-viewCache=true').expect(200);
+            expect(response.text).toMatchSnapshot();
+        });
+
+        test('test/flp.html missing sap-ui-xx-viewCache set to false', async () => {
+            const response = await server.get('/test/flp.html').expect(302);
             expect(response.text).toMatchSnapshot();
         });
 
@@ -457,7 +467,7 @@ describe('FlpSandbox', () => {
             const server = await supertest(app);
 
             expect(flp.templateConfig).toMatchSnapshot();
-            const response = await server.get('/test/flp.html').expect(200);
+            const response = await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 
@@ -520,7 +530,7 @@ describe('FlpSandbox', () => {
         });
 
         test('editor with config', async () => {
-            const response = await server.get('/test/flp.html').expect(200);
+            const response = await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
             expect(response.text).toMatchSnapshot();
         });
 
@@ -717,13 +727,13 @@ describe('FlpSandbox', () => {
             const app = express();
             app.use(flp.router);
 
-            server = await supertest(app);
+            server = supertest(app);
         });
 
         test('test/existingFlp.html', async () => {
             logger.info.mockReset();
             mockProject.byPath.mockResolvedValueOnce({});
-            await server.get('/test/existingFlp.html');
+            await server.get('/test/existingFlp.html?sap-ui-xx-viewCache=false');
             expect(logger.info).toBeCalledWith(
                 'HTML file returned at /test/existingFlp.html is loaded from the file system.'
             );

--- a/packages/preview-middleware/test/unit/ui5/middleware.test.ts
+++ b/packages/preview-middleware/test/unit/ui5/middleware.test.ts
@@ -87,14 +87,14 @@ describe('ui5/middleware', () => {
 
     test('no config', async () => {
         const server = await getTestServer('simple-app');
-        await server.get('/test/flp.html').expect(200);
+        await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
         await server.get('/preview/client/flp/init.js').expect(200);
     }, 10000);
 
     test('simple config', async () => {
         const path = '/my/preview/is/here.html';
         const server = await getTestServer('simple-app', { flp: { path, libs: true } });
-        await server.get(path).expect(200);
+        await server.get(path).expect(302);
         await server.get('/preview/client/flp/init.js').expect(200);
         await server.get('/test/flp.html').expect(404);
     }, 10000);
@@ -131,7 +131,7 @@ describe('ui5/middleware', () => {
                 editors: [{ path: '/adp/editor.html', developerMode: true }]
             }
         });
-        await server.get('/test/flp.html').expect(200);
+        await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
         await server.get('/adp/editor.html').expect(200);
     }, 10000);
 


### PR DESCRIPTION
The `sap-ui-xx-viewCache=false` URL parameter ensures that changes made during development are reflected in the applications preview. Some projects and scripts are missing this parameter - In that case a reroute will happen and the parameter will be added.