### PR TITLE
fix(deploy-config): fix errors running standalone

### DIFF
--- a/packages/deploy-config-sub-generator/src/app/index.ts
+++ b/packages/deploy-config-sub-generator/src/app/index.ts
@@ -8,19 +8,18 @@ import {
     TargetName,
     getExtensionGenPromptOpts
 } from '@sap-ux/deploy-config-generator-shared';
-import { parseTarget, getYUIDetails } from './utils';
+import { parseTarget } from './utils';
 import {
     getApiHubOptions,
     getEnvApiHubConfig,
     t,
     generatorNamespace,
-    generatorTitle,
     getBackendConfig,
     getSupportedTargets
 } from '../utils';
-import { AppWizard, Prompts } from '@sap-devx/yeoman-ui-types';
 import { promptDeployConfigQuestions } from './prompting';
 import { promptNames } from '../prompts/deploy-target';
+import { AppWizard, type Prompts } from '@sap-devx/yeoman-ui-types';
 import type { Answers } from 'inquirer';
 import type { AbapDeployConfigAnswersInternal } from '@sap-ux/abap-deploy-config-sub-generator';
 import type { DeployConfigGenerator, DeployConfigOptions } from '../types';
@@ -91,17 +90,6 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             this.apiHubConfig = this.options.apiHubConfig ?? getEnvApiHubConfig();
             this.launchStandaloneFromYui = false;
         }
-
-        // If launched standalone, set the header, title and description
-        if (this.launchStandaloneFromYui) {
-            this.appWizard.setHeaderTitle(generatorTitle);
-            this.prompts = new Prompts(getYUIDetails(this.options.projectRoot));
-            this.setPromptsCallback = (fn): void => {
-                if (this.prompts) {
-                    this.prompts.setCallback(fn);
-                }
-            };
-        }
     }
 
     /**
@@ -126,7 +114,7 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             this.fs,
             this.options as DeployConfigOptions,
             this.launchStandaloneFromYui,
-            this.options.projectRoot
+            this.options.appRootPath
         ));
         const { destinationName, servicePath } = await getApiHubOptions(this.fs, {
             appPath: this.options.appRootPath,
@@ -176,7 +164,7 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             this.answers = answers;
         }
 
-        if ((this.answers as Answers)?.confirmConfigUpdate !== false && this.target) {
+        if (this.target) {
             this._composeWithSubGenerator(this.target, this.answers);
         } else {
             DeploymentGenerator.logger?.debug(t('debug.exit'));
@@ -212,7 +200,7 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             }
             this.composeWith(generatorNamespace(this.genNamespace, generatorName), subGenOpts);
         } catch (error) {
-            DeploymentGenerator.logger?.error(error);
+            DeploymentGenerator.logger?.error(error.message);
         }
     }
 }

--- a/packages/deploy-config-sub-generator/src/app/utils.ts
+++ b/packages/deploy-config-sub-generator/src/app/utils.ts
@@ -1,4 +1,3 @@
-import { basename } from 'path';
 import type { DeployConfigOptions } from '../types';
 
 /**
@@ -19,19 +18,4 @@ export function parseTarget(args: string | string[], opts: DeployConfigOptions):
         result = opts.target;
     }
     return result;
-}
-
-/**
- * Returns the details for the YUI prompt.
- *
- * @param appRootPath - path to the application to be displayed in YUI step description
- * @returns step details
- */
-export function getYUIDetails(appRootPath: string): { name: string; description: string }[] {
-    return [
-        {
-            name: 'Deployment Configuration',
-            description: `Configure Deployment settings - ${basename(appRootPath)}`
-        }
-    ];
 }

--- a/packages/deploy-config-sub-generator/src/utils/constants.ts
+++ b/packages/deploy-config-sub-generator/src/utils/constants.ts
@@ -7,5 +7,3 @@ export const generatorNamespace = (bundledRootGeneratorName: string, subGenName:
 
 export const abapChoice: Target = { name: TargetName.ABAP, description: 'ABAP' };
 export const cfChoice: Target = { name: TargetName.CF, description: 'Cloud Foundry' };
-
-export const generatorTitle = 'Deployment Configuration Generator';

--- a/packages/deploy-config-sub-generator/test/app.test.ts
+++ b/packages/deploy-config-sub-generator/test/app.test.ts
@@ -9,7 +9,6 @@ import { generatorNamespace, initI18n } from '../src/utils';
 import { TargetName } from '@sap-ux/deploy-config-generator-shared';
 import { isAppStudio } from '@sap-ux/btp-utils';
 import * as cfInquirer from '@sap-ux/cf-deploy-config-inquirer';
-import * as envUtils from '@sap-ux/fiori-generator-shared';
 import * as abapDeploySubGen from '@sap-ux/abap-deploy-config-sub-generator';
 import * as projectAccess from '@sap-ux/project-access';
 import Generator from 'yeoman-generator';

--- a/packages/flp-config-sub-generator/test/app.test.ts
+++ b/packages/flp-config-sub-generator/test/app.test.ts
@@ -208,17 +208,7 @@ describe('flp-config generator', () => {
                 )
                 .withPrompts({
                     s4Continue: true,
-                    confirmConfigUpdate: true,
                     ...answers
-                })
-                .withOptions({
-                    data: {
-                        additionalPrompts: {
-                            confirmConfigUpdate: {
-                                show: true
-                            }
-                        }
-                    }
                 })
                 .run()
         ).resolves.not.toThrow();


### PR DESCRIPTION
- Remove references to `confirmConfigUpdate` as the prompt has been removed
- Remove responsibility of setting standalone header/description out of the subgen
- Fix logging error message 