### PR TITLE
fix: enable manifest actions for v2 apps with array page structure

### DIFF
--- a/.changeset/spicy-coats-build.md
+++ b/.changeset/spicy-coats-build.md
@@ -3,4 +3,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-Enable manifest actions for v2 apps with array page structure
+fix: enable manifest actions for v2 apps with array page structure

--- a/.changeset/spicy-coats-build.md
+++ b/.changeset/spicy-coats-build.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+Enable manifest actions for v2 apps with array page structure

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -70,17 +70,17 @@ export function isManifestArrayStructured(manifest: Manifest): boolean {
  *
  * Returns `false`
  *
- *  - If the manifest is structured is an array
+ *  - If the manifest is structured is an array and is below version 1.134
  *  - If the UI5 version is not supported
  * Otherwise, returns `true`.
  *
  */
 export async function areManifestChangesSupported(manifest: Manifest): Promise<boolean> {
-    if (isManifestArrayStructured(manifest)) {
+    const version = await getUi5Version();
+    if (isLowerThanMinimalUi5Version(version, { major: 1, minor: 134 }) && isManifestArrayStructured(manifest)) {
         return false;
     }
 
-    const version = await getUi5Version();
     const isAboveOrEqualMinimalVersion = !isLowerThanMinimalUi5Version(version, { major: 1, minor: 128 });
     const isSupportedPatchVersion =
         isVersionEqualOrHasNewerPatch(version, { major: 1, minor: 96, patch: 35 }) ||

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -928,6 +928,11 @@ describe('FE V2 quick actions', () => {
                     validVersion: true,
                     versionInfo: '1.130',
                     isManifestPagesAsArray: true
+                },
+                {
+                    validVersion: true,
+                    versionInfo: '1.134.0',
+                    isManifestPagesAsArray: true
                 }
             ];
             test.each(testCases)('initialize and execute action (%s)', async (testCase) => {
@@ -1047,6 +1052,16 @@ describe('FE V2 quick actions', () => {
                                                   : 'listReport0-enable-semantic-daterange-filterbar',
                                               title: 'Enable Semantic Date Range in Filter Bar',
                                               enabled: true
+                                          }
+                                      ]
+                                    : testCase.versionInfo === '1.134.0' && testCase.isManifestPagesAsArray // support manifest pages as array from version 1.134 and above
+                                    ? [
+                                          {
+                                              enabled: true,
+                                              id: 'listReport0-enable-semantic-daterange-filterbar',
+                                              kind: 'simple',
+                                              title: 'Enable Semantic Date Range in Filter Bar',
+                                              tooltip: undefined
                                           }
                                       ]
                                     : []


### PR DESCRIPTION
Enable quick action for v2 for app descriptor changes where manifest pages has array strucure.