### PR TITLE
fix: Handling of ignoreCertError property from service in proxy middleware

### DIFF
--- a/.changeset/cyan-islands-look.md
+++ b/.changeset/cyan-islands-look.md
@@ -3,4 +3,4 @@
 '@sap-ux/ui5-config': patch
 ---
 
-Handle ignoreCertError in proxy middleware coming from service.
+Handling of `ignoreCertError` property from service in proxy middleware.

--- a/.changeset/cyan-islands-look.md
+++ b/.changeset/cyan-islands-look.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/odata-service-writer': patch
+'@sap-ux/ui5-config': patch
+---
+
+Handle ignoreCertError in proxy middleware coming from service.

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -104,7 +104,10 @@ async function generateMockserverMiddlewareBasedOnUi5MockYaml(
  */
 function extendBackendMiddleware(fs: Editor, service: OdataService, ui5Config: UI5Config, ui5ConfigPath: string): void {
     try {
-        ui5Config.addBackendToFioriToolsProxydMiddleware(service.previewSettings as ProxyBackend);
+        ui5Config.addBackendToFioriToolsProxydMiddleware(
+            service.previewSettings as ProxyBackend,
+            service.ignoreCertError
+        );
     } catch (error: any) {
         if (
             (error instanceof YAMLError && error.code === yamlErrorCode.nodeNotFound) ||

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -325,7 +325,8 @@ describe('generate', () => {
                     apiHub: true,
                     scp: false,
                     pathPrefix: '/~prefix'
-                }
+                },
+                ignoreCertError: true
             };
 
             await generate(testDir, config as OdataService, fs);
@@ -337,7 +338,7 @@ describe('generate', () => {
                     - name: fiori-tools-proxy
                       afterMiddleware: compression
                       configuration:
-                        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+                        ignoreCertError: true # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
                         ui5:
                           path:
                             - /resources

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -324,7 +324,7 @@ export class UI5Config {
     public addBackendToFioriToolsProxydMiddleware(
         backend: FioriToolsProxyConfigBackend,
         ignoreCertError: boolean = false
-    ): UI5Config {
+    ): this {
         const middlewareList = this.document.getSequence({ path: 'server.customMiddleware' });
         const proxyMiddleware = this.document.findItem(middlewareList, (item: any) => item.name === fioriToolsProxy);
         if (!proxyMiddleware) {

--- a/packages/ui5-config/src/ui5config.ts
+++ b/packages/ui5-config/src/ui5config.ts
@@ -317,10 +317,14 @@ export class UI5Config {
      * Adds a backend configuration to an existing fiori-tools-proxy middleware keeping any existing 'fiori-tools-proxy' backend configurations. If the config does not contain a fiori-tools-proxy middleware, an error is thrown.
      *
      * @param backend config of backend that is to be proxied
+     * @param ignoreCertError if true some certificate errors are ignored
      * @returns {UI5Config} the UI5Config instance
      * @memberof UI5Config
      */
-    public addBackendToFioriToolsProxydMiddleware(backend: FioriToolsProxyConfigBackend): UI5Config {
+    public addBackendToFioriToolsProxydMiddleware(
+        backend: FioriToolsProxyConfigBackend,
+        ignoreCertError: boolean = false
+    ): UI5Config {
         const middlewareList = this.document.getSequence({ path: 'server.customMiddleware' });
         const proxyMiddleware = this.document.findItem(middlewareList, (item: any) => item.name === fioriToolsProxy);
         if (!proxyMiddleware) {
@@ -340,6 +344,9 @@ export class UI5Config {
                 start: proxyMiddleware as YAMLMap,
                 path: 'configuration'
             });
+            if (ignoreCertError !== undefined && proxyMiddlewareConfig.ignoreCertError !== ignoreCertError) {
+                configuration.set('ignoreCertError', ignoreCertError);
+            }
             const backendConfigs = this.document.getSequence({ start: configuration, path: 'backend' });
             if (backendConfigs.items.length === 0) {
                 configuration.set('backend', [backendNode]);
@@ -352,6 +359,11 @@ export class UI5Config {
             this.document
                 .getMap({ start: proxyMiddleware as YAMLMap, path: 'configuration' })
                 .set('backend', [backendNode]);
+            if (ignoreCertError !== undefined && proxyMiddlewareConfig?.ignoreCertError !== ignoreCertError) {
+                this.document
+                    .getMap({ start: proxyMiddleware as YAMLMap, path: 'configuration' })
+                    .set('ignoreCertError', ignoreCertError);
+            }
         }
         return this;
     }

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -266,6 +266,21 @@ describe('UI5Config', () => {
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
+        test('add backend and update the "ignoreCertError" property', () => {
+            const expectedIgnoreCertError = true;
+            ui5Config.addFioriToolsProxydMiddleware({ ui5: {}, ignoreCertError: false });
+            ui5Config.addBackendToFioriToolsProxydMiddleware(
+                {
+                    url,
+                    path
+                },
+                expectedIgnoreCertError
+            );
+            const fioriToolsProxyMiddlewareConfig =
+                ui5Config.findCustomMiddleware<FioriToolsProxyConfig>(fioriToolsProxy)?.configuration;
+            expect(fioriToolsProxyMiddlewareConfig?.ignoreCertError).toEqual(expectedIgnoreCertError);
+        });
+
         test('handle duplicate backend', () => {
             ui5Config.addFioriToolsProxydMiddleware({ backend: [{ url, path }], ui5: {} });
             // Add same backend

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -281,6 +281,21 @@ describe('UI5Config', () => {
             expect(fioriToolsProxyMiddlewareConfig?.ignoreCertError).toEqual(expectedIgnoreCertError);
         });
 
+        test('add backend and do not update the "ignoreCertError" property', () => {
+            const expectedIgnoreCertError = false;
+            ui5Config.addFioriToolsProxydMiddleware({ ui5: {}, ignoreCertError: false });
+            ui5Config.addBackendToFioriToolsProxydMiddleware(
+                {
+                    url,
+                    path
+                },
+                expectedIgnoreCertError
+            );
+            const fioriToolsProxyMiddlewareConfig =
+                ui5Config.findCustomMiddleware<FioriToolsProxyConfig>(fioriToolsProxy)?.configuration;
+            expect(fioriToolsProxyMiddlewareConfig?.ignoreCertError).toEqual(expectedIgnoreCertError);
+        });
+
         test('handle duplicate backend', () => {
             ui5Config.addFioriToolsProxydMiddleware({ backend: [{ url, path }], ui5: {} });
             // Add same backend


### PR DESCRIPTION
Issue - https://github.com/SAP/open-ux-tools/issues/2885

`ignoreCertError` is a part of OData service interface and also a part of proxy `middlware.configuration`.
If `ignoreCertError` in middleware differs from the `ignoreCertError` of the service that is being added, `addBackendToFioriToolsProxydMiddleware` will also update the `middlware.configuration.ignoreCertError`.