### PR TITLE
fix(cf-deploy-config-sub-generator): ensure completion message is shown to user

### DIFF
--- a/.changeset/curly-dolls-look.md
+++ b/.changeset/curly-dolls-look.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+Ensure the completion msg is shown to the user

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -338,7 +338,7 @@ export default class extends DeploymentGenerator {
                     await this._runNpmInstall(this.appPath);
                 }
             } catch (error) {
-                handleErrorMessage(this.appWizard, { errorMsg: t('cfGen.error.install', { error }) });
+                handleErrorMessage(this.appWizard, { errorMsg: t('cfGen.error.install', { error: error.message }) });
             }
         } else {
             DeploymentGenerator.logger?.info(t('cfGen.info.skippedInstallation'));
@@ -366,7 +366,8 @@ export default class extends DeploymentGenerator {
     public async end(): Promise<void> {
         try {
             if (
-                this.options.launchStandaloneFromYui &&
+                (this.options.launchStandaloneFromYui || !this.launchDeployConfigAsSubGenerator) &&
+                !this.abort &&
                 isExtensionInstalled(this.vscode, YUI_EXTENSION_ID, YUI_MIN_VER_FILES_GENERATED_MSG)
             ) {
                 this.appWizard?.showInformation(t('cfGen.info.filesGenerated'), MessageType.notification);

--- a/packages/cf-deploy-config-sub-generator/test/cap-app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/cap-app.test.ts
@@ -162,7 +162,7 @@ describe('Cloud foundry generator tests', () => {
         mockFindCapProjectRoot.mockReturnValue(join('/output/', '/capmissingmta'));
         const mockGenerateCAPConfig = jest.spyOn(cfDeployWriter, 'generateCAPConfig').mockResolvedValue(fsMock);
         const mockGenerateAppConfig = jest.spyOn(cfDeployWriter, 'generateAppConfig').mockResolvedValue(fsMock);
-        jest.spyOn(fioriGenShared, 'isExtensionInstalled').mockImplementation(() => {
+        const mockisExtensionInstalled = jest.spyOn(fioriGenShared, 'isExtensionInstalled').mockImplementation(() => {
             return true;
         });
 
@@ -223,5 +223,6 @@ describe('Cloud foundry generator tests', () => {
         expect(mockGenerateAppConfig).toHaveBeenCalled();
         expect(mockFindCapProjectRoot).toHaveBeenCalled();
         expect(mockSendTelemetry).toHaveBeenCalled();
+        expect(mockisExtensionInstalled).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION

Fix for https://github.com/SAP/open-ux-tools/issues/3069
- Completion message should be shown to the user if no issues were found
- Should only be shown to the user if loaded as root generator