### PR TITLE
Move validate Target Folder path logic to `project-input-validator`

### DIFF
--- a/.changeset/dirty-needles-sin.md
+++ b/.changeset/dirty-needles-sin.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-application-inquirer': minor
+'@sap-ux/project-input-validator': minor
+---
+
+Move validate target project path logic from ui5-application-inquirer to project-input-validator for improved reuse

--- a/packages/project-input-validator/package.json
+++ b/packages/project-input-validator/package.json
@@ -27,7 +27,8 @@
     },
     "dependencies": {
         "i18next": "23.5.1",
-        "validate-npm-package-name": "5.0.0"
+        "validate-npm-package-name": "5.0.0",
+        "@sap-ux/project-access": "workspace:*"
     },
     "devDependencies": {
         "@types/validate-npm-package-name": "4.0.1",

--- a/packages/project-input-validator/src/index.ts
+++ b/packages/project-input-validator/src/index.ts
@@ -1,5 +1,6 @@
 export * from './deploy/validators';
 export * from './ui5/validators';
+export * from './ui5/project-path-validators';
 export * from './general/validators';
 export * from './adp/validators';
 export * from './flp/validators';

--- a/packages/project-input-validator/src/translations/project-input-validator.i18n.json
+++ b/packages/project-input-validator/src/translations/project-input-validator.i18n.json
@@ -40,7 +40,10 @@
         "nameContainsSpecialCharacters": "Module name cannot contain special characters (\"~'!()*)",
         "nameNotUrlFriendly": "Module name can only contain URL-friendly characters",
         "invalidModuleName": "Invalid module name",
-        "moduleAlreadyExists": "The module folder named: {{folderName}} already exists at the specified path"
+        "moduleAlreadyExists": "The module folder named: {{folderName}} already exists at the specified path",
+        "appFolderExistsAtPath": "A module with this name already exists in the folder: {{-path}}",
+        "folderContainsFioriApp": "The project folder path already contains an SAP Fiori application in the folder: {{-path}}. Please choose a different folder and try again.",
+        "folderContainsCapApp": "The selected project folder is part of an existing CAP project. This application must therefore use the local CAP project as the data source."
     },
     "general": {
         "invalidUrl": "Invalid URL: [{{-input}}]",

--- a/packages/project-input-validator/src/ui5/project-path-validators.ts
+++ b/packages/project-input-validator/src/ui5/project-path-validators.ts
@@ -1,0 +1,46 @@
+import { findRootsForPath, findCapProjectRoot, getCapProjectType } from '@sap-ux/project-access';
+import { validateProjectFolder } from './validators';
+import { t } from '../i18n';
+/**
+ * Returns true if the specified target path does not contain a Fiori project.
+ *
+ * @param targetDir the target directory path.
+ * @returns true, if not Fiori Project, or string message indicating that the path contains a Fiori project.
+ */
+async function validateFioriAppProjectFolder(targetDir: string): Promise<string | boolean> {
+    // Check if the target directory contains a CAP project
+    if (!!(await findCapProjectRoot(targetDir, false)) || !!(await getCapProjectType(targetDir))) {
+        return t('ui5.folderContainsCapApp');
+    }
+    // Check if the target directory contains a Fiori project
+    const appRoot = await findRootsForPath(targetDir);
+    if (appRoot) {
+        return t('ui5.folderContainsFioriApp', { path: appRoot.appRoot });
+    } else {
+        return true;
+    }
+}
+
+/**
+ * @param targetPath the target directory path.
+ * @param appName the application directory name.
+ * @param validateFioriAppFolder if true, validates the target path as a Fiori App project.
+ * @returns true if validated for Fiori App Project and Project Folder, false if appName length is less than 2. Otherwise appropriate validation message.
+ */
+export async function validateTargetFolderForFioriApp(
+    targetPath: string,
+    appName: string,
+    validateFioriAppFolder?: boolean
+): Promise<string | boolean> {
+    if (validateFioriAppFolder === true) {
+        const isFioriValid = await validateFioriAppProjectFolder(targetPath);
+        if (isFioriValid !== true) {
+            return isFioriValid;
+        }
+    }
+    const isProjectValid = validateProjectFolder(targetPath, appName);
+    if (isProjectValid !== true) {
+        return isProjectValid;
+    }
+    return true;
+}

--- a/packages/project-input-validator/src/ui5/project-path-validators.ts
+++ b/packages/project-input-validator/src/ui5/project-path-validators.ts
@@ -25,7 +25,7 @@ async function validateFioriAppProjectFolder(targetDir: string): Promise<string 
  * @param targetPath the target directory path.
  * @param appName the application directory name.
  * @param validateFioriAppFolder if true, validates the target path as a Fiori App project.
- * @returns true if validated for Fiori App Project and Project Folder, false if appName length is less than 2. Otherwise appropriate validation message.
+ * @returns true if validated for Fiori App Project and Project Folder. Otherwise appropriate validation message.
  */
 export async function validateTargetFolderForFioriApp(
     targetPath: string,

--- a/packages/project-input-validator/test/project-validators.test.ts
+++ b/packages/project-input-validator/test/project-validators.test.ts
@@ -1,0 +1,61 @@
+import { validateTargetFolderForFioriApp } from '../src/ui5/project-path-validators';
+import { findCapProjectRoot, getCapProjectType, findRootsForPath } from '@sap-ux/project-access';
+import { t } from '../src/i18n';
+import { validateProjectFolder } from '../src/ui5/validators';
+
+jest.mock('@sap-ux/project-access', () => ({
+    ...jest.requireActual('@sap-ux/project-access'),
+    findCapProjectRoot: jest.fn(),
+    getCapProjectType: jest.fn(),
+    findRootsForPath: jest.fn()
+}));
+
+jest.mock('../src/ui5/validators', () => ({
+    ...jest.requireActual('../src/ui5/validators'),
+    validateProjectFolder: jest.fn()
+}));
+
+describe('validateTargetFolderForFioriApp', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it('should return an error message if a CAP project is found in the target directory', async () => {
+        (findCapProjectRoot as jest.Mock).mockReturnValue(true);
+        (getCapProjectType as jest.Mock).mockReturnValue(null);
+        (findRootsForPath as jest.Mock).mockReturnValue(null);
+
+        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        expect(result).toBe(t('ui5.folderContainsCapApp'));
+    });
+
+    it('should return an error message if a Fiori project is found in the target directory', async () => {
+        (findCapProjectRoot as jest.Mock).mockReturnValue(null);
+        (getCapProjectType as jest.Mock).mockReturnValue(null);
+        (findRootsForPath as jest.Mock).mockReturnValue({ appRoot: '/path/to/fioriAppRoot' });
+
+        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        expect(result).toBe(t('ui5.folderContainsFioriApp'));
+    });
+
+    it('should return true if no Fiori project is found in the target directory', async () => {
+        (findCapProjectRoot as jest.Mock).mockReturnValue(null);
+        (getCapProjectType as jest.Mock).mockReturnValue(null);
+        (findRootsForPath as jest.Mock).mockReturnValue(null);
+        (validateProjectFolder as jest.Mock).mockReturnValue(true);
+
+        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        expect(result).toBe(true);
+    });
+
+    it('should return fiori app project validation error', async () => {
+        (findCapProjectRoot as jest.Mock).mockReturnValue(null);
+        (getCapProjectType as jest.Mock).mockReturnValue(null);
+        (findRootsForPath as jest.Mock).mockReturnValue(null);
+        (validateProjectFolder as jest.Mock).mockReturnValue(t('ui5.folderDoesNotExist'));
+
+        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', false);
+        expect(result).toBe(t('ui5.folderDoesNotExist'));
+    });
+});

--- a/packages/project-input-validator/tsconfig.json
+++ b/packages/project-input-validator/tsconfig.json
@@ -7,5 +7,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist"
-  }
+  },
+  "references": [
+    {
+      "path": "../project-access"
+    }
+  ]
 }

