### PR TITLE
feat: create application access from project -> `createApplicationAccessFromProject`

### DIFF
--- a/packages/project-access/src/index.ts
+++ b/packages/project-access/src/index.ts
@@ -4,6 +4,7 @@ export {
     addPackageDevDependency,
     clearCdsModuleCache,
     createApplicationAccess,
+    createApplicationAccessFromProject,
     createProjectAccess,
     deleteCapApp,
     filterDataSourcesByType,

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -304,6 +304,40 @@ function isEditor(argument: Editor | ApplicationAccessOptions): argument is Edit
 }
 
 /**
+ * Extracts `ApplicationAccessOptions` from the provided `fs` parameter.
+ *
+ * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node.
+ * In case of CAP project, some CDS APIs are used internally which depends on `fs` of node and not `mem-fs-editor`.
+ * When calling this function, adding or removing a CDS file in memory or changing CDS configuration will not be considered until present on real file system.
+ * @returns The extracted `ApplicationAccessOptions`.
+ */
+function getApplicationAccessOptions(fs?: Editor | ApplicationAccessOptions): ApplicationAccessOptions | undefined {
+    let options: ApplicationAccessOptions | undefined;
+    if (fs) {
+        options = isEditor(fs) ? { fs } : fs;
+    }
+    return options;
+}
+
+/**
+ * Create an instance of ApplicationAccess from passed project that contains information about the application, like paths and services.
+ *
+ * @param project - Project data
+ * @param appId - application ID
+ * @param fs optional `mem-fs-editor` instance. If provided, `mem-fs-editor` api is used instead of `fs` of node.
+ * In case of CAP project, some CDS APIs are used internally which depends on `fs` of node and not `mem-fs-editor`.
+ * When calling this function, adding or removing a CDS file in memory or changing CDS configuration will not be considered until present on real file system.
+ * @returns - Instance of ApplicationAccess that contains information about the application, like paths and services
+ */
+export async function createApplicationAccessFromProject(
+    project: Project,
+    appId: string,
+    fs?: Editor | ApplicationAccessOptions
+): Promise<ApplicationAccess> {
+    return new ApplicationAccessImp(project, appId, getApplicationAccessOptions(fs));
+}
+
+/**
  * Create an instance of ApplicationAccess that contains information about the application, like paths and services.
  *
  * @param appRoot - Application root path
@@ -322,13 +356,10 @@ export async function createApplicationAccess(
         if (!app) {
             throw new Error(`Could not find app with root ${appRoot}`);
         }
-        let options: ApplicationAccessOptions | undefined;
-        if (fs) {
-            options = isEditor(fs) ? { fs } : fs;
-        }
+        const options = getApplicationAccessOptions(fs);
         const project = await getProject(app.projectRoot, options?.fs);
         const appId = relative(project.root, appRoot);
-        return new ApplicationAccessImp(project, appId, options);
+        return createApplicationAccessFromProject(project, appId, fs);
     } catch (error) {
         throw Error(`Error when creating application access for ${appRoot}: ${error}`);
     }

--- a/packages/project-access/src/project/index.ts
+++ b/packages/project-access/src/project/index.ts
@@ -39,6 +39,6 @@ export {
 } from './search';
 export { getWebappPath, readUi5Yaml, getAllUi5YamlFileNames } from './ui5-config';
 export { getMtaPath } from './mta';
-export { createApplicationAccess, createProjectAccess } from './access';
+export { createApplicationAccess, createProjectAccess, createApplicationAccessFromProject } from './access';
 export { updatePackageScript, hasUI5CliV3 } from './script';
 export { getSpecification, getSpecificationPath, refreshSpecificationDistTags } from './specification';


### PR DESCRIPTION
There is existing method `createApplicationAccess`, which calls `getProject`, where `getProject` could be performant action for large project.
In this PR adding additional method `createApplicationAccessFromProject` - so that it could be posible to create `applicationAccess` using previously resolved object of `project` data and avoid multiple calls for `getProject`