### PR TITLE
feat(project-access): improve performance for application search

### DIFF
--- a/packages/project-access/src/project/search-cache.ts
+++ b/packages/project-access/src/project/search-cache.ts
@@ -1,0 +1,65 @@
+import type { CdsEnvironment } from '../types';
+
+interface ApplicationSearchCacheStore {
+    /**
+     * Cache for retrieve of capEnvironment using `cds.env.for`.
+     */
+    capEnvironment: Map<string, CdsEnvironment | undefined>;
+    // ToDo - other cached values???
+    types: Map<string, string | undefined>;
+}
+
+interface ApplicationSearchCache {
+    /**
+     * Is cache enabled.
+     * @default false
+     */
+    enabled: boolean;
+    /**
+     * Cache store
+     */
+    store: ApplicationSearchCacheStore;
+}
+
+let searchCache = initCache();
+
+function initCache(): ApplicationSearchCache {
+    return {
+        enabled: false,
+        store: {
+            capEnvironment: new Map([]),
+            types: new Map([])
+        }
+    };
+}
+
+export function enableSearchCache(): void {
+    searchCache.enabled = true;
+}
+
+export function disableSearchCache(): void {
+    searchCache = initCache();
+}
+
+export function updateCache<K extends keyof ApplicationSearchCacheStore>(
+    store: K,
+    key: string,
+    value: ApplicationSearchCacheStore[K] extends Map<string, infer V> ? V : never
+): void {
+    if (!searchCache.enabled) {
+        return;
+    }
+    (searchCache.store[store] as Map<string, typeof value>).set(key, value);
+}
+
+export function getCache<K extends keyof ApplicationSearchCacheStore>(
+    store: K,
+    key: string
+): (ApplicationSearchCacheStore[K] extends Map<string, infer V> ? V : never) | undefined {
+    if (!searchCache.enabled) {
+        return undefined;
+    }
+    return searchCache.store[store].get(key) as
+        | (ApplicationSearchCacheStore[K] extends Map<string, infer V> ? V : never)
+        | undefined;
+}

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -17,6 +17,7 @@ import { fileExists, findBy, findFileUp, readJSON } from '../file';
 import { hasDependency } from './dependencies';
 import { getCapProjectType } from './cap';
 import { getWebappPath } from './ui5-config';
+import { disableSearchCache, enableSearchCache } from './search-cache';
 
 /**
  * Map artifact to file that is specific to the artifact type. Some artifacts can
@@ -484,6 +485,7 @@ export async function findFioriArtifacts(options: {
     artifacts: FioriArtifactTypes[];
     memFs?: Editor;
 }): Promise<FoundFioriArtifacts> {
+    enableSearchCache();
     const results: FoundFioriArtifacts = {};
     const fileNames: string[] = getFilterFileNames(options.artifacts);
     const wsRoots = wsFoldersToRootPaths(options.wsFolders);
@@ -516,6 +518,7 @@ export async function findFioriArtifacts(options: {
     if (options.artifacts.includes('components')) {
         results.components = await filterComponents(pathMap, options.memFs);
     }
+    disableSearchCache();
     return results;
 }
 


### PR DESCRIPTION
improve performance for application search using `findFioriArtifacts`:
1. cache result of `getCapEnvironment`(`loadCdsModuleFromProject` + `cds.env.for`) during search
2. todo