### PR TITLE
fix: nested quick action flattening

### DIFF
--- a/.changeset/small-jars-invent.md
+++ b/.changeset/small-jars-invent.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux-private/control-property-editor-common': patch
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/control-property-editor': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: nested Quick Actions not working if there are sections with only one child (e.g Change Table Columns)

--- a/packages/control-property-editor-common/src/api.ts
+++ b/packages/control-property-editor-common/src/api.ts
@@ -258,6 +258,7 @@ export interface NestedQuickAction {
 }
 
 export interface NestedQuickActionChild {
+    path: string;
     label: string;
     tooltip?: string;
     enabled: boolean;

--- a/packages/control-property-editor/src/panels/quick-actions/NestedQuickAction.tsx
+++ b/packages/control-property-editor/src/panels/quick-actions/NestedQuickAction.tsx
@@ -43,6 +43,8 @@ export function NestedQuickActionListItem({
         null
     );
 
+    const flattened = flattenAction(action);
+
     /**
      * Build menu items for nested quick actions.
      *
@@ -55,13 +57,12 @@ export function NestedQuickActionListItem({
         nestedLevel: number[] = []
     ): UIContextualMenuItem[] {
         return children.map((child, index) => {
-            const hasChildren = child?.children?.length > 1;
-            const value = child?.children?.length === 1 ? `${child.label}-${child.children[0].label}` : child.label;
+            const hasChildren = child.children.length > 1;
             return {
-                key: `${value}-${index}`,
-                text: value,
+                key: `${child.label}-${index}`,
+                text: child.label,
                 disabled: !child.enabled,
-                title: child?.tooltip ?? value,
+                title: child.tooltip ?? child.label,
                 subMenuProps: hasChildren
                     ? {
                           directionalHint: UIDirectionalHint.leftTopEdge,
@@ -72,7 +73,7 @@ export function NestedQuickActionListItem({
                     dispatch(
                         executeQuickAction({
                             kind: action.kind,
-                            path: nestedLevel.length ? `${nestedLevel.join('/')}/${index}` : index.toString(),
+                            path: child.path,
                             id: action.id
                         })
                     );
@@ -84,26 +85,28 @@ export function NestedQuickActionListItem({
     const buttonId = `quick-action-children-button-${groupIndex}-${actionIndex}`;
     return (
         <div className="quick-action-item">
-            {action.children.length === 1 && (
+            {flattened.children.length === 1 && (
                 <UILink
                     underline={false}
-                    disabled={isDisabled || !action.children[0].enabled}
+                    disabled={isDisabled || !flattened.children[0].enabled}
                     title={
-                        action.children[0].tooltip ?? action.tooltip ?? `${action.title} - ${action.children[0].label}`
+                        action.children[0].tooltip ??
+                        action.tooltip ??
+                        `${action.title} - ${flattened.children[0].label}`
                     }
                     onClick={(): void => {
                         dispatch(
                             executeQuickAction({
                                 kind: action.kind,
                                 id: action.id,
-                                path: [0].join('/')
+                                path: flattened.children[0].path
                             })
                         );
                     }}>
                     <span className="link-text">{action.title}</span>
                 </UILink>
             )}
-            {action.children.length > 1 && (
+            {flattened.children.length > 1 && (
                 <>
                     <UILink
                         title={action.tooltip ?? action.title}
@@ -132,7 +135,7 @@ export function NestedQuickActionListItem({
                             showSubmenuBeneath={true}
                             target={target}
                             isBeakVisible={true}
-                            items={buildMenuItems(action.children)}
+                            items={buildMenuItems(flattened.children)}
                             directionalHint={UIDirectionalHint.bottomRightEdge}
                             onDismiss={() => setShowContextualMenu(false)}
                             iconToLeft={true}
@@ -142,4 +145,75 @@ export function NestedQuickActionListItem({
             )}
         </div>
     );
+}
+
+/**
+ * Flatten nested quick action children.
+ *
+ * @param action - Nested quick action.
+ * @returns Quick action with flattened children.
+ */
+function flattenAction(action: NestedQuickAction): NestedQuickAction {
+    const result = structuredClone(action);
+    const stack: { node: NestedQuickActionChild; parent?: NestedQuickActionChild }[] = result.children.map((child) => ({
+        node: child,
+        parent: undefined
+    }));
+    const mergeTuples: [string | undefined, string, string][] = [];
+    const lookup = new Map<string, NestedQuickActionChild>();
+
+    while (stack.length > 0) {
+        const current = stack.pop();
+        if (!current) {
+            continue;
+        }
+        const { node, parent } = current;
+        lookup.set(node.path, node);
+        if (node.children.length === 1) {
+            const child = node.children[0];
+            mergeTuples.push([parent?.path ?? '', node.path, child.path]);
+        }
+        for (const child of node.children) {
+            stack.push({ node: child, parent: node });
+        }
+    }
+
+    mergeNodes(result, mergeTuples, lookup);
+
+    if (result.children.length === 1 && result.children[0].children.length > 0) {
+        const parent = result.children[0];
+        result.children = parent.children.map((child) => ({
+            ...child,
+            label: `${parent.label}-${child.label}`
+        }));
+    }
+
+    return result;
+}
+
+/**
+ * Merge nodes in the nested quick action.
+ *
+ * @param result - Nested quick action.
+ * @param mergeTuples - Array of tuples containing parent, start and end node paths.
+ * @param lookup - Lookup map of node paths to nested quick action children.
+ */
+function mergeNodes(
+    result: NestedQuickAction,
+    mergeTuples: [string | undefined, string, string][],
+    lookup: Map<string, NestedQuickActionChild>
+): void {
+    for (const [parent, start, end] of mergeTuples) {
+        const parentNode = parent ? lookup.get(parent) : result;
+        const startNode = lookup.get(start);
+        const endNode = lookup.get(end);
+        if (!parentNode || !startNode || !endNode) {
+            continue;
+        }
+        endNode.label = `${startNode.label}-${endNode.label}`;
+        const index = parentNode.children.findIndex((parentChild) => parentChild === startNode);
+        if (index !== -1) {
+            parentNode.children[index] = endNode;
+        }
+    }
 }

--- a/packages/control-property-editor/test/unit/panels/quick-actions/QuickActionList.test.tsx
+++ b/packages/control-property-editor/test/unit/panels/quick-actions/QuickActionList.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 
 import { render } from '../../utils';
-import type { NestedQuickActionChild } from '@sap-ux-private/control-property-editor-common';
+import type { NestedQuickAction, NestedQuickActionChild } from '@sap-ux-private/control-property-editor-common';
 import { executeQuickAction } from '@sap-ux-private/control-property-editor-common';
 import { QuickActionList } from '../../../../src/panels/quick-actions';
 
@@ -10,20 +10,24 @@ describe('QuickActionList', () => {
     test('check if quick action list rendered', () => {
         const children: NestedQuickActionChild[] = [
             {
+                path: '0',
                 label: 'submenu1',
                 enabled: true,
                 children: []
             },
             {
+                path: '1',
                 label: 'submenu2',
                 enabled: true,
                 children: [
                     {
+                        path: '1/0',
                         label: 'submenu2-submenu1',
                         enabled: true,
                         children: []
                     },
                     {
+                        path: '1/1',
                         label: 'submenu2-submenu2',
                         enabled: true,
                         children: []
@@ -128,6 +132,7 @@ describe('QuickActionList', () => {
     test('disable actions in navigation mode', () => {
         const children = [
             {
+                path: '0',
                 label: 'submenu1',
                 enabled: true,
                 children: []
@@ -188,6 +193,7 @@ describe('QuickActionList', () => {
         test('disable actions in navigation mode', () => {
             const children1: NestedQuickActionChild[] = [
                 {
+                    path: '0',
                     label: 'submenu1',
                     enabled: false,
                     children: [],
@@ -197,11 +203,13 @@ describe('QuickActionList', () => {
 
             const children2: NestedQuickActionChild[] = [
                 {
+                    path: '0',
                     label: 'submenu1',
                     enabled: true,
                     children: []
                 },
                 {
+                    path: '1',
                     label: 'submenu2',
                     enabled: false,
                     children: [],
@@ -276,6 +284,353 @@ describe('QuickActionList', () => {
             // nested quick action - single child, tooltip from action
             const quickAction4 = screen.getByRole('button', { name: /quick action 4/i });
             expect(quickAction4.title).toBe('Disabled action 4');
+        });
+    });
+
+    describe('nested quick action flattening', () => {
+        const fixture: NestedQuickAction = {
+            kind: 'nested',
+            id: 'root-action',
+            title: 'Root Action',
+            enabled: true,
+            children: [
+                {
+                    label: 'Child 1',
+                    enabled: true,
+                    path: 'child1',
+                    children: [
+                        {
+                            label: 'Child 1.1',
+                            enabled: true,
+                            path: 'child1.1',
+                            children: [
+                                {
+                                    label: 'Child 1.1.1',
+                                    enabled: true,
+                                    path: 'child1.1.1',
+                                    children: []
+                                },
+                                {
+                                    label: 'Child 1.1.2',
+                                    enabled: true,
+                                    path: 'child1.1.2',
+                                    children: []
+                                }
+                            ]
+                        },
+                        {
+                            label: 'Child 1.2',
+                            enabled: true,
+                            path: 'child1.2',
+                            children: [
+                                {
+                                    label: 'Child 1.2.1',
+                                    enabled: true,
+                                    path: 'child1.2.1',
+                                    children: []
+                                },
+                                {
+                                    label: 'Child 1.2.2',
+                                    enabled: true,
+                                    path: 'child1.2.2',
+                                    children: []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    label: 'Child 2',
+                    enabled: true,
+                    path: 'child2',
+                    children: [
+                        {
+                            label: 'Child 2.1',
+                            enabled: true,
+                            path: 'child2.1',
+                            children: [
+                                {
+                                    label: 'Child 2.1.1',
+                                    enabled: true,
+                                    path: 'child2.1.1',
+                                    children: []
+                                },
+                                {
+                                    label: 'Child 2.1.2',
+                                    enabled: true,
+                                    path: 'child2.1.2',
+                                    children: []
+                                }
+                            ]
+                        },
+                        {
+                            label: 'Child 2.2',
+                            enabled: true,
+                            path: 'child2.2',
+                            children: [
+                                {
+                                    label: 'Child 2.2.1',
+                                    enabled: true,
+                                    path: 'child2.2.1',
+                                    children: []
+                                },
+                                {
+                                    label: 'Child 2.2.2',
+                                    enabled: true,
+                                    path: 'child2.2.2',
+                                    children: []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        test('drop one level', () => {
+            const element = <QuickActionList />;
+            render(element, {
+                initialState: {
+                    quickActions: [
+                        {
+                            title: 'List Report',
+                            actions: [
+                                {
+                                    id: 'quick-action-1',
+                                    enabled: true,
+                                    kind: 'nested',
+                                    title: 'Quick Action 1',
+                                    children: [
+                                        {
+                                            path: '0',
+                                            label: 'submenu0',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '0/0',
+                                                    label: 'submenu0-0',
+                                                    enabled: true,
+                                                    children: []
+                                                },
+                                                {
+                                                    path: '0/1',
+                                                    label: 'submenu0-1',
+                                                    enabled: true,
+                                                    children: []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            // nested quick action - multiple children
+            let quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            quickAction.click();
+            quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            expect(quickAction).toBeEnabled();
+
+            const child1 = screen.getByRole('menuitem', { name: /submenu0-submenu0-0/i });
+            expect(child1.getAttribute('aria-disabled')).toBe('false');
+
+            const child2 = screen.getByRole('menuitem', { name: /submenu0-submenu0-1/i });
+            expect(child2.getAttribute('aria-disabled')).toBe('false');
+        });
+
+        test('two leaf nodes without siblings', () => {
+            const element = <QuickActionList />;
+            render(element, {
+                initialState: {
+                    quickActions: [
+                        {
+                            title: 'List Report',
+                            actions: [
+                                {
+                                    id: 'quick-action-1',
+                                    enabled: true,
+                                    kind: 'nested',
+                                    title: 'Quick Action 1',
+                                    children: [
+                                        {
+                                            path: '0',
+                                            label: 'submenu0',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '0/0',
+                                                    label: 'submenu0.0',
+                                                    enabled: true,
+                                                    children: []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            path: '1',
+                                            label: 'submenu1',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '1/0',
+                                                    label: 'submenu1.0',
+                                                    enabled: true,
+                                                    children: []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            // nested quick action - multiple children
+            let quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            quickAction.click();
+            quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            expect(quickAction).toBeEnabled();
+
+            const child1 = screen.getByRole('menuitem', { name: /submenu0-submenu0.0/i });
+            expect(child1.getAttribute('aria-disabled')).toBe('false');
+
+            const child2 = screen.getByRole('menuitem', { name: /submenu1-submenu1.0/i });
+            expect(child2.getAttribute('aria-disabled')).toBe('false');
+        });
+        test('one leaf nodes without siblings', () => {
+            const element = <QuickActionList />;
+            render(element, {
+                initialState: {
+                    quickActions: [
+                        {
+                            title: 'List Report',
+                            actions: [
+                                {
+                                    id: 'quick-action-1',
+                                    enabled: true,
+                                    kind: 'nested',
+                                    title: 'Quick Action 1',
+                                    children: [
+                                        {
+                                            path: '0',
+                                            label: 'submenu0',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '0/0',
+                                                    label: 'submenu0.0',
+                                                    enabled: true,
+                                                    children: []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            path: '1',
+                                            label: 'submenu1',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '1/0',
+                                                    label: 'submenu1.0',
+                                                    enabled: true,
+                                                    children: []
+                                                },
+                                                {
+                                                    path: '1/1',
+                                                    label: 'submenu1.1',
+                                                    enabled: true,
+                                                    children: []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            // nested quick action - multiple children
+            let quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            quickAction.click();
+            quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            expect(quickAction).toBeEnabled();
+
+            const child1 = screen.getByRole('menuitem', { name: /submenu0-submenu0.0/i });
+            expect(child1.getAttribute('aria-disabled')).toBe('false');
+
+            screen.getByRole('menuitem', { name: /submenu1/i }).click();
+
+            const child2 = screen.getByRole('menuitem', { name: /submenu1.0/i });
+            expect(child2.getAttribute('aria-disabled')).toBe('false');
+            const child3 = screen.getByRole('menuitem', { name: /submenu1.1/i });
+            expect(child3.getAttribute('aria-disabled')).toBe('false');
+        });
+
+        test('drop two levels', () => {
+            const element = <QuickActionList />;
+            render(element, {
+                initialState: {
+                    quickActions: [
+                        {
+                            title: 'List Report',
+                            actions: [
+                                {
+                                    id: 'quick-action-1',
+                                    enabled: true,
+                                    kind: 'nested',
+                                    title: 'Quick Action 1',
+                                    children: [
+                                        {
+                                            path: '0',
+                                            label: 'submenu0',
+                                            enabled: true,
+                                            children: [
+                                                {
+                                                    path: '0/0',
+                                                    label: 'submenu0.0',
+                                                    enabled: true,
+                                                    children: [
+                                                        {
+                                                            path: '0/0/0',
+                                                            label: 'submenu0.0.0',
+                                                            enabled: true,
+                                                            children: []
+                                                        },
+                                                        {
+                                                            path: '0/0/1',
+                                                            label: 'submenu0.0.1',
+                                                            enabled: true,
+                                                            children: []
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            });
+
+            // nested quick action - multiple children
+            let quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            quickAction.click();
+            quickAction = screen.getByRole('button', { name: /quick action 1/i });
+            expect(quickAction).toBeEnabled();
+
+            const child1 = screen.getByRole('menuitem', { name: /submenu0-submenu0.0-submenu0.0.0/i });
+            expect(child1.getAttribute('aria-disabled')).toBe('false');
+
+            const child2 = screen.getByRole('menuitem', { name: /submenu0-submenu0.0-submenu0.0.1/i });
+            expect(child2.getAttribute('aria-disabled')).toBe('false');
         });
     });
 });

--- a/packages/control-property-editor/test/unit/setup.ts
+++ b/packages/control-property-editor/test/unit/setup.ts
@@ -8,3 +8,6 @@ mockResizeObserver();
 initI18n();
 registerAppIcons();
 initIcons();
+
+// structuredClone is not available in jsdom
+global.structuredClone = (v) => JSON.parse(JSON.stringify(v));

--- a/packages/control-property-editor/test/unit/slice.test.ts
+++ b/packages/control-property-editor/test/unit/slice.test.ts
@@ -708,15 +708,18 @@ describe('main redux slice', () => {
                                 kind: 'nested',
                                 children: [
                                     {
+                                        path: '0',
                                         label: 'test label',
                                         enabled: true,
                                         children: [
                                             {
+                                                path: '0/0',
                                                 label: 'test label 2',
                                                 enabled: true,
                                                 children: []
                                             },
                                             {
+                                                path: '0/1',
                                                 label: 'test label 3',
                                                 enabled: true,
                                                 children: []

--- a/packages/preview-middleware-client/src/adp/quick-actions/common/add-new-annotation-file.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/common/add-new-annotation-file.ts
@@ -1,9 +1,6 @@
 import FlexCommand from 'sap/ui/rta/command/FlexCommand';
 
-import {
-    QuickActionContext,
-    NestedQuickActionDefinition
-} from '../../../cpe/quick-actions/quick-action-definition';
+import { QuickActionContext, NestedQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
 import type { AnnotationDataSourceResponse } from '../../api-handler';
 import { getDataSourceAnnotationFileMap } from '../../api-handler';
 import {
@@ -65,6 +62,7 @@ export class AddNewAnnotationFile
                 const { annotationExistsInWS } = source.annotationDetails;
                 if (source.metadataReadErrorMsg) {
                     this.children.push({
+                        path: this.children.length.toString(),
                         enabled: false,
                         tooltip: source.metadataReadErrorMsg,
                         label: this.context.resourceBundle.getText('ADD_ANNOTATION_FILE', [key]),
@@ -72,6 +70,7 @@ export class AddNewAnnotationFile
                     });
                 } else {
                     this.children.push({
+                        path: this.children.length.toString(),
                         enabled: true,
                         label: annotationExistsInWS
                             ? this.context.resourceBundle.getText('SHOW_ANNOTATION_FILE', [key])

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/change-table-columns.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/change-table-columns.ts
@@ -39,12 +39,14 @@ export class ChangeTableColumnsQuickAction
             const actions = await this.context.actionService.get(smartTable.getId());
             const changeColumnAction = actions.find((action) => action.id === ACTION_ID);
             if (changeColumnAction) {
+                const path = this.children.length.toString();
                 this.children.push({
+                    path,
                     label: `'${(smartTable as Table).getHeader()}' table`,
                     enabled: true,
                     children: []
                 });
-                this.tableMap[`${this.children.length - 1}`] = {
+                this.tableMap[path] = {
                     table: smartTable,
                     tableUpdateEventAttachedOnce: false
                 };

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/lr-enable-table-filtering.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/lr-enable-table-filtering.ts
@@ -48,13 +48,15 @@ export class EnableTableFilteringQuickAction
                 'personalization'
             ) as Personalization;
             const isFilterEnabled = value?.filter === undefined ? personalizationData.includes('Filter') : value.filter;
+            const path = this.children.length.toString();
             this.children.push({
+                path,
                 label: `'${(smartTable as Table).getHeader()}' table`,
                 enabled: !isFilterEnabled,
                 tooltip: isFilterEnabled ? tooltipText : undefined,
                 children: []
             });
-            this.tableMap[`${this.children.length - 1}`] = {
+            this.tableMap[path] = {
                 table: smartTable,
                 tableUpdateEventAttachedOnce: false
             };

--- a/packages/preview-middleware-client/src/adp/quick-actions/table-quick-action-base.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/table-quick-action-base.ts
@@ -148,9 +148,9 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
                 await this.collectChildrenInSection(section, table);
             } else if (this.iconTabBar && tabKey) {
                 const label = `'${iconTabBarfilterMap[tabKey]}' table`;
-                const child = this.createChild(label, table);
+                const tableMapKey = this.children.length.toString();
+                const child = this.createChild(label, table, tableMapKey);
                 this.children.push(child);
-                const tableMapKey = `${this.children.length - 1}`;
                 this.tableMap[tableMapKey] = {
                     table,
                     iconTabBarFilterKey: tabKey,
@@ -202,9 +202,9 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
                 return `'${header}' table`;
             }
         } else if (isA<Table>(M_TABLE_TYPE, table)) {
-            const tilte = table?.getHeaderToolbar()?.getTitleControl()?.getText();
-            if (tilte) {
-                return `'${tilte}' table`;
+            const title = table?.getHeaderToolbar()?.getTitleControl()?.getText();
+            if (title) {
+                return `'${title}' table`;
             }
         }
 
@@ -255,20 +255,19 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
                 );
                 let tableMapIndex;
                 const label = this.getTableLabel(table);
-                const child = this.createChild(label, table);
                 if (existingChildIdx < 0) {
+                    tableMapIndex = `${this.children.length}/0`;
+                    const child = this.createChild(label, table, tableMapIndex);
                     this.children.push({
+                        path: this.children.length.toString(),
                         label: `'${section?.getTitle()}' section`,
                         enabled: true,
                         children: [child]
                     });
-
-                    tableMapIndex = `${this.children.length - 1}/0`;
                 } else {
+                    tableMapIndex = `${existingChildIdx}/${this.children[existingChildIdx].children.length}`;
+                    const child = this.createChild(label, table, tableMapIndex);
                     this.children[existingChildIdx].children.push(child);
-                    tableMapIndex = `${existingChildIdx.toFixed(0)}/${
-                        this.children[existingChildIdx].children.length - 1
-                    }`;
                 }
 
                 this.tableMap[tableMapIndex] = {
@@ -290,6 +289,7 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
         table: UI5Element,
         sectionInfo?: { section: ObjectPageSection; subSection: ObjectPageSubSection; layout?: ObjectPageLayout }
     ): Promise<void> {
+        const tableMapKey = this.children.length.toString();
         if (
             [
                 SMART_TABLE_TYPE,
@@ -301,11 +301,10 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
             ].some((type) => isA(type, table))
         ) {
             const label = this.getTableLabel(table);
-            const child = this.createChild(label, table);
+            const child = this.createChild(label, table, tableMapKey);
             this.children.push(child);
         }
 
-        const tableMapKey = `${this.children.length - 1}`;
         this.tableMap[tableMapKey] = {
             table,
             sectionInfo: sectionInfo,
@@ -340,8 +339,9 @@ export abstract class TableQuickActionDefinitionBase extends QuickActionDefiniti
         };
     }
 
-    createChild(label: string, table: UI5Element): NestedQuickActionChild {
+    createChild(label: string, table: UI5Element, path: string): NestedQuickActionChild {
         const child: NestedQuickActionChild = {
+            path,
             label,
             enabled: true,
             children: []

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v2.test.ts
@@ -511,6 +511,7 @@ describe('FE V2 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: true,
                                             label: testCase.isWithIconTabBar ? `'Tab 1' table` : `'MyTable' table`
@@ -750,6 +751,7 @@ describe('FE V2 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: !(testCase.tableToolbar === 'None'),
                                             label: `'MyTable' table`,
@@ -763,6 +765,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: true,
                                             label: `'MyTable' table`
@@ -1044,6 +1047,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             enabled: true,
                                             'label': `'MyTable' table`
@@ -1057,6 +1061,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             enabled: true,
                                             'label': `'MyTable' table`
@@ -1492,6 +1497,7 @@ describe('FE V2 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: true,
                                             label: `'MyTable' table`
@@ -1501,6 +1507,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             enabled: true,
                                             'label': `'MyTable' table`
@@ -1683,12 +1690,14 @@ describe('FE V2 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: testCase.metadataReadErrorMsg ? false : true,
                                             label: `Add Annotation File for ''{0}''`,
                                             tooltip: testCase.metadataReadErrorMsg
                                         },
                                         {
+                                            path: '1',
                                             children: [],
                                             enabled: testCase.metadataReadErrorMsg ? false : true,
                                             label: testCase.metadataReadErrorMsg
@@ -2441,8 +2450,11 @@ describe('FE V2 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             enabled: true,
-                                            children: [{ enabled: true, children: [], label: `'MyTable' table` }],
+                                            children: [
+                                                { path: '0/0', enabled: true, children: [], label: `'MyTable' table` }
+                                            ],
                                             label: `'section 01' section`
                                         }
                                     ]
@@ -2450,8 +2462,16 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             enabled: true,
-                                            'children': [{ enabled: true, 'children': [], 'label': `'MyTable' table` }],
+                                            'children': [
+                                                {
+                                                    path: '0/0',
+                                                    enabled: true,
+                                                    'children': [],
+                                                    'label': `'MyTable' table`
+                                                }
+                                            ],
                                             'label': `'section 01' section`
                                         }
                                     ],
@@ -2630,9 +2650,11 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             enabled: true,
                                             'children': [
                                                 {
+                                                    path: '0/0',
                                                     'children': [],
                                                     enabled: true,
                                                     'label': `'MyTable' table`
@@ -3038,8 +3060,10 @@ describe('FE V2 quick actions', () => {
                                           title: 'Enable Empty Row Mode for Tables',
                                           children: [
                                               {
+                                                  path: '0',
                                                   'children': [
                                                       {
+                                                          path: '0/0',
                                                           'children': [],
                                                           'enabled': !testCase.expectDisabledReason,
                                                           'label': `'MyTable' table`,
@@ -3303,8 +3327,10 @@ describe('FE V2 quick actions', () => {
                                           title: 'Enable Variant Management in Tables',
                                           children: [
                                               {
+                                                  path: '0',
                                                   'children': [
                                                       {
+                                                          path: '0/0',
                                                           'children': [],
                                                           'enabled':
                                                               testCase.isEnabled || testCase.isCustomTable
@@ -3449,6 +3475,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             enabled: true,
                                             'label': `'MyTable' table`
@@ -3463,6 +3490,7 @@ describe('FE V2 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             'enabled': true,
                                             'label': `'MyTable' table`
@@ -4205,6 +4233,7 @@ describe('FE V2 quick actions', () => {
                                 enabled: true,
                                 children: [
                                     {
+                                        path: '0',
                                         children: [],
                                         enabled: !!testCase.expect.isEnabled,
                                         label: testCase.isWithIconTabBar ? `'Tab 1' table` : `'MyTable' table`,

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -628,13 +628,7 @@ describe('FE V4 quick actions', () => {
                                     id: 'listReport0-change-table-columns',
                                     title: 'Change Table Columns',
                                     enabled: true,
-                                    children: [
-                                        {
-                                            children: [],
-                                            enabled: true,
-                                            label: `'MyTable' table`
-                                        }
-                                    ]
+                                    children: [{ path: '0', children: [], enabled: true, label: `'MyTable' table` }]
                                 }
                             ]
                         }
@@ -759,6 +753,7 @@ describe('FE V4 quick actions', () => {
                                     enabled: true,
                                     children: [
                                         {
+                                            path: '0',
                                             children: [],
                                             enabled: true,
                                             label: `'MyTable' table`
@@ -868,6 +863,7 @@ describe('FE V4 quick actions', () => {
                                 {
                                     'children': [
                                         {
+                                            path: '0',
                                             'children': [],
                                             'enabled': true,
                                             'label': `'MyTable' table`
@@ -1030,6 +1026,7 @@ describe('FE V4 quick actions', () => {
                                           {
                                               'children': [
                                                   {
+                                                      path: '0',
                                                       'children': [],
                                                       'enabled': testCase.expectedIsEnabled,
                                                       'label': `'MyTable' table`,
@@ -1832,9 +1829,11 @@ describe('FE V4 quick actions', () => {
                                     {
                                         'children': [
                                             {
+                                                path: '0',
                                                 enabled: true,
                                                 'children': [
                                                     {
+                                                        path: '0/0',
                                                         'children': [],
                                                         enabled: true,
                                                         'label': `'MyTable' table`
@@ -2120,8 +2119,10 @@ describe('FE V4 quick actions', () => {
                                                   title: 'Enable Empty Row Mode for Tables',
                                                   children: [
                                                       {
+                                                          path: '0',
                                                           children: [
                                                               {
+                                                                  path: '0/0',
                                                                   label: testCase.isWithHeader
                                                                       ? `'MyTable' table`
                                                                       : `Unnamed table`,
@@ -3064,6 +3065,7 @@ describe('FE V4 quick actions', () => {
                                 enabled: true,
                                 children: [
                                     {
+                                        path: '0',
                                         children: [],
                                         enabled: testCase.expect.isEnabled,
                                         label: `'MyTable' table`,


### PR DESCRIPTION
Quick Action flattening did not work correctly in case there are multiple sections, but only one table.

- Moved all path calculation to the `preview-middleware-client` so it is only done once.
- Separated logic to remove nodes with only one child from rendering