### PR TITLE
fix(ui-components): UISections. Error `Cannot read properties of undefined (reading 'size')` is throws for section on initial rendering 

### DIFF
--- a/.changeset/itchy-students-retire.md
+++ b/.changeset/itchy-students-retire.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UISections. Error `Cannot read properties of undefined (reading 'size')` is throws for section on initial rendering 

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -256,7 +256,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
         let recalculateSizes = false;
         const sizesInfo: Array<SizeCalculationInfo> = [];
         for (let i = 0; i < this.props.children.length; i++) {
-            const size = sizes[i].size ?? 0;
+            const size = sizes[i]?.size ?? 0;
             const minSize = this.getMinSectionSize(i);
             if (minSize > size) {
                 recalculateSizes = true;

--- a/packages/ui-components/test/unit/components/UISections.test.tsx
+++ b/packages/ui-components/test/unit/components/UISections.test.tsx
@@ -1106,4 +1106,22 @@ describe('<Sections />', () => {
             { end: 0, percentage: false, size: 450, start: 200 }
         ]);
     });
+
+    it('Test "hidden" section - restore visibility', () => {
+        const hiddenWrapper = Enzyme.mount(
+            <UISections vertical={false} splitter={true} minSectionSize={6}>
+                <UISections.Section>
+                    <div>Left</div>
+                </UISections.Section>
+                <UISections.Section hidden={true}>
+                    <div>Right</div>
+                </UISections.Section>
+            </UISections>
+        );
+        jest.spyOn(UISections, 'getVisibleSections').mockReturnValueOnce([]);
+        hiddenWrapper.setProps({
+            minSectionSize: 100
+        });
+        expect(hiddenWrapper.find('.sections__item').length).toEqual(2);
+    });
 });


### PR DESCRIPTION
Part of #2971
Regression after https://github.com/SAP/open-ux-tools/pull/2979

There was missing check for `undefined`:
```
const size = sizes[i].size ?? 0;
```

In case if previous/original sizes from state are not set yet.