### PR TITLE
fix(project-integrity): ensure encoded write for project-integrity

### DIFF
--- a/.changeset/nine-shoes-protect.md
+++ b/.changeset/nine-shoes-protect.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-integrity': patch
+---
+
+Fix to ensure writing of encoded integrity data

--- a/packages/project-integrity/src/integrity/persistence.ts
+++ b/packages/project-integrity/src/integrity/persistence.ts
@@ -35,25 +35,26 @@ export async function readIntegrityData(integrityFilePath: string): Promise<Inte
  * @param content - content to write to the integrity file
  */
 export async function writeIntegrityData(integrityFilePath: string, content: Integrity): Promise<void> {
+    const clonedContent = structuredClone(content); // clone to ensure integrity data has no getters
     const integrityDir = dirname(integrityFilePath);
     if (!existsSync(integrityDir)) {
         await mkdir(integrityDir, { recursive: true });
     }
 
-    for (const fileIntegrity of content.fileIntegrity) {
+    for (const fileIntegrity of clonedContent.fileIntegrity) {
         fileIntegrity.filePath = relative(integrityDir, fileIntegrity.filePath);
         if (typeof fileIntegrity.content === 'string') {
             fileIntegrity.content = compressToBase64(fileIntegrity.content);
         }
     }
 
-    for (const contentIntegrity of content.contentIntegrity) {
+    for (const contentIntegrity of clonedContent.contentIntegrity) {
         if (typeof contentIntegrity.content === 'string') {
             contentIntegrity.content = compressToBase64(contentIntegrity.content);
         }
     }
 
-    await writeFile(integrityFilePath, JSON.stringify(content), { encoding: 'utf-8' });
+    await writeFile(integrityFilePath, JSON.stringify(clonedContent), { encoding: 'utf-8' });
 }
 
 /**

--- a/packages/project-integrity/test/unit/integrity/persistence.test.ts
+++ b/packages/project-integrity/test/unit/integrity/persistence.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'fs/promises';
+import { mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 import { readIntegrityData, writeIntegrityData } from '../../../src/integrity/persistence';
 import type { Integrity } from '../../../src/types';
@@ -31,6 +31,10 @@ describe('Test readIntegrityData()', () => {
 });
 
 describe('Test writeIntegrityData()', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     test('Write integrity data, path to integrity data does not exists', async () => {
         const mockedMkdir = mkdir as jest.Mock;
         const integrityFilePath = join(__dirname, '../../test-input/new-folder/integrity.json');
@@ -40,6 +44,15 @@ describe('Test writeIntegrityData()', () => {
         };
         await writeIntegrityData(integrityFilePath, content as Integrity);
         expect(mockedMkdir).toBeCalledWith(expect.stringContaining('new-folder'), { recursive: true });
+    });
+
+    test('Read and write integrity data, content should be same', async () => {
+        const mockedWriteFile = writeFile as jest.Mock;
+        const integrityFilePath = join(__dirname, '../../test-input/valid-fiori-project/.fiori-ai/ai-integrity.json');
+        const originalContent = await readFile(integrityFilePath, { encoding: 'utf-8' });
+        const content = await readIntegrityData(integrityFilePath);
+        await writeIntegrityData(integrityFilePath, content);
+        expect(mockedWriteFile).toBeCalledWith(integrityFilePath, originalContent, { encoding: 'utf-8' });
     });
 
     // Other, valid cases, are tested in project.test.ts


### PR DESCRIPTION
When using `disableProjectIntegrity()` or `enableProjectIntegrity()` the content of integrity data was written not encoded. 

This pull request fixes this issue.