### PR TITLE
fix: bump playwright and use chrome as browser

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,9 +64,9 @@ jobs:
                   ${{ runner.os != 'Windows' }}:
                     ~/.cache/ms-playwright
                 key: playwright-browsers-os-${{ matrix.os }}-node-version-${{ matrix.node-version }}
-            - name: Install playwright browsers
+            - name: Install playwright chrome browsers
               if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-              run: npx playwright install --with-deps
+              run: npx playwright install chrome
             - name: Run integration tests
               run: pnpm run test:integration
               env:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "private": true,
     "devDependencies": {
         "@changesets/cli": "2.27.10",
-        "@playwright/test": "1.39.0",
+        "@playwright/test": "1.50.1",
         "@types/jest": "29.5.5",
         "@types/node": "18.11.9",
         "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -33,7 +33,7 @@
         "!dist/**/*.map"
     ],
     "dependencies": {
-        "@playwright/test": "1.39.0",
+        "@playwright/test": "1.50.1",
         "@sap-ux/logger": "0.6.0",
         "fs-extra": "11.1.1",
         "jest-dev-server": "10.0.0",

--- a/packages/preview-middleware/playwright.config.ts
+++ b/packages/preview-middleware/playwright.config.ts
@@ -31,8 +31,8 @@ const config: PlaywrightTestConfig = {
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'chromium',
-            use: { ...devices['Desktop Chrome'], viewport: { width: 1720, height: 900 } }
+            name: 'Google Chrome',
+            use: { ...devices['Desktop Chrome'], channel: 'chrome', viewport: { width: 1720, height: 900 } }
         }
     ],
     /* 5 min for npm i + 30000 ms default timeout */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 2.27.10
         version: 2.27.10
       '@playwright/test':
-        specifier: 1.39.0
-        version: 1.39.0
+        specifier: 1.50.1
+        version: 1.50.1
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -2672,8 +2672,8 @@ importers:
   packages/playwright:
     dependencies:
       '@playwright/test':
-        specifier: 1.39.0
-        version: 1.39.0
+        specifier: 1.50.1
+        version: 1.50.1
       '@sap-ux/logger':
         specifier: 0.6.0
         version: link:../logger
@@ -8226,11 +8226,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@playwright/test@1.39.0:
-    resolution: {integrity: sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.50.1:
+    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
+    engines: {node: '>=18'}
+    hasBin: true
     dependencies:
-      playwright: 1.39.0
+      playwright: 1.50.1
 
   /@pnpm/config.env-replace@1.1.0:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -19042,15 +19043,17 @@ packages:
       find-up: 6.3.0
     dev: true
 
-  /playwright-core@1.39.0:
-    resolution: {integrity: sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==}
-    engines: {node: '>=16'}
+  /playwright-core@1.50.1:
+    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
-  /playwright@1.39.0:
-    resolution: {integrity: sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==}
-    engines: {node: '>=16'}
+  /playwright@1.50.1:
+    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
+    engines: {node: '>=18'}
+    hasBin: true
     dependencies:
-      playwright-core: 1.39.0
+      playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
This PR
* Bump playwright version
* Adapt Github action to only install Chrome browser - as this is the only browser UI integration tests are running. 