### PR TITLE
fix(ui-components): UISections. Issue with window resize hiding section on fullscreen toggle event

### DIFF
--- a/.changeset/early-ligers-beam.md
+++ b/.changeset/early-ligers-beam.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UISections. Issue with window resize hiding section on fullscreen toggle event

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -114,9 +114,9 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
      * @returns Calculated sizes and position for all sections
      */
     updateStateSizes(
-        layoutSize: number,
+        newSize: number,
         sizes: Array<number | UISectionSize | undefined>,
-        oldSize = layoutSize
+        oldSize = newSize
     ): UISectionSize[] {
         let uiSizes: UISectionSize[] = sizes as UISectionSize[];
         const dynamicSectionIndex = this.getDynamicSectionIndex();
@@ -130,7 +130,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
                 availableSize += (typeof section === 'object' ? section.size : section) ?? 0;
             }
         });
-        availableSize = layoutSize - availableSize;
+        availableSize = newSize - availableSize;
         // Check if number array is passed as sizes. Convert array of number to array of UISectionSize
         if (typeof sizes[0] !== 'object') {
             uiSizes = [];

--- a/packages/ui-components/test/unit/components/UISections.test.tsx
+++ b/packages/ui-components/test/unit/components/UISections.test.tsx
@@ -1124,4 +1124,50 @@ describe('<Sections />', () => {
         });
         expect(hiddenWrapper.find('.sections__item').length).toEqual(2);
     });
+
+    it('Test window resize and ToggleFullscreen', () => {
+        const mockWidth = (windowWidth: number) => {
+            jest.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => {
+                return windowWidth;
+            });
+            jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
+                return {
+                    top: 0,
+                    height: 1000,
+                    width: windowWidth,
+                    left: 0
+                } as DOMRect;
+            });
+        };
+
+        const onToggleFullscreen = jest.fn().mockImplementation(() => {
+            jest.spyOn(UISections, 'getVisibleSections').mockReturnValueOnce([0]);
+        });
+        mockWidth(1000);
+        wrapper = Enzyme.mount(
+            <UISections
+                vertical={false}
+                splitter={true}
+                sizes={[450, undefined]}
+                minSectionSize={[430, 530]}
+                onToggleFullscreen={onToggleFullscreen}>
+                <UISections.Section>
+                    <div>Left</div>
+                </UISections.Section>
+                <UISections.Section>
+                    <div>Right</div>
+                </UISections.Section>
+            </UISections>
+        );
+
+        // Simulate restore for min size
+        mockWidth(670);
+
+        windowEventListenerMock.simulateEvent('resize', {});
+        expect(onToggleFullscreen).toBeCalledTimes(1);
+        expect(wrapper.state().sizes).toEqual([
+            { end: 220, percentage: false, size: 450, start: 0 },
+            { end: 0, percentage: false, size: 220, start: 450 }
+        ]);
+    });
 });


### PR DESCRIPTION
issue/regression after https://github.com/SAP/open-ux-tools/pull/2979
Scenario of issue:
1. Two sections with initial size `[400, available_space]` and with min sizes `minSectionSize={[400, 400]}` and window size `1000px x 600px`;
2.  Make screens size less than 800px in width to trigger full screen toggle - hide one of section;
3. Then make screen wider to toggle non-fullscreen mode back and restore visibility of section back;

Problem - size of restored section is wrong. 