### PR TITLE
fix(fiori-annotation-api): empty path values

### DIFF
--- a/.changeset/witty-suns-whisper.md
+++ b/.changeset/witty-suns-whisper.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/cds-odata-annotation-converter': patch
+'@sap-ux/fiori-annotation-api': patch
+---
+
+fix: writing empty path values results in a compile error in CDS projects

--- a/packages/cds-odata-annotation-converter/src/printer/csdl-to-cds.ts
+++ b/packages/cds-odata-annotation-converter/src/printer/csdl-to-cds.ts
@@ -453,7 +453,11 @@ export const printPrimitiveValue = (expressionName: ElementName | AttributeName,
         case Edm.PropertyPath:
         case Edm.Path:
             // other paths: use quotation mark only if @ is contained
-            result = printPathValue(expressionValue);
+            if (expressionValue.trim() === '') {
+                result = stringLiteral(expressionValue);
+            } else {
+                result = printPathValue(expressionValue);
+            }
             break;
         default:
             return '';

--- a/packages/cds-odata-annotation-converter/test/printer/__snapshots__/csdl-to-cds.test.ts.snap
+++ b/packages/cds-odata-annotation-converter/test/printer/__snapshots__/csdl-to-cds.test.ts.snap
@@ -93,6 +93,10 @@ exports[`csdlToCds print complete term 1`] = `
 }"
 `;
 
+exports[`csdlToCds print primitive values AnnotationPath attribute  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values AnnotationPath element  1`] = `"Primitive.Value : ''"`;
+
 exports[`csdlToCds print primitive values Bool attribute false 1`] = `"Primitive.Value : false"`;
 
 exports[`csdlToCds print primitive values Bool attribute true 1`] = `"Primitive.Value : true"`;
@@ -112,6 +116,26 @@ exports[`csdlToCds print primitive values Int attribute 1 1`] = `"Primitive.Valu
 exports[`csdlToCds print primitive values Int element $0 1`] = `"Primitive.Value : $0"`;
 
 exports[`csdlToCds print primitive values Int element 1 1`] = `"Primitive.Value : 1"`;
+
+exports[`csdlToCds print primitive values ModelElementPath attribute  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values ModelElementPath element  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values NavigationPropertyPath attribute  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values NavigationPropertyPath element  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values Path attribute      1`] = `"Primitive.Value : '    '"`;
+
+exports[`csdlToCds print primitive values Path attribute  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values Path element      1`] = `"Primitive.Value : '    '"`;
+
+exports[`csdlToCds print primitive values Path element  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values PropertyPath attribute  1`] = `"Primitive.Value : ''"`;
+
+exports[`csdlToCds print primitive values PropertyPath element  1`] = `"Primitive.Value : ''"`;
 
 exports[`csdlToCds print primitive values String attribute abc 1`] = `"Primitive.Value : 'abc'"`;
 

--- a/packages/cds-odata-annotation-converter/test/printer/csdl-to-cds.test.ts
+++ b/packages/cds-odata-annotation-converter/test/printer/csdl-to-cds.test.ts
@@ -2152,6 +2152,12 @@ describe('csdlToCds', () => {
             primitiveValueTest('Bool', 'true');
             primitiveValueTest('Bool', 'false');
             primitiveValueTest('EnumMember', 'Alias.Type/Value');
+            primitiveValueTest(Edm.Path, '');
+            primitiveValueTest(Edm.Path, '    ');
+            primitiveValueTest(Edm.PropertyPath, '');
+            primitiveValueTest(Edm.NavigationPropertyPath, '');
+            primitiveValueTest(Edm.AnnotationPath, '');
+            primitiveValueTest(Edm.ModelElementPath, '');
         });
 
         describe('Default boolean true value:', () => {

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -649,6 +649,21 @@ annotate IncidentService.Incidents with {
 "
 `;
 
+exports[`fiori annotation service insert SideEffects annotation with empty target CAPNodejs cap-start v4 1`] = `
+"using IncidentService as service from '../../srv/incidentservice';
+
+annotate service.Incidents with @(
+    Common.SideEffects : {
+        $Type : 'Common.SideEffectsType',
+        TargetEntities : [
+            '',
+        ],
+    }
+);
+
+"
+`;
+
 exports[`fiori annotation service insert collection empty collection CAPNodejs cap-start v4 1`] = `
 "using IncidentService as service from '../../srv/incidentservice';
 

--- a/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
+++ b/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
@@ -2103,6 +2103,42 @@ rating : Rating;
             });
         });
 
+        createEditTestCase({
+            name: 'SideEffects annotation with empty target',
+            projectTestModels: TEST_TARGETS.filter((target) => target === PROJECTS.V4_CDS_START),
+            getInitialChanges: (files) => [],
+            getChanges: (files) => [
+                {
+                    kind: ChangeType.InsertAnnotation,
+                    uri: files.annotations,
+                    content: {
+                        type: 'annotation',
+                        target: TARGET_INCIDENTS,
+                        value: {
+                            term: `${COMMON}.SideEffects`,
+                            record: {
+                                type: `${COMMON}.SideEffectsType`,
+                                propertyValues: [
+                                    {
+                                        name: 'TargetEntities',
+                                        value: {
+                                            type: 'Collection',
+                                            Collection: [
+                                                {
+                                                    type: 'NavigationPropertyPath',
+                                                    NavigationPropertyPath: ''
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        });
+
         describe('SAP annotations for CDS projects', () => {
             const dataField = createDataField();
             dataField.propertyValues.push({


### PR DESCRIPTION
Fixes writing empty path values in CDS files.

CDS does not support empty paths, so we need to use empty string values which later gets translated into empty path value by the compiler.