--- a/packages/ui5-application-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompt-helpers.ts
@@ -4,8 +4,6 @@ import { join } from 'path';
 import { coerce, gte } from 'semver';
 import { defaultProjectNumber, t } from '../i18n';
 import { promptNames, type UI5ApplicationPromptOptions, type UI5ApplicationQuestion } from '../types';
-import { validateProjectFolder } from '@sap-ux/project-input-validator';
-import { validateFioriAppProjectFolder } from './validators';
 
 /**
  * Tests if a directory with the specified `appName` exists at the path specified by `targetPath`.
@@ -84,28 +82,4 @@ export function hidePrompts(
         questions.push(...Object.values(prompts));
     }
     return questions;
-}
-
-/**
- * @param targetPath the target directory path.
- * @param appName the application directory name.
- * @param validateFioriAppFolder if true, validates the target path as a Fiori App project.
- * @returns true if validated for Fiori App Project and Project Folder, false if appName length is less than 2. Otherwise appropriate validation message.
- */
-export async function validateTargetFolder(
-    targetPath: string,
-    appName: string,
-    validateFioriAppFolder?: boolean
-): Promise<string | boolean> {
-    if (validateFioriAppFolder === true) {
-        const isFioriValid = await validateFioriAppProjectFolder(targetPath);
-        if (isFioriValid !== true) {
-            return isFioriValid;
-        }
-    }
-    const isProjectValid = validateProjectFolder(targetPath, appName);
-    if (isProjectValid !== true) {
-        return isProjectValid;
-    }
-    return true;
 }

