### PR TITLE
fix: Adaptation Editor opens multiple re-entrance ticket tabs for Cloud systems

### DIFF
--- a/.changeset/many-ties-impress.md
+++ b/.changeset/many-ties-impress.md
@@ -2,4 +2,4 @@
 "@sap-ux/adp-tooling": patch
 ---
 
-Adaptation Editor opens multiple re-entrance ticket tabs for Cloud systems
+fix: Adaptation Editor opens multiple re-entrance ticket tabs for Cloud systems

--- a/.changeset/many-ties-impress.md
+++ b/.changeset/many-ties-impress.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/adp-tooling": patch
+---
+
+Adaptation Editor opens multiple re-entrance ticket tabs for Cloud systems

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -110,9 +110,7 @@ export class AdpPreview {
         private readonly project: ReaderCollection,
         private readonly util: MiddlewareUtils,
         private readonly logger: ToolsLogger
-    ) {
-        this.routesHandler = new RoutesHandler(project, util, logger);
-    }
+    ) {}
 
     /**
      * Fetch all required configurations from the backend and initialize all configurations.
@@ -128,6 +126,8 @@ export class AdpPreview {
             true,
             this.logger
         );
+        this.routesHandler = new RoutesHandler(this.project, this.util, provider, this.logger);
+
         this.lrep = provider.getLayeredRepository();
         // fetch a merged descriptor from the backend
         await this.lrep.getCsrfToken();

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -10,13 +10,12 @@ import type { ReaderCollection, Resource } from '@ui5/fs';
 import type { NextFunction, Request, Response } from 'express';
 
 import { TemplateFileName, HttpStatusCodes } from '../types';
-import { DirName, FileName } from '@sap-ux/project-access';
+import { DirName } from '@sap-ux/project-access';
 import { type CodeExtChange } from '../types';
 import { ManifestService } from '../base/abap/manifest-service';
 import type { DataSources } from '../base/abap/manifest-service';
-import { getAdpConfig, getVariant, isTypescriptSupported } from '../base/helper';
-import { AbapServiceProvider } from '@sap-ux/axios-extension';
-import { createAbapServiceProvider } from '@sap-ux/system-access';
+import { getVariant, isTypescriptSupported } from '../base/helper';
+import type { AbapServiceProvider } from '@sap-ux/axios-extension';
 
 interface WriteControllerBody {
     controllerName: string;
@@ -372,7 +371,6 @@ export default class RoutesHandler {
     /**
      * Returns manifest service.
      *
-     * @param provider AbapServiceProvider
      * @returns Promise<ManifestService>
      */
     private async getManifestService(): Promise<ManifestService> {

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -15,6 +15,7 @@ import { type CodeExtChange } from '../types';
 import { ManifestService } from '../base/abap/manifest-service';
 import type { DataSources } from '../base/abap/manifest-service';
 import { getAdpConfig, getVariant, isTypescriptSupported } from '../base/helper';
+import { AbapServiceProvider } from '@sap-ux/axios-extension';
 import { createAbapServiceProvider } from '@sap-ux/system-access';
 
 interface WriteControllerBody {
@@ -50,11 +51,13 @@ export default class RoutesHandler {
      *
      * @param project Reference to the root of the project
      * @param util middleware utilities provided by the UI5 CLI
+     * @param provider AbapServiceProvider instance
      * @param logger Logger instance
      */
     constructor(
         private readonly project: ReaderCollection,
         private readonly util: MiddlewareUtils,
+        private readonly provider: AbapServiceProvider,
         private readonly logger: ToolsLogger
     ) {}
 
@@ -369,18 +372,15 @@ export default class RoutesHandler {
     /**
      * Returns manifest service.
      *
+     * @param provider AbapServiceProvider
      * @returns Promise<ManifestService>
      */
     private async getManifestService(): Promise<ManifestService> {
         const project = this.util.getProject();
         const basePath = project.getRootPath();
         const variant = await getVariant(basePath);
-        const { target, ignoreCertErrors = false } = await getAdpConfig(
-            basePath,
-            path.join(basePath, FileName.Ui5Yaml)
-        );
-        const provider = await createAbapServiceProvider(target, { ignoreCertErrors }, true, this.logger);
-        return await ManifestService.initMergedManifest(provider, basePath, variant, this.logger);
+
+        return await ManifestService.initMergedManifest(this.provider, basePath, variant, this.logger);
     }
 }
 

--- a/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
+++ b/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
@@ -521,6 +521,7 @@ describe('AdaptationProject', () => {
                 middlewareUtil,
                 logger
             );
+            await adp.init(JSON.parse(descriptorVariant));
             jest.spyOn(helper, 'getVariant').mockResolvedValue({
                 content: [],
                 id: 'adp/project',


### PR DESCRIPTION
Issue: When Adaptation Editor is started for a project using a re-entrance ticket authentication, there are multiple authentication tabs opened on each interaction with the application.

Fix: Reuse already created service provider instead of creating a new provider on each request.