### PR TITLE
fix(deploy-gen): support running deploy generator standalone

### DIFF
--- a/.changeset/lazy-taxis-cover.md
+++ b/.changeset/lazy-taxis-cover.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/deploy-config-sub-generator': patch
+---
+
+support yui standalone

--- a/packages/deploy-config-sub-generator/src/app/index.ts
+++ b/packages/deploy-config-sub-generator/src/app/index.ts
@@ -8,18 +8,19 @@ import {
     TargetName,
     getExtensionGenPromptOpts
 } from '@sap-ux/deploy-config-generator-shared';
-import { parseTarget } from './utils';
+import { parseTarget, getYUIDetails } from './utils';
 import {
     getApiHubOptions,
     getEnvApiHubConfig,
     t,
     generatorNamespace,
     getBackendConfig,
-    getSupportedTargets
+    getSupportedTargets,
+    generatorTitle
 } from '../utils';
+import { AppWizard, Prompts } from '@sap-devx/yeoman-ui-types';
 import { promptDeployConfigQuestions } from './prompting';
 import { promptNames } from '../prompts/deploy-target';
-import { AppWizard, type Prompts } from '@sap-devx/yeoman-ui-types';
 import type { Answers } from 'inquirer';
 import type { AbapDeployConfigAnswersInternal } from '@sap-ux/abap-deploy-config-sub-generator';
 import type { DeployConfigGenerator, DeployConfigOptions } from '../types';
@@ -69,6 +70,11 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
         this.target = parseTarget(args, opts);
         this.vscode = opts.vscode;
 
+        if (!this.env.isPackageRegistered(this.genNamespace) && this.rootGeneratorName()) {
+            // registers all the root generator's namespaces i.e the subgenerators
+            this.env.lookup({ packagePatterns: [this.rootGeneratorName()] });
+        }
+
         // Extensions use options.data to pass in the options
         if (this.options.data?.destinationRoot) {
             this.launchStandaloneFromYui = true;
@@ -90,6 +96,17 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
             this.apiHubConfig = this.options.apiHubConfig ?? getEnvApiHubConfig();
             this.launchStandaloneFromYui = false;
         }
+
+        // If launched standalone, set the header, title and description
+        if (this.launchStandaloneFromYui) {
+            this.appWizard.setHeaderTitle(generatorTitle);
+            this.prompts = new Prompts(getYUIDetails(this.options.projectRoot));
+            this.setPromptsCallback = (fn): void => {
+                if (this.prompts) {
+                    this.prompts.setCallback(fn);
+                }
+            };
+        }
     }
 
     /**
@@ -108,7 +125,7 @@ export default class extends DeploymentGenerator implements DeployConfigGenerato
         if (this.isCap && !this.mtaPath) {
             this.target = TargetName.CF; // when CAP project and no mta.yaml, default to Cloud Foundry
         }
-        this.options.projectRoot = capRoot ?? this.mtaPath ?? this.options.appRootPath;
+        this.options.projectRoot = capRoot ?? (this.mtaPath && dirname(this.mtaPath)) ?? this.options.appRootPath;
 
         ({ backendConfig: this.backendConfig, isLibrary: this.isLibrary } = await getBackendConfig(
             this.fs,

--- a/packages/deploy-config-sub-generator/src/app/utils.ts
+++ b/packages/deploy-config-sub-generator/src/app/utils.ts
@@ -1,3 +1,4 @@
+import { basename } from 'path';
 import type { DeployConfigOptions } from '../types';
 
 /**
@@ -18,4 +19,19 @@ export function parseTarget(args: string | string[], opts: DeployConfigOptions):
         result = opts.target;
     }
     return result;
+}
+
+/**
+ * Returns the details for the YUI prompt.
+ *
+ * @param appRootPath - path to the application to be displayed in YUI step description
+ * @returns step details
+ */
+export function getYUIDetails(appRootPath: string): { name: string; description: string }[] {
+    return [
+        {
+            name: 'Deployment Configuration',
+            description: `Configure Deployment settings - ${basename(appRootPath)}`
+        }
+    ];
 }

--- a/packages/deploy-config-sub-generator/src/utils/constants.ts
+++ b/packages/deploy-config-sub-generator/src/utils/constants.ts
@@ -5,5 +5,6 @@ import type { Target } from '../types';
 export const generatorNamespace = (bundledRootGeneratorName: string, subGenName: string): string =>
     `${bundledRootGeneratorName}_${subGenName}`;
 
+export const generatorTitle = 'Deployment Configuration Generator';
 export const abapChoice: Target = { name: TargetName.ABAP, description: 'ABAP' };
 export const cfChoice: Target = { name: TargetName.CF, description: 'Cloud Foundry' };

--- a/packages/deploy-config-sub-generator/test/utils.test.ts
+++ b/packages/deploy-config-sub-generator/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { parseTarget } from '../src/app/utils';
+import { getYUIDetails, parseTarget } from '../src/app/utils';
 import { isMTAInstalled, getEnvApiHubConfig } from '../src/utils';
 import type { DeployConfigOptions } from '../src/types';
 import hasbin from 'hasbin';
@@ -54,5 +54,12 @@ describe('Test utils - Deploy', () => {
         delete process.env['API_HUB_API_KEY'];
         delete process.env['API_HUB_TYPE'];
         expect(getEnvApiHubConfig()).toBeUndefined();
+    });
+
+    it('should return prompt step details for yui usage', () => {
+        const yuiDetails = getYUIDetails('/path/to/app/project1');
+        expect(yuiDetails).toHaveLength(1);
+        expect(yuiDetails[0].name).toEqual('Deployment Configuration');
+        expect(yuiDetails[0].description).toEqual('Configure Deployment settings - project1');
     });
 });


### PR DESCRIPTION
Revert some changes made in https://github.com/SAP/open-ux-tools/pull/3012 to fully support running this generator standalone in YUI, without the requirment for a 'wrapper' generator