### PR TITLE
feat: Delete one backend per service

### DIFF
--- a/.changeset/rude-lobsters-punch.md
+++ b/.changeset/rude-lobsters-punch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-config': patch
+---
+
+Delete only one backend entry per service.

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -332,22 +332,19 @@ export class UI5Config {
         const proxyMiddlewareConfig = proxyMiddlewareYamlContent?.configuration;
         // Add new entry to existing backend configurations in yaml
         if (proxyMiddlewareConfig?.backend) {
-            // Avoid adding duplicates by checking existing backend configs
-            if (!proxyMiddlewareConfig.backend.find((existingBackend) => existingBackend.url === backend.url)) {
-                backendNode = this.document.createNode({
-                    value: backend,
-                    comments
-                });
-                const configuration = this.document.getMap({
-                    start: proxyMiddleware as YAMLMap,
-                    path: 'configuration'
-                });
-                const backendConfigs = this.document.getSequence({ start: configuration, path: 'backend' });
-                if (backendConfigs.items.length === 0) {
-                    configuration.set('backend', [backendNode]);
-                } else {
-                    backendConfigs.add(backendNode);
-                }
+            backendNode = this.document.createNode({
+                value: backend,
+                comments
+            });
+            const configuration = this.document.getMap({
+                start: proxyMiddleware as YAMLMap,
+                path: 'configuration'
+            });
+            const backendConfigs = this.document.getSequence({ start: configuration, path: 'backend' });
+            if (backendConfigs.items.length === 0) {
+                configuration.set('backend', [backendNode]);
+            } else {
+                backendConfigs.add(backendNode);
             }
         } else {
             // Create a new 'backend' node in yaml for middleware config
@@ -374,9 +371,13 @@ export class UI5Config {
             const proxyMiddlewareConfig = fioriToolsProxyMiddleware?.configuration;
             // Remove backend from middleware configurations in yaml
             if (proxyMiddlewareConfig?.backend) {
-                proxyMiddlewareConfig.backend = proxyMiddlewareConfig.backend.filter(
-                    (existingBackend) => existingBackend.url !== backendUrl
+                // Avoid using filter method, because multiple services could have same backend url, we should delete one entry per service
+                const existingBackendIndex = proxyMiddlewareConfig.backend.findIndex(
+                    (backend) => backend.url === backendUrl
                 );
+                if (existingBackendIndex !== -1) {
+                    proxyMiddlewareConfig.backend.splice(existingBackendIndex, 1);
+                }
                 this.updateCustomMiddleware(fioriToolsProxyMiddleware);
             }
         }

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -266,14 +266,9 @@ describe('UI5Config', () => {
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
-        test('should not add duplicate', () => {
-            ui5Config.addFioriToolsProxydMiddleware({ ui5: {} });
-            // Add backend
-            ui5Config.addBackendToFioriToolsProxydMiddleware({
-                url,
-                path
-            });
-            // Try to add same backend
+        test('handle duplicate backend', () => {
+            ui5Config.addFioriToolsProxydMiddleware({ backend: [{ url, path }], ui5: {} });
+            // Add same backend
             ui5Config.addBackendToFioriToolsProxydMiddleware({
                 url,
                 path
@@ -281,6 +276,10 @@ describe('UI5Config', () => {
             const fioriToolsProxyMiddlewareConfig =
                 ui5Config.findCustomMiddleware<FioriToolsProxyConfig>(fioriToolsProxy)?.configuration;
             expect(fioriToolsProxyMiddlewareConfig?.backend).toStrictEqual([
+                {
+                    path: '/~testpath~',
+                    url: 'http://localhost:8080'
+                },
                 {
                     path: '/~testpath~',
                     url: 'http://localhost:8080'
@@ -370,6 +369,25 @@ describe('UI5Config', () => {
         test('try removing backend without a proxy middleware added before', () => {
             ui5Config.addFioriToolsAppReloadMiddleware();
             expect(() => ui5Config.removeBackendFromFioriToolsProxydMiddleware(url)).toThrowError();
+        });
+
+        test('only one occurance per backend should be deleted', () => {
+            // Create proxy middleware with backend config
+            ui5Config.addFioriToolsProxydMiddleware({ backend: [{ url, path }], ui5: {} });
+            // Add same backend
+            ui5Config.addBackendToFioriToolsProxydMiddleware({
+                url,
+                path
+            });
+            ui5Config.removeBackendFromFioriToolsProxydMiddleware(url);
+            const fioriToolsProxyMiddlewareConfig =
+                ui5Config.findCustomMiddleware<FioriToolsProxyConfig>(fioriToolsProxy)?.configuration;
+            expect(fioriToolsProxyMiddlewareConfig?.backend).toStrictEqual([
+                {
+                    path: '/~testpath~',
+                    url: 'http://localhost:8080'
+                }
+            ]);
         });
     });
 


### PR DESCRIPTION
Replaced deletion logic from `filter` in `removeBackendFromFioriToolsProxydMiddleware` method to `findIndex` and `splice` combination to allow to delete only one backend instance for `fiori-tools-proxy middleware`.

Reason: Possible duplicated backend entries for multiple services from same system and filter deletes all of them.