### PR TITLE
fix: Create Custom Column quick action generates incorrect fragment for Grid and Tree table 

### DIFF
--- a/.changeset/fifty-crabs-film.md
+++ b/.changeset/fifty-crabs-film.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/adp-tooling': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: 'Add Custom Table Column' CPE quick action is generating incorrect column fragment for Grid and Tree tables

--- a/packages/adp-tooling/src/preview/change-handler.ts
+++ b/packages/adp-tooling/src/preview/change-handler.ts
@@ -19,6 +19,7 @@ const V2_SMART_TABLE_COLUMN = 'V2_SMART_TABLE_COLUMN';
 const V2_SMART_TABLE_CELL = 'V2_SMART_TABLE_CELL';
 const V4_MDC_TABLE_COLUMN = 'V4_MDC_TABLE_COLUMN';
 const ANALYTICAL_TABLE_COLUMN = 'ANALYTICAL_TABLE_COLUMN';
+const GRID_TREE_TABLE_COLUMN = 'GRID_TREE_TABLE_COLUMN';
 const TABLE_ACTION = 'TABLE_ACTION';
 
 interface FragmentTemplateConfig<T = { [key: string]: any }> {
@@ -112,6 +113,22 @@ const fragmentTemplateDefinitions: Record<string, FragmentTemplateConfig> = {
                 ids: {
                     column: `column-${uuid}`,
                     text: `text-${uuid}`
+                }
+            };
+        }
+    },
+    [GRID_TREE_TABLE_COLUMN]: {
+        path: 'common/grid-tree-custom-column.xml',
+        getData: (change: AddXMLChange) => {
+            const uuid = randomBytes(4).toString('hex');
+            const columnIndex = change.content.index;
+            return {
+                ids: {
+                    column: `column-${uuid}`,
+                    label: `label-${uuid}`,
+                    text: `text-${uuid}`,
+                    customData: `custom-data-${uuid}`,
+                    index: columnIndex.toFixed(0)
                 }
             };
         }

--- a/packages/adp-tooling/templates/rta/common/grid-tree-custom-column.xml
+++ b/packages/adp-tooling/templates/rta/common/grid-tree-custom-column.xml
@@ -2,7 +2,7 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:table="sap.ui.table" xmlns:smartfield="sap.ui.comp.smartfield"	xmlns:core="sap.ui.core">
 	<table:Column
 		autoResizable="true"
-        width="150px" 
+		width="150px" 
 		id="<%- ids.column %>" >
 
 		<Label id="<%- ids.label %>" text="New Column"></Label>

--- a/packages/adp-tooling/templates/rta/common/grid-tree-custom-column.xml
+++ b/packages/adp-tooling/templates/rta/common/grid-tree-custom-column.xml
@@ -1,0 +1,19 @@
+<!-- Use stable and unique id's!-->
+<core:FragmentDefinition xmlns="sap.m" xmlns:table="sap.ui.table" xmlns:smartfield="sap.ui.comp.smartfield"	xmlns:core="sap.ui.core">
+	<table:Column
+		autoResizable="true"
+        width="150px" 
+		id="<%- ids.column %>" >
+
+		<Label id="<%- ids.label %>" text="New Column"></Label>
+
+		<table:template>
+			<Text id="<%- ids.text %>" text="Sample data"/>
+		</table:template>
+
+		<table:customData>
+			<core:CustomData key="p13nData" id="<%- ids.customData %>"
+				value='\{"columnKey": "<%- ids.column %>", "columnIndex": "<%- ids.index %>"}' />
+		</table:customData>
+	</table:Column>
+</core:FragmentDefinition>

--- a/packages/adp-tooling/test/unit/preview/change-handler.test.ts
+++ b/packages/adp-tooling/test/unit/preview/change-handler.test.ts
@@ -401,13 +401,26 @@ id="<%- ids.text %>
                 expect(mockLogger.info).toHaveBeenCalledWith(`XML Fragment "${fragmentName}.fragment.xml" was created`);
             });
 
