### PR TITLE
fix(cf-deploy-config-writer): spawn options required for windows

### DIFF
--- a/.changeset/tasty-islands-nail.md
+++ b/.changeset/tasty-islands-nail.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+add spawn options for windows

--- a/packages/cf-deploy-config-writer/src/mta-config/index.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/index.ts
@@ -137,13 +137,16 @@ export function doesCDSBinaryExist(): void {
  * @param options
  */
 export function createCAPMTA(cwd: string, options?: string[]): void {
-    let result = spawnSync(CDSExecutable, [...CDSAddMtaParams, ...(options ?? [])], { cwd });
+    const spawnOpts = process.platform.startsWith('win')
+        ? { windowsVerbatimArguments: true, shell: true, cwd }
+        : { cwd };
+    let result = spawnSync(CDSExecutable, [...CDSAddMtaParams, ...(options ?? [])], spawnOpts);
     if (result?.error) {
         throw new Error(`Something went wrong creating mta.yaml! ${result.error}`);
     }
     // Ensure the package-lock is created otherwise mta build will fail
     const cmd = process.platform === 'win32' ? `npm.cmd` : 'npm';
-    result = spawnSync(cmd, ['install', '--ignore-engines'], { cwd });
+    result = spawnSync(cmd, ['install', '--ignore-engines'], spawnOpts);
     if (result?.error) {
         throw new Error(`Something went wrong installing node modules! ${result.error}`);
     }

--- a/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
@@ -93,6 +93,7 @@ describe('CF Writer CAP', () => {
             );
             expect(spawnMock.mock.calls[1][0]).toStrictEqual('npm.cmd'); // Just always test for windows!
             expect(spawnMock.mock.calls[1][1]).toStrictEqual(['install', '--ignore-engines']);
+            expect(spawnMock.mock.calls[1][2]).toHaveProperty('shell');
             if (RouterModuleType.Standard === routerType) {
                 expect(localFs.read(join(mtaPath, `router`, 'package.json'))).toMatchSnapshot();
                 expect(localFs.read(join(mtaPath, `router`, 'xs-app.json'))).toMatchSnapshot();


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2821

- when generating mta on windows getting an error;
```
Error: Something went wrong creating mta.yaml!
```
The `cds` binary is not being inherited from the shell.
