### PR TITLE
fix(cf-deploy-sub-gen): handle flow when loaded as sub-gen

### DIFF
--- a/.changeset/long-panthers-deliver.md
+++ b/.changeset/long-panthers-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+Init should only be run when standalone

--- a/packages/cf-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/questions.ts
@@ -1,5 +1,5 @@
 import { isAppStudio } from '@sap-ux/btp-utils';
-import { DeploymentGenerator } from '@sap-ux/deploy-config-generator-shared';
+import { DeploymentGenerator, getConfirmMtaContinuePrompt } from '@sap-ux/deploy-config-generator-shared';
 import { getMtaPath } from '@sap-ux/project-access';
 import {
     appRouterPromptNames,
@@ -11,7 +11,7 @@ import {
     getPrompts,
     promptNames
 } from '@sap-ux/cf-deploy-config-inquirer';
-import { getHostEnvironment, hostEnvironment, getConfirmMtaContinuePrompt } from '@sap-ux/fiori-generator-shared';
+import { getHostEnvironment, hostEnvironment } from '@sap-ux/fiori-generator-shared';
 import { destinationQuestionDefaultOption, getCFChoices } from './utils';
 import { t } from '../utils';
 import type { ApiHubConfig } from '@sap-ux/cf-deploy-config-writer';

--- a/packages/cf-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/questions.ts
@@ -11,11 +11,10 @@ import {
     getPrompts,
     promptNames
 } from '@sap-ux/cf-deploy-config-inquirer';
-import { getHostEnvironment, hostEnvironment } from '@sap-ux/fiori-generator-shared';
+import { getHostEnvironment, hostEnvironment, getConfirmMtaContinuePrompt } from '@sap-ux/fiori-generator-shared';
 import { destinationQuestionDefaultOption, getCFChoices } from './utils';
 import { t } from '../utils';
 import type { ApiHubConfig } from '@sap-ux/cf-deploy-config-writer';
-import { getConfirmMtaContinuePrompt } from '@sap-ux/deploy-config-generator-shared';
 import type { Answers, Question } from 'inquirer';
 import { withCondition } from '@sap-ux/inquirer-common';
 

--- a/packages/cf-deploy-config-sub-generator/test/app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/app.test.ts
@@ -960,6 +960,32 @@ describe('Cloud foundry generator tests', () => {
         );
     });
 
+    it('Ensure init is loaded when loaded as a subgenerator', async () => {
+        hasbinSyncMock.mockReturnValue(true);
+        mockGetHostEnvironment.mockReturnValue(hostEnvironment.cli);
+        memfs.vol.fromNestedJSON({}, '/');
+        const appDir = join(OUTPUT_DIR_PREFIX, 'app1');
+
+        await expect(
+            yeomanTest
+                .create(
+                    CFGenerator,
+                    {
+                        resolved: cfGenPath
+                    },
+                    { cwd: appDir }
+                )
+                .withOptions({
+                    skipInstall: true,
+                    launchDeployConfigAsSubGenerator: true
+                })
+                .withPrompts({})
+                .run()
+        ).resolves.not.toThrow();
+        expect(hasbinSyncMock).toHaveBeenCalledWith('mta');
+        expect(mockFindCapProjectRoot).toHaveBeenCalled();
+    });
+
     it('Should throw error when base config is not found', async () => {
         hasbinSyncMock.mockReturnValue(true);
         mockGetHostEnvironment.mockReturnValue(hostEnvironment.cli);


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2821

- found when testing locally in tools-suite
- init should only be called when run standalone
- add tests to cover this change