-            it('should create custom table column fragment (analytical table)', () => {
+            const testCases: {
+                tableType: 'ANALYTICAL_TABLE_COLUMN' | 'GRID_TREE_TABLE_COLUMN';
+                fragmentFileName: string;
+            }[] = [
+                {
+                    tableType: 'ANALYTICAL_TABLE_COLUMN',
+                    fragmentFileName: 'templates/rta/common/analytical-custom-column.xml'
+                },
+                {
+                    tableType: 'GRID_TREE_TABLE_COLUMN',
+                    fragmentFileName: 'templates/rta/common/grid-tree-custom-column.xml'
+                }
+            ];
+            it.each(testCases)('should create custom table column fragment (%s table)', (testCase) => {
                 mockFs.exists.mockReturnValue(false);
                 const updatedChange = {
                     ...change,
                     content: {
                         ...change.content,
-                        templateName: `ANALYTICAL_TABLE_COLUMN`,
+                        templateName: testCase.tableType,
                         index: 1
                     }
                 } as unknown as AddXMLChange;
@@ -422,9 +435,7 @@ id="<%- ids.index %>
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
-                    (mockFs.read.mock.calls[0][0] as string)
-                        .replace(/\\/g, '/')
-                        .endsWith('templates/rta/common/analytical-custom-column.xml')
+                    (mockFs.read.mock.calls[0][0] as string).replace(/\\/g, '/').endsWith(testCase.fragmentFileName)
                 ).toBe(true);
 
                 expect(mockFs.write).toHaveBeenCalled();

--- a/packages/preview-middleware-client/src/adp/controllers/AddFragment.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/AddFragment.controller.ts
@@ -31,7 +31,12 @@ import CommandExecutor from '../command-executor';
 import { getFragments } from '../api-handler';
 import BaseDialog from './BaseDialog.controller';
 import { notifyUser } from '../utils';
-import { ANALYTICAL_TABLE_TYPE, GRID_TABLE_TYPE, TREE_TABLE_TYPE } from '../quick-actions/control-types';
+import {
+    ANALYTICAL_TABLE_TYPE,
+    GRID_TABLE_TYPE,
+    MDC_TABLE_TYPE,
+    TREE_TABLE_TYPE
+} from '../quick-actions/control-types';
 
 interface CreateFragmentProps {
     fragmentName: string;
@@ -262,13 +267,18 @@ export default class AddFragment extends BaseDialog<AddFragmentModel> {
             return 'CUSTOM_ACTION';
         } else if (this.isObjectPageHeaderField(currentControlName, targetAggregation)) {
             return 'OBJECT_PAGE_HEADER_FIELD';
-        } else if (currentControlName === 'sap.ui.mdc.Table' && targetAggregation === 'columns') {
-            return 'V4_MDC_TABLE_COLUMN';
-        } else if (
-            [TREE_TABLE_TYPE, GRID_TABLE_TYPE, ANALYTICAL_TABLE_TYPE].includes(currentControlName) &&
-            targetAggregation === 'columns'
-        ) {
-            return 'ANALYTICAL_TABLE_COLUMN';
+        } else if (targetAggregation === 'columns') {
+            switch (currentControlName) {
+                case MDC_TABLE_TYPE:
+                    return 'V4_MDC_TABLE_COLUMN';
+                case TREE_TABLE_TYPE:
+                case GRID_TABLE_TYPE:
+                    return 'GRID_TREE_TABLE_COLUMN';
+                case ANALYTICAL_TABLE_TYPE:
+                    return 'ANALYTICAL_TABLE_COLUMN';
+                default:
+                    return '';
+            }
         } else if (currentControlName === 'sap.ui.mdc.Table' && targetAggregation === 'actions') {
             return 'TABLE_ACTION';
         }

--- a/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/AddFragment.controller.test.ts
@@ -19,6 +19,7 @@ import { type AddFragmentChangeContentType } from 'sap/ui/fl/Change';
 import {
     ANALYTICAL_TABLE_TYPE,
     GRID_TABLE_TYPE,
+    MDC_TABLE_TYPE,
     TREE_TABLE_TYPE
 } from 'open/ux/preview/client/adp/quick-actions/control-types';
 
@@ -1577,14 +1578,38 @@ describe('AddFragment', () => {
                 });
             });
 
-            const tableTypes = [TREE_TABLE_TYPE, GRID_TABLE_TYPE, ANALYTICAL_TABLE_TYPE];
-            test.each(tableTypes)(
+            const testCases: {
+                tableType:
+                    | typeof TREE_TABLE_TYPE
+                    | typeof GRID_TABLE_TYPE
+                    | typeof ANALYTICAL_TABLE_TYPE
+                    | typeof MDC_TABLE_TYPE;
+                templateName: 'ANALYTICAL_TABLE_COLUMN' | 'GRID_TREE_TABLE_COLUMN' | 'V4_MDC_TABLE_COLUMN';
+            }[] = [
+                {
+                    tableType: MDC_TABLE_TYPE,
+                    templateName: 'V4_MDC_TABLE_COLUMN'
+                },
+                {
+                    tableType: GRID_TABLE_TYPE,
+                    templateName: 'GRID_TREE_TABLE_COLUMN'
+                },
+                {
+                    tableType: TREE_TABLE_TYPE,
+                    templateName: 'GRID_TREE_TABLE_COLUMN'
+                },
+                {
+                    tableType: ANALYTICAL_TABLE_TYPE,
+                    templateName: 'ANALYTICAL_TABLE_COLUMN'
+                }
+            ];
+            test.each(testCases)(
                 'creates new analytical custom column fragment and a change (%s)',
-                async (tableType) => {
+                async (testCase) => {
                     jest.spyOn(ControlUtils, 'getRuntimeControl').mockReturnValue({
                         getMetadata: jest.fn().mockReturnValue({
                             getAllAggregations: jest.fn().mockReturnValue({}),
-                            getName: jest.fn().mockReturnValue(tableType)
+                            getName: jest.fn().mockReturnValue(testCase.tableType)
                         })
                     } as unknown as ManagedObject);
                     await addFragment.setup({
@@ -1609,7 +1634,7 @@ describe('AddFragment', () => {
 
                     expect(setContentSpy).toHaveBeenCalledWith({
                         ...dummyContent,
-                        templateName: 'ANALYTICAL_TABLE_COLUMN'
+                        templateName: testCase.templateName
                     });
                 }
             );


### PR DESCRIPTION
Fixed bug - Create Custom Column quick action generates incorrect column fragment for Grid and Tree tables