### PR TITLE
fix(cf-gen): fix unstable windows test

### DIFF
--- a/packages/cf-deploy-config-sub-generator/test/app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/app.test.ts
@@ -745,7 +745,7 @@ describe('Cloud foundry generator tests', () => {
             cfDestination: 'ABHE_sap_opu_odata_sap_ZUI_RAP_TRAVEL_M_U025',
             isAbapDirectServiceBinding: false,
             isCap: false,
-            projectRoot: appDir
+            projectRoot: expect.stringContaining(appDir)
         });
     });
 


### PR DESCRIPTION
The `D:` is seems to be intermittently included in the path, and failing the expected test

![image](https://github.com/user-attachments/assets/46b34ddc-5b62-4d8e-9e3d-feaeffd9dc0a)