--- a/packages/ui5-application-inquirer/src/prompts/prompts.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts.ts
@@ -14,7 +14,11 @@ import {
     extendWithOptions
 } from '@sap-ux/inquirer-common';
 import { getMtaPath } from '@sap-ux/project-access';
-import { validateModuleName, validateNamespace } from '@sap-ux/project-input-validator';
+import {
+    validateModuleName,
+    validateNamespace,
+    validateTargetFolderForFioriApp
+} from '@sap-ux/project-input-validator';
 import {
     defaultVersion,
     getDefaultUI5Theme,
@@ -25,7 +29,7 @@ import type { ListChoiceOptions } from 'inquirer';
 import { t } from '../i18n';
 import type { UI5ApplicationAnswers, UI5ApplicationPromptOptions, UI5ApplicationQuestion } from '../types';
 import { promptNames } from '../types';
-import { defaultAppName, hidePrompts, isVersionIncluded, validateTargetFolder } from './prompt-helpers';
+import { defaultAppName, hidePrompts, isVersionIncluded } from './prompt-helpers';
 import { validateAppName } from './validators';
 import { Severity } from '@sap-devx/yeoman-ui-types';
 
@@ -344,7 +348,7 @@ function getTargetFolderPrompt(targetDir: string, validateFioriAppFolder?: boole
         default: (answers: UI5ApplicationAnswers) => answers.targetFolder || targetDir,
         validate: async (target, { name = '' }: UI5ApplicationAnswers): Promise<boolean | string> => {
             if (name.length > 2) {
-                return await validateTargetFolder(target, name, validateFioriAppFolder);
+                return await validateTargetFolderForFioriApp(target, name, validateFioriAppFolder);
             }
             return false;
         }

--- a/packages/ui5-application-inquirer/src/prompts/validators.ts
+++ b/packages/ui5-application-inquirer/src/prompts/validators.ts
@@ -1,7 +1,7 @@
 import { validateModuleName } from '@sap-ux/project-input-validator';
 import { appPathExists } from './prompt-helpers';
 import { t } from '../i18n';
-import { findRootsForPath, findCapProjectRoot, getCapProjectType } from '@sap-ux/project-access';
+
 /**
  * Returns true (valid) if the specified projectName is a valid module name
  * and if an application folder (directory) at the specified path does not exist.
@@ -21,24 +21,4 @@ export function validateAppName(appName: string, targetDir: string): boolean | s
         return t('validators.appFolderExistsAtPath', { path: targetDir });
     }
     return true;
-}
-
-/**
- * Returns true if the specified target path does not contain a Fiori project.
- *
- * @param targetDir the target directory path.
- * @returns true, if not Fiori Project, or string message indicating that the path contains a Fiori project.
- */
-export async function validateFioriAppProjectFolder(targetDir: string): Promise<string | boolean> {
-    // Check if the target directory contains a CAP project
-    if (!!(await findCapProjectRoot(targetDir, false)) || !!(await getCapProjectType(targetDir))) {
-        return t('validators.folderContainsCapApp');
-    }
-    // Check if the target directory contains a Fiori project
-    const appRoot = await findRootsForPath(targetDir);
-    if (appRoot) {
-        return t('validators.folderContainsFioriApp', { path: appRoot.appRoot });
-    } else {
-        return true;
-    }
 }

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompt-helpers.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompt-helpers.test.ts
@@ -2,17 +2,9 @@ import { latestVersionString } from '@sap-ux/ui5-info';
 import { join } from 'path';
 import { initI18nUi5AppInquirer } from '../../../src/i18n';
 import * as promptHelpers from '../../../src/prompts/prompt-helpers';
-import {
-    appPathExists,
-    defaultAppName,
-    hidePrompts,
-    isVersionIncluded,
-    validateTargetFolder
-} from '../../../src/prompts/prompt-helpers';
+import { appPathExists, defaultAppName, hidePrompts, isVersionIncluded } from '../../../src/prompts/prompt-helpers';
 import type { UI5ApplicationAnswers, UI5ApplicationPromptOptions, UI5ApplicationQuestion } from '../../../src/types';
 import { promptNames } from '../../../src/types';
-import * as projectValidators from '@sap-ux/project-input-validator';
-import * as validators from '../../../src/prompts/validators';
 
 jest.mock('@sap-ux/project-input-validator', () => ({
     ...jest.requireActual('@sap-ux/project-input-validator'),
@@ -141,26 +133,5 @@ describe('prompt-helpers', () => {
         expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.addDeployConfig }]));
         expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.skipAnnotations }]));
         expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.ui5Version }]));
