### PR TITLE
project-access - filter CAP services to only include odata services

### DIFF
--- a/.changeset/short-knives-clean.md
+++ b/.changeset/short-knives-clean.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+filter CAP services to include odata only

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -208,6 +208,15 @@ export async function getCapModelAndServices(
     _logger?.info(`@sap-ux/project-access:getCapModelAndServices - Using 'projectRoot': ${_projectRoot}`);
 
     let services = cds.compile.to.serviceinfo(model, { root: _projectRoot }) ?? [];
+    // filter services that have ( urlPath defined AND no endpoints) OR have endpoints with kind 'odata'
+    // i.e. ignore services for websockets and other unsupported protocols
+    if (services.filter) {
+        services = services.filter(
+            (service) =>
+                (service.urlPath && service.endpoints === undefined) ||
+                service.endpoints?.find((endpoint) => endpoint.kind === 'odata')
+        );
+    }
     if (services.map) {
         services = services.map((value) => {
             const { endpoints, urlPath } = value;

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -153,6 +153,16 @@ describe('Test getCapModelAndServices()', () => {
                                 }
                             ],
                             'runtime': 'Node.js'
+                        },
+                        {
+                            'name': 'withRuntime',
+                            'endpoints': [
+                                {
+                                    'path': 'url',
+                                    'kind': 'websocket'
+                                }
+                            ],
+                            'runtime': 'Node.js'
                         }
                     ])
                 }
@@ -231,7 +241,7 @@ describe('Test getCapModelAndServices()', () => {
                             'endpoints': [
                                 {
                                     'path': 'url',
-                                    'kind': 'rest'
+                                    'kind': 'odata'
                                 }
                             ],
                             'runtime': 'Node.js'
@@ -252,14 +262,6 @@ describe('Test getCapModelAndServices()', () => {
         expect(capMS).toEqual({
             model: 'MODEL',
             services: [
-                {
-                    'name': 'Forwardslash',
-                    'urlPath': 'odata/service/with/forwardslash/'
-                },
-                {
-                    'name': 'Backslash',
-                    'urlPath': 'odata/service/with/backslash/'
-                },
                 {
                     'name': 'withRuntime',
                     'urlPath': 'url',


### PR DESCRIPTION
Accomodate change in `@sap/cds@8.5.0` where services might not have a urlPath or `endpoints property in the serviceinfo 

```
@protocol: 'websocket'
service CatalogService {
    entity Books {
        key ID : Integer;
        title  : String;
        stock  : Integer;
    }
}
```
now results in:

$  cds c srv -2 serviceinfo
```
[
  {
    name: 'CatalogService',
    destination: 'srv-api',
    runtime: 'Node.js',
    location: {
      file: 'srv/cat-service.cds',
      line: 2,
      col: 9
    }
  }
]
```