### PR TITLE
fix: disable header field page action with tooltip

### DIFF
--- a/.changeset/yellow-rocks-perform.md
+++ b/.changeset/yellow-rocks-perform.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: disable header field page action when show header content are set to false

--- a/packages/preview-middleware-client/src/adp/quick-actions/common/op-add-header-field.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/common/op-add-header-field.ts
@@ -9,6 +9,8 @@ import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/qu
 import { isA } from '../../../utils/core';
 import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
 import { DIALOG_ENABLEMENT_VALIDATOR } from '../dialog-enablement-validator';
+import { EnablementValidatorResult } from '../enablement-validator';
+import { getTextBundle } from '../../../i18n';
 
 export const OP_ADD_HEADER_FIELD_TYPE = 'op-add-header-field';
 const CONTROL_TYPES = ['sap.uxap.ObjectPageLayout'];
@@ -19,7 +21,24 @@ const CONTROL_TYPES = ['sap.uxap.ObjectPageLayout'];
 export class AddHeaderFieldQuickAction extends SimpleQuickActionDefinitionBase implements SimpleQuickActionDefinition {
     constructor(context: QuickActionContext) {
         super(OP_ADD_HEADER_FIELD_TYPE, CONTROL_TYPES, 'QUICK_ACTION_OP_ADD_HEADER_FIELD', context, [
-            DIALOG_ENABLEMENT_VALIDATOR
+            DIALOG_ENABLEMENT_VALIDATOR,
+            {
+                run: async (): Promise<EnablementValidatorResult> => {
+                    const i18n = await getTextBundle();
+                    const objectPageLayout = getRelevantControlFromActivePage(
+                        this.context.controlIndex,
+                        this.context.view,
+                        CONTROL_TYPES
+                    )[0] as ObjectPageLayout;
+                    if (!objectPageLayout.getShowHeaderContent()) {
+                        return {
+                            type: 'error',
+                            message: i18n.getText('DISABLE_SHOW_HEADER_CONTENT')
+                        };
+                    }
+                    return undefined;
+                }
+            }
         ]);
     }
 

--- a/packages/preview-middleware-client/src/messagebundle.properties
+++ b/packages/preview-middleware-client/src/messagebundle.properties
@@ -52,7 +52,7 @@ VARIANT_MANAGEMENT_FOR_PAGE_CONTROLS_IS_ALREADY_ENABLED=This option has been dis
 VARIANT_MANAGEMENT_FOR_TABLE_CONTROLS_IS_ALREADY_ENABLED=This option has been disabled because variant management is already enabled for the ''{0}''
 VARIANT_MANAGEMENT_FOR_CUSTOM_TABLES_NOT_SUPPORTED=Variant management cannot be set for custom table ''{0}''
 NO_TABLE_HEADER_TOOLBAR=This option has been disabled because the table does not have a header toolbar.
-
+DISABLE_SHOW_HEADER_CONTENT=This option has been disabled because the "Show Header Content" page property is set to false.
 ADD_ANNOTATION_FILE=Add Annotation File for ''{0}''
 SHOW_ANNOTATION_FILE=Show Annotation File for ''{0}''
 EXTEND_WITH_ANNOTATION=Extend With Annotation

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -737,7 +737,7 @@ describe('FE V2 quick actions', () => {
                         ]
                     });
                 }
-               
+
                 expect(sendActionMock).toHaveBeenCalledWith(
                     quickActionListChanged([
                         {
@@ -780,7 +780,7 @@ describe('FE V2 quick actions', () => {
                 await subscribeMock.mock.calls[0][0](
                     executeQuickAction({ id: 'listReport0-create-table-action', kind: 'nested', path: '0' })
                 );
-               
+
                 expect(DialogFactory.createDialog).toHaveBeenCalledTimes(testCase.tableToolbar === 'None' ? 0 : 1);
 
                 if (testCase.tableToolbar !== 'None') {
@@ -796,8 +796,7 @@ describe('FE V2 quick actions', () => {
                             title: 'QUICK_ACTION_ADD_CUSTOM_TABLE_ACTION'
                         }
                     );
-
-                };
+                }
             });
         });
 
@@ -1904,7 +1903,15 @@ describe('FE V2 quick actions', () => {
     });
     describe('ObjectPage', () => {
         describe('add header field', () => {
-            test('initialize and execute action', async () => {
+            const testCases = [
+                {
+                    ShowHeaderContent: true
+                },
+                {
+                    ShowHeaderContent: false
+                }
+            ];
+            test.each(testCases)('initialize and execute action (%s)', async (testCase) => {
                 const pageView = new XMLView();
                 FlexUtils.getViewForControl.mockImplementation(() => {
                     return {
@@ -1939,6 +1946,7 @@ describe('FE V2 quick actions', () => {
                         return {
                             getDomRef: () => ({}),
                             getParent: () => pageView,
+                            getShowHeaderContent: () => testCase.ShowHeaderContent,
                             getHeaderContent: () => {
                                 return [new FlexBox()];
                             }
@@ -2002,6 +2010,13 @@ describe('FE V2 quick actions', () => {
                     ]
                 });
 
+                const actions = (sendActionMock.mock.calls[0][0].payload[0]?.actions as QuickAction[]) ?? [];
+                for (let i = actions.length - 1; i >= 0; i--) {
+                    if (actions[i].title !== 'Add Header Field') {
+                        actions.splice(i, 1);
+                    }
+                }
+
                 expect(sendActionMock).toHaveBeenCalledWith(
                     quickActionListChanged([
                         {
@@ -2009,21 +2024,12 @@ describe('FE V2 quick actions', () => {
                             actions: [
                                 {
                                     kind: 'simple',
-                                    id: 'objectPage0-add-controller-to-page',
-                                    enabled: true,
-                                    title: 'Add Controller to Page'
-                                },
-                                {
-                                    kind: 'simple',
                                     id: 'objectPage0-op-add-header-field',
                                     title: 'Add Header Field',
-                                    enabled: true
-                                },
-                                {
-                                    kind: 'simple',
-                                    id: 'objectPage0-op-add-custom-section',
-                                    title: 'Add Custom Section',
-                                    enabled: true
+                                    enabled: testCase.ShowHeaderContent,
+                                    tooltip: testCase.ShowHeaderContent
+                                        ? undefined
+                                        : 'This option has been disabled because the "Show Header Content" page property is set to false.'
                                 }
                             ]
                         }
@@ -2082,6 +2088,7 @@ describe('FE V2 quick actions', () => {
                         return {
                             getDomRef: () => ({}),
                             getParent: () => pageView,
+                            getShowHeaderContent: () => true,
                             getHeaderContent: () => {
                                 return [new FlexBox()];
                             }


### PR DESCRIPTION
disable **"Add Header Field"** quick action, if `showHeaderField` property is set to false with tooltip.