### PR TITLE
fix(deploy-gen): fix undefined error when no backend config found

### DIFF
--- a/.changeset/short-penguins-explain.md
+++ b/.changeset/short-penguins-explain.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-config-sub-generator': patch
+---
+
+fix undefined error when no backend config

--- a/packages/deploy-config-sub-generator/src/app/index.ts
+++ b/packages/deploy-config-sub-generator/src/app/index.ts
@@ -133,7 +133,7 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             servicePath: this.options.appGenServicePath
         });
         this.options.appGenServicePath ||= servicePath;
-        this.cfDestination = destinationName ?? this.options.appGenDestination ?? this.backendConfig.destination;
+        this.cfDestination = destinationName ?? this.options.appGenDestination ?? this.backendConfig?.destination;
     }
 
     /**

--- a/packages/deploy-config-sub-generator/test/fixtures/mta1/app1/ui5.yaml
+++ b/packages/deploy-config-sub-generator/test/fixtures/mta1/app1/ui5.yaml
@@ -1,25 +1,20 @@
 specVersion: '2.4'
 metadata:
-  name: 'travel'
+    name: 'travel'
 type: application
 server:
-  customMiddleware:
-    - name: fiori-tools-proxy
-      afterMiddleware: compression
-      configuration:
-        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
-        backend:
-          - path: /sap
-            url: https://abap.staging.hana.ondemand.com
-            scp: true 
-        ui5:
-          path:
-            - /resources
-            - /test-resources
-          url: https://ui5.sap.com
-          version:  # The UI5 version, for instance, 1.78.1. Empty means latest version
-    - name: fiori-tools-appreload
-      afterMiddleware: compression
-      configuration:
-        port: 35729
-        path: webapp
+    customMiddleware:
+        - name: fiori-tools-proxy
+          afterMiddleware: compression
+          configuration:
+              ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+              ui5:
+                  path:
+                      - /resources
+                      - /test-resources
+                  url: https://ui5.sap.com
+        - name: fiori-tools-appreload
+          afterMiddleware: compression
+          configuration:
+              port: 35729
+              path: webapp


### PR DESCRIPTION
When the deployment generator is ran standalone, against a project with no existing backend configuration, the generator is throwing an undefined error when trying to read `backendConfig.destination`