### PR TITLE
Fixing failing test in windows for `repo-app-download-sub-generator`

### DIFF
--- a/.changeset/stale-ghosts-matter.md
+++ b/.changeset/stale-ghosts-matter.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-download-sub-generator': patch
+---
+
+Fix unit tests for download utils

--- a/packages/repo-app-download-sub-generator/test/utils/download-utils.test.ts
+++ b/packages/repo-app-download-sub-generator/test/utils/download-utils.test.ts
@@ -3,7 +3,7 @@ import AdmZip from 'adm-zip';
 import { join } from 'path';
 import { t } from '../../src/utils/i18n';
 import RepoAppDownloadLogger from '../../src/utils/logger';
-import * as PromptStateModule from '../../src/prompts/prompt-state';
+import * as PromptState from '../../src/prompts/prompt-state';
 
 jest.mock('adm-zip');
 jest.mock('../../src/utils/logger', () => ({
@@ -85,7 +85,7 @@ describe('downloadApp', () => {
         jest.clearAllMocks();
         mockDownloadFiles.mockReset();
 
-        PromptStateModule.PromptState.systemSelection = {
+        PromptState.PromptState.systemSelection = {
             connectedSystem: {
                 serviceProvider: mockServiceProvider
             }
@@ -100,11 +100,11 @@ describe('downloadApp', () => {
 
         expect(mockServiceProvider.getUi5AbapRepository).toHaveBeenCalled();
         expect(mockDownloadFiles).toHaveBeenCalledWith('repo-1');
-        expect(PromptStateModule.PromptState.downloadedAppPackage).toEqual(mockPackage);
+        expect(PromptState.PromptState.downloadedAppPackage).toEqual(mockPackage);
     });
 
     it('should throw if serviceProvider is undefined', async () => {
-        PromptStateModule.PromptState.systemSelection = undefined as any;
+        PromptState.PromptState.systemSelection = undefined as any;
 
         await expect(downloadApp('repo-1')).rejects.toThrow();
     });

--- a/packages/repo-app-download-sub-generator/test/utils/download-utils.test.ts
+++ b/packages/repo-app-download-sub-generator/test/utils/download-utils.test.ts
@@ -1,9 +1,9 @@
 import { downloadApp, extractZip } from '../../src/utils/download-utils';
 import AdmZip from 'adm-zip';
-import { PromptState } from '../../src/prompts/prompt-state';
+import { join } from 'path';
 import { t } from '../../src/utils/i18n';
 import RepoAppDownloadLogger from '../../src/utils/logger';
-import type { SystemSelectionAnswers } from '../../src/app/types';
+import * as PromptStateModule from '../../src/prompts/prompt-state';
 
 jest.mock('adm-zip');
 jest.mock('../../src/utils/logger', () => ({
@@ -19,6 +19,7 @@ describe('extractZip', () => {
     let mockFs: any;
 
     beforeEach(() => {
+        jest.clearAllMocks();
         mockEntry1 = {
             isDirectory: false,
             entryName: 'file1.txt',
@@ -40,20 +41,18 @@ describe('extractZip', () => {
     });
 
     it('should extract files from zip and write them using fs', async () => {
-        const extractedPath = '/tmp/project';
+        const extractedPath = join('/tmp/project');
         const dummyBuffer = Buffer.from('fake zip content');
 
         await extractZip(extractedPath, dummyBuffer, mockFs);
 
         expect(mockZip.getEntries).toHaveBeenCalled();
-
         expect(mockFs.write).toHaveBeenCalledWith(
-            '/tmp/project/file1.txt',
+            join(extractedPath, 'file1.txt'),
             'File 1 content'
         );
-
         expect(mockFs.write).toHaveBeenCalledWith(
-            '/tmp/project/folder/file2.txt',
+            join(extractedPath, 'folder/file2.txt'),
             'File 2 content'
         );
     });
@@ -83,9 +82,10 @@ describe('downloadApp', () => {
     };
 
     beforeEach(() => {
+        jest.clearAllMocks();
         mockDownloadFiles.mockReset();
-        mockGetUi5AbapRepository.mockClear();
-        PromptState.systemSelection = {
+
+        PromptStateModule.PromptState.systemSelection = {
             connectedSystem: {
                 serviceProvider: mockServiceProvider
             }
@@ -98,12 +98,14 @@ describe('downloadApp', () => {
 
         await downloadApp('repo-1');
 
+        expect(mockServiceProvider.getUi5AbapRepository).toHaveBeenCalled();
         expect(mockDownloadFiles).toHaveBeenCalledWith('repo-1');
-        expect(PromptState.downloadedAppPackage).toEqual(mockPackage);
+        expect(PromptStateModule.PromptState.downloadedAppPackage).toEqual(mockPackage);
     });
 
     it('should throw if serviceProvider is undefined', async () => {
-        PromptState.systemSelection = undefined as unknown as Partial<SystemSelectionAnswers>;
+        PromptStateModule.PromptState.systemSelection = undefined as any;
+
         await expect(downloadApp('repo-1')).rejects.toThrow();
     });
 });


### PR DESCRIPTION
- Fixing failing test in windows for `repo-app-download-sub-generator`