### PR TITLE
fix: add check for initialized fiori integrity

### DIFF
--- a/.changeset/late-plants-accept.md
+++ b/.changeset/late-plants-accept.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-integrity': minor
+---
+
+Add function to check if Fiori project integrity is initialized

--- a/packages/project-integrity/src/fiori-project/index.ts
+++ b/packages/project-integrity/src/fiori-project/index.ts
@@ -116,3 +116,14 @@ export async function disableFioriProjectIntegrity(projectRoot: string): Promise
     const integrityFilePath = join(projectRoot, fioriIntegrityDataPath);
     await disableProjectIntegrity(integrityFilePath);
 }
+
+/**
+ * Check if the Fiori project integrity is initialized for given root path of a project.
+ * This is also true if the Fiori project is disabled, but the integrity data is present.
+ *
+ * @param projectRoot - root folder of the project
+ * @returns - true if the Fiori project integrity is initialized, false otherwise
+ */
+export function isFioriProjectIntegrityInitialized(projectRoot: string): boolean {
+    return existsSync(join(projectRoot, fioriIntegrityDataPath));
+}

--- a/packages/project-integrity/src/index.ts
+++ b/packages/project-integrity/src/index.ts
@@ -12,5 +12,6 @@ export {
     enableFioriProjectIntegrity,
     initFioriProject,
     isFioriProjectIntegrityEnabled,
+    isFioriProjectIntegrityInitialized,
     updateFioriProjectIntegrity
 } from './fiori-project';

--- a/packages/project-integrity/test/unit/fiori-project/index.test.ts
+++ b/packages/project-integrity/test/unit/fiori-project/index.test.ts
@@ -5,6 +5,7 @@ import {
     enableFioriProjectIntegrity,
     initFioriProject,
     isFioriProjectIntegrityEnabled,
+    isFioriProjectIntegrityInitialized,
     updateFioriProjectIntegrity
 } from '../../../src';
 import * as persistence from '../../../src/integrity/persistence';
@@ -119,5 +120,21 @@ describe('Test disableFioriProjectIntegrity()', () => {
             'fileIntegrity': [],
             'contentIntegrity': []
         });
+    });
+});
+
+describe('Test isFioriProjectIntegrityInitialized()', () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('Disabled but initialized Fiori project', () => {
+        const projectRoot = join(__dirname, '../../test-input/disabled-fiori-project');
+        expect(isFioriProjectIntegrityInitialized(projectRoot)).toBe(true);
+    });
+
+    test('Uninitialized Fiori project', () => {
+        const projectRoot = join(__dirname, '../../test-input/invalid-fiori-project-no-schema-cds');
+        expect(isFioriProjectIntegrityInitialized(projectRoot)).toBe(false);
     });
 });

--- a/packages/project-integrity/test/unit/index.test.ts
+++ b/packages/project-integrity/test/unit/index.test.ts
@@ -1,6 +1,7 @@
 import {
     initFioriProject,
     initProject,
+    isFioriProjectIntegrityInitialized,
     checkFioriProjectIntegrity,
     checkProjectIntegrity,
     updateFioriProjectIntegrity,
@@ -17,4 +18,5 @@ test('Check public interface for Fiori project integrity', () => {
     expect(typeof initFioriProject).toBe('function');
     expect(typeof checkFioriProjectIntegrity).toBe('function');
     expect(typeof updateFioriProjectIntegrity).toBe('function');
+    expect(typeof isFioriProjectIntegrityInitialized).toBe('function');
 });


### PR DESCRIPTION
When using module `@sap-ux/project-integrity`, there is currently no way to check if a Fiori project has enabled integrity check. The only way is with try and error. 

This pull request adds function `isFioriProjectIntegrityInitialized(projectRoot: string): boolean` to check, whether integrity has been enabled for a Fiori project without the need of `try`/`catch`.