### PR TITLE
fix(cf-deploy-sub-generator): fix failing windows test

### DIFF
--- a/.changeset/pretty-years-know.md
+++ b/.changeset/pretty-years-know.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+Fix windows test

--- a/packages/cf-deploy-config-sub-generator/test/cap-app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/cap-app.test.ts
@@ -213,7 +213,7 @@ describe('Cloud foundry generator tests', () => {
             expect.objectContaining({
                 addCapMtaContinue: true,
                 mtaId: 'capmtaid',
-                mtaPath: '/output/capmissingmta',
+                mtaPath: join(OUTPUT_DIR_PREFIX, 'capmissingmta'),
                 routerType: 'managed'
             }),
             expect.anything(),


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/actions/runs/13628636855/job/38091306473?pr=2981

```
      Expected: ObjectContaining {"addCapMtaContinue": true, "mtaId": "capmtaid", "mtaPath": "/output/capmissingmta", "routerType": "managed"}, Anything, Anything
      Received: {"addCapMtaContinue": true, "mtaId": "capmtaid", "mtaPath": "\\output\\capmissingmta", "routerType": "managed"}, {"store": {"_events": {"change": [[Function anonymous], [Function anonymous], [Function bound onceWrapper]]}, "_eventsCount": 1, "_maxListeners": 0, Symbol(shapeMode): false, Symbol(kCapture): false}}, {}
```