### PR TITLE
fix: Bind i18n models with namespace

### DIFF
--- a/packages/preview-middleware-client/src/cpe/changes/flex-change.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/flex-change.ts
@@ -35,7 +35,7 @@ export async function applyChange(options: UI5AdaptationOptions, change: Propert
         const changeType = isBindingString ? 'BindProperty' : 'Property';
 
         if (isBindingModel) {
-            validateBindingModel(modifiedControl, change.value as string);
+            await validateBindingModel(modifiedControl, change.value as string);
         }
 
         const property = isBindingString ? 'newBinding' : 'newValue';

--- a/packages/preview-middleware-client/src/cpe/changes/validator.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/validator.ts
@@ -1,6 +1,7 @@
 import ResourceBundle from 'sap/base/i18n/ResourceBundle';
 import ResourceModel from 'sap/ui/model/resource/ResourceModel';
 import type UI5Element from 'sap/ui/core/Element';
+import { getTextBundle } from '../../i18n';
 
 /**
  * Function to validate if a given value is a valid binding model.
@@ -8,26 +9,27 @@ import type UI5Element from 'sap/ui/core/Element';
  * @param modifiedControl control to be modified.
  * @param value value to be checked.
  */
-export function validateBindingModel(modifiedControl: UI5Element, value: string): void {
+export async function validateBindingModel(modifiedControl: UI5Element, value: string): Promise<void> {
+    const textBundle = await getTextBundle();
     const bindingValue = value.replace(/[{}]/gi, '').trim();
     const bindingParts = bindingValue.split('>').filter((el) => el !== '');
 
     if (!bindingParts.length) {
-        throw new SyntaxError('Invalid binding string.');
+        throw new SyntaxError(textBundle.getText('INVALID_BINDING_STRING'));
     }
 
-    if (bindingParts[0].trim() === 'i18n') {
-        if (bindingParts.length === 2) {
-            const resourceKey = bindingParts[1].trim();
-            const resourceBundle = (modifiedControl.getModel('i18n') as ResourceModel).getResourceBundle() as ResourceBundle;
-            if (!resourceBundle.getText(resourceKey, undefined, true)) {
-                throw new SyntaxError(
-                    'Invalid key in the binding string. Supported value pattern is {i18n>YOUR_KEY}. Check if the key already exists in i18n.properties.' +
-                        'If not, add the key in the i18n.properties file and reload the editor for the new key to take effect.'
-                );
-            }
-        } else {
-            throw new SyntaxError('Invalid binding string. Supported value pattern is {i18n>YOUR_KEY}');
+    if (bindingParts.length === 2) {
+        const bindingModel = bindingParts[0];
+        const resourceKey = bindingParts[1].trim();
+        const resourceModel = (modifiedControl.getModel(bindingModel) as ResourceModel);
+        if(!resourceModel) {
+            throw new SyntaxError(textBundle.getText('INVALID_BINDING_MODEL'));
         }
+        const resourceBundle = resourceModel.getResourceBundle() as ResourceBundle;
+        if (!resourceBundle.getText(resourceKey, undefined, true)) {
+            throw new SyntaxError(textBundle.getText('INVALID_BINDING_MODEL_KEY'));
+        }
+    } else {
+        throw new SyntaxError(textBundle.getText('INVALID_BINDING_STRING_FORMAT'));
     }
 }

--- a/packages/preview-middleware-client/src/messagebundle.properties
+++ b/packages/preview-middleware-client/src/messagebundle.properties
@@ -56,3 +56,8 @@ EXTEND_WITH_ANNOTATION=Extend With Annotation
 ANNOTATION_FILE_HAS_BEEN_FOUND=An annotation file has been found.
 SHOW_FILE_IN_VSCODE=Show File in VSCode
 
+INVALID_BINDING_STRING=Invalid binding string.
+INVALID_BINDING_STRING_FORMAT=Invalid binding string. Supported value pattern is {i18n>YOUR_KEY}
+INVALID_BINDING_MODEL=Invalid binding model.
+INVALID_BINDING_MODEL_KEY=Invalid key in the binding string. Supported value pattern is {i18n>YOUR_KEY}. Check if the key already exists in i18n.properties.If not, add the key in the i18n.properties file and reload the editor for the new key to take effect.
+

--- a/packages/preview-middleware-client/test/unit/cpe/changes/validator.spec.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/changes/validator.spec.ts
@@ -11,31 +11,45 @@ describe('vaildateBindingModel', () => {
             )
         })
     };
-    test('should throw when invalid binding model string is provided', () => {
+    test('should throw when invalid binding model string is provided', async () => {
         try {
-            validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{}');
+            await validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{}');
         } catch (error) {
             expect(error).toBeInstanceOf(SyntaxError);
             expect(error.message).toBe('Invalid binding string.');
         }
     });
 
-    test('should throw when invalid binding string for i18n model is provided', () => {
+    test('should throw when invalid binding string for i18n model is provided', async () => {
         try {
-            validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{ i18n }');
+            await validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{ i18n }');
         } catch (error) {
             expect(error).toBeInstanceOf(SyntaxError);
             expect(error.message).toBe('Invalid binding string. Supported value pattern is {i18n>YOUR_KEY}');
         }
     });
 
-    test('should throw when the provided key does not exist in i18n.properties', () => {
+    test('should throw when the provided key does not exist in i18n.properties', async () => {
         try {
-            validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{ i18n>test }');
+            await validateBindingModel(mockModifiedcontrol as unknown as UI5Element, '{ i18n>test }');
         } catch (error) {
             expect(error).toBeInstanceOf(SyntaxError);
             expect(error.message).toBe(
                 'Invalid key in the binding string. Supported value pattern is {i18n>YOUR_KEY}. Check if the key already exists in i18n.properties.If not, add the key in the i18n.properties file and reload the editor for the new key to take effect.'
+            );
+        }
+    });
+
+    test('should throw error when invalid binding model is provided', async () => {
+        const control = {
+            getModel: jest.fn().mockReturnValue(undefined)
+        };
+        try {
+            await validateBindingModel(control as unknown as UI5Element, '{ i18n|namespace>test }');
+        } catch (error) {
+            expect(error).toBeInstanceOf(SyntaxError);
+            expect(error.message).toBe(
+                'Invalid binding model.'
             );
         }
     });


### PR DESCRIPTION
Fix for #2829 

- Bind i18n models that contains namespace