### PR TITLE
fix: make sure the canvas dependency is not required

### DIFF
--- a/packages/jest-environment-ui5/README.md
+++ b/packages/jest-environment-ui5/README.md
@@ -59,6 +59,27 @@ framework:
         - name: sap.m
 ```
 
+### Options
+
+You can define with the following options in the `jest.config.js` file:
+
+##### Enable css support
+
+By default the css is not supported and are not loaded when you run the test through jest.
+In some case, it might make sense to have css enabled. To enable it, you need to add the following configuration in jest.config.js
+If you enable CSS, you will need to pull the `canvas` package as a dependency.
+```javascript
+module.exports = {
+    // use custom test environment
+    testEnvironment: "@sap-ux/jest-environment-ui5",
+    
+    testEnvironmentOptions: {
+        allowCSS: true
+    }   
+};
+```
+
+
 ## Enable reporting
 ```json
     "devDependencies": {

--- a/packages/jest-environment-ui5/src/index.js
+++ b/packages/jest-environment-ui5/src/index.js
@@ -52,6 +52,12 @@ class UI5DOMEnvironment extends JSDOMEnvironment {
         context.testPath = this.testPath;
         global.window = context;
         global.Object = context.Object;
+        if (!this.allowCSS) {
+            global.CanvasRenderingContext2D = function () {};
+            context.HTMLCanvasElement.prototype.getContext = () => {};
+            window.CanvasRenderingContext2D = function () {};
+        }
+
         window.NewObject = Object;
         [
             'sap',

--- a/packages/jest-environment-ui5/test/unit/index.test.js
+++ b/packages/jest-environment-ui5/test/unit/index.test.js
@@ -1,4 +1,5 @@
 const jestCLI = require('jest');
+const UI5DOMEnvironment = require('../../src');
 describe('Custom environment', () => {
     it('Can be created', async () => {
         let failed = false;
@@ -11,4 +12,42 @@ describe('Custom environment', () => {
 
         // This is done centrally in the CustomEnvironment constructor but we need to call it here for the test purpose
     }, 60000);
+
+    it('should not mock the canvas runtime if allowCSS is true', async () => {
+        global.requireFn = require;
+        global.CanvasRenderingContext2D = undefined;
+        const domStuff = new UI5DOMEnvironment(
+            { globalConfig: {}, projectConfig: { setupFiles: [], testEnvironmentOptions: { allowCSS: true } } },
+            { console: console, testPath: '' }
+        );
+        try {
+            await domStuff.setup();
+        } catch (e) {
+            console.error(e);
+        }
+        expect(global.CanvasRenderingContext2D).toBeUndefined();
+    });
+
+    it('should mock the canvas runtime if allowCSS is false', async () => {
+        global.requireFn = require;
+        global.CanvasRenderingContext2D = undefined;
+        const domStuff = new UI5DOMEnvironment(
+            { globalConfig: {}, projectConfig: { setupFiles: [], testEnvironmentOptions: {} } },
+            { console: console, testPath: '' }
+        );
+        try {
+            await domStuff.setup();
+        } catch (e) {
+            console.error(e);
+        }
+
+        expect(global.CanvasRenderingContext2D).toBeDefined();
+        let hasError = false;
+        try {
+            global.CanvasRenderingContext2D();
+        } catch (e) {
+            hasError = true;
+        }
+        expect(hasError).toBe(false);
+    });
 });


### PR DESCRIPTION
With the previous change I removed the possibility to run the test without having `canvas` installed.
This is now enabled again, and `canvas` is only required when `allowCSS` is set to true