### PR TITLE
fix: set timeout in before all

### DIFF
--- a/packages/preview-middleware/playwright.config.ts
+++ b/packages/preview-middleware/playwright.config.ts
@@ -6,7 +6,6 @@ import type { PlaywrightTestConfig } from '@sap-ux-private/playwright';
  */
 import 'dotenv/config';
 
-const timeout = 5 * 60000 + 30000;
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -35,8 +34,6 @@ const config: PlaywrightTestConfig = {
             use: { ...devices['Desktop Chrome'], channel: 'chrome', viewport: { width: 1720, height: 900 } }
         }
     ],
-    /* 5 min for npm i + 30000 ms default timeout */
-    timeout,
     globalSetup: require.resolve('./test/integration/utils/global-setup')
 };
 export default defineConfig(config);

--- a/packages/preview-middleware/test/integration/preview/preview.spec.ts
+++ b/packages/preview-middleware/test/integration/preview/preview.spec.ts
@@ -11,6 +11,7 @@ import type { Page } from '@sap-ux-private/playwright';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import type { UI5Version } from '@sap-ux/ui5-info';
+import { SERVER_TIMEOUT, TIMEOUT } from '../utils/constant';
 
 const buildUrl =
     (port = 3000) =>
@@ -75,7 +76,6 @@ middleware:
   path: ../../../dist/ui5/middleware.js
 `;
 };
-const timeout = 50 * 1000;
 
 const getYamlPath = (cwd: string): string => {
     return join(cwd, 'ui5.yaml');
@@ -97,7 +97,7 @@ const prepare = async (ui5Version: string) => {
     getUrl = buildUrl(port);
     await startServer({
         command: `cd ${testCwd} && npx ui5 serve --port ${port}`,
-        launchTimeout: timeout,
+        launchTimeout: SERVER_TIMEOUT,
         port: port,
         host: 'localhost',
         protocol: 'http',
@@ -117,11 +117,15 @@ const UI5Versions = JSON.parse(process.env.UI5Versions ?? '[]') as UI5Version[];
 
 for (const { version } of UI5Versions) {
     test.describe(`UI5 version: ${version}`, () => {
+        test.beforeAll(async () => {
+            test.setTimeout(TIMEOUT);
+            await prepare(version);
+        });
+
         test.afterEach(async () => {
             await teardownServer();
         });
         test('Click on Go button and check an element ', async ({ page }) => {
-            await prepare(version);
             await check({ page });
         });
     });

--- a/packages/preview-middleware/test/integration/utils/constant.ts
+++ b/packages/preview-middleware/test/integration/utils/constant.ts
@@ -1,0 +1,2 @@
+export const TIMEOUT = 5 * 60000; // 5 min for npm install
+export const SERVER_TIMEOUT = 50 * 1000;


### PR DESCRIPTION
Problem:
Timeout was set in config which effects all tests timeout.[More on timeout](https://playwright.dev/docs/test-timeouts). 
If there was any failure, playwright would re-try one more time after waiting `5 min + 30 second` and this caused timeout in pipeline which has only [30 min](https://github.com/SAP/open-ux-tools/blob/main/.github/workflows/pipeline.yml#L15). Playwright report artifacts were not uploaded due to pipeline time out.

Possible solution:
Add time out only in `beforeAll` which affects only before all. [More on this check.](https://playwright.dev/docs/test-timeouts#change-timeout-for-beforeallafterall-hook). 
