### PR TITLE
feat: use webappPath for mockserver generation

### DIFF
--- a/.changeset/neat-grapes-design.md
+++ b/.changeset/neat-grapes-design.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/mockserver-config-writer': patch
+'@sap-ux/ui5-config': patch
+---
+
+Adds webappPath and basePath parameters to resolve service paths during mockserver generation/update.

--- a/.changeset/neat-grapes-design.md
+++ b/.changeset/neat-grapes-design.md
@@ -3,4 +3,4 @@
 '@sap-ux/ui5-config': patch
 ---
 
-Adds webappPath and basePath parameters to resolve service paths during mockserver generation/update.
+Adds `webappPath` and `basePath` parameters to resolve service paths during mockserver generation/update.

--- a/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
+++ b/packages/mockserver-config-writer/src/mockserver-config/ui5-mock-yaml.ts
@@ -72,6 +72,8 @@ export async function enhanceYaml(
     if (fs.exists(ui5MockYamlPath)) {
         mockConfig = await updateUi5MockYamlConfig(
             fs,
+            basePath,
+            webappPath,
             ui5MockYamlPath,
             dataSourcesConfig,
             annotationsConfig,
@@ -79,8 +81,14 @@ export async function enhanceYaml(
         );
     } else {
         mockConfig = fs.exists(join(basePath, 'ui5.yaml'))
-            ? await generateUi5MockYamlBasedOnUi5Yaml(fs, basePath, dataSourcesConfig, annotationsConfig)
-            : await generateNewUi5MockYamlConfig(manifest['sap.app']?.id || '', dataSourcesConfig, annotationsConfig);
+            ? await generateUi5MockYamlBasedOnUi5Yaml(fs, basePath, webappPath, dataSourcesConfig, annotationsConfig)
+            : await generateNewUi5MockYamlConfig(
+                  manifest['sap.app']?.id || '',
+                  basePath,
+                  webappPath,
+                  dataSourcesConfig,
+                  annotationsConfig
+              );
     }
     const yaml = mockConfig.toString();
     fs.write(ui5MockYamlPath, yaml);
@@ -115,6 +123,8 @@ export async function removeMockDataFolders(fs: Editor, basePath: string): Promi
  * 'sap-fe-mockserver' with state of the art config.
  *
  * @param fs - Editor instance to read existing information
+ * @param basePath - path to project root, where package.json and ui5.yaml is
+ * @param webappPath - path to webapp folder, where manifest.json is
  * @param ui5MockYamlPath - path to ui5-mock.yaml file
  * @param dataSourcesConfig - dataSources config from manifest to add to mockserver middleware services list
  * @param annotationsConfig - annotations config to add to mockserver mockserver middleware annotations list
@@ -123,6 +133,8 @@ export async function removeMockDataFolders(fs: Editor, basePath: string): Promi
  */
 async function updateUi5MockYamlConfig(
     fs: Editor,
+    basePath: string,
+    webappPath: string,
     ui5MockYamlPath: string,
     dataSourcesConfig: DataSourceConfig[],
     annotationsConfig: MockserverConfig['annotations'],
@@ -130,13 +142,19 @@ async function updateUi5MockYamlConfig(
 ): Promise<UI5Config> {
     const existingUi5MockYamlConfig = await UI5Config.newInstance(fs.read(ui5MockYamlPath));
     if (overwrite) {
-        const newMockserverMiddleware = await getNewMockserverMiddleware(dataSourcesConfig, annotationsConfig);
+        const newMockserverMiddleware = await getNewMockserverMiddleware(
+            basePath,
+            webappPath,
+            dataSourcesConfig,
+            annotationsConfig
+        );
         existingUi5MockYamlConfig.updateCustomMiddleware(newMockserverMiddleware);
     } else {
         for (const dataSourceName in dataSourcesConfig) {
             existingUi5MockYamlConfig.addServiceToMockserverMiddleware(
+                basePath,
+                webappPath,
                 dataSourcesConfig[dataSourceName],
-                undefined,
                 annotationsConfig
             );
         }
@@ -149,6 +167,7 @@ async function updateUi5MockYamlConfig(
  *
  * @param fs - Editor instance to read existing information
  * @param basePath - the base path where the package.json and ui5.yaml is
+ * @param webappPath - path to webapp folder, where manifest.json is
  * @param dataSourcesConfig - dataSources config from manifest to add to mockserver middleware services list
  * @param annotationsConfig - annotations config to add to mockserver mockserver middleware annotations list
  * @returns {*}  {Promise<UI5Config>} - Update Yaml Doc
@@ -156,11 +175,17 @@ async function updateUi5MockYamlConfig(
 async function generateUi5MockYamlBasedOnUi5Yaml(
     fs: Editor,
     basePath: string,
+    webappPath: string,
     dataSourcesConfig: DataSourceConfig[],
     annotationsConfig: MockserverConfig['annotations']
 ): Promise<UI5Config> {
     const ui5MockYamlConfig = await readUi5Yaml(basePath, FileName.Ui5Yaml, fs);
-    const ui5MockServerMiddleware = await getNewMockserverMiddleware(dataSourcesConfig, annotationsConfig);
+    const ui5MockServerMiddleware = await getNewMockserverMiddleware(
+        basePath,
+        webappPath,
+        dataSourcesConfig,
+        annotationsConfig
+    );
     ui5MockYamlConfig.updateCustomMiddleware(ui5MockServerMiddleware);
     return ui5MockYamlConfig;
 }
@@ -169,12 +194,16 @@ async function generateUi5MockYamlBasedOnUi5Yaml(
  * Create fresh ui5-mock.yaml configuration which can be stringified and written.
  *
  * @param appId - application id
+ * @param basePath - path to project root, where package.json and ui5.yaml is
+ * @param webappPath - path to webapp folder, where manifest.json is
  * @param dataSourcesConfig - dataSources config from manifest to add to mockserver middleware services list
  * @param annotationsConfig - annotations config to add to mockserver mockserver middleware annotations list
  * @returns {*}  {Promise<UI5Config>} - Update Yaml Doc
  */
 async function generateNewUi5MockYamlConfig(
     appId: string,
+    basePath: string,
+    webappPath: string,
     dataSourcesConfig: DataSourceConfig[],
     annotationsConfig: MockserverConfig['annotations']
 ): Promise<UI5Config> {
@@ -185,23 +214,27 @@ async function generateNewUi5MockYamlConfig(
     ui5MockYaml.setType('application');
     ui5MockYaml.addFioriToolsProxydMiddleware({ ui5: {} });
     ui5MockYaml.addFioriToolsAppReloadMiddleware();
-    ui5MockYaml.addMockServerMiddleware(dataSourcesConfig, annotationsConfig);
+    ui5MockYaml.addMockServerMiddleware(basePath, webappPath, dataSourcesConfig, annotationsConfig);
     return ui5MockYaml;
 }
 
 /**
  * Return new mockserver middleware.
  *
+ * @param basePath - path to project root, where package.json and ui5.yaml is
+ * @param webappPath - path to webapp folder, where manifest.json is
  * @param dataSourcesConfig - dataSources config from manifest to add to mockserver middleware services list
  * @param annotationsConfig - annotations config to add to mockserver mockserver middleware annotations list
  * @returns - mockserver middleware
  */
 async function getNewMockserverMiddleware(
+    basePath: string,
+    webappPath: string,
     dataSourcesConfig: DataSourceConfig[],
     annotationsConfig: MockserverConfig['annotations']
 ): Promise<CustomMiddleware<MockserverConfig>> {
     const ui5MockYaml = await UI5Config.newInstance('');
-    ui5MockYaml.addMockServerMiddleware(dataSourcesConfig, annotationsConfig);
+    ui5MockYaml.addMockServerMiddleware(basePath, webappPath, dataSourcesConfig, annotationsConfig);
     const mockserverMiddleware = ui5MockYaml.findCustomMiddleware('sap-fe-mockserver');
     if (!mockserverMiddleware) {
         throw Error('Could not create new mockserver config');

--- a/packages/mockserver-config-writer/test/unit/mockserver-config/ui5-mock-yaml.test.ts
+++ b/packages/mockserver-config-writer/test/unit/mockserver-config/ui5-mock-yaml.test.ts
@@ -71,6 +71,30 @@ describe('Test enhanceYaml()', () => {
         ]);
     });
 
+    test('Create new ui5-mock.yaml with services and annotations from mock manifest.json in custom webapp', async () => {
+        const customWebappPath = join(basePath, 'custom_webapp');
+        const customManifestJsonPath = join(customWebappPath, 'manifest.json');
+
+        const fs = getFs({ [customManifestJsonPath]: mockManifestJson });
+        await enhanceYaml(fs, basePath, customWebappPath);
+
+        const ui5Config = await UI5Config.newInstance(fs.read(ui5MockYamlPath));
+        const mockserverConfig = ui5Config.findCustomMiddleware<MockserverConfig>('sap-fe-mockserver');
+        expect(mockserverConfig?.configuration.services?.[0]).toStrictEqual({
+            generateMockData: true,
+            metadataPath: './custom_webapp/localService/mainService/metadata.xml',
+            mockdataPath: './custom_webapp/localService/mainService/data',
+            urlPath: '/sap/opu/odata/sap/SEPMRA_PROD_MAN'
+        });
+        expect(mockserverConfig?.configuration.annotations).toEqual([
+            {
+                localPath: './custom_webapp/localService/SEPMRA_PROD_MAN.xml',
+                urlPath:
+                    "/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/"
+            }
+        ]);
+    });
+
     test('Update ui5-mock.yaml, path and service name from manifest', async () => {
         const fs = getFsWithUi5MockYaml(manifestWithMainService);
         await enhanceYaml(fs, basePath, webappPath);

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -1147,6 +1147,8 @@ async function getSingleServiceMock(): Promise<Editor> {
     const ui5LocalYaml = (await UI5Config.newInstance(''))
         .addFioriToolsProxydMiddleware({ ui5: {}, backend: [{ path: '/sap', url: 'https://localhost' }] })
         .addMockServerMiddleware(
+            testDir,
+            join(testDir, 'webapp'),
             [{ serviceName: 'mainService', servicePath: '/sap' }],
             [
                 {
@@ -1158,6 +1160,8 @@ async function getSingleServiceMock(): Promise<Editor> {
     const ui5MockYaml = (await UI5Config.newInstance(''))
         .addFioriToolsProxydMiddleware({ ui5: {}, backend: [{ path: '/sap', url: 'https://localhost' }] })
         .addMockServerMiddleware(
+            testDir,
+            join(testDir, 'webapp'),
             [{ serviceName: 'mainService', servicePath: '/sap' }],
             [
                 {

--- a/packages/ui5-config/src/middlewares.ts
+++ b/packages/ui5-config/src/middlewares.ts
@@ -1,3 +1,4 @@
+import { join, posix, relative, sep } from 'path';
 import type {
     FioriToolsProxyConfigBackend,
     CustomMiddleware,
@@ -129,16 +130,19 @@ export function getFioriToolsProxyMiddlewareConfig(
 }
 
 export const getMockServerMiddlewareConfig = (
+    basePath: string,
+    webappPath: string,
     dataSourcesConfig: DataSourceConfig[],
-    annotationsConfig: MockserverConfig['annotations'],
-    appRoot?: string
+    annotationsConfig: MockserverConfig['annotations']
 ): CustomMiddleware<MockserverConfig> => {
     const services: MockserverConfig['services'] = [];
 
     // Populate services based on dataSourcesConfig
     dataSourcesConfig.forEach((dataSource) => {
-        const serviceRoot = `${appRoot ?? './webapp'}/localService/${dataSource.serviceName}`;
-
+        const serviceRoot = `.${posix.sep}${relative(
+            basePath,
+            join(webappPath, 'localService', dataSource.serviceName)
+        ).replaceAll(sep, posix.sep)}`;
         const newServiceData = {
             urlPath: dataSource.servicePath.replace(/\/$/, ''), // Mockserver is sensitive to trailing '/'
             metadataPath: dataSource.metadataPath ?? `${serviceRoot}/metadata.xml`,

--- a/packages/ui5-config/test/__snapshots__/index.test.ts.snap
+++ b/packages/ui5-config/test/__snapshots__/index.test.ts.snap
@@ -442,22 +442,6 @@ exports[`UI5Config addMockServerMiddleware add with services and annotations 1`]
 "
 `;
 
-exports[`UI5Config addMockServerMiddleware add with services and appRoot 1`] = `
-"server:
-  customMiddleware:
-    - name: sap-fe-mockserver
-      beforeMiddleware: csp
-      configuration:
-        mountPath: /
-        services:
-          - urlPath: /path/to/service
-            metadataPath: ./appRoot/webapp/localService/new-service/metadata.xml
-            mockdataPath: ./appRoot/webapp/localService/new-service/data
-            generateMockData: true
-        annotations: []
-"
-`;
-
 exports[`UI5Config addMockServerMiddleware add without services and annotations 1`] = `
 "server:
   customMiddleware:
@@ -584,22 +568,6 @@ exports[`UI5Config addServiceToMockserverMiddleware add new service with annotat
         annotations:
           - localPath: ./webapp/annotations/annotations.xml
             urlPath: annotations.xml
-"
-`;
-
-exports[`UI5Config addServiceToMockserverMiddleware add new service with appRoot 1`] = `
-"server:
-  customMiddleware:
-    - name: sap-fe-mockserver
-      beforeMiddleware: csp
-      configuration:
-        mountPath: /
-        services:
-          - urlPath: /path/to/service
-            metadataPath: ./appRoot/localService/new-service/metadata.xml
-            mockdataPath: ./appRoot/localService/new-service/data
-            generateMockData: true
-        annotations: []
 "
 `;
 

--- a/packages/ui5-config/test/index.test.ts
+++ b/packages/ui5-config/test/index.test.ts
@@ -433,27 +433,27 @@ describe('UI5Config', () => {
     });
 
     describe('addMockServerMiddleware', () => {
+        const basePath = '/';
+        const webappPath = '/webapp';
         test('add without services and annotations', () => {
-            ui5Config.addMockServerMiddleware([], []);
+            ui5Config.addMockServerMiddleware(basePath, webappPath, [], []);
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
         test('add with services', () => {
-            ui5Config.addMockServerMiddleware([{ serviceName: 'new-service', servicePath: '/path/to/service' }], []);
-            expect(ui5Config.toString()).toMatchSnapshot();
-        });
-
-        test('add with services and appRoot', () => {
             ui5Config.addMockServerMiddleware(
+                basePath,
+                webappPath,
                 [{ serviceName: 'new-service', servicePath: '/path/to/service' }],
-                [],
-                './appRoot/webapp'
+                []
             );
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
         test('add with services and annotations', () => {
             ui5Config.addMockServerMiddleware(
+                basePath,
+                webappPath,
                 [{ serviceName: 'new-service', servicePath: '/path/to/service' }],
                 annotationsConfig
             );
@@ -462,33 +462,36 @@ describe('UI5Config', () => {
     });
 
     describe('addServiceToMockserverMiddleware', () => {
+        const basePath = '/';
+        const webappPath = '/webapp';
         test('add new service', () => {
-            ui5Config.addMockServerMiddleware([], []);
-            ui5Config.addServiceToMockserverMiddleware({ serviceName: 'new-service', servicePath: '/path/to/service' });
-            expect(ui5Config.toString()).toMatchSnapshot();
-        });
-
-        test('add new service with appRoot', () => {
-            ui5Config.addMockServerMiddleware([], []);
-            ui5Config.addServiceToMockserverMiddleware(
-                { serviceName: 'new-service', servicePath: '/path/to/service' },
-                './appRoot'
-            );
+            ui5Config.addMockServerMiddleware(basePath, webappPath, [], []);
+            ui5Config.addServiceToMockserverMiddleware(basePath, webappPath, {
+                serviceName: 'new-service',
+                servicePath: '/path/to/service'
+            });
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
         test('try to add service duplicate', () => {
-            ui5Config.addMockServerMiddleware([], []);
-            ui5Config.addServiceToMockserverMiddleware({ serviceName: 'new-service', servicePath: '/path/to/service' });
-            ui5Config.addServiceToMockserverMiddleware({ serviceName: 'new-service', servicePath: '/path/to/service' });
+            ui5Config.addMockServerMiddleware(basePath, webappPath, [], []);
+            ui5Config.addServiceToMockserverMiddleware(basePath, webappPath, {
+                serviceName: 'new-service',
+                servicePath: '/path/to/service'
+            });
+            ui5Config.addServiceToMockserverMiddleware(basePath, webappPath, {
+                serviceName: 'new-service',
+                servicePath: '/path/to/service'
+            });
             expect(ui5Config.toString()).toMatchSnapshot();
         });
 
         test('add new service with annotationsConfig', () => {
-            ui5Config.addMockServerMiddleware([], []);
+            ui5Config.addMockServerMiddleware(basePath, webappPath, [], []);
             ui5Config.addServiceToMockserverMiddleware(
+                basePath,
+                webappPath,
                 { serviceName: 'new-service', servicePath: '/path/to/service' },
-                undefined,
                 annotationsConfig
             );
             expect(ui5Config.toString()).toMatchSnapshot();
@@ -496,9 +499,16 @@ describe('UI5Config', () => {
     });
 
     describe('removeServiceFromMockServerMiddleware', () => {
+        const basePath = '/';
+        const webappPath = '/webapp';
         test('remove exisisting service', () => {
             // Create middleware with one service
-            ui5Config.addMockServerMiddleware([{ serviceName: 'new-service', servicePath: '/path/to/service' }], []);
+            ui5Config.addMockServerMiddleware(
+                basePath,
+                webappPath,
+                [{ serviceName: 'new-service', servicePath: '/path/to/service' }],
+                []
+            );
             let mockserverMiddleware = ui5Config.findCustomMiddleware('sap-fe-mockserver');
             expect(mockserverMiddleware?.configuration).toStrictEqual({
                 services: [
@@ -525,6 +535,8 @@ describe('UI5Config', () => {
         test('remove exisisting service with annotations', () => {
             // Create middleware with one service
             ui5Config.addMockServerMiddleware(
+                basePath,
+                webappPath,
                 [{ serviceName: 'new-service', servicePath: '/path/to/service' }],
                 [{ urlPath: '/path/to/annotation' }]
             );
@@ -557,7 +569,7 @@ describe('UI5Config', () => {
 
         test('remove unexisting service', () => {
             // Create middleware without any services
-            ui5Config.addMockServerMiddleware([], []);
+            ui5Config.addMockServerMiddleware(basePath, webappPath, [], []);
             let mockserverMiddleware = ui5Config.findCustomMiddleware('sap-fe-mockserver');
             expect(mockserverMiddleware?.configuration).toStrictEqual({
                 services: [],


### PR DESCRIPTION
Adds `webappPath` and `basePath` parameters to resolve service paths during mockserver generation/update.
Fixes cases when custom webapp paths are used.