### PR TITLE
Add `enableVSCodeReload` flag to control VS Code reload on workspace update

### DIFF
--- a/.changeset/slow-beers-drum.md
+++ b/.changeset/slow-beers-drum.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/launch-config': minor
+---
+
+Add enableVSCodeReload flag to control VS Code reload on workspace update

--- a/packages/launch-config/src/index.ts
+++ b/packages/launch-config/src/index.ts
@@ -1,5 +1,5 @@
 export * from './types';
-export { createLaunchConfig } from './launch-config-crud/create';
+export { createLaunchConfig, updateWorkspaceFoldersIfNeeded } from './launch-config-crud/create';
 export { deleteLaunchConfig } from './launch-config-crud/delete';
 export { convertOldLaunchConfigToFioriRun } from './launch-config-crud/modify';
 export { getLaunchConfigs, getLaunchConfigByName } from './launch-config-crud/read';

--- a/packages/launch-config/src/launch-config-crud/create.ts
+++ b/packages/launch-config/src/launch-config-crud/create.ts
@@ -102,9 +102,15 @@ async function handleExistingLaunchJson(
 }
 
 /**
- * Updates the workspace folders in VSCode if the update options are provided.
+ * Updates the workspace folders in VS Code if update options are provided.
  *
- * @param {UpdateWorkspaceFolderOptions} updateWorkspaceFolders - The options for updating workspace folders.
+ * This function checks if updateWorkspaceFolders is defined and contains valid data.
+ * If a valid uri and vscode instance are provided, it adds the specified workspace folder to VS Code.
+ *
+ * @param {UpdateWorkspaceFolderOptions} [updateWorkspaceFolders] - The options for updating workspace folders.
+ * @param {Uri} updateWorkspaceFolders.uri - The URI of the workspace folder to be added.
+ * @param {typeof vscode} updateWorkspaceFolders.vscode - The VS Code instance used for updating the workspace.
+ * @param {string} updateWorkspaceFolders.projectName - The name of the workspace folder to be added.
  */
 export function updateWorkspaceFoldersIfNeeded(updateWorkspaceFolders?: UpdateWorkspaceFolderOptions): void {
     if (updateWorkspaceFolders) {
@@ -167,12 +173,12 @@ async function handleDebugOptions(
         // This URI is populated when a reload of the workspace is required. It allows us to identify and update
         // the workspace folder correctly within VS Code.
         const updateWorkspaceFolders = workspaceFolderUri
-        ? ({
-            uri: workspaceFolderUri,
-            projectName: basename(rootFolder),
-            vscode: debugOptions.vscode
-        } as UpdateWorkspaceFolderOptions)
-        : undefined;
+            ? ({
+                  uri: workspaceFolderUri,
+                  projectName: basename(rootFolder),
+                  vscode: debugOptions.vscode
+              } as UpdateWorkspaceFolderOptions)
+            : undefined;
         updateWorkspaceFoldersIfNeeded(updateWorkspaceFolders);
     }
     return fs;

--- a/packages/launch-config/src/types/types.ts
+++ b/packages/launch-config/src/types/types.ts
@@ -23,13 +23,13 @@ export interface FioriOptions {
     debugOptions?: DebugOptions;
     /**
      * Controls whether VS Code should reload when updating workspace folders.
-     * 
+     *
      * VS Code automatically reloads when workspace folders change and no files are open.
      * This flag allows you to override that behavior.
-     * 
+     *
      * - true (default) - Triggers a VS Code reload when updating workspace folders and no files are open.
      * - false - Prevents automatic reloads.
-     * 
+     *
      * Use this flag to dynamically manage workspace modifications.
      */
     enableVSCodeReload?: boolean;

--- a/packages/launch-config/src/types/types.ts
+++ b/packages/launch-config/src/types/types.ts
@@ -21,6 +21,18 @@ export interface FioriOptions {
     urlParameters?: string;
     visible?: boolean;
     debugOptions?: DebugOptions;
+    /**
+     * Controls whether VS Code should reload when updating workspace folders.
+     * 
+     * VS Code automatically reloads when workspace folders change and no files are open.
+     * This flag allows you to override that behavior.
+     * 
+     * - true (default) - Triggers a VS Code reload when updating workspace folders and no files are open.
+     * - false - Prevents automatic reloads.
+     * 
+     * Use this flag to dynamically manage workspace modifications.
+     */
+    enableVSCodeReload?: boolean;
 }
 
 export interface LaunchJSON {


### PR DESCRIPTION
- Introduced the `enableVSCodeReload` flag to `FioriOptions`.
- Exported `updateWorkspaceFoldersIfNeeded`  function to handle the workspace folder update logic.
- When the flag is set to `true`, it triggers an automatic update of workspace folders and a reload of the VS Code window based on the provided `workspaceFolderUri`. By default this is set to `true`.
- This change allows developers to control the reload behaviour of VS Code when workspace configurations are modified.