### PR TITLE
chore: update dependencies

### DIFF
--- a/.changeset/beige-days-applaud.md
+++ b/.changeset/beige-days-applaud.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fiori-annotation-api': patch
+'@sap-ux/i18n': patch
+---
+
+Update `vscode-languageserver-textdocument` dependency

--- a/packages/fiori-annotation-api/package.json
+++ b/packages/fiori-annotation-api/package.json
@@ -34,7 +34,7 @@
         "@xml-tools/parser": "1.0.11",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
-        "vscode-languageserver-textdocument": "1.0.8"
+        "vscode-languageserver-textdocument": "1.0.11"
     },
     "devDependencies": {
         "@sap/cds-compiler": "4.8.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "jsonc-parser": "3.2.0",
-        "vscode-languageserver-textdocument": "1.0.7",
+        "vscode-languageserver-textdocument": "1.0.11",
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {

--- a/packages/preview-middleware-client/jest.config.js
+++ b/packages/preview-middleware-client/jest.config.js
@@ -2,9 +2,11 @@ const config = require('../../jest.base');
 config.testEnvironment = 'jsdom';
 config.moduleNameMapper = {
     '^sap/(.+)$': '<rootDir>/test/__mock__/sap/$1.ts',
-    // Jest will try to load browser version, because environment is set to jsdom, but that is not what we want 
+    // Jest will try to load browser version, because environment is set to jsdom, but that is not what we want
     // https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#packagejson-exports
     '^@sap-ux/i18n$': require.resolve('@sap-ux/i18n'),
+    // same as above, starting 1.0.11 "exports" property is added in package.json
+    'vscode-languageserver-textdocument': require.resolve('vscode-languageserver-textdocument'),
     '^mock/(.+)$': '<rootDir>/test/__mock__/$1.ts',
     '^open/ux/preview/client/(.+)$': '<rootDir>/src/$1.ts'
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1804,8 +1804,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       vscode-languageserver-textdocument:
-        specifier: 1.0.8
-        version: 1.0.8
+        specifier: 1.0.11
+        version: 1.0.11
     devDependencies:
       '@sap/cds-compiler':
         specifier: 4.8.0
@@ -2176,8 +2176,8 @@ importers:
         specifier: 3.2.0
         version: 3.2.0
       vscode-languageserver-textdocument:
-        specifier: 1.0.7
-        version: 1.0.7
+        specifier: 1.0.11
+        version: 1.0.11
     devDependencies:
       '@types/mem-fs':
         specifier: 1.1.2
@@ -22434,12 +22434,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vscode-languageserver-textdocument@1.0.7:
-    resolution: {integrity: sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==}
-    dev: false
-
-  /vscode-languageserver-textdocument@1.0.8:
-    resolution: {integrity: sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==}
+  /vscode-languageserver-textdocument@1.0.11:
+    resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
     dev: false
 
   /vscode-languageserver-types@3.17.2:


### PR DESCRIPTION
Update `vscode-languageserver-textdocument` to match language server.

This update was causing tests to fail in `preview-middleware-client`, because `vscode-languageserver-textdocument` now includes `exports` field in package.json which is used to determine package entry points. When using `jsdom` environment Jest uses `browser` entry point which defaults to ESM, but that it is not compatible with the current test setup, so we need to override the module import logic. 

https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28/#packagejson-exports 