### PR TITLE
fix(cf-deploy-config-sub-generator): issues found when testing

### DIFF
--- a/.changeset/eleven-coats-teach.md
+++ b/.changeset/eleven-coats-teach.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+'@sap-ux/cf-deploy-config-inquirer': patch
+---
+
+update text label and handle options

--- a/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
+++ b/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
@@ -135,7 +135,7 @@ function getRouterOptionsPrompt(): CfDeployConfigRouterQuestions {
             let additionalMessage;
             if (selectedRouter && selectedRouter === RouterModuleType.AppFront) {
                 additionalMessage = {
-                    message: t('warnings.appFrontendServiceRouterChoice'),
+                    message: t('warning.appFrontendServiceRouterChoice'),
                     severity: Severity.warning
                 };
             }

--- a/packages/cf-deploy-config-inquirer/test/prompts.test.ts
+++ b/packages/cf-deploy-config-inquirer/test/prompts.test.ts
@@ -272,7 +272,7 @@ describe('Prompt Generation Tests', () => {
             expect(
                 ((routerTypePrompt as YUIQuestion)?.additionalMessages as Function)(RouterModuleType.AppFront)
             ).toStrictEqual({
-                message: t('warnings.appFrontendServiceRouterChoice'),
+                message: t('warning.appFrontendServiceRouterChoice'),
                 severity: Severity.warning
             });
         });

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -258,9 +258,13 @@ export default class extends DeploymentGenerator {
         const isDestinationFullUrl =
             this.options.isFullUrlDest ?? (destination && isFullUrlDestination(destination)) ?? false;
         const addManagedAppRouter =
-            this.options.addManagedAppRouter ?? this.answers.routerType === RouterModuleType.Managed;
+            this.options.addManagedAppRouter ??
+            (this.options.routerType === RouterModuleType.Managed ||
+                this.answers.routerType === RouterModuleType.Managed);
         const addAppFrontendRouter =
-            this.options.addAppFrontendRouter ?? this.answers.routerType === RouterModuleType.AppFront;
+            this.options.addAppFrontendRouter ??
+            (this.options.routerType === RouterModuleType.AppFront ||
+                this.answers.routerType === RouterModuleType.AppFront);
         const destinationAuthentication =
             this.options.destinationAuthType ?? destination?.Authentication ?? DESTINATION_AUTHTYPE_NOTFOUND;
         const overwrite = this.options.overwrite ?? this.answers.overwrite;

--- a/packages/cf-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/questions.ts
@@ -17,6 +17,7 @@ import { t } from '../utils';
 import type { ApiHubConfig } from '@sap-ux/cf-deploy-config-writer';
 import type { Answers, Question } from 'inquirer';
 import { withCondition } from '@sap-ux/inquirer-common';
+import type { Logger } from '@sap-ux/logger';
 
 /**
  * Fetches the Cloud Foundry deployment configuration questions.
@@ -68,7 +69,7 @@ export async function getCFQuestions({
     };
 
     DeploymentGenerator.logger?.debug(t('cfGen.debug.promptOptions', { options: JSON.stringify(options) }));
-    return getPrompts(options);
+    return getPrompts(options, DeploymentGenerator.logger as unknown as Logger);
 }
 
 /**

--- a/packages/cf-deploy-config-sub-generator/test/app.test.ts
+++ b/packages/cf-deploy-config-sub-generator/test/app.test.ts
@@ -498,10 +498,10 @@ describe('Cloud foundry generator tests', () => {
                     skipInstall: true,
                     appRootPath: join(appDir, projectName),
                     launchDeployConfigAsSubGenerator: false,
-                    destinationAuthType: 'NoAuthentication' // Validating SH4
+                    destinationAuthType: 'NoAuthentication', // Validating SH4
+                    routerType: cfConfigWriter.RouterModuleType.Managed
                 })
                 .withPrompts({
-                    routerType: cfConfigWriter.RouterModuleType.Managed,
                     destinationName: 'testDestination'
                 })
                 .run()

--- a/packages/deploy-config-sub-generator/test/app/app.test.ts
+++ b/packages/deploy-config-sub-generator/test/app/app.test.ts
@@ -258,17 +258,20 @@ describe('Deployment Generator', () => {
                 .withGenerators([[mockSubGen, generatorNamespace('test', 'cf')]])
                 .run()
         ).resolves.not.toThrow();
-        expect(getCFQuestionsSpy).toHaveBeenCalledWith({
-            destinationName: {
-                addBTPDestinationList: false,
-                additionalChoiceList: expect.any(Array),
-                defaultValue: '~Destination',
-                hint: false,
-                useAutocomplete: true
+        expect(getCFQuestionsSpy).toHaveBeenCalledWith(
+            {
+                destinationName: {
+                    addBTPDestinationList: false,
+                    additionalChoiceList: expect.any(Array),
+                    defaultValue: '~Destination',
+                    hint: false,
+                    useAutocomplete: true
+                },
+                overwriteDestinationName: false,
+                routerType: true
             },
-            overwriteDestinationName: false,
-            routerType: true
-        });
+            expect.any(Object)
+        );
         expect(getABAPPromptsSpy).toHaveBeenCalledWith({
             appRootPath: expect.stringContaining('project1'),
             backendConfig: expect.objectContaining({


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/3022

- text label using incorrect property
- options passed to subgenerator not being used
- pass logger to cf-inquirer