### PR TITLE
fix: CPE Add Subpage quick action bug fix in v4 projects

### DIFF
--- a/.changeset/pink-guests-peel.md
+++ b/.changeset/pink-guests-peel.md
@@ -3,4 +3,4 @@
 '@sap-ux/preview-middleware': patch
 ---
 
-fix: Fixed CPE Add Subpage quick action bug in V4 ADP projects. The action was not dispalyed if current page has context path defined in manifest instead of entitySet
+fix: CPE Add Subpage Quick Action not displayed for SAP Fiori Elements for OData V4 applications in Adaptation Projects, if current page has `contextPath` defined in manifest instead of `entitySet`.

--- a/.changeset/pink-guests-peel.md
+++ b/.changeset/pink-guests-peel.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: Fixed CPE Add Subpage quick action bug in V4 ADP projects. The action was not dispalyed if current page has context path defined in manifest instead of entitySet

--- a/packages/preview-middleware-client/src/adp/quick-actions/add-new-subpage-quick-action-base.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/add-new-subpage-quick-action-base.ts
@@ -60,8 +60,11 @@ export abstract class AddNewSubpageBase<ODataMetaModelType>
     protected abstract getApplicationPages(): ApplicationPageData[];
     protected abstract isPageExists(targetEntitySet: string, metaModel: ODataMetaModelType): boolean | Promise<boolean>;
     protected abstract isCurrentObjectPage(): boolean;
-    protected abstract getEntitySetNameFromPageComponent(component: Component | undefined): string;
-    protected abstract prepareNavigationData(entitySetName: string, metaModel: ODataMetaModelType): Promise<void>;
+    protected abstract getEntitySetNameFromPageComponent(
+        component: Component | undefined,
+        metaModel: ODataMetaModelType
+    ): Promise<string | undefined>;
+    protected abstract prepareNavigationData(metaModel: ODataMetaModelType): Promise<void>;
     protected abstract getODataMetaModel(): ODataMetaModelType | undefined;
 
     protected async addNavigationOptionIfAvailable(
@@ -101,7 +104,7 @@ export abstract class AddNewSubpageBase<ODataMetaModelType>
         }
 
         const component = Component.getOwnerComponentFor(modifiedControl);
-        const entitySetName = this.getEntitySetNameFromPageComponent(component);
+        const entitySetName = await this.getEntitySetNameFromPageComponent(component, metaModel);
         if (!entitySetName) {
             return Promise.resolve();
         }
@@ -111,7 +114,7 @@ export abstract class AddNewSubpageBase<ODataMetaModelType>
         if (!this.isCurrentObjectPage()) {
             await this.addNavigationOptionIfAvailable(metaModel, this.entitySet);
         } else {
-            await this.prepareNavigationData(entitySetName, metaModel);
+            await this.prepareNavigationData(metaModel);
         }
         this.control = modifiedControl;
 

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/add-new-subpage.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/add-new-subpage.ts
@@ -52,15 +52,15 @@ export class AddNewSubpage extends AddNewSubpageBase<ODataMetaModelV2> {
         return (this.context.rta.getRootControlInstance().getModel() as ODataModelV2)?.getMetaModel();
     }
 
-    protected getEntitySetNameFromPageComponent(component: Component | undefined): string {
+    protected getEntitySetNameFromPageComponent(component: Component | undefined): Promise<string> {
         if (!isA<TemplateComponent>('sap.suite.ui.generic.template.lib.TemplateComponent', component)) {
             throw new Error('Unexpected type of page owner component');
         }
-        return component.getEntitySet();
+        return Promise.resolve(component.getEntitySet());
     }
 
-    protected async prepareNavigationData(entitySetName: string, metaModel: ODataMetaModelV2): Promise<void> {
-        const entitySet = metaModel.getODataEntitySet(entitySetName) as EntitySet;
+    protected async prepareNavigationData(metaModel: ODataMetaModelV2): Promise<void> {
+        const entitySet = metaModel.getODataEntitySet(this.entitySet!) as EntitySet;
         const entityType = metaModel.getODataEntityType(entitySet.entityType) as EntityType;
 
         for (const navProp of entityType?.navigationProperty || []) {

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/add-new-subpage.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v2/add-new-subpage.ts
@@ -63,7 +63,7 @@ export class AddNewSubpage extends AddNewSubpageBase<ODataMetaModelV2> {
         const entitySet = metaModel.getODataEntitySet(this.entitySet!) as EntitySet;
         const entityType = metaModel.getODataEntityType(entitySet.entityType) as EntityType;
 
-        for (const navProp of entityType?.navigationProperty || []) {
+        for (const navProp of entityType?.navigationProperty ?? []) {
             const associationEnd = metaModel.getODataAssociationEnd(entityType, navProp.name);
             if (associationEnd?.multiplicity !== '*') {
                 continue;

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/add-new-subpage.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/add-new-subpage.ts
@@ -129,7 +129,7 @@ export class AddNewSubpage extends AddNewSubpageBase<ODataMetaModelV4> {
         }
         let entitySet: string | undefined = component.getEntitySet();
         let contextPath = component.getContextPath();
-        if (!entitySet && contextPath) {
+        if (contextPath) {
             entitySet = await this.resolveContextPathTargetName(contextPath, metaModel);
         }
         return entitySet;

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -2595,7 +2595,20 @@ describe('FE V4 quick actions', () => {
                     getEntitySet: jest
                         .fn()
                         .mockReturnValue(
-                            testCase.componentHasNoEntitySet ? undefined : testCase.isListReport ? 'Travel' : 'Booking'
+                            testCase.componentHasNoEntitySet || testCase.isContextPathDefined
+                                ? undefined
+                                : testCase.isListReport
+                                ? 'Travel'
+                                : 'Booking'
+                        ),
+                    getContextPath: jest
+                        .fn()
+                        .mockReturnValue(
+                            testCase.componentHasNoEntitySet || !testCase.isContextPathDefined
+                                ? undefined
+                                : testCase.isListReport
+                                ? '/Travel'
+                                : '/Booking'
                         )
                 } as unknown as UIComponent;
             });
@@ -2659,9 +2672,13 @@ describe('FE V4 quick actions', () => {
                     'id': 'TravelList',
                     'name': 'sap.fe.templates.ListReport',
                     'options': {
-                        'settings': {
-                            'entitySet': 'Travel'
-                        }
+                        'settings': testCase.isContextPathDefined
+                            ? {
+                                  'contextPath': '/Travel'
+                              }
+                            : {
+                                  'entitySet': 'Travel'
+                              }
                     }
                 },
                 ...(testCase.isListReport && testCase.isNewPageUnavailable

--- a/packages/preview-middleware-client/types/sap.fe.templates.d.ts
+++ b/packages/preview-middleware-client/types/sap.fe.templates.d.ts
@@ -2,6 +2,7 @@ declare module 'sap/fe/templates/ObjectPage/Component' {
     import UIComponent from 'sap/ui/core/UIComponent';
     interface FEObjectPageComponent extends UIComponent {
         getEntitySet: () => string;
+        getContextPath: () => string;
     }
 
     export default FEObjectPageComponent;
@@ -11,6 +12,7 @@ declare module 'sap/fe/templates/ListReport/Component' {
     import UIComponent from 'sap/ui/core/UIComponent';
     interface FEListReportComponent extends UIComponent {
         getEntitySet: () => string;
+        getContextPath: () => string;
     }
 
     export default FEListReportComponent;


### PR DESCRIPTION
Fixed CPE Add Subpage quick action bug. The action is not shown when current page has context path defined in page settings in manifest