### PR TITLE
fix(odata-inq): prevent changing service path casing

### DIFF
--- a/.changeset/wise-feet-warn.md
+++ b/.changeset/wise-feet-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+prevent converting service path to lower case

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -601,7 +601,7 @@ export class ConnectionValidator {
         this.resetConnectionState();
         this.resetValidity();
         // Get the destination URL in the BAS specific form <protocol>://<destinationName>.dest. This function lowercases the origin.
-        const destUrl = getDestinationUrlForAppStudio(destination.Name, servicePath).toLowerCase();
+        const destUrl = getDestinationUrlForAppStudio(destination.Name.toLowerCase(), servicePath);
         // Get the destination URL in the portable form <protocol>://<host>:<port>.
         // We remove trailing slashes (up to 10, infinite would allow DOS attack) from the host to avoid double slashes when appending the service path.
         this._destinationUrl = servicePath

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -573,7 +573,7 @@ describe('ConnectionValidator', () => {
         expect(
             await connectValidator.validateDestination({
                 Name: 'DEST1',
-                Host: 'https://system1:12345/path/to/service',
+                Host: 'https://system1:12345/path/to/Service',
                 Type: 'HTTP',
                 Authentication: 'NoAuthentication',
                 ProxyType: 'Internet',
@@ -584,7 +584,7 @@ describe('ConnectionValidator', () => {
         ).toEqual({ valResult: true });
 
         expect(connectValidator.validatedUrl).toEqual('https://dest1.dest');
-        expect(connectValidator.destinationUrl).toEqual('https://system1:12345/path/to/service');
+        expect(connectValidator.destinationUrl).toEqual('https://system1:12345/path/to/Service');
         expect(connectValidator.validity).toEqual({
             authenticated: true,
             reachable: true


### PR DESCRIPTION
#3066 

Change only lowers the case of the destination name within the URL and leave the service path as it is. 
Some backends return a 404 for the service path as lower case