### PR TITLE
feat: Scroll into view when clicking on a `control` that is not currently visible in the `iframe`

### DIFF
--- a/.changeset/pretty-rats-change.md
+++ b/.changeset/pretty-rats-change.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+feat: Scroll into view when clicking on a control that is not currently visible in the iframe

--- a/packages/preview-middleware-client/src/cpe/selection.ts
+++ b/packages/preview-middleware-client/src/cpe/selection.ts
@@ -136,7 +136,9 @@ export class SelectionService implements Service {
                     selectedOverlayControl.setSelected(false); //deselect previously selected control
                 }
 
-                if (!controlOverlay?.getDomRef()) {
+                const controlRef = controlOverlay?.getDomRef?.();
+                controlRef?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+                if (!controlRef) {
                     //look for closest control in order to highlight in UI the (without firing the selection event)
                     controlOverlay = OverlayUtil.getClosestOverlayFor(control);
                 }


### PR DESCRIPTION
Feat for #2873.
- Calls the `scrollIntoView` method on the dom element of the control.