-    });
-    test('validateTargetFolder', async () => {
-        // Test when name length > 2 and both validations pass
-        jest.spyOn(projectValidators, 'validateProjectFolder').mockReturnValue(true);
-        jest.spyOn(validators, 'validateFioriAppProjectFolder').mockResolvedValue(true);
-        const resultForValidCase = await validateTargetFolder('/some/target/path', 'validName', true);
-        expect(resultForValidCase).toBe(true);
-    });
-    test('validateTargetFolder - project folder validation error', async () => {
-        // Test when Project validation fails
-        const projectErrorMessage = 'Project validation error';
-        jest.spyOn(projectValidators, 'validateProjectFolder').mockReturnValue(projectErrorMessage);
-        const resultForProjectError = await validateTargetFolder('/some/target/path', 'validName');
-        expect(resultForProjectError).toBe(projectErrorMessage);
-    });
-    test('validateTargetFolder - fiori app project validation error', async () => {
-        // Test when Fiori validation fails
-        const fioriErrorMessage = 'Fiori validation error';
-        jest.spyOn(validators, 'validateFioriAppProjectFolder').mockResolvedValue(fioriErrorMessage);
-        const resultForFioriError = await validateTargetFolder('/some/target/path', 'validName', true);
-        expect(resultForFioriError).toBe(fioriErrorMessage);
     });
 });

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -216,7 +216,9 @@ describe('getQuestions', () => {
 
         await expect(targetFolderPrompt?.validate!(undefined, {})).resolves.toEqual(false);
 
-        const validateTargetFolderSpy = jest.spyOn(promptHelpers, 'validateTargetFolder').mockResolvedValueOnce(true);
+        const validateTargetFolderSpy = jest
+            .spyOn(projectValidators, 'validateTargetFolderForFioriApp')
+            .mockResolvedValueOnce(true);
         const args = ['/some/target/path', { name: 'project1' }] as const;
         await expect(targetFolderPrompt?.validate!(...args)).resolves.toEqual(true);
         expect(validateTargetFolderSpy).toHaveBeenCalledWith(...[args[0]], args[1].name, undefined);

--- a/packages/ui5-application-inquirer/test/unit/prompts/validators.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/validators.test.ts
@@ -2,9 +2,7 @@ import * as projectValidators from '@sap-ux/project-input-validator';
 import * as promptHelpers from '../../../src/prompts/prompt-helpers';
 import { join } from 'path';
 import { initI18nUi5AppInquirer, t } from '../../../src/i18n';
-import { validateAppName, validateFioriAppProjectFolder } from '../../../src/prompts/validators';
-import { findRootsForPath, findCapProjectRoot } from '@sap-ux/project-access';
-import * as projectAccess from '@sap-ux/project-access';
+import { validateAppName } from '../../../src/prompts/validators';
 
 /**
  * Workaround to allow spyOn
@@ -49,38 +47,5 @@ describe('validators', () => {
         expect(validateAppName(appName, targetPath)).toBe(
             `A module with this name already exists in the folder: ${targetPath}`
         );
-    });
-    describe('validateFioriAppProjectFolder', () => {
-        const mockFindRootsForPath = jest.fn();
-        const mockFindCapProjectRoot = jest.fn();
-
-        beforeEach(() => {
-            (findRootsForPath as jest.Mock) = mockFindRootsForPath;
-            (findCapProjectRoot as jest.Mock) = mockFindCapProjectRoot;
-            jest.clearAllMocks();
-        });
-
-        test('should return true if no Fiori project is found in the target directory', async () => {
-            mockFindRootsForPath.mockResolvedValueOnce(null);
-            const result = await validateFioriAppProjectFolder('/path/to/dir');
-            expect(result).toBe(true);
-            expect(mockFindRootsForPath).toHaveBeenCalledWith('/path/to/dir');
-        });
-
-        test('should return an error message if a Fiori project is found in the target directory', async () => {
-            const appRootPath = '/path/to/fiori/project';
-            const projectRootPath = 'test/path';
-            mockFindRootsForPath.mockResolvedValueOnce({ appRoot: appRootPath, projectRoot: projectRootPath });
-            const result = await validateFioriAppProjectFolder('some/path');
-            expect(result).toEqual(t('validators.folderContainsFioriApp', { path: appRootPath }));
-            expect(mockFindRootsForPath).toHaveBeenCalledWith('some/path');
-        });
-
-        test('should return an error message if a CAP project is found in the target directory', async () => {
-            mockFindRootsForPath.mockResolvedValueOnce(null);
-            mockFindCapProjectRoot.mockResolvedValueOnce('CAPJava');
-            const result = await validateFioriAppProjectFolder('any/path');
-            expect(result).toEqual(t('validators.folderContainsCapApp'));
-        });
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3010,6 +3010,9 @@ importers:
 
   packages/project-input-validator:
     dependencies:
+      '@sap-ux/project-access':
+        specifier: workspace:*
+        version: link:../project-access
       i18next:
         specifier: 23.5.1
         version: 23.5.1


### PR DESCRIPTION
- Move `validateTargetFolder` from `ui5-application-inquirer` to `project-input-validator` for improved reuse
- Updated tests