### PR TITLE
Rename `validateTargetFolderForFioriApp` to `validateFioriAppTargetFolder`

### DIFF
--- a/.changeset/healthy-tips-wave.md
+++ b/.changeset/healthy-tips-wave.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-application-inquirer': minor
+'@sap-ux/project-input-validator': minor
+---
+
+Rename validateTargetFolderForFioriApp to validateFioriAppTargetFolder for clarity and improve ts docs

--- a/packages/project-input-validator/src/ui5/project-path-validators.ts
+++ b/packages/project-input-validator/src/ui5/project-path-validators.ts
@@ -22,14 +22,25 @@ async function validateFioriAppProjectFolder(targetDir: string): Promise<string 
 }
 
 /**
- * Validates the provided target path as a Fiori App project folder.
- *
- * @param {string} targetPath - The target directory path where the Fiori App project is to be generated.
- * @param {string} appName - The application name.
- * @param {boolean} [validateFioriAppFolder] - If true, performs additional validation to check
- *        if the target path is a valid Fiori App project folder.
- * @returns {Promise<string | boolean>} - Returns `true` if all validations pass successfully.
- *        If a validation fails, returns an appropriate validation message as a string.
+ * Validates whether the specified target path is suitable for creating a Fiori App project.
+ * The function performs the following checks:
+ * 
+ * 1. **CAP Project Check:** If `validateFioriAppFolder` is true, it checks if the target path is part of an existing CAP project.
+ *    - Uses `findCapProjectRoot()` and `getCapProjectType()` to verify the presence of a CAP project.
+ *    - Returns an error message if a CAP project is detected.
+ * 
+ * 2. **Fiori App Project Check:** If `validateFioriAppFolder` is true, it checks if the target path contains a Fiori project.
+ *    - Uses `findRootsForPath()` to determine if a Fiori application root exists.
+ *    - Returns a success message if a valid Fiori app root is found, otherwise returns true.
+ * 
+ * 3. **General Project Folder Check:** 
+ *    - Uses `validateProjectFolder()` to verify if the provided target path exists.
+ *    - Ensures the target folder does not already contain a subfolder with the intended project name.
+ * 
+ * @param targetPath - The target directory path where the Fiori app is to be created.
+ * @param appName - The application directory name.
+ * @param validateFioriAppFolder - If true, validates the target path as a Fiori App project folder.
+ * @returns A boolean value `true` if all validations pass; otherwise, an error message.
  */
 export async function validateFioriAppTargetFolder(
     targetPath: string,

--- a/packages/project-input-validator/src/ui5/project-path-validators.ts
+++ b/packages/project-input-validator/src/ui5/project-path-validators.ts
@@ -22,12 +22,16 @@ async function validateFioriAppProjectFolder(targetDir: string): Promise<string 
 }
 
 /**
- * @param targetPath the target directory path.
- * @param appName the application directory name.
- * @param validateFioriAppFolder if true, validates the target path as a Fiori App project.
- * @returns true if validated for Fiori App Project and Project Folder. Otherwise appropriate validation message.
+ * Validates the provided target path as a Fiori App project folder.
+ *
+ * @param {string} targetPath - The target directory path where the Fiori App project is to be generated.
+ * @param {string} appName - The application name.
+ * @param {boolean} [validateFioriAppFolder] - If true, performs additional validation to check
+ *        if the target path is a valid Fiori App project folder.
+ * @returns {Promise<string | boolean>} - Returns `true` if all validations pass successfully.
+ *        If a validation fails, returns an appropriate validation message as a string.
  */
-export async function validateTargetFolderForFioriApp(
+export async function validateFioriAppTargetFolder(
     targetPath: string,
     appName: string,
     validateFioriAppFolder?: boolean

--- a/packages/project-input-validator/src/ui5/project-path-validators.ts
+++ b/packages/project-input-validator/src/ui5/project-path-validators.ts
@@ -24,19 +24,19 @@ async function validateFioriAppProjectFolder(targetDir: string): Promise<string 
 /**
  * Validates whether the specified target path is suitable for creating a Fiori App project.
  * The function performs the following checks:
- * 
+ *
  * 1. **CAP Project Check:** If `validateFioriAppFolder` is true, it checks if the target path is part of an existing CAP project.
  *    - Uses `findCapProjectRoot()` and `getCapProjectType()` to verify the presence of a CAP project.
  *    - Returns an error message if a CAP project is detected.
- * 
+ *
  * 2. **Fiori App Project Check:** If `validateFioriAppFolder` is true, it checks if the target path contains a Fiori project.
  *    - Uses `findRootsForPath()` to determine if a Fiori application root exists.
  *    - Returns a success message if a valid Fiori app root is found, otherwise returns true.
- * 
- * 3. **General Project Folder Check:** 
+ *
+ * 3. **General Project Folder Check:**
  *    - Uses `validateProjectFolder()` to verify if the provided target path exists.
  *    - Ensures the target folder does not already contain a subfolder with the intended project name.
- * 
+ *
  * @param targetPath - The target directory path where the Fiori app is to be created.
  * @param appName - The application directory name.
  * @param validateFioriAppFolder - If true, validates the target path as a Fiori App project folder.

--- a/packages/project-input-validator/test/project-validators.test.ts
+++ b/packages/project-input-validator/test/project-validators.test.ts
@@ -1,4 +1,4 @@
-import { validateTargetFolderForFioriApp } from '../src/ui5/project-path-validators';
+import { validateFioriAppTargetFolder } from '../src/ui5/project-path-validators';
 import { findCapProjectRoot, getCapProjectType, findRootsForPath } from '@sap-ux/project-access';
 import { t } from '../src/i18n';
 import { validateProjectFolder } from '../src/ui5/validators';
@@ -15,7 +15,7 @@ jest.mock('../src/ui5/validators', () => ({
     validateProjectFolder: jest.fn()
 }));
 
-describe('validateTargetFolderForFioriApp', () => {
+describe('validateFioriAppTargetFolder', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         jest.restoreAllMocks();
@@ -26,7 +26,7 @@ describe('validateTargetFolderForFioriApp', () => {
         (getCapProjectType as jest.Mock).mockReturnValue(null);
         (findRootsForPath as jest.Mock).mockReturnValue(null);
 
-        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        const result = await validateFioriAppTargetFolder('/path/to/dir', 'AppName', true);
         expect(result).toBe(t('ui5.folderContainsCapApp'));
     });
 
@@ -35,7 +35,7 @@ describe('validateTargetFolderForFioriApp', () => {
         (getCapProjectType as jest.Mock).mockReturnValue(null);
         (findRootsForPath as jest.Mock).mockReturnValue({ appRoot: '/path/to/fioriAppRoot' });
 
-        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        const result = await validateFioriAppTargetFolder('/path/to/dir', 'AppName', true);
         expect(result).toBe(t('ui5.folderContainsFioriApp'));
     });
 
@@ -45,7 +45,7 @@ describe('validateTargetFolderForFioriApp', () => {
         (findRootsForPath as jest.Mock).mockReturnValue(null);
         (validateProjectFolder as jest.Mock).mockReturnValue(true);
 
-        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', true);
+        const result = await validateFioriAppTargetFolder('/path/to/dir', 'AppName', true);
         expect(result).toBe(true);
     });
 
@@ -55,7 +55,7 @@ describe('validateTargetFolderForFioriApp', () => {
         (findRootsForPath as jest.Mock).mockReturnValue(null);
         (validateProjectFolder as jest.Mock).mockReturnValue(t('ui5.folderDoesNotExist'));
 
-        const result = await validateTargetFolderForFioriApp('/path/to/dir', 'AppName', false);
+        const result = await validateFioriAppTargetFolder('/path/to/dir', 'AppName', false);
         expect(result).toBe(t('ui5.folderDoesNotExist'));
     });
 });

--- a/packages/ui5-application-inquirer/src/prompts/prompts.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts.ts
@@ -14,11 +14,7 @@ import {
     extendWithOptions
 } from '@sap-ux/inquirer-common';
 import { getMtaPath } from '@sap-ux/project-access';
-import {
-    validateModuleName,
-    validateNamespace,
-    validateTargetFolderForFioriApp
-} from '@sap-ux/project-input-validator';
+import { validateModuleName, validateNamespace, validateFioriAppTargetFolder } from '@sap-ux/project-input-validator';
 import {
     defaultVersion,
     getDefaultUI5Theme,
@@ -348,7 +344,7 @@ function getTargetFolderPrompt(targetDir: string, validateFioriAppFolder?: boole
         default: (answers: UI5ApplicationAnswers) => answers.targetFolder || targetDir,
         validate: async (target, { name = '' }: UI5ApplicationAnswers): Promise<boolean | string> => {
             if (name.length > 2) {
-                return await validateTargetFolderForFioriApp(target, name, validateFioriAppFolder);
+                return await validateFioriAppTargetFolder(target, name, validateFioriAppFolder);
             }
             return false;
         }

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -217,7 +217,7 @@ describe('getQuestions', () => {
         await expect(targetFolderPrompt?.validate!(undefined, {})).resolves.toEqual(false);
 
         const validateTargetFolderSpy = jest
-            .spyOn(projectValidators, 'validateTargetFolderForFioriApp')
+            .spyOn(projectValidators, 'validateFioriAppTargetFolder')
             .mockResolvedValueOnce(true);
         const args = ['/some/target/path', { name: 'project1' }] as const;
         await expect(targetFolderPrompt?.validate!(...args)).resolves.toEqual(true);


### PR DESCRIPTION
Addressed comments in [PR](https://github.com/SAP/open-ux-tools/pull/3042)