### PR TITLE
fix: Added support for missing 'showClearButton', 'showMessages', and 'liveMode' properties in FilterBar building block generation.

### DIFF
--- a/.changeset/wild-chicken-perform.md
+++ b/.changeset/wild-chicken-perform.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Added support for 'showClearButton', 'showMessages', and 'liveMode' properties in FilterBar building block generation.

--- a/packages/fe-fpm-writer/src/building-block/types.ts
+++ b/packages/fe-fpm-writer/src/building-block/types.ts
@@ -139,16 +139,19 @@ export interface FilterBar extends BuildingBlock {
     search?: string;
     /**
      * If true, the search is triggered automatically when a filter value is changed.
+     *
      * @default false
      */
     liveMode?: boolean;
     /**
      * Handles the visibility of the 'Clear' button on the FilterBar.
+     *
      * @default false
      */
     showClearButton?: boolean;
     /**
      * Displays possible errors during the search in a message box.
+     *
      * @default true
      */
     showMessages?: boolean;

--- a/packages/fe-fpm-writer/src/building-block/types.ts
+++ b/packages/fe-fpm-writer/src/building-block/types.ts
@@ -137,6 +137,21 @@ export interface FilterBar extends BuildingBlock {
      * This event is fired when the Go button is pressed or after a condition change.
      */
     search?: string;
+    /**
+     * If true, the search is triggered automatically when a filter value is changed.
+     * @default false
+     */
+    liveMode?: boolean;
+    /**
+     * Handles the visibility of the 'Clear' button on the FilterBar.
+     * @default false
+     */
+    showClearButton?: boolean;
+    /**
+     * Displays possible errors during the search in a message box.
+     * @default true
+     */
+    showMessages?: boolean;
 }
 
 /**

--- a/packages/fe-fpm-writer/templates/building-block/filter-bar/View.xml
+++ b/packages/fe-fpm-writer/templates/building-block/filter-bar/View.xml
@@ -3,5 +3,8 @@
     metaPath="<%- data.metaPath %>"<% } %><% if (data.contextPath) { %>
     contextPath="<%- data.contextPath %>"<% } %><% if (data.search) { %>
     search="<%- data.search %>"<% } %><% if (data.filterChanged) { %>
-    filterChanged="<%- data.filterChanged %>"<% } %>
+    filterChanged="<%- data.filterChanged %>"<% } %><% if (data.liveMode !== undefined) { %>
+    liveMode="<%- data.liveMode %>"<% } %><% if (data.showClearButton !== undefined) { %>
+    showClearButton="<%- data.showClearButton %>"<% } %><% if (data.showMessages !== undefined) { %>
+    showMessages="<%- data.showMessages %>"<% } %>
 />

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/building-block.test.ts.snap
@@ -28,6 +28,16 @@ Object {
 }
 `;
 
+exports[`Building Blocks FilterBar properties: filterbar-properties 1`] = `
+"<mvc:View xmlns:core=\\"sap.ui.core\\" xmlns:mvc=\\"sap.ui.core.mvc\\" xmlns=\\"sap.m\\" xmlns:html=\\"http://www.w3.org/1999/xhtml\\" controllerName=\\"com.test.myApp.ext.main.Main\\" xmlns:macros=\\"sap.fe.macros\\">
+    <Page title=\\"Main\\">
+        <content>
+            <macros:FilterBar id=\\"testFilterBar\\" search=\\"onSearch\\" filterChanged=\\"onFilterChanged\\" liveMode=\\"true\\" showClearButton=\\"false\\" showMessages=\\"true\\"/>
+        </content>
+    </Page>
+</mvc:View>"
+`;
+
 exports[`Building Blocks Generate with just ID and xml view without macros namespace generate chart building block: generate-chart-with-id-no-macros-ns 1`] = `
 Object {
   "generate-chart-with-id-no-macros-ns/webapp/ext/main/Main.view.xml": Object {

--- a/packages/fe-fpm-writer/test/unit/building-block.test.ts
+++ b/packages/fe-fpm-writer/test/unit/building-block.test.ts
@@ -262,6 +262,34 @@ describe('Building Blocks', () => {
         expect(testFS.read(join(basePath, xmlViewFilePath))).toMatchSnapshot();
     });
 
+    test('FilterBar properties', async () => {
+        const aggregationPath = `/mvc:View/*[local-name()='Page']/*[local-name()='content']`;
+        const basePath = join(__dirname, 'sample/building-block/filterbar-properties');
+        const testXmlViewFilePath = join(basePath, xmlViewFilePath);
+        fs.write(join(basePath, manifestFilePath), JSON.stringify(testManifestContent));
+        fs.write(testXmlViewFilePath, testXmlViewContent);
+
+        await generateBuildingBlock<FilterBar>(
+            basePath,
+            {
+                viewOrFragmentPath: xmlViewFilePath,
+                aggregationPath: aggregationPath,
+                buildingBlockData: {
+                    id: 'testFilterBar',
+                    buildingBlockType: BuildingBlockType.FilterBar,
+                    filterChanged: 'onFilterChanged',
+                    search: 'onSearch',
+                    liveMode: true,
+                    showClearButton: false,
+                    showMessages: true
+                }
+            },
+            fs
+        );
+        expect(fs.read(testXmlViewFilePath)).toMatchSnapshot('filterbar-properties');
+        await writeFilesForDebugging(fs);
+    });
+
     describe('Generate with just ID and xml view without macros namespace', () => {
         const testInput = [
             {


### PR DESCRIPTION
Issue #2952

Added support for missing 'showClearButton', 'showMessages', and 'liveMode' properties in FilterBar building block generation.:
Documentation - https://sapui5.hana.ondemand.com/sdk/#/api/sap.fe.macros.FilterBar%23controlProperties
Generation example:
```
<mvc:View xmlns:core="sap.ui.core" xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m" xmlns:html="http://www.w3.org/1999/xhtml" controllerName="com.test.myApp.ext.main.Main" xmlns:macros="sap.fe.macros">
    <Page title="Main">
        <content>
            <macros:FilterBar id="testFilterBar" search="onSearch" filterChanged="onFilterChanged" liveMode="true" showClearButton="false" showMessages="true"/>
        </content>
    </Page>
</mvc:View>
```