### PR TITLE
chore(fiori-generator-shared): Export type used by exported function

### DIFF
--- a/.changeset/cuddly-rabbits-invent.md
+++ b/.changeset/cuddly-rabbits-invent.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-generator-shared': patch
+---
+
+Export interface used by exported API, `generateReadMe`

--- a/packages/fiori-generator-shared/src/index.ts
+++ b/packages/fiori-generator-shared/src/index.ts
@@ -9,4 +9,4 @@ export { getBootstrapResourceUrls } from './ui5/ui5';
 export { getDefaultTargetFolder, isExtensionInstalled } from './vscode-helpers/vscode-helpers';
 export { generateReadMe } from './read-me';
 export { getHostEnvironment } from './environment';
-export { YeomanEnvironment, VSCodeInstance, hostEnvironment, HostEnvironmentId } from './types';
+export { YeomanEnvironment, VSCodeInstance, hostEnvironment, HostEnvironmentId, ReadMe } from './types';


### PR DESCRIPTION
Chore: Exported function is using an not-exported interface.