### PR TITLE
fix: Cannot create a Extension Point fragment when clicking create button in the dialog

### DIFF
--- a/.changeset/hungry-terms-pretend.md
+++ b/.changeset/hungry-terms-pretend.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: Cannot create a Extension Point fragment when clicking create button in the dialog

--- a/packages/preview-middleware-client/src/adp/controllers/ExtensionPoint.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/ExtensionPoint.controller.ts
@@ -61,9 +61,10 @@ export default class ExtensionPoint extends BaseDialog<ExtensionPointModel> {
      * @param event Event
      */
     async onCreateBtnPress(event: Event) {
-        await super.onCreateBtnPressHandler();
         const source = event.getSource<Button>();
         source.setEnabled(false);
+
+        await super.onCreateBtnPressHandler();
 
         const fragmentName = this.model.getProperty('/newFragmentName');
 


### PR DESCRIPTION
Fix for #3078.
- Changes the order of execution inside the handler to capture the event before calling the base class.