### PR TITLE
fix: ADP Generator integration test mocking

### DIFF
--- a/.changeset/tricky-spiders-sniff.md
+++ b/.changeset/tricky-spiders-sniff.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/generator-adp': patch
+'@sap-ux/adp-tooling': patch
+---
+
+fix: ADP Generator integration test mocking

--- a/packages/adp-tooling/src/base/prompt.ts
+++ b/packages/adp-tooling/src/base/prompt.ts
@@ -199,8 +199,8 @@ async function fetchSystemInformation(
         adp: {
             environment: ato.operationsType ?? 'P',
             support: {
-                id: packageJson.name,
-                version: packageJson.version,
+                id: packageJson.name ?? '',
+                version: packageJson.version ?? '',
                 toolsId: uuidv4()
             }
         }

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -13,8 +13,6 @@ export interface DescriptorVariant {
     content: DescriptorVariantContent[];
 }
 
-export type PackageJson = { name: string; version: string };
-
 export interface DescriptorVariantContent {
     changeType: string;
     content: Record<string, unknown>;

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { readFileSync } from 'fs';
 import { v4 as uuidv4 } from 'uuid';
 import type { Editor } from 'mem-fs-editor';
-import type { CloudApp, AdpWriterConfig, CustomConfig, PackageJson } from '../types';
+import type { CloudApp, AdpWriterConfig, CustomConfig } from '../types';
 import {
     enhanceUI5DeployYaml,
     enhanceUI5Yaml,
@@ -19,9 +19,9 @@ import { UI5Config, getEsmTypesVersion, getTypesPackage } from '@sap-ux/ui5-conf
 /**
  * Retrieves the package name and version from the package.json file located two levels up the directory tree.
  *
- * @returns {PackageJson} An object containing the `name` and `version` of the package.
+ * @returns {Package} An object containing the `name` and `version` of the package.
  */
-export function getPackageJSONInfo(): PackageJson {
+export function getPackageJSONInfo(): Package {
     const defaultPackage = {
         name: '@sap-ux/adp-tooling',
         version: 'NO_VERSION_FOUND'

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -12,8 +12,9 @@ import {
     enhanceUI5YamlWithTranspileMiddleware
 } from './options';
 
-import { UI5Config, getEsmTypesVersion, getTypesPackage } from '@sap-ux/ui5-config';
+import type { Package } from '@sap-ux/project-access';
 import type { OperationsType } from '@sap-ux/axios-extension';
+import { UI5Config, getEsmTypesVersion, getTypesPackage } from '@sap-ux/ui5-config';
 
 /**
  * Retrieves the package name and version from the package.json file located two levels up the directory tree.
@@ -42,13 +43,13 @@ export function getPackageJSONInfo(): PackageJson {
  * @param {string} pkg.version - The version of the tool generating the config.
  * @returns {CustomConfig} The generated ADP custom configuration object.
  */
-export function getCustomConfig(environment: OperationsType, { name: id, version }: PackageJson): CustomConfig {
+export function getCustomConfig(environment: OperationsType, { name: id, version }: Package): CustomConfig {
     return {
         adp: {
             environment,
             support: {
-                id,
-                version,
+                id: id ?? '',
+                version: version ?? '',
                 toolsId: uuidv4()
             }
         }

--- a/packages/adp-tooling/src/writer/writer-config.ts
+++ b/packages/adp-tooling/src/writer/writer-config.ts
@@ -1,11 +1,12 @@
 import type { ToolsLogger } from '@sap-ux/logger';
+import type { Package } from '@sap-ux/project-access';
 import type { AbapServiceProvider } from '@sap-ux/axios-extension';
 
 import { FlexLayer } from '../types';
 import { getProviderConfig } from '../abap';
 import { getCustomConfig } from './project-utils';
+import type { AdpWriterConfig, ConfigAnswers } from '../types';
 import { getNewModelEnhanceWithChange } from './descriptor-content';
-import type { AdpWriterConfig, ConfigAnswers, PackageJson } from '../types';
 import { UI5VersionInfo, getFormattedVersion, getOfficialBaseUI5VersionUrl } from '../ui5';
 
 interface ConfigOptions {
@@ -33,7 +34,7 @@ interface ConfigOptions {
     /**
      * The package.json information used to generate custom configuration.
      */
-    packageJson: PackageJson;
+    packageJson: Package;
     /**
      * Logger instance for debugging and error reporting.
      */

--- a/packages/adp-tooling/src/writer/writer-config.ts
+++ b/packages/adp-tooling/src/writer/writer-config.ts
@@ -50,7 +50,7 @@ interface ConfigOptions {
  * @param {FlexLayer} options.layer - The FlexLayer indicating the deployment layer.
  * @param {object} options.defaults - Default project parameters.
  * @param {string} options.defaults.namespace - The default namespace to be used.
- * @param {PackageJson} options.packageJson - The package.json information for generating custom configuration.
+ * @param {Package} options.packageJson - The package.json information for generating custom configuration.
  * @param {ToolsLogger} options.logger - The logger for debugging and error logging.
  * @returns {Promise<AdpWriterConfig>} A promise that resolves to the generated ADP writer configuration.
  */

--- a/packages/adp-tooling/test/unit/writer/writer-config.test.ts
+++ b/packages/adp-tooling/test/unit/writer/writer-config.test.ts
@@ -1,8 +1,9 @@
 import type { ToolsLogger } from '@sap-ux/logger';
+import type { Package } from '@sap-ux/project-access';
 import type { AbapServiceProvider } from '@sap-ux/axios-extension';
 
 import { FlexLayer, UI5VersionInfo, getProviderConfig, getConfig } from '../../../src';
-import type { ConfigAnswers, PackageJson, SourceApplication } from '../../../src';
+import type { ConfigAnswers, SourceApplication } from '../../../src';
 
 jest.mock('../../../src/abap/config.ts', () => ({
     getProviderConfig: jest.fn()
@@ -48,7 +49,7 @@ describe('getConfig', () => {
             configAnswers,
             layer: FlexLayer.CUSTOMER_BASE,
             defaults,
-            packageJson: { name: '@sap-ux/generator-adp', version: '0.0.1' } as PackageJson,
+            packageJson: { name: '@sap-ux/generator-adp', version: '0.0.1' } as Package,
             logger: {} as ToolsLogger
         });
 

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -1,5 +1,3 @@
-import { join } from 'path';
-import { readFileSync } from 'fs';
 import Generator from 'yeoman-generator';
 import { AppWizard, Prompts } from '@sap-devx/yeoman-ui-types';
 
@@ -20,8 +18,8 @@ import { t, initI18n } from '../utils/i18n';
 import { EventName } from '../telemetryEvents';
 import AdpFlpConfigLogger from '../utils/logger';
 import type { AdpGeneratorOptions } from './types';
-import { installDependencies } from '../utils/deps';
 import { ConfigPrompter } from './questions/configuration';
+import { getPackageInfo, installDependencies } from '../utils/deps';
 import { generateValidNamespace, getDefaultProjectName } from './questions/helper/default-values';
 
 /**
@@ -127,7 +125,7 @@ export default class extends Generator {
             const namespace = generateValidNamespace(projectName, this.layer);
             this.targetFolder = this.destinationPath(projectName);
 
-            const packageJson = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+            const packageJson = getPackageInfo();
             const config = await getConfig({
                 provider: this.prompter.provider,
                 configAnswers: this.configAnswers,

--- a/packages/generator-adp/src/utils/deps.ts
+++ b/packages/generator-adp/src/utils/deps.ts
@@ -1,5 +1,18 @@
+import { join } from 'path';
 import * as util from 'util';
+import { readFileSync } from 'fs';
 import { exec } from 'child_process';
+
+import type { Package } from '@sap-ux/project-access';
+
+/**
+ * Reads the package.json of the current package.
+ *
+ * @returns {Package} Package.json of the current package.
+ */
+export function getPackageInfo(): Package {
+    return JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+}
 
 /**
  * Installs dependencies in the project directory.

--- a/packages/generator-adp/test/__snapshots__/app.test.ts.snap
+++ b/packages/generator-adp/test/__snapshots__/app.test.ts.snap
@@ -57,7 +57,7 @@ customConfiguration:
   adp:
     support:
       id: '@sap-ux/generator-adp'
-      version: 0.1.1
+      version: mocked-version
       toolsId: mocked-uuid
 server:
   customMiddleware:

--- a/packages/generator-adp/test/app.test.ts
+++ b/packages/generator-adp/test/app.test.ts
@@ -52,6 +52,11 @@ jest.mock('@sap-ux/adp-tooling', () => ({
     getProviderConfig: jest.fn()
 }));
 
+jest.mock('../src/utils/deps.ts', () => ({
+    ...jest.requireActual('../src/utils/deps.ts'),
+    getPackageInfo: jest.fn().mockReturnValue({ name: '@sap-ux/generator-adp', version: 'mocked-version' })
+}));
+
 jest.mock('@sap-ux/fiori-generator-shared', () => ({
     ...(jest.requireActual('@sap-ux/fiori-generator-shared') as {}),
     sendTelemetry: jest.fn().mockReturnValue(new Promise(() => {})),

--- a/packages/generator-adp/test/unit/utils/deps.test.ts
+++ b/packages/generator-adp/test/unit/utils/deps.test.ts
@@ -1,17 +1,24 @@
 import { exec } from 'child_process';
-import { installDependencies } from '../../../src/utils/deps';
+import { getPackageInfo, installDependencies } from '../../../src/utils/deps';
+import { readFileSync } from 'fs';
 
 jest.mock('child_process', () => ({
     ...jest.requireActual('child_process'),
     exec: jest.fn()
 }));
 
+jest.mock('fs', () => ({
+    ...jest.requireActual('fs'),
+    readFileSync: jest.fn()
+}));
+
 const execMock = exec as unknown as jest.Mock;
+const readFileSyncMock = readFileSync as jest.Mock;
 
 describe('installDependencies', () => {
     const dummyProjectPath = '/dummy/path';
 
-    beforeEach(() => {
+    afterEach(() => {
         jest.clearAllMocks();
     });
 
@@ -32,5 +39,20 @@ describe('installDependencies', () => {
         });
 
         await expect(installDependencies(dummyProjectPath)).rejects.toThrow('Installation of dependencies failed.');
+    });
+});
+
+describe('getPackageInfo', () => {
+    const mockPackage = { name: '@sap-ux/generator-adp', version: '0.0.1' };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return the correct package.json', async () => {
+        readFileSyncMock.mockReturnValue(JSON.stringify(mockPackage));
+        const result = getPackageInfo();
+
+        expect(result).toEqual(mockPackage);
     });
 });


### PR DESCRIPTION
Fix for #3015.
- Fixes the mocking of package.json retrieval and the snapshot having dynamic value instead of mocked.
