### PR TITLE
fix(cf-gen): move cap check logic

### DIFF
--- a/.changeset/bright-buses-obey.md
+++ b/.changeset/bright-buses-obey.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+move cap conditional logic

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -165,20 +165,23 @@ export default class extends DeploymentGenerator {
             return;
         }
 
+        if (!this.launchDeployConfigAsSubGenerator) {
+            await this._prompting();
+        }
+
+        await this._reconcileAnswersWithOptions();
+    }
+
+    private async _prompting(): Promise<void> {
         if (this.isCap && this.projectRoot && !this.mtaPath) {
             // if the user is adding deploy config to a CAP project and there is no mta.yaml in the root, then log error and exit
             this.abort = true;
             handleErrorMessage(this.appWizard, { errorType: ERROR_TYPE.CAP_DEPLOYMENT_NO_MTA });
             return;
         }
-
-        if (!this.launchDeployConfigAsSubGenerator) {
-            await this._handleApiHubConfig();
-            const questions = await this._getCFQuestions();
-            this.answers = await this.prompt(questions);
-        }
-
-        await this._reconcileAnswersWithOptions();
+        await this._handleApiHubConfig();
+        const questions = await this._getCFQuestions();
+        this.answers = await this.prompt(questions);
     }
 
     /**

--- a/packages/cf-deploy-config-sub-generator/test/app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/app.test.ts
@@ -847,6 +847,39 @@ describe('Cloud foundry generator tests', () => {
         `);
     });
 
+    it('Should throw error when no mta found for CAP project', async () => {
+        hasbinSyncMock.mockReturnValue(true);
+        mockGetHostEnvironment.mockReturnValue(hostEnvironment.cli);
+        mockFindCapProjectRoot.mockReturnValueOnce('/capRoot');
+
+        memfs.vol.fromNestedJSON(
+            {
+                [`.${OUTPUT_DIR_PREFIX}/app1/package.json`]: JSON.stringify({ scripts: {} }),
+                [`.${OUTPUT_DIR_PREFIX}/app1/ui5.yaml`]: testFixture.getContents('app1/ui5.yaml')
+            },
+            '/'
+        );
+        const appDir = join(OUTPUT_DIR_PREFIX, 'app1');
+
+        await expect(
+            yeomanTest
+                .create(
+                    CFGenerator,
+                    {
+                        resolved: cfGenPath
+                    },
+                    { cwd: appDir }
+                )
+                .withOptions({
+                    skipInstall: true
+                })
+                .withPrompts({})
+                .run()
+        ).rejects.toThrowError(
+            `The SAP Fiori application is within a CAP project and deployment should be configured as part of the CAP project. Please ensure you have a mta.yaml file defined for this project.`
+        );
+    });
+
     it('Should throw error when mta executable is not found (CLI)', async () => {
         hasbinSyncMock.mockReturnValue(false);
         mockGetHostEnvironment.mockReturnValue(hostEnvironment.cli);


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2843

As `this.isCap` is only defined when the generator is not ran as `launchDeployConfigAsSubGenerator`, the check for `isCap` should move within the same condition