### PR TITLE
fix: undo redo issue for v2 manifest changes

### DIFF
--- a/.changeset/nine-dancers-greet.md
+++ b/.changeset/nine-dancers-greet.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: undo redo issue for v2 manifest changes created via quickactions

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -5,6 +5,24 @@ import CommandFactory from 'sap/ui/rta/command/CommandFactory';
 import { QuickActionContext } from '../../../cpe/quick-actions/quick-action-definition';
 import { getUi5Version, isLowerThanMinimalUi5Version, isVersionEqualOrHasNewerPatch } from '../../../utils/version';
 import { Manifest } from 'sap/ui/rta/RuntimeAuthoring';
+import Component from 'sap/ui/core/Component';
+import AppComponent from 'sap/suite/ui/generic/template/lib/AppComponent';
+import ManagedObject from 'sap/ui/base/ManagedObject';
+import TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateComponent';
+
+/**
+ * Gets app component of a v2 project.
+ *
+ * @param control - ManagedObject.
+ * @returns AppComponent.
+ */
+export function getAppComponent(control: ManagedObject): AppComponent | undefined {
+    const ownerComponent = Component.getOwnerComponentFor(control);
+    if (ownerComponent?.isA<TemplateComponent>('sap/suite/ui/generic/template/lib/TemplateComponent')) {
+        return ownerComponent.getAppComponent();
+    }
+    return undefined;
+}
 
 /**
  * Prepares the change for the manifest setting.
@@ -27,10 +45,11 @@ export async function prepareManifestChange(
     propertyValue: object | string
 ): Promise<FlexCommand[]> {
     const { flexSettings } = context;
-
+    const appComponent = getAppComponent(control);
     const modifiedValue = {
         changeType: 'appdescr_ui_generic_app_changePageConfiguration',
         reference: flexSettings.projectId,
+        appComponent,
         parameters: {
             parentPage: {
                 component,

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -18,10 +18,11 @@ import TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateCompone
  */
 export function getAppComponent(control: ManagedObject): AppComponent | undefined {
     const ownerComponent = Component.getOwnerComponentFor(control);
+    let result;
     if (ownerComponent?.isA<TemplateComponent>('sap.suite.ui.generic.template.lib.TemplateComponent')) {
-        return ownerComponent.getAppComponent();
+        result = ownerComponent.getAppComponent();
     }
-    return undefined;
+    return result;
 }
 
 /**

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -16,7 +16,7 @@ import type TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateCo
  * @param control - ManagedObject.
  * @returns AppComponent.
  */
-export function getAppComponent(control: ManagedObject): AppComponent | undefined {
+export function getV2AppComponent(control: ManagedObject): AppComponent | undefined {
     const ownerComponent = Component.getOwnerComponentFor(control);
     let result;
     if (ownerComponent?.isA<TemplateComponent>('sap.suite.ui.generic.template.lib.TemplateComponent')) {
@@ -46,7 +46,7 @@ export async function prepareManifestChange(
     propertyValue: object | string
 ): Promise<FlexCommand[]> {
     const { flexSettings } = context;
-    const appComponent = getAppComponent(control);
+    const appComponent = getV2AppComponent(control);
     const modifiedValue = {
         changeType: 'appdescr_ui_generic_app_changePageConfiguration',
         reference: flexSettings.projectId,

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -6,9 +6,9 @@ import { QuickActionContext } from '../../../cpe/quick-actions/quick-action-defi
 import { getUi5Version, isLowerThanMinimalUi5Version, isVersionEqualOrHasNewerPatch } from '../../../utils/version';
 import { Manifest } from 'sap/ui/rta/RuntimeAuthoring';
 import Component from 'sap/ui/core/Component';
-import AppComponent from 'sap/suite/ui/generic/template/lib/AppComponent';
-import ManagedObject from 'sap/ui/base/ManagedObject';
-import TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateComponent';
+import type AppComponent from 'sap/suite/ui/generic/template/lib/AppComponent';
+import type ManagedObject from 'sap/ui/base/ManagedObject';
+import type TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateComponent';
 
 /**
  * Gets app component of a v2 project.
@@ -81,7 +81,6 @@ export async function prepareManifestChange(
 export function isManifestArrayStructured(manifest: Manifest): boolean {
     return Array.isArray(manifest['sap.ui.generic.app']?.pages);
 }
-
 
 /**
  * Checks if the current UI5 version and manifest structure is supported in v2 applications.

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/utils.ts
@@ -18,7 +18,7 @@ import TemplateComponent from 'sap/suite/ui/generic/template/lib/TemplateCompone
  */
 export function getAppComponent(control: ManagedObject): AppComponent | undefined {
     const ownerComponent = Component.getOwnerComponentFor(control);
-    if (ownerComponent?.isA<TemplateComponent>('sap/suite/ui/generic/template/lib/TemplateComponent')) {
+    if (ownerComponent?.isA<TemplateComponent>('sap.suite.ui.generic.template.lib.TemplateComponent')) {
         return ownerComponent.getAppComponent();
     }
     return undefined;

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/utils.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/utils.ts
@@ -2,7 +2,7 @@ import { getControlById } from '../../../utils/core';
 import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import { QuickActionContext } from '../../../cpe/quick-actions/quick-action-definition';
 import CommandFactory from 'sap/ui/rta/command/CommandFactory';
-import { getAppComponent, getPageName, getReference } from '../../../utils/fe-v4';
+import { getV4AppComponent, getPageName, getReference } from '../../../utils/fe-v4';
 
 export async function executeToggleAction(
     context: QuickActionContext,
@@ -26,7 +26,7 @@ export async function executeToggleAction(
 
         const modifiedValue = {
             reference: getReference(modifiedControl),
-            appComponent: getAppComponent(modifiedControl),
+            appComponent: getV4AppComponent(modifiedControl),
             changeType: 'appdescr_fe_changePageConfiguration',
             parameters: {
                 page: getPageName(parent),

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -75,12 +75,12 @@ interface BaseChange {
     selector: ChangeSelector;
 }
 
-const PROPRTY_CHANGE = 'propertyChange';
-const PROPRTY_BINDING_CHANGE = 'propertyBindingChange';
+const PROPERTY_CHANGE = 'propertyChange';
+const PROPERTY_BINDING_CHANGE = 'propertyBindingChange';
 const MANIFEST_V4_CHANGE = 'appdescr_fe_changePageConfiguration';
 
 interface PropertyChange extends BaseChange {
-    changeType: typeof PROPRTY_CHANGE | typeof PROPRTY_BINDING_CHANGE;
+    changeType: typeof PROPERTY_CHANGE | typeof PROPERTY_BINDING_CHANGE;
     controlId: string;
     propertyName: string;
     content: ChangeContent;
@@ -578,10 +578,12 @@ export class ChangeService extends EventTarget {
             };
             page: string;
         };
-        const propertyName = Object.keys(entityPropertyChange.propertyValue)[0];
-        const propertyValue = entityPropertyChange.propertyValue[propertyName];
-        const controlId = this.getCommandSelectorId(command) ?? '';
         const propertyPathSegments = entityPropertyChange.propertyPath.split('/');
+        const propertyName =
+            Object.keys(entityPropertyChange.propertyValue)?.[0] ??
+            propertyPathSegments[propertyPathSegments.length - 1];
+        const propertyValue = entityPropertyChange.propertyValue?.[propertyName] ?? entityPropertyChange.propertyValue;
+        const controlId = this.getCommandSelectorId(command) ?? '';
 
         const key = getConfigMapControlIdMap(page, propertyPathSegments);
 

--- a/packages/preview-middleware-client/src/utils/fe-v4.ts
+++ b/packages/preview-middleware-client/src/utils/fe-v4.ts
@@ -16,7 +16,7 @@ import FlexCommand from 'sap/ui/rta/command/FlexCommand';
  * @param control - ManagedObject.
  * @returns AppComponent.
  */
-export function getAppComponent(control: ManagedObject): AppComponent | undefined {
+export function getV4AppComponent(control: ManagedObject): AppComponent | undefined {
     const ownerComponent = Component.getOwnerComponentFor(control);
     if (ownerComponent?.isA<TemplateComponent>('sap.fe.core.TemplateComponent')) {
         return ownerComponent.getAppComponent();
@@ -31,7 +31,7 @@ export function getAppComponent(control: ManagedObject): AppComponent | undefine
  * @returns string.
  */
 export function getReference(control: ManagedObject): string {
-    const manifest = getAppComponent(control)?.getManifest() as Manifest;
+    const manifest = getV4AppComponent(control)?.getManifest() as Manifest;
     return manifest?.['sap.app']?.id ?? '';
 }
 

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -930,6 +930,12 @@ describe('FE V2 quick actions', () => {
                     isManifestPagesAsArray: true
                 }
             ];
+            jest.spyOn(ComponentMock, 'getOwnerComponentFor').mockImplementation(() => {
+                return {
+                    isA: (type: string) => type === 'sap.suite.ui.generic.template.lib.TemplateComponent',
+                    getAppComponent: jest.fn().mockReturnValue({} as any)
+                } as unknown as UIComponent;
+            });
             test.each(testCases)('initialize and execute action (%s)', async (testCase) => {
                 VersionInfo.load.mockResolvedValue({ name: 'sap.ui.core', version: testCase.versionInfo });
                 sapCoreMock.byId.mockImplementation((id) => {
@@ -1066,6 +1072,7 @@ describe('FE V2 quick actions', () => {
                         'settings': {},
                         'type': 'appDescriptor',
                         'value': {
+                            'appComponent': {},
                             'changeType': 'appdescr_ui_generic_app_changePageConfiguration',
                             'parameters': {
                                 'entityPropertyChange': {

--- a/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
@@ -1528,6 +1528,21 @@ describe('ChangeService', () => {
                         }
                     ]
                 ])
+            ),
+            createCommand(
+                new Map<string, any>([
+                    ['changeType', 'appdescr_ui_generic_app_changePageConfiguration'],
+                    [
+                        'parameters',
+                        {
+                            'entityPropertyChange': {
+                                'propertyPath': 'controlConfig/settings/useDateRange',
+                                'operation': 'upsert',
+                                'propertyValue': true
+                            }
+                        }
+                    ]
+                ])
             )
         ];
         rtaMock.getCommandStack.mockReturnValue({
@@ -1554,6 +1569,16 @@ describe('ChangeService', () => {
                         kind: 'configuration',
                         propertyName: 'someSetting',
                         propertyPath: 'controlConfig/settings',
+                        value: true
+                    },
+                    {
+                        controlIds: ['ListReport.view.ListReport::SEPMRA_C_PD_Product--app.my-test-button'],
+                        isActive: true,
+                        fileName: 'testFileName',
+                        type: 'pending',
+                        kind: 'configuration',
+                        propertyName: 'useDateRange',
+                        propertyPath: 'controlConfig/settings/useDateRange',
                         value: true
                     }
                 ]

--- a/packages/preview-middleware-client/test/unit/utils/fe-v4/utils.test.ts
+++ b/packages/preview-middleware-client/test/unit/utils/fe-v4/utils.test.ts
@@ -1,4 +1,4 @@
-import { getAppComponent, getReference, getV4PageType } from '../../../../src/utils/fe-v4';
+import { getV4AppComponent, getReference, getV4PageType } from '../../../../src/utils/fe-v4';
 import ComponentMock from 'mock/sap/ui/core/Component';
 
 describe('fe-v4/utils', () => {
@@ -28,11 +28,11 @@ describe('fe-v4/utils', () => {
     });
 
     test('getAppComponent - undefined', () => {
-        expect(getAppComponent({ id: 'buttonId' } as any)).toBe(undefined);
+        expect(getV4AppComponent({ id: 'buttonId' } as any)).toBe(undefined);
     });
 
     test('getAppComponent - defined', () => {
-        expect(getAppComponent({ id: 'buttonId2' } as any)).toBe(appComponent);
+        expect(getV4AppComponent({ id: 'buttonId2' } as any)).toBe(appComponent);
     });
 
     test('getV4PageType - undefined', () => {

--- a/packages/preview-middleware-client/types/sap.suite.ui.generic.template.d.ts
+++ b/packages/preview-middleware-client/types/sap.suite.ui.generic.template.d.ts
@@ -1,8 +1,17 @@
+declare module 'sap/suite/ui/generic/template/lib/AppComponent' {
+    import UIComponent from 'sap/ui/core/UIComponent';
+    interface AppComponent extends UIComponent {}
+
+    export default AppComponent;
+}
+
 declare module 'sap/suite/ui/generic/template/lib/TemplateComponent' {
     import UIComponent from 'sap/ui/core/UIComponent';
-
+    import AppComponent from 'sap/suite/ui/generic/template/lib/AppComponent';
+    
     export interface TemplateComponent extends UIComponent {
         getEntitySet: () => string;
+        getAppComponent(): AppComponent;
     }
 
     export default TemplateComponent;
@@ -13,7 +22,7 @@ declare module 'sap/suite/ui/generic/template/ListReport' {
 
     export interface ListReportComponent extends TemplateComponent {
         getSmartVariantManagement: () => boolean;
-        getVariantManagement: ()=> string;
+        getVariantManagement: () => string;
     }
 
     export default ListReportComponent;


### PR DESCRIPTION
When v2 manifest changes created via quick actions are undone(by undo) they still get written to file system on save(rta save).
