### PR TITLE
fix(abap-inq): check cloud systems are connected before making backend call

### DIFF
--- a/.changeset/spotty-ravens-agree.md
+++ b/.changeset/spotty-ravens-agree.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+check cloud systems are connected before making backend call

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -672,6 +672,7 @@ async function validatePackageType(input: string, backendTarget?: BackendTarget)
  * @param {PackagePromptOptions} [promptOption] - Optional settings for additional package validation.
  * @param {UI5AbapRepoPromptOptions} [ui5AbapPromptOptions] - Optional for ui5AbapRepo.
  * @param {BackendTarget} [backendTarget] - The backend target for validation context.
+ * @param {boolean} [useStandalone] - indicates if the package prompts are being ran in standalone.
  * @returns {Promise<boolean | string>} - Resolves to `true` if the package is valid,
  *                                        a `string` with an error message if validation fails,
  *                                        or the result of additional cloud package validation if applicable.
@@ -681,7 +682,8 @@ export async function validatePackageExtended(
     answers: AbapDeployConfigAnswersInternal,
     promptOption?: PackagePromptOptions,
     ui5AbapPromptOptions?: UI5AbapRepoPromptOptions,
-    backendTarget?: BackendTarget
+    backendTarget?: BackendTarget,
+    useStandalone?: boolean
 ): Promise<boolean | string> {
     const baseValidation = await validatePackage(input);
     if (typeof baseValidation === 'string') {
@@ -698,8 +700,15 @@ export async function validatePackageExtended(
         }
     }
 
-    // checks if package is a local package and will update prompt state accordingly
-    await getTransportListFromService(input.toUpperCase(), answers.ui5AbapRepo ?? '', backendTarget);
+    if (
+        useStandalone ||
+        !PromptState.abapDeployConfig.scp ||
+        // we need to verify cloud systems are connected before checking the package to avoid multiple browser windows opening
+        (PromptState.abapDeployConfig.scp && AbapServiceProviderManager.isConnected())
+    ) {
+        // checks if package is a local package and will update prompt state accordingly
+        await getTransportListFromService(input.toUpperCase(), answers.ui5AbapRepo ?? '', backendTarget);
+    }
 
     if (shouldValidatePackageForStartingPrefix(answers, promptOption, ui5AbapPromptOptions)) {
         const startingPrefix = getPackageStartingPrefix(input);

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
@@ -49,6 +49,15 @@ export class AbapServiceProviderManager {
     }
 
     /**
+     * Checks if the service provider has a valid connection.
+     *
+     * @returns true if the system is cloud and the service provider is connected
+     */
+    public static isConnected(): boolean {
+        return !!AbapServiceProviderManager.abapServiceProvider?.cookies;
+    }
+
+    /**
      * Returns the system config from the prompt state or the backend target.
      *
      * @param backendTarget - backend target from prompt options

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -368,6 +368,7 @@ describe('Test validators', () => {
     describe('validatePackageExtended', () => {
         beforeEach(() => {
             PromptState.resetTransportAnswers();
+            jest.resetAllMocks();
         });
 
         it('should return true for onPremise system with default onPremise package', async () => {
@@ -486,6 +487,39 @@ describe('Test validators', () => {
                 additionalValidation: { shouldValidatePackageType: true }
             });
             expect(result).toBe(true);
+        });
+
+        it('should run getTransportListFromService when package prompts are ran standalone', async () => {
+            const getTransportListFromServiceSpy = jest.spyOn(serviceProviderUtils, 'getTransportListFromService');
+            const result = await validatePackageExtended('ZPACKAGE', previousAnswers, {}, {}, undefined, true);
+            expect(result).toBe(true);
+            expect(getTransportListFromServiceSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should run getTransportListFromService when the system is on-prem', async () => {
+            PromptState.abapDeployConfig.scp = false;
+            const getTransportListFromServiceSpy = jest.spyOn(serviceProviderUtils, 'getTransportListFromService');
+            const result = await validatePackageExtended('ZPACKAGE', previousAnswers);
+            expect(result).toBe(true);
+            expect(getTransportListFromServiceSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should run getTransportListFromService when the cloud system is connected', async () => {
+            PromptState.abapDeployConfig.scp = true;
+            jest.spyOn(AbapServiceProviderManager, 'isConnected').mockReturnValue(true);
+            const getTransportListFromServiceSpy = jest.spyOn(serviceProviderUtils, 'getTransportListFromService');
+            const result = await validatePackageExtended('ZPACKAGE', previousAnswers);
+            expect(result).toBe(true);
+            expect(getTransportListFromServiceSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not run getTransportListFromService when the cloud system is not connected', async () => {
+            PromptState.abapDeployConfig.scp = true;
+            jest.spyOn(AbapServiceProviderManager, 'isConnected').mockReturnValue(false);
+            const getTransportListFromServiceSpy = jest.spyOn(serviceProviderUtils, 'getTransportListFromService');
+            const result = await validatePackageExtended('ZPACKAGE', previousAnswers);
+            expect(result).toBe(true);
+            expect(getTransportListFromServiceSpy).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Add check that connection has been made for cloud systems before validating package (otherwise validator will run for every character entered, which in turns means a browser window opens for every character opened)