### PR TITLE
fix: method 'getCapModelAndServices' not returning 'odata-v4' services

### DIFF
--- a/.changeset/thick-fishes-invite.md
+++ b/.changeset/thick-fishes-invite.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Fix: method 'getCapModelAndServices' not returning 'odata-v4' services

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -171,7 +171,13 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
     return result;
 }
 
-function filterCapServiceEndpoints(endpoint: { kind: string; path: string }) {
+/**
+ * Filters service endpoints to include only OData endpoints.
+ *
+ * @param endpoint The endpoint object to check.
+ * @returns `true` if the endpoint is of kind 'odata' or 'odata-v4'.
+ */
+function filterCapServiceEndpoints(endpoint: { kind: string }) {
     return endpoint.kind === 'odata' || endpoint.kind === 'odata-v4';
 }
 

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -175,6 +175,7 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
  * Filters service endpoints to include only OData endpoints.
  *
  * @param endpoint The endpoint object to check.
+ * @param endpoint.kind The type of the endpoint.
  * @returns `true` if the endpoint is of kind 'odata' or 'odata-v4'.
  */
 function filterCapServiceEndpoints(endpoint: { kind: string }) {

--- a/packages/project-access/src/project/cap.ts
+++ b/packages/project-access/src/project/cap.ts
@@ -171,6 +171,10 @@ export async function getCapCustomPaths(capProjectPath: string): Promise<CapCust
     return result;
 }
 
+function filterCapServiceEndpoints(endpoint: { kind: string; path: string }) {
+    return endpoint.kind === 'odata' || endpoint.kind === 'odata-v4';
+}
+
 /**
  * Return the CAP model and all services. The cds.root will be set to the provided project root path.
  *
@@ -214,13 +218,13 @@ export async function getCapModelAndServices(
         services = services.filter(
             (service) =>
                 (service.urlPath && service.endpoints === undefined) ||
-                service.endpoints?.find((endpoint) => endpoint.kind === 'odata')
+                service.endpoints?.find(filterCapServiceEndpoints)
         );
     }
     if (services.map) {
         services = services.map((value) => {
             const { endpoints, urlPath } = value;
-            const odataEndpoint = endpoints?.find((endpoint) => endpoint.kind === 'odata');
+            const odataEndpoint = endpoints?.find(filterCapServiceEndpoints);
             const endpointPath = odataEndpoint?.path ?? urlPath;
             return {
                 name: value.name,

--- a/packages/project-access/test/project/cap.test.ts
+++ b/packages/project-access/test/project/cap.test.ts
@@ -155,6 +155,16 @@ describe('Test getCapModelAndServices()', () => {
                             'runtime': 'Node.js'
                         },
                         {
+                            'name': 'oDataV4Kind',
+                            'endpoints': [
+                                {
+                                    'path': 'url',
+                                    'kind': 'odata-v4'
+                                }
+                            ],
+                            'runtime': 'Node.js'
+                        },
+                        {
                             'name': 'withRuntime',
                             'endpoints': [
                                 {
@@ -190,6 +200,11 @@ describe('Test getCapModelAndServices()', () => {
                 },
                 {
                     'name': 'withRuntime',
+                    'urlPath': 'url',
+                    'runtime': 'Node.js'
+                },
+                {
+                    'name': 'oDataV4Kind',
                     'urlPath': 'url',
                     'runtime': 'Node.js'
                 }


### PR DESCRIPTION
method 'getCapModelAndServices' not returning 'odata-v4' services.

According to documentation - https://cap.cloud.sap/docs/node.js/cds-serve#trace
```
odata is a shortcut for odata-v4.
```