### PR TITLE
fix(abap-inq): init transport config for scp systems

### DIFF
--- a/.changeset/spicy-kids-develop.md
+++ b/.changeset/spicy-kids-develop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+make backend call for scp systems when initialising transport config

--- a/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/conditions.ts
@@ -109,7 +109,6 @@ export async function showUsernameQuestion(backendTarget?: BackendTarget): Promi
         warning
     } = await initTransportConfig({
         backendTarget: backendTarget,
-        scp: PromptState.abapDeployConfig.scp,
         url: PromptState.abapDeployConfig.url,
         client: PromptState.abapDeployConfig.client,
         destination: PromptState.abapDeployConfig.destination,

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -295,7 +295,6 @@ export async function validateCredentials(
         warning
     } = await initTransportConfig({
         backendTarget: backendTarget,
-        scp: PromptState.abapDeployConfig.scp,
         url: PromptState.abapDeployConfig.url,
         client: PromptState.abapDeployConfig.client,
         credentials: {

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
@@ -216,22 +216,15 @@ class DefaultTransportConfig implements TransportConfig {
  *
  * @param transportConfigOptions - transport configuration options
  * @param transportConfigOptions.backendTarget - backend target from prompt options
- * @param transportConfigOptions.scp - scp
  * @param transportConfigOptions.credentials - user credentials
  * @returns transport configuration instance
  */
 export async function getTransportConfigInstance({
     backendTarget,
-    scp,
     credentials
 }: {
     backendTarget?: BackendTarget;
-    scp?: boolean;
     credentials?: Credentials;
 }): Promise<InitTransportConfigResult> {
-    if (scp) {
-        return { transportConfig: new DummyTransportConfig() };
-    }
-
     return new DefaultTransportConfig().init({ backendTarget, credentials });
 }

--- a/packages/abap-deploy-config-inquirer/src/utils.ts
+++ b/packages/abap-deploy-config-inquirer/src/utils.ts
@@ -92,7 +92,6 @@ export function isSameSystem(abapSystem?: SystemConfig, url?: string, client?: s
  *
  * @param transportConfigParams - transport configuration parameters
  * @param transportConfigParams.backendTarget - backend target from prompt options
- * @param transportConfigParams.scp - scp
  * @param transportConfigParams.url - url
  * @param transportConfigParams.client - client
  * @param transportConfigParams.destination - destination
@@ -102,14 +101,12 @@ export function isSameSystem(abapSystem?: SystemConfig, url?: string, client?: s
  */
 export async function initTransportConfig({
     backendTarget,
-    scp,
     url,
     destination,
     credentials,
     errorHandler
 }: {
     backendTarget?: BackendTarget;
-    scp?: boolean;
     url?: string;
     client?: string;
     destination?: string;
@@ -124,7 +121,6 @@ export async function initTransportConfig({
     try {
         result = await getTransportConfigInstance({
             backendTarget,
-            scp,
             credentials
         });
     } catch (e) {

--- a/packages/abap-deploy-config-inquirer/test/service-provider-utils/transport-config.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/service-provider-utils/transport-config.test.ts
@@ -14,7 +14,6 @@ describe('getTransportConfigInstance', () => {
     it('should return the dummy instance of TransportConfig', async () => {
         const transportConfigResult = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: true,
             credentials: {}
         });
         expect(transportConfigResult.transportConfig?.getPackage()).toBe(undefined);
@@ -41,7 +40,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
 
@@ -69,7 +67,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
 
@@ -87,7 +84,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult2 = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
 
@@ -112,7 +108,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
 
@@ -137,7 +132,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
         expect(transportConfigResult.transportConfigNeedsCreds).toBe(true);
@@ -156,7 +150,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResultWithoutHeaders = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
         expect(transportConfigResultWithoutHeaders.transportConfigNeedsCreds).toBe(false);
@@ -175,7 +168,6 @@ describe('getTransportConfigInstance', () => {
 
         const transportConfigResult2 = await getTransportConfigInstance({
             backendTarget: undefined,
-            scp: false,
             credentials: {}
         });
         expect(transportConfigResult2.transportConfigNeedsCreds).toBe(false);

--- a/packages/abap-deploy-config-inquirer/test/utils.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/utils.test.ts
@@ -120,7 +120,6 @@ describe('Test utils', () => {
         });
         const initTransportConfigResult = await initTransportConfig({
             backendTarget: undefined,
-            scp: false,
             url: 'https://mocktarget.url',
             client: '100',
             errorHandler: jest.fn()
@@ -128,7 +127,6 @@ describe('Test utils', () => {
 
         expect(mockGetTransportConfigInstance).toBeCalledWith({
             backendTarget: undefined,
-            scp: false,
             credentials: undefined
         });
         expect(initTransportConfigResult.transportConfigNeedsCreds).toBe(true);
@@ -136,7 +134,7 @@ describe('Test utils', () => {
 
     it('should log error when transport config initialisation fails', async () => {
         const errorHandler = jest.fn();
-        const result = await initTransportConfig({ backendTarget: undefined, scp: false, errorHandler });
+        const result = await initTransportConfig({ backendTarget: undefined, errorHandler });
         expect(result).toStrictEqual({});
 
         const loggerSpy = jest.spyOn(LoggerHelper.logger, 'debug');
@@ -145,7 +143,6 @@ describe('Test utils', () => {
         mockGetTransportConfigInstance.mockRejectedValueOnce(errorObj);
         const initTransportConfigResult = await initTransportConfig({
             backendTarget: undefined,
-            scp: false,
             url: 'https://mocktarget.url',
             client: '100',
             errorHandler
@@ -153,7 +150,6 @@ describe('Test utils', () => {
 
         expect(mockGetTransportConfigInstance).toBeCalledWith({
             backendTarget: undefined,
-            scp: false,
             credentials: undefined
         });
         expect(initTransportConfigResult.error).toStrictEqual(errorObj);


### PR DESCRIPTION
Current implementation does not initiliase the abap service provider for SCP systems at selection,
but only created if they are needed later in the flow - for packages, and transports

However with the change to validate packages (if they are local or not) coming in regardless if the package is entered manually, it makes sense to start initialising the transport when we do the init for on prem

This prevents multiple browsers opening for BTP systems (for every character entered in package manual) as the service provider will already be in the state