### PR TITLE
fix(deploy-config-sub-generator): append destination to backendconfig

### DIFF
--- a/.changeset/strange-otters-sleep.md
+++ b/.changeset/strange-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-config-sub-generator': patch
+---
+
+ensure destination is appended to backend config

--- a/packages/deploy-config-sub-generator/src/utils/config.ts
+++ b/packages/deploy-config-sub-generator/src/utils/config.ts
@@ -34,7 +34,7 @@ export async function getBackendConfig(
     } else {
         // Launched as subgenerator from app gen
         backendConfig = {
-            destination: options.connectedSystem?.destination?.Name,
+            destination: options.appGenDestination || options.connectedSystem?.destination?.Name,
             url: options.appGenServiceHost,
             client: options.appGenClient,
             scp: !!options.connectedSystem?.backendSystem?.serviceKeys || false


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/3010

- ensure the destination passed from another generator is appended to backend config
- add unit tests to cover change