### PR TITLE
fix: disable quick action if control has unstable ID

### DIFF
--- a/.changeset/quick-cups-jog.md
+++ b/.changeset/quick-cups-jog.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+CPE: disable quick action, if the control has unstable ID

--- a/packages/preview-middleware-client/src/adp/quick-actions/simple-quick-action-base.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/simple-quick-action-base.ts
@@ -4,8 +4,11 @@ import { SIMPLE_QUICK_ACTION_KIND, SimpleQuickAction } from '@sap-ux-private/con
 
 import { getRelevantControlFromActivePage } from '../../cpe/quick-actions/utils';
 import { QuickActionContext } from '../../cpe/quick-actions/quick-action-definition';
-import { EnablementValidator } from './enablement-validator';
+import { EnablementValidator, EnablementValidatorResult } from './enablement-validator';
 import { QuickActionDefinitionBase } from './quick-action-base';
+import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
+import hasStableId from 'sap/ui/rta/util/hasStableId';
+import { getTextBundle } from '../../i18n';
 
 /**
  * Base class for all simple quick actions.
@@ -38,6 +41,7 @@ export abstract class SimpleQuickActionDefinitionBase<
             this.control = control;
             break;
         }
+        this.enablementValidators.push(this.CONTROL_HAS_STABLEID);
         return Promise.resolve();
     }
 
@@ -50,4 +54,21 @@ export abstract class SimpleQuickActionDefinitionBase<
             title: this.context.resourceBundle.getText(this.textKey)
         };
     }
+
+    CONTROL_HAS_STABLEID: EnablementValidator = {
+        run: async (): Promise<EnablementValidatorResult> => {
+            if (this.control) {
+                const controlOverLay = OverlayRegistry.getOverlay(this.control);
+                if (!hasStableId(controlOverLay)) {
+                    const i18n = await getTextBundle();
+
+                    return {
+                        type: 'error',
+                        message: i18n.getText('CONTROL_HAS_NO_STABLE_ID')
+                    };
+                }
+            }
+            return undefined;
+        }
+    };
 }

--- a/packages/preview-middleware-client/src/messagebundle.properties
+++ b/packages/preview-middleware-client/src/messagebundle.properties
@@ -63,3 +63,4 @@ INVALID_BINDING_STRING_FORMAT=Invalid binding string. Supported value pattern is
 INVALID_BINDING_MODEL=Invalid binding model.
 INVALID_BINDING_MODEL_KEY=Invalid key in the binding string. Supported value pattern is {i18n>YOUR_KEY}. Check if the key already exists in i18n.properties.If not, add the key in the i18n.properties file and reload the editor for the new key to take effect.
 
+CONTROL_HAS_NO_STABLE_ID=This option has been disabled because the control has no stable ID

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -41,6 +41,7 @@ import type { ChangeService } from '../../../../src/cpe/changes/service';
 import VersionInfo from 'mock/sap/ui/VersionInfo';
 import ComponentMock from 'mock/sap/ui/core/Component';
 import UIComponent from 'sap/ui/core/UIComponent';
+import hasStableId from 'mock/sap/ui/rta/util/hasStableId';
 
 describe('FE V2 quick actions', () => {
     let sendActionMock: jest.Mock;
@@ -737,7 +738,7 @@ describe('FE V2 quick actions', () => {
                         ]
                     });
                 }
-               
+
                 expect(sendActionMock).toHaveBeenCalledWith(
                     quickActionListChanged([
                         {
@@ -780,7 +781,7 @@ describe('FE V2 quick actions', () => {
                 await subscribeMock.mock.calls[0][0](
                     executeQuickAction({ id: 'listReport0-create-table-action', kind: 'nested', path: '0' })
                 );
-               
+
                 expect(DialogFactory.createDialog).toHaveBeenCalledTimes(testCase.tableToolbar === 'None' ? 0 : 1);
 
                 if (testCase.tableToolbar !== 'None') {
@@ -796,13 +797,15 @@ describe('FE V2 quick actions', () => {
                             title: 'QUICK_ACTION_ADD_CUSTOM_TABLE_ACTION'
                         }
                     );
-
-                };
+                }
             });
         });
 
         describe('add page action', () => {
             test('initialize and execute action', async () => {
+                hasStableId.mockImplementation(() => {
+                    return true;
+                });
                 const pageView = new XMLView();
                 FlexUtils.getViewForControl.mockImplementation(() => {
                     return {
@@ -1757,6 +1760,9 @@ describe('FE V2 quick actions', () => {
                 jest.spyOn(versionUtils, 'getUi5Version').mockResolvedValue(
                     testCase.ui5version ?? { major: 1, minor: 131 }
                 );
+                hasStableId.mockImplementation(() => {
+                    return true;
+                });
                 sapCoreMock.byId.mockImplementation((id) => {
                     if (id == 'DynamicPage') {
                         return {
@@ -1905,6 +1911,9 @@ describe('FE V2 quick actions', () => {
     describe('ObjectPage', () => {
         describe('add header field', () => {
             test('initialize and execute action', async () => {
+                hasStableId.mockImplementation(() => {
+                    return true;
+                });
                 const pageView = new XMLView();
                 FlexUtils.getViewForControl.mockImplementation(() => {
                     return {

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -46,6 +46,7 @@ import { TableQuickActionDefinitionBase } from '../../../../src/adp/quick-action
 import * as QCUtils from '../../../../src/cpe/quick-actions/utils';
 import ManagedObject from 'sap/ui/base/ManagedObject';
 import * as versionUtils from 'open/ux/preview/client/utils/version';
+import hasStableId from 'mock/sap/ui/rta/util/hasStableId';
 
 describe('FE V4 quick actions', () => {
     let sendActionMock: jest.Mock;
@@ -212,6 +213,9 @@ describe('FE V4 quick actions', () => {
 
             test('available since UI5 version 1.130', async () => {
                 VersionInfo.load.mockResolvedValue({ name: 'sap.ui.core', version: '1.130.1' });
+                hasStableId.mockImplementation(() => {
+                    return true;
+                });
                 await setupContext();
                 expect(sendActionMock).toHaveBeenCalledWith(
                     quickActionListChanged([
@@ -1195,21 +1199,16 @@ describe('FE V4 quick actions', () => {
 
                 rtaMock = new RuntimeAuthoringMock({} as RTAOptions) as unknown as RuntimeAuthoring;
                 const registry = new FEV4QuickActionRegistry();
-                service = new QuickActionService(
-                    rtaMock,
-                    new OutlineService(rtaMock, mockChangeService),
-                    [registry],
-                    {
-                        onStackChange: jest.fn(),
-                        getConfigurationPropertyValue: jest
-                            .fn()
-                            .mockReturnValueOnce(undefined)
-                            .mockReturnValueOnce(undefined)
-                            .mockReturnValueOnce(true)
-                            .mockReturnValueOnce(undefined)
-                            .mockReturnValue(undefined)
-                    } as any
-                );
+                service = new QuickActionService(rtaMock, new OutlineService(rtaMock, mockChangeService), [registry], {
+                    onStackChange: jest.fn(),
+                    getConfigurationPropertyValue: jest
+                        .fn()
+                        .mockReturnValueOnce(undefined)
+                        .mockReturnValueOnce(undefined)
+                        .mockReturnValueOnce(true)
+                        .mockReturnValueOnce(undefined)
+                        .mockReturnValue(undefined)
+                } as any);
             });
 
             test('initialize and execute action', async () => {
@@ -1338,6 +1337,9 @@ describe('FE V4 quick actions', () => {
                 jest.spyOn(versionUtils, 'getUi5Version').mockResolvedValue(
                     testCase.ui5version ?? { major: 1, minor: 131 }
                 );
+                hasStableId.mockImplementation(() => {
+                    return true;
+                });
                 fetchMock.mockResolvedValue({
                     json: jest
                         .fn()
@@ -1537,6 +1539,9 @@ describe('FE V4 quick actions', () => {
             describe('add header field', () => {
                 test('initialize and execute action', async () => {
                     const pageView = new XMLView();
+                    hasStableId.mockImplementation(() => {
+                        return true;
+                    });
                     FlexUtils.getViewForControl.mockImplementation(() => {
                         return {
                             getId: () => 'MyView',
@@ -2224,6 +2229,9 @@ describe('FE V4 quick actions', () => {
                     jest.spyOn(versionUtils, 'getUi5Version').mockResolvedValue(
                         testCase.ui5version ?? { major: 1, minor: 131 }
                     );
+                    hasStableId.mockImplementation(() => {
+                        return true;
+                    });
                     fetchMock.mockResolvedValue({
                         json: jest
                             .fn()


### PR DESCRIPTION
Disable quick action with tooltip, if the control id is not stable.

