### PR TITLE
fix(odata-service-inquirer): set connected system CF prompts

### DIFF
--- a/.changeset/friendly-colts-play.md
+++ b/.changeset/friendly-colts-play.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for connected system not returned for Cloud Foundry related prompts

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-btp/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-btp/questions.ts
@@ -146,6 +146,7 @@ async function validateCFServiceInfo(
     requiredOdataVersion?: OdataVersion,
     isCli = false
 ): Promise<ValidationResult> {
+    PromptState.resetConnectedSystem();
     const cfAbapServiceName = abapService.label;
     const uaaCreds = await apiGetInstanceCredentials(cfAbapServiceName); // should be abapService.serviceName in BAS?
 
@@ -188,6 +189,9 @@ async function validateCFServiceInfo(
     if (connectionValidator.serviceProvider && getPromptHostEnvironment() !== hostEnvironment.bas) {
         // Connected system name is only used for VSCode as a default stored system name
         connectionValidator.connectedSystemName = await generateABAPCloudDestinationName(cfAbapServiceName);
+        PromptState.odataService.connectedSystem = {
+            serviceProvider: connectionValidator.serviceProvider
+        };
     }
     return true;
 }
@@ -283,6 +287,7 @@ function getServiceKeyPrompt(connectionValidator: ConnectionValidator): FileBrow
             mandatory: true
         },
         validate: async (keyPath) => {
+            PromptState.resetConnectedSystem();
             const serviceKeyValResult = validateServiceKey(keyPath);
             if (typeof serviceKeyValResult === 'string' || typeof serviceKeyValResult === 'boolean') {
                 return serviceKeyValResult;

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/new-system/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/new-system/questions.ts
@@ -103,6 +103,7 @@ export function getSystemUrlQuestion<T extends Answers>(
             breadcrumb: true
         },
         validate: async (url) => {
+            PromptState.resetConnectedSystem();
             const valResult = await connectValidator.validateUrl(url, {
                 isSystem: true,
                 odataVersion: convertODataVersionType(requiredOdataVersion)

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -43,6 +43,7 @@ export async function connectWithBackendSystem(
     requiredOdataVersion?: OdataVersion
 ): Promise<ValidationResult> {
     // Create a new connection with the selected system
+    PromptState.resetConnectedSystem();
     let connectValResult: ValidationResult = false;
     if (backendSystem) {
         // Assumption: non-BAS systems are BackendSystems
@@ -110,6 +111,7 @@ export async function connectWithDestination(
     requiredOdataVersion?: OdataVersion,
     addServicePath?: string
 ): Promise<ValidationResult> {
+    PromptState.resetConnectedSystem();
     const { valResult: connectValResult, errorType } = await connectionValidator.validateDestination(
         destination,
         convertODataVersionType(requiredOdataVersion),

--- a/packages/odata-service-inquirer/src/utils/prompt-state.ts
+++ b/packages/odata-service-inquirer/src/utils/prompt-state.ts
@@ -17,4 +17,8 @@ export class PromptState {
             PromptState.odataService[key as keyof OdataServiceAnswers] = undefined;
         });
     }
+
+    static resetConnectedSystem(): void {
+        PromptState.odataService.connectedSystem = undefined;
+    }
 }

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-btp/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-btp/questions.test.ts
@@ -12,7 +12,7 @@ import * as sapSystemValidators from '../../../../../src/prompts/datasources/sap
 const validateUrlMock = jest.fn().mockResolvedValue(true);
 const validateAuthMock = jest.fn().mockResolvedValue(true);
 const isAuthRequiredMock = jest.fn().mockResolvedValue(false);
-const serviceProviderMock = {} as Partial<ServiceProvider>;
+const serviceProviderMock = {} as Partial<ServiceProvider> | undefined;
 let validateServiceInfoMock: boolean | string = true;
 
 const connectionValidatorMock = {
@@ -281,6 +281,7 @@ describe('questions', () => {
         ]);
         expect(await ((cfDiscoPrompt as ListQuestion).validate as Function)(cfDiscoveredAbapEnvsMock[1])).toBe(true);
         expect(connectionValidatorMock.connectedSystemName).toBe('abap-cloud-test2-testorg-testspace');
+        expect(PromptState.odataService.connectedSystem).toEqual({ serviceProvider: serviceProviderMock });
 
         // Validation error message is returned
         validateServiceInfoMock = 'Cannot connect';
@@ -288,6 +289,7 @@ describe('questions', () => {
             'Cannot connect'
         );
         expect(connectionValidatorMock.connectedSystemName).toBe(undefined);
+        expect(PromptState.odataService.connectedSystem).toBeUndefined();
     });
 
     test('Cloud Foundry discovery prompt should connect to the choosen Abap environment (cli)', async () => {
@@ -323,6 +325,7 @@ describe('questions', () => {
             })
         ).toBe(false); // cliCfServicePrompt is never shown so when always should be false
         expect(connectionValidatorMock.connectedSystemName).toBe('abap-cloud-test2-testorg-testspace');
+        expect(PromptState.odataService.connectedSystem).toEqual({ serviceProvider: serviceProviderMock });
 
         // Validation error message is returned
         validateServiceInfoMock = 'Cannot connect';
@@ -334,6 +337,7 @@ describe('questions', () => {
         ).rejects.toThrowError('Cannot connect');
 
         expect(connectionValidatorMock.connectedSystemName).toBe(undefined);
+        expect(PromptState.odataService.connectedSystem).toBeUndefined();
     });
 
     test('Service key prompt should validate service key and connect', async () => {


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/2911

- Re-adds the setting of connected system for CF flows, this was lost in a recent update (2.0.0)
- Adds tests to cover
- Ensure the `PromptState.connectedSystem` is reset everytime a new connection is validated to prevent stale data