### PR TITLE
fix(cf-deploy-config-writer): update the mta post install script

### DIFF
--- a/.changeset/clever-ducks-refuse.md
+++ b/.changeset/clever-ducks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+Change post install script

--- a/packages/cf-deploy-config-writer/src/mta-config/index.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/index.ts
@@ -146,7 +146,7 @@ export function createCAPMTA(cwd: string, options?: string[]): void {
     }
     // Ensure the package-lock is created otherwise mta build will fail
     const cmd = process.platform === 'win32' ? `npm.cmd` : 'npm';
-    result = spawnSync(cmd, ['install', '--ignore-engines'], spawnOpts);
+    result = spawnSync(cmd, ['update', '--package-lock-only'], spawnOpts);
     if (result?.error) {
         throw new Error(`Something went wrong installing node modules! ${result.error}`);
     }

--- a/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
@@ -92,7 +92,7 @@ describe('CF Writer CAP', () => {
                 expect.objectContaining({ cwd: expect.stringContaining(mtaId) })
             );
             expect(spawnMock.mock.calls[1][0]).toStrictEqual('npm.cmd'); // Just always test for windows!
-            expect(spawnMock.mock.calls[1][1]).toStrictEqual(['install', '--ignore-engines']);
+            expect(spawnMock.mock.calls[1][1]).toStrictEqual(['update', '--package-lock-only']);
             expect(spawnMock.mock.calls[1][2]).toHaveProperty('shell');
             if (RouterModuleType.Standard === routerType) {
                 expect(localFs.read(join(mtaPath, `router`, 'package.json'))).toMatchSnapshot();


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2821

Based on changes in CDS, the following CLI commands are now required when adding an mta to a CAP project;

```
cds init meme && cd meme && npm install && cds add sample && cds add hana && cds add mta && npm update --package-lock-only
```

In order to build the mta.yaml `npm update --package-lock-only` is now required.