### PR TITLE
fix: TypeScript template causes the iframe to break when controller extension is loaded

### DIFF
--- a/.changeset/young-months-develop.md
+++ b/.changeset/young-months-develop.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/adp-tooling': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: TypeScript template causes the iframe to break when controller extension is loaded

--- a/packages/adp-tooling/templates/rta/ts-controller.ejs
+++ b/packages/adp-tooling/templates/rta/ts-controller.ejs
@@ -11,8 +11,6 @@ export default class <%= name %> extends ControllerExtension {
      * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
      * @memberOf <%= ns %>.<%= name %>
      */
-    onInit: () => {
-      const view = this.getView();
-    },
+    onInit: () => {},
   };
 }

--- a/packages/adp-tooling/templates/rta/ts-controller.ejs
+++ b/packages/adp-tooling/templates/rta/ts-controller.ejs
@@ -11,6 +11,8 @@ export default class <%= name %> extends ControllerExtension {
      * Can be used to modify the View before it is displayed, to bind event handlers and do other one-time initialization.
      * @memberOf <%= ns %>.<%= name %>
      */
-    onInit: () => {},
+    onInit(this: <%- name %>) {
+      const view = this.getView();
+    },
   };
 }


### PR DESCRIPTION
Fix for #2964.
- Refactores `onInit` method to accept a `this` parameter that causes problems during controller extension loading.