### PR TITLE
fix(cf-deploy-config-writer): remove fs from addPackageDevDependency

### DIFF
--- a/.changeset/smooth-trees-attack.md
+++ b/.changeset/smooth-trees-attack.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+remove fs, causing issues when cds is updating package.json

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -298,8 +298,8 @@ export async function updateRootPackage(
     const packageExists = fs.exists(join(rootPath, FileName.Package));
     // Append mta scripts only if mta.yaml is at a different level to the HTML5 app
     if (packageExists) {
-        await addPackageDevDependency(rootPath, Rimraf, RimrafVersion, fs);
-        await addPackageDevDependency(rootPath, MbtPackage, MbtPackageVersion, fs);
+        await addPackageDevDependency(rootPath, Rimraf, RimrafVersion);
+        await addPackageDevDependency(rootPath, MbtPackage, MbtPackageVersion);
         let deployArgs: string[] = [];
         if (fs.exists(join(rootPath, MTAFileExtension))) {
             deployArgs = ['-e', MTAFileExtension];
@@ -309,7 +309,7 @@ export async function updateRootPackage(
             { name: 'build', run: `${MTABuildScript} --mtar archive` },
             { name: 'deploy', run: rootDeployMTAScript(deployArgs) }
         ]) {
-            await updatePackageScript(rootPath, script.name, script.run, fs);
+            await updatePackageScript(rootPath, script.name, script.run);
         }
     }
 }

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -286,6 +286,8 @@ export function setMtaDefaults(config: CFBaseConfig): void {
 /**
  * Update the root package.json with scripts to deploy the MTA.
  *
+ * Note: The fs editor is not passed to `addPackageDevDependency` since the package.json could be updated by other third party tools.
+ *
  * @param {object} Options Input params
  * @param {string} Options.mtaId - MTA ID to be written to package.json
  * @param {string} Options.rootPath - MTA project path

--- a/packages/cf-deploy-config-writer/test/unit/__snapshots__/cap.test.ts.snap
+++ b/packages/cf-deploy-config-writer/test/unit/__snapshots__/cap.test.ts.snap
@@ -279,22 +279,6 @@ builder:
 ",
     "state": "modified",
   },
-  "package.json": Object {
-    "contents": "{
-    \\"cds\\": {},
-    \\"devDependencies\\": {
-        \\"rimraf\\": \\"^5.0.5\\",
-        \\"mbt\\": \\"^1.2.29\\"
-    },
-    \\"scripts\\": {
-        \\"undeploy\\": \\"cf undeploy cappapp --delete-services --delete-service-keys --delete-service-brokers\\",
-        \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
-        \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
-    }
-}
-",
-    "state": "modified",
-  },
   "xs-security.json": Object {
     "contents": "{
   \\"xsappname\\": \\"cappapp\\",
@@ -449,268 +433,23 @@ resources:
 "
 `;
 
-exports[`CF Writer Validate HTML5 app is added with a managed approuter to an existing a CAP project 1`] = `
-Object {
-  "app/project1/package.json": Object {
-    "contents": "{
-  \\"name\\": \\"project1\\",
-  \\"version\\": \\"0.0.1\\",
-  \\"description\\": \\"An SAP Fiori application.\\",
-  \\"keywords\\": [
-    \\"ui5\\",
-    \\"openui5\\",
-    \\"sapui5\\"
-  ],
-  \\"main\\": \\"webapp/index.html\\",
-  \\"dependencies\\": {},
-  \\"devDependencies\\": {
-    \\"@ui5/cli\\": \\"^3.0.0\\",
-    \\"@sap/ux-ui5-tooling\\": \\"1\\",
-    \\"@sap/ui5-builder-webide-extension\\": \\"^1.1.9\\",
-    \\"ui5-task-zipper\\": \\"^3.1.3\\",
-    \\"rimraf\\": \\"^5.0.5\\",
-    \\"mbt\\": \\"^1.2.29\\"
-  },
-  \\"scripts\\": {
-    \\"deploy-config\\": \\"npx -p @sap/ux-ui5-tooling fiori add deploy-config cf\\",
-    \\"build:cf\\": \\"ui5 build preload --clean-dest --config ui5-deploy.yaml --include-task=generateCachebusterInfo\\"
-  }
-}
-",
-    "state": "modified",
-  },
-  "app/project1/ui5-deploy.yaml": Object {
-    "contents": "# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
-
-specVersion: \\"3.1\\"
-metadata:
-  name: project1
-type: application
-resources:
-  configuration:
-    propertiesFileSourceEncoding: UTF-8
-builder:
-  resources:
-    excludes:
-      - /test/**
-      - /localService/**
-  customTasks:
-    - name: webide-extension-task-updateManifestJson
-      afterTask: replaceVersion
-      configuration:
-        appFolder: webapp
-        destDir: dist
-    - name: ui5-task-zipper
-      afterTask: generateCachebusterInfo
-      configuration:
-        archiveName: project1
-        additionalFiles:
-          - xs-app.json
-",
-    "state": "modified",
-  },
-  "app/project1/webapp/manifest.json": Object {
-    "contents": "{
-  \\"_version\\": \\"1.65.0\\",
-  \\"sap.app\\": {
-    \\"id\\": \\"project1\\",
-    \\"type\\": \\"application\\",
-    \\"i18n\\": \\"i18n/i18n.properties\\",
-    \\"applicationVersion\\": {
-      \\"version\\": \\"0.0.1\\"
+exports[`CF Writer Generate deployment config for CAP project Add destination instance to a HTML5 app inside a CAP project 3`] = `
+"{
+    \\"cds\\": {},
+    \\"devDependencies\\": {
+        \\"rimraf\\": \\"^5.0.5\\",
+        \\"mbt\\": \\"^1.2.29\\"
     },
-    \\"title\\": \\"{{appTitle}}\\",
-    \\"description\\": \\"{{appDescription}}\\",
-    \\"resources\\": \\"resources.json\\",
-    \\"sourceTemplate\\": {
-      \\"id\\": \\"@sap/generator-fiori:basic\\",
-      \\"version\\": \\"1.16.5\\",
-      \\"toolsId\\": \\"3f0f4df7-2a6b-465d-a13f-f57618317a4f\\"
-    },
-    \\"dataSources\\": {
-      \\"mainService\\": {
-        \\"uri\\": \\"/odata/v4/catalog/\\",
-        \\"type\\": \\"OData\\",
-        \\"settings\\": {
-          \\"annotations\\": [],
-          \\"odataVersion\\": \\"4.0\\"
-        }
-      }
+    \\"scripts\\": {
+        \\"undeploy\\": \\"cf undeploy cappapp --delete-services --delete-service-keys --delete-service-brokers\\",
+        \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
+        \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
     }
-  },
-  \\"sap.ui\\": {
-    \\"technology\\": \\"UI5\\",
-    \\"icons\\": {
-      \\"icon\\": \\"\\",
-      \\"favIcon\\": \\"\\",
-      \\"phone\\": \\"\\",
-      \\"phone@2\\": \\"\\",
-      \\"tablet\\": \\"\\",
-      \\"tablet@2\\": \\"\\"
-    },
-    \\"deviceTypes\\": {
-      \\"desktop\\": true,
-      \\"tablet\\": true,
-      \\"phone\\": true
-    }
-  },
-  \\"sap.ui5\\": {
-    \\"flexEnabled\\": true,
-    \\"dependencies\\": {
-      \\"minUI5Version\\": \\"1.133.0\\",
-      \\"libs\\": {
-        \\"sap.m\\": {},
-        \\"sap.ui.core\\": {}
-      }
-    },
-    \\"contentDensities\\": {
-      \\"compact\\": true,
-      \\"cozy\\": true
-    },
-    \\"models\\": {
-      \\"i18n\\": {
-        \\"type\\": \\"sap.ui.model.resource.ResourceModel\\",
-        \\"settings\\": {
-          \\"bundleName\\": \\"project1.i18n.i18n\\"
-        }
-      },
-      \\"\\": {
-        \\"dataSource\\": \\"mainService\\",
-        \\"preload\\": true,
-        \\"settings\\": {
-          \\"operationMode\\": \\"Server\\",
-          \\"autoExpandSelect\\": true,
-          \\"earlyRequests\\": true
-        }
-      }
-    },
-    \\"resources\\": {
-      \\"css\\": [
-        {
-          \\"uri\\": \\"css/style.css\\"
-        }
-      ]
-    },
-    \\"routing\\": {
-      \\"config\\": {
-        \\"routerClass\\": \\"sap.m.routing.Router\\",
-        \\"controlAggregation\\": \\"pages\\",
-        \\"controlId\\": \\"app\\",
-        \\"transition\\": \\"slide\\",
-        \\"type\\": \\"View\\",
-        \\"viewType\\": \\"XML\\",
-        \\"path\\": \\"project1.view\\",
-        \\"async\\": true,
-        \\"viewPath\\": \\"project1.view\\"
-      },
-      \\"routes\\": [
-        {
-          \\"name\\": \\"RouteView1\\",
-          \\"pattern\\": \\":?query:\\",
-          \\"target\\": [
-            \\"TargetView1\\"
-          ]
-        }
-      ],
-      \\"targets\\": {
-        \\"TargetView1\\": {
-          \\"id\\": \\"View1\\",
-          \\"name\\": \\"View1\\"
-        }
-      }
-    },
-    \\"rootView\\": {
-      \\"viewName\\": \\"project1.view.App\\",
-      \\"type\\": \\"XML\\",
-      \\"id\\": \\"App\\",
-      \\"async\\": true
-    }
-  },
-  \\"sap.cloud\\": {
-    \\"public\\": true,
-    \\"service\\": \\"captestproject\\"
-  }
 }
-",
-    "state": "modified",
-  },
-  "app/project1/xs-app.json": Object {
-    "contents": "{
-  \\"welcomeFile\\": \\"/index.html\\",
-  \\"authenticationMethod\\": \\"route\\",
-  \\"routes\\": [
-    {
-      \\"source\\": \\"^/odata/(.*)$\\",
-      \\"target\\": \\"/odata/$1\\",
-      \\"destination\\": \\"captestproject-srv-api\\",
-      \\"authenticationType\\": \\"xsuaa\\",
-      \\"csrfProtection\\": false
-    },
-    {
-      \\"source\\": \\"^/resources/(.*)$\\",
-      \\"target\\": \\"/resources/$1\\",
-      \\"authenticationType\\": \\"none\\",
-      \\"destination\\": \\"ui5\\"
-    },
-    {
-      \\"source\\": \\"^/test-resources/(.*)$\\",
-      \\"target\\": \\"/test-resources/$1\\",
-      \\"authenticationType\\": \\"none\\",
-      \\"destination\\": \\"ui5\\"
-    },
-    {
-      \\"source\\": \\"^(.*)$\\",
-      \\"target\\": \\"$1\\",
-      \\"service\\": \\"html5-apps-repo-rt\\",
-      \\"authenticationType\\": \\"xsuaa\\"
-    }
-  ]
-}
-",
-    "state": "modified",
-  },
-  "package.json": Object {
-    "contents": "{
-  \\"name\\": \\"captestproject\\",
-  \\"version\\": \\"1.0.0\\",
-  \\"description\\": \\"A simple CAP project.\\",
-  \\"repository\\": \\"<Add your repository here>\\",
-  \\"license\\": \\"UNLICENSED\\",
-  \\"private\\": true,
-  \\"dependencies\\": {
-    \\"@sap/cds\\": \\"^8\\",
-    \\"express\\": \\"^4\\",
-    \\"@sap/xssec\\": \\"^4\\"
-  },
-  \\"devDependencies\\": {
-    \\"@cap-js/cds-types\\": \\"^0.8.0\\",
-    \\"@cap-js/sqlite\\": \\"^1\\",
-    \\"@sap/cds-dk\\": \\"^8\\",
-    \\"rimraf\\": \\"^5.0.5\\",
-    \\"mbt\\": \\"^1.2.29\\"
-  },
-  \\"scripts\\": {
-    \\"start\\": \\"cds-serve\\",
-    \\"undeploy\\": \\"cf undeploy captestproject --delete-services --delete-service-keys --delete-service-brokers\\",
-    \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
-    \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
-  },
-  \\"cds\\": {
-    \\"requires\\": {
-      \\"auth\\": \\"xsuaa\\",
-      \\"connectivity\\": true,
-      \\"destinations\\": true,
-      \\"html5-repo\\": true
-    }
-  }
-}
-",
-    "state": "modified",
-  },
-}
+"
 `;
 
-exports[`CF Writer Validate HTML5 app is added with a managed approuter to an existing a CAP project 2`] = `
+exports[`CF Writer Validate HTML5 app is added with a managed approuter to an existing a CAP project 1`] = `
 "_schema-version: 3.3.0
 ID: captestproject
 version: 1.0.0
@@ -858,6 +597,44 @@ resources:
 "
 `;
 
+exports[`CF Writer Validate HTML5 app is added with a managed approuter to an existing a CAP project 2`] = `
+"{
+  \\"name\\": \\"captestproject\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"A simple CAP project.\\",
+  \\"repository\\": \\"<Add your repository here>\\",
+  \\"license\\": \\"UNLICENSED\\",
+  \\"private\\": true,
+  \\"dependencies\\": {
+    \\"@sap/cds\\": \\"^8\\",
+    \\"express\\": \\"^4\\",
+    \\"@sap/xssec\\": \\"^4\\"
+  },
+  \\"devDependencies\\": {
+    \\"@cap-js/cds-types\\": \\"^0.8.0\\",
+    \\"@cap-js/sqlite\\": \\"^1\\",
+    \\"@sap/cds-dk\\": \\"^8\\",
+    \\"rimraf\\": \\"^5.0.5\\",
+    \\"mbt\\": \\"^1.2.29\\"
+  },
+  \\"scripts\\": {
+    \\"start\\": \\"cds-serve\\",
+    \\"undeploy\\": \\"cf undeploy captestproject --delete-services --delete-service-keys --delete-service-brokers\\",
+    \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
+    \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
+  },
+  \\"cds\\": {
+    \\"requires\\": {
+      \\"auth\\": \\"xsuaa\\",
+      \\"connectivity\\": true,
+      \\"destinations\\": true,
+      \\"html5-repo\\": true
+    }
+  }
+}
+"
+`;
+
 exports[`CF Writer Validate HTML5 is added without a managed approuter to a CAP project 1`] = `
 Object {
   "app/project1/package.json": Object {
@@ -949,44 +726,6 @@ builder:
       \\"authenticationType\\": \\"xsuaa\\"
     }
   ]
-}
-",
-    "state": "modified",
-  },
-  "package.json": Object {
-    "contents": "{
-  \\"name\\": \\"captestproject\\",
-  \\"version\\": \\"1.0.0\\",
-  \\"description\\": \\"A simple CAP project.\\",
-  \\"repository\\": \\"<Add your repository here>\\",
-  \\"license\\": \\"UNLICENSED\\",
-  \\"private\\": true,
-  \\"dependencies\\": {
-    \\"@sap/cds\\": \\"^8\\",
-    \\"express\\": \\"^4\\",
-    \\"@sap/xssec\\": \\"^4\\"
-  },
-  \\"devDependencies\\": {
-    \\"@cap-js/cds-types\\": \\"^0.8.0\\",
-    \\"@cap-js/sqlite\\": \\"^1\\",
-    \\"@sap/cds-dk\\": \\"^8\\",
-    \\"rimraf\\": \\"^5.0.5\\",
-    \\"mbt\\": \\"^1.2.29\\"
-  },
-  \\"scripts\\": {
-    \\"start\\": \\"cds-serve\\",
-    \\"undeploy\\": \\"cf undeploy captestproject --delete-services --delete-service-keys --delete-service-brokers\\",
-    \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
-    \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
-  },
-  \\"cds\\": {
-    \\"requires\\": {
-      \\"auth\\": \\"xsuaa\\",
-      \\"connectivity\\": true,
-      \\"destinations\\": true,
-      \\"html5-repo\\": true
-    }
-  }
 }
 ",
     "state": "modified",
@@ -1107,6 +846,44 @@ resources:
       config:
         xsappname: 'captestproject-\${org}-\${space}'
         tenant-mode: dedicated
+"
+`;
+
+exports[`CF Writer Validate HTML5 is added without a managed approuter to a CAP project 3`] = `
+"{
+  \\"name\\": \\"captestproject\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"A simple CAP project.\\",
+  \\"repository\\": \\"<Add your repository here>\\",
+  \\"license\\": \\"UNLICENSED\\",
+  \\"private\\": true,
+  \\"dependencies\\": {
+    \\"@sap/cds\\": \\"^8\\",
+    \\"express\\": \\"^4\\",
+    \\"@sap/xssec\\": \\"^4\\"
+  },
+  \\"devDependencies\\": {
+    \\"@cap-js/cds-types\\": \\"^0.8.0\\",
+    \\"@cap-js/sqlite\\": \\"^1\\",
+    \\"@sap/cds-dk\\": \\"^8\\",
+    \\"rimraf\\": \\"^5.0.5\\",
+    \\"mbt\\": \\"^1.2.29\\"
+  },
+  \\"scripts\\": {
+    \\"start\\": \\"cds-serve\\",
+    \\"undeploy\\": \\"cf undeploy captestproject --delete-services --delete-service-keys --delete-service-brokers\\",
+    \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
+    \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\"
+  },
+  \\"cds\\": {
+    \\"requires\\": {
+      \\"auth\\": \\"xsuaa\\",
+      \\"connectivity\\": true,
+      \\"destinations\\": true,
+      \\"html5-repo\\": true
+    }
+  }
+}
 "
 `;
 

--- a/packages/cf-deploy-config-writer/test/unit/cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/cap.test.ts
@@ -9,6 +9,7 @@ import { generateAppConfig } from '../../src';
 import type { Editor } from 'mem-fs-editor';
 import { DefaultMTADestination, MTABinNotFound } from '../../src/constants';
 import { isAppStudio } from '@sap-ux/btp-utils';
+import fs from 'fs';
 
 jest.mock('@sap/mta-lib', () => {
     return {
@@ -78,7 +79,8 @@ describe('CF Writer', () => {
             expect(findCapProjectRootMock).toBeCalledWith(expect.stringContaining(capPath));
             expect(spawnMock).not.toHaveBeenCalled();
             expect(unitTestFs.dump(capPath)).toMatchSnapshot();
-            expect(unitTestFs.read(join(capPath, 'mta.yaml'))).toMatchSnapshot();
+            expect(fs.readFileSync(join(capPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
+            expect(fs.readFileSync(join(capPath, 'package.json'), { encoding: 'utf8' })).toMatchSnapshot();
         });
 
         test('Validate dependency on MTA binary', async () => {
@@ -121,8 +123,8 @@ describe('CF Writer', () => {
             },
             unitTestFs
         );
-        expect(unitTestFs.dump(capPath)).toMatchSnapshot();
-        expect(unitTestFs.read(join(capPath, 'mta.yaml'))).toMatchSnapshot();
+        expect(fs.readFileSync(join(capPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
+        expect(fs.readFileSync(join(capPath, 'package.json'), { encoding: 'utf8' })).toMatchSnapshot();
     });
 
     test('Validate HTML5 is added without a managed approuter to a CAP project', async () => {
@@ -141,7 +143,8 @@ describe('CF Writer', () => {
             unitTestFs
         );
         expect(unitTestFs.dump(capPath)).toMatchSnapshot();
-        expect(unitTestFs.read(join(capPath, 'mta.yaml'))).toMatchSnapshot();
+        expect(fs.readFileSync(join(capPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
+        expect(fs.readFileSync(join(capPath, 'package.json'), { encoding: 'utf8' })).toMatchSnapshot();
     });
 
     test('Validate a 2nd HTML5 app is added', async () => {

--- a/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-cap.test.ts
@@ -82,8 +82,8 @@ describe('CF Writer CAP', () => {
                 undefined,
                 logger
             );
-            expect(localFs.read(join(mtaPath, 'mta.yaml'))).toMatchSnapshot();
-            expect(localFs.read(join(mtaPath, 'package.json'))).toMatchSnapshot(); // Ensure it hasn't changed!
+            expect(fs.readFileSync(join(mtaPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
+            expect(fs.readFileSync(join(mtaPath, 'package.json'), { encoding: 'utf8' })).toMatchSnapshot(); // Ensure it hasn't changed!
             expect(getCapProjectTypeMock).toHaveBeenCalled();
             expect(spawnMock.mock.calls).toHaveLength(2);
             expect(spawnMock).toHaveBeenCalledWith(


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/2821

During the deployment generator flow, the `cds` binary appends a devDep `"@sap/cds-dk": "^8" ` to the package.json, for example;

```
  "devDependencies": {
    "@cap-js/cds-types": "^0.8.0",
    "@cap-js/sqlite": "^1",
    "@sap/cds-dk": "^8" 
 },
```
However, the `addPackageDevDependency` exposed from `project-access` is not reading the latest modifications, so overwrites the devDep since deployment-generator is appending its own, for exmaple;

```
  "devDependencies": {
    "@cap-js/cds-types": "^0.8.0",
    "@cap-js/sqlite": "^1",
    "rimraf": "^5.0.5",
    "mbt": "^1.2.29"
  },
```

The correct result should include both the CDs, rimraf and mbt depdencies, as shown;
```
  "devDependencies": {
    "@cap-js/cds-types": "^0.8.0",
    "@cap-js/sqlite": "^1",
    "@sap/cds-dk": "^8",
    "rimraf": "^5.0.5",
    "mbt": "^1.2.29"
  },
```


