### PR TITLE
fix(cf-deploy-config-writer): append install script

### DIFF
--- a/.changeset/lemon-lizards-provide.md
+++ b/.changeset/lemon-lizards-provide.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+append install script

--- a/packages/cf-deploy-config-writer/src/mta-config/index.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/index.ts
@@ -145,8 +145,6 @@ export function createCAPMTA(cwd: string, options?: string[]): void {
         throw new Error(`Something went wrong creating mta.yaml! ${result.error}`);
     }
     const cmd = process.platform === 'win32' ? `npm.cmd` : 'npm';
-    // Update the package-lock.json, to reflect any cds changes or dependency changes
-    result = spawnSync(cmd, ['update', '--package-lock-only'], spawnOpts);
     // Install latest dev dependencies, if any, added by the CF writer
     result = spawnSync(cmd, ['install', '--ignore-engines'], spawnOpts);
     if (result?.error) {

--- a/packages/cf-deploy-config-writer/src/mta-config/index.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/index.ts
@@ -144,9 +144,11 @@ export function createCAPMTA(cwd: string, options?: string[]): void {
     if (result?.error) {
         throw new Error(`Something went wrong creating mta.yaml! ${result.error}`);
     }
-    // Ensure the package-lock is created otherwise mta build will fail
     const cmd = process.platform === 'win32' ? `npm.cmd` : 'npm';
+    // Update the package-lock.json, to reflect any cds changes or dependency changes
     result = spawnSync(cmd, ['update', '--package-lock-only'], spawnOpts);
+    // Install latest dev dependencies, if any, added by the CF writer
+    result = spawnSync(cmd, ['install', '--ignore-engines'], spawnOpts);
     if (result?.error) {
         throw new Error(`Something went wrong installing node modules! ${result.error}`);
     }

--- a/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
@@ -85,7 +85,7 @@ describe('CF Writer CAP', () => {
             expect(localFs.read(join(mtaPath, 'mta.yaml'))).toMatchSnapshot();
             expect(localFs.read(join(mtaPath, 'package.json'))).toMatchSnapshot(); // Ensure it hasn't changed!
             expect(getCapProjectTypeMock).toHaveBeenCalled();
-            expect(spawnMock.mock.calls).toHaveLength(2);
+            expect(spawnMock.mock.calls).toHaveLength(3);
             expect(spawnMock).toHaveBeenCalledWith(
                 'cds',
                 ['add', 'mta', 'xsuaa', 'destination', 'html5-repo'],
@@ -94,6 +94,8 @@ describe('CF Writer CAP', () => {
             expect(spawnMock.mock.calls[1][0]).toStrictEqual('npm.cmd'); // Just always test for windows!
             expect(spawnMock.mock.calls[1][1]).toStrictEqual(['update', '--package-lock-only']);
             expect(spawnMock.mock.calls[1][2]).toHaveProperty('shell');
+            expect(spawnMock.mock.calls[2][0]).toStrictEqual('npm.cmd');
+            expect(spawnMock.mock.calls[2][1]).toStrictEqual(['install', '--ignore-engines']);
             if (RouterModuleType.Standard === routerType) {
                 expect(localFs.read(join(mtaPath, `router`, 'package.json'))).toMatchSnapshot();
                 expect(localFs.read(join(mtaPath, `router`, 'xs-app.json'))).toMatchSnapshot();

--- a/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
@@ -85,17 +85,15 @@ describe('CF Writer CAP', () => {
             expect(localFs.read(join(mtaPath, 'mta.yaml'))).toMatchSnapshot();
             expect(localFs.read(join(mtaPath, 'package.json'))).toMatchSnapshot(); // Ensure it hasn't changed!
             expect(getCapProjectTypeMock).toHaveBeenCalled();
-            expect(spawnMock.mock.calls).toHaveLength(3);
+            expect(spawnMock.mock.calls).toHaveLength(2);
             expect(spawnMock).toHaveBeenCalledWith(
                 'cds',
                 ['add', 'mta', 'xsuaa', 'destination', 'html5-repo'],
                 expect.objectContaining({ cwd: expect.stringContaining(mtaId) })
             );
-            expect(spawnMock.mock.calls[1][0]).toStrictEqual('npm.cmd'); // Just always test for windows!
-            expect(spawnMock.mock.calls[1][1]).toStrictEqual(['update', '--package-lock-only']);
-            expect(spawnMock.mock.calls[1][2]).toHaveProperty('shell');
-            expect(spawnMock.mock.calls[2][0]).toStrictEqual('npm.cmd');
-            expect(spawnMock.mock.calls[2][1]).toStrictEqual(['install', '--ignore-engines']);
+            expect(spawnMock.mock.calls[0][2]).toHaveProperty('shell');
+            expect(spawnMock.mock.calls[1][0]).toStrictEqual('npm.cmd');
+            expect(spawnMock.mock.calls[1][1]).toStrictEqual(['install', '--ignore-engines']);
             if (RouterModuleType.Standard === routerType) {
                 expect(localFs.read(join(mtaPath, `router`, 'package.json'))).toMatchSnapshot();
                 expect(localFs.read(join(mtaPath, `router`, 'xs-app.json'))).toMatchSnapshot();


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2821

Current issue;
when `mta.yaml` is added, CDS expects the following command to be run;
```
npm update --package-lock-only
```

However, we are appending `devDependencies` that are putting the `package.json` and `package-lock.json` out of sync.

This can be replicated;
```
step1. Remove existing mta.yaml
step2. Add mta running `cds add mta`
step3. update the package.json with a new devDep i.e. "@ui5/logger": "^4.0.1"
step4. run the command `npm update --package-lock-only`
step5. build the mta.yaml `npm run build`
Build fails when `npm ci` is run
```

To fix the issue;
```
step1. Remove existing mta.yaml
step2. Add mta running `cds add mta`
step3. update the package.json with a new devDep i.e. "@ui5/fs": "^4.0.1",
step4. run the command `npm i`
step5. build the mta.yaml `npm run build`
Build passes when `npm ci` is run
```

