### PR TITLE
Fix/preview middleware/ui5 version request protocol for karma

### DIFF
--- a/.changeset/olive-bulldogs-tie.md
+++ b/.changeset/olive-bulldogs-tie.md
@@ -2,4 +2,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-fix: ui5 version host for karma tests
+fix: ui5 version protocol for karma tests

--- a/.changeset/olive-bulldogs-tie.md
+++ b/.changeset/olive-bulldogs-tie.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix: ui5 version host for karma tests

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -318,7 +318,8 @@ export class FlpSandbox {
             } else {
                 const ui5Version = await this.getUi5Version(
                     req.protocol,
-                    req.headers.host,
+                    //use host from request header referer as fallback for karma (connect API)
+                    req.headers.host ?? req.headers.referer?.substring(0, req.headers.referer.indexOf(':')),
                     req['ui5-patched-router']?.baseUrl
                 );
                 const html = render(this.getSandboxTemplate(ui5Version.major), this.templateConfig);

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -348,7 +348,7 @@ export class FlpSandbox {
             this.logger.error('Unable to fetch UI5 version: No host found in request header.');
         } else {
             try {
-                const versionUrl = `${protocol}://${host}${baseUrl}/resources/sap-ui-version.json`;
+                const versionUrl = `${protocol ?? 'http'}://${host}${baseUrl}/resources/sap-ui-version.json`;
                 const responseJson = (await fetch(versionUrl).then((res) => res.json())) as
                     | { libraries: { name: string; version: string }[] }
                     | undefined;


### PR DESCRIPTION
The `headers` object of a [connect](https://github.com/senchalabs/connect) API request does not know the `host` property. In this case we extract it from the `referer`.