### PR TITLE
fix(odata-service-inquirer): `removeCircularFromServiceProvider` undefined ref

### DIFF
--- a/.changeset/seven-plants-grin.md
+++ b/.changeset/seven-plants-grin.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for undefined ref exception

--- a/packages/odata-service-inquirer/src/utils/index.ts
+++ b/packages/odata-service-inquirer/src/utils/index.ts
@@ -139,7 +139,7 @@ export function getDefaultChoiceIndex(list: ListChoiceOptions[]): number | undef
  */
 export function removeCircularFromServiceProvider(serviceProvider: ServiceProvider): ServiceProvider {
     for (const service in (serviceProvider as any).services) {
-        delete (serviceProvider as any)[service].log;
+        delete (serviceProvider as any).services?.[service]?.log;
     }
     delete (serviceProvider as any).log;
     return serviceProvider;

--- a/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
+++ b/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { ServiceProvider } from '@sap-ux/axios-extension';
+import type { ServiceProvider } from '@sap-ux/axios-extension';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import { readFile } from 'fs/promises';
 import { join } from 'path';

--- a/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
+++ b/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
@@ -1,7 +1,8 @@
+import { ServiceProvider } from '@sap-ux/axios-extension';
+import { OdataVersion } from '@sap-ux/odata-service-writer';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { OdataVersion } from '@sap-ux/odata-service-writer';
-import { originToRelative, parseOdataVersion } from '../../../src/utils';
+import { originToRelative, parseOdataVersion, removeCircularFromServiceProvider } from '../../../src/utils';
 
 describe('Utils', () => {
     test('parseOdataVersion - should return the odata version of metadata', async () => {
@@ -52,5 +53,61 @@ describe('Utils', () => {
                 </edmx:Reference>
             </edmx:Edmx>"
         `);
+    });
+
+    test('removeCircularFromServiceProvider - should remove specific properties from serviceProvider', async () => {
+        let serviceProvider = {} as ServiceProvider;
+        let cleanedServiceProvider = removeCircularFromServiceProvider(serviceProvider);
+        expect(cleanedServiceProvider).toEqual(serviceProvider);
+
+        serviceProvider = {
+            services: {
+                service1: {
+                    log: 'log1'
+                },
+                service2: {
+                    log: 'log2'
+                }
+            }
+        } as unknown as ServiceProvider;
+
+        cleanedServiceProvider = removeCircularFromServiceProvider(serviceProvider);
+        expect(cleanedServiceProvider).toEqual({
+            services: {
+                service1: {},
+                service2: {}
+            }
+        });
+
+        serviceProvider = {
+            log: 'log',
+            services: {
+                service1: {
+                    log: 'log1'
+                },
+                service2: {
+                    log: 'log2'
+                }
+            }
+        } as unknown as ServiceProvider;
+        cleanedServiceProvider = removeCircularFromServiceProvider(serviceProvider);
+        expect(cleanedServiceProvider).toEqual({
+            services: {
+                service1: {},
+                service2: {}
+            }
+        });
+
+        serviceProvider = {
+            services: {
+                service1: undefined
+            }
+        } as unknown as ServiceProvider;
+        cleanedServiceProvider = removeCircularFromServiceProvider(serviceProvider);
+        expect(cleanedServiceProvider).toEqual({
+            services: {
+                service1: undefined
+            }
+        });
     });
 });


### PR DESCRIPTION
Fixes reference to `serviceProvider.services` and optionally chains in case of undefined in function `removeCircularFromServiceProvider `