### PR TITLE
fix: Add Table Custom Column quick action fragment bug fix

### DIFF
--- a/packages/adp-tooling/src/preview/change-handler.ts
+++ b/packages/adp-tooling/src/preview/change-handler.ts
@@ -80,12 +80,15 @@ const fragmentTemplateDefinitions: Record<string, FragmentTemplateConfig> = {
     },
     [V2_SMART_TABLE_COLUMN]: {
         path: 'v2/m-table-custom-column.xml',
-        getData: () => {
+        getData: (change: AddXMLChange) => {
             const uuid = randomBytes(4).toString('hex');
+            const columnIndex = change.content.index;
             return {
                 ids: {
                     column: `column-${uuid}`,
-                    columnTitle: `column-title-${uuid}`
+                    columnTitle: `column-title-${uuid}`,
+                    customData: `custom-data-${uuid}`,
+                    index: columnIndex.toFixed(0)
                 }
             };
         }

--- a/packages/adp-tooling/templates/rta/v2/m-table-custom-column.xml
+++ b/packages/adp-tooling/templates/rta/v2/m-table-custom-column.xml
@@ -6,5 +6,10 @@
         hAlign="Left"
         vAlign="Middle">
         <Text id="<%- ids.columnTitle %>" text="New column" />
+
+        <customData>
+			<core:CustomData key="p13nData" id="<%- ids.customData %>"
+				value='\{"columnKey": "<%- ids.column %>", "columnIndex": "<%- ids.index %>"}' />
+		</customData>
     </Column>
 </core:FragmentDefinition>

--- a/packages/adp-tooling/test/unit/preview/change-handler.test.ts
+++ b/packages/adp-tooling/test/unit/preview/change-handler.test.ts
@@ -296,12 +296,15 @@ id="<%- ids.toolbarActionButton %>`);
                     ...change,
                     content: {
                         ...change.content,
-                        templateName: `V2_SMART_TABLE_COLUMN`
+                        templateName: `V2_SMART_TABLE_COLUMN`,
+                        index: 1
                     }
                 } as unknown as AddXMLChange;
                 mockFs.read.mockReturnValue(`
 id="<%- ids.column %>
 id="<%- ids.columnTitle %>
+id="<%- ids.customData %>
+id="<%- ids.index %>
 `);
                 addXmlFragment(path, updatedChange, mockFs as unknown as Editor, mockLogger as unknown as Logger);
 
@@ -320,6 +323,8 @@ id="<%- ids.columnTitle %>
                     "
                     id=\\"column-30303030
                     id=\\"column-title-30303030
+                    id=\\"custom-data-30303030
+                    id=\\"1
                     "
                 `);
 


### PR DESCRIPTION
Fixed Add Table Custom Column quick action bug. Column data fragment was incomplete, due to that new column was not displayed in some V2 apps 