### PR TITLE
fix: re-route issue with cds-plugin-ui5

### DIFF
--- a/.changeset/red-mails-carry.md
+++ b/.changeset/red-mails-carry.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix: re-route issue with cds-plugin-ui5

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -288,10 +288,10 @@ export class FlpSandbox {
         previewUrl: string,
         editor: RtaEditor
     ): Promise<void> {
-        const url =
-            'ui5-patched-router' in req ? join(req['ui5-patched-router']?.baseUrl ?? '', previewUrl) : previewUrl;
         if (!req.query['fiori-tools-rta-mode']) {
             // Redirect to the same URL but add the necessary parameter
+            const url =
+                'ui5-patched-router' in req ? join(req['ui5-patched-router']?.baseUrl ?? '', previewUrl) : previewUrl;
             const params = structuredClone(req.query);
             params['sap-ui-xx-viewCache'] = 'false';
             params['fiori-tools-rta-mode'] = 'true';

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -47,7 +47,7 @@ export type EnhancedRouter = Router & {
 /**
  * Enhanced request object that contains additional properties from cds-plugin-ui5.
  */
-type EnhancedRequest = Request & { 'ui5-patched-router'?: { baseUrl?: string } };
+export type EnhancedRequest = Request & { 'ui5-patched-router'?: { baseUrl?: string } };
 
 type OnChangeRequestHandler = (
     type: OperationType,

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -282,12 +282,14 @@ export class FlpSandbox {
      * @private
      */
     private async editorGetHandler(
-        req: Request,
+        req: EnhancedRequest,
         res: Response,
         rta: RtaConfig,
         previewUrl: string,
         editor: RtaEditor
     ): Promise<void> {
+        const url =
+            'ui5-patched-router' in req ? join(req['ui5-patched-router']?.baseUrl ?? '', previewUrl) : previewUrl;
         if (!req.query['fiori-tools-rta-mode']) {
             // Redirect to the same URL but add the necessary parameter
             const params = structuredClone(req.query);
@@ -295,7 +297,7 @@ export class FlpSandbox {
             params['fiori-tools-rta-mode'] = 'true';
             params['sap-ui-rta-skip-flex-validation'] = 'true';
             params['sap-ui-xx-condense-changes'] = 'true';
-            res.redirect(302, `${previewUrl}?${new URLSearchParams(params)}`);
+            res.redirect(302, `${url}?${new URLSearchParams(params)}`);
             return;
         }
         const html = (await this.generateSandboxForEditor(req, rta, editor)).replace(
@@ -348,10 +350,14 @@ export class FlpSandbox {
     ): Promise<void> {
         // connect API (karma test runner) has no request query property
         if ('query' in req && 'redirect' in res && !req.query['sap-ui-xx-viewCache']) {
+            const url =
+                'ui5-patched-router' in req
+                    ? join(req['ui5-patched-router']?.baseUrl ?? '', this.flpConfig.path)
+                    : this.flpConfig.path;
             // Redirect to the same URL but add the necessary parameter
             const params = structuredClone(req.query);
             params['sap-ui-xx-viewCache'] = 'false';
-            res.redirect(302, `${this.flpConfig.path}?${new URLSearchParams(params)}`);
+            res.redirect(302, `${url}?${new URLSearchParams(params)}`);
             return;
         }
         await this.setApplicationDependencies();

--- a/packages/preview-middleware/src/base/index.ts
+++ b/packages/preview-middleware/src/base/index.ts
@@ -1,2 +1,2 @@
 export { FlpSandbox, initAdp } from './flp';
-export { generatePreviewFiles, getPreviewPaths } from './config';
+export { generatePreviewFiles, getPreviewPaths, sanitizeRtaConfig } from './config';

--- a/packages/preview-middleware/src/index.ts
+++ b/packages/preview-middleware/src/index.ts
@@ -1,5 +1,5 @@
 export * from './ui5/middleware';
-export { FlpSandbox, initAdp, generatePreviewFiles, getPreviewPaths } from './base';
+export { FlpSandbox, initAdp, generatePreviewFiles, getPreviewPaths, sanitizeRtaConfig } from './base';
 export {
     FlpConfig,
     RtaConfig,

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -6,7 +6,7 @@ import type { MiddlewareUtils } from '@ui5/server';
 import type { Logger, ToolsLogger } from '@sap-ux/logger';
 import type { ProjectAccess, I18nBundles, Manifest } from '@sap-ux/project-access';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, posix } from 'path';
 import type { SuperTest, Test } from 'supertest';
 import supertest from 'supertest';
 import express, { type Response, type NextFunction } from 'express';
@@ -966,7 +966,7 @@ describe('FlpSandbox', () => {
             const app = express();
             app.use([
                 function (req: EnhancedRequest, _res: Response, next: NextFunction) {
-                    req['ui5-patched-router'] = { baseUrl: '/base' };
+                    req['ui5-patched-router'] = { baseUrl: '/ui5-patched-router-base' };
                     next();
                 },
                 flp.router
@@ -977,14 +977,12 @@ describe('FlpSandbox', () => {
 
         test('rta', async () => {
             const response = await server.get('/my/rta.html').expect(302);
-            expect(response.header.location).toEqual(
-                `\\base\\my\\rta.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true`
-            );
+            expect(response.header.location).toContain('ui5-patched-router-base');
         });
 
         test('test/flp.html', async () => {
-            const response = await server.get('/test/flp.html#app-preview').expect(302);
-            expect(response.header.location).toEqual(`\\base\\test\\flp.html?sap-ui-xx-viewCache=false`);
+            const response = await server.get(`/test/flp.html#app-preview`).expect(302);
+            expect(response.header.location).toContain('ui5-patched-router-base');
         });
     });
 });


### PR DESCRIPTION
re-routing currently ignores the namespace from cds-plugin-ui5

Besides that `sanitizeRtaConfig` method is being exposed for usage outside of preview-middleware (e.g. to be used in fiori-tools-preview)