### PR TITLE
fix(odata-service-inquirer):Annotations (v2) not download generic dests

### DIFF
--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/service-helper.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/service-helper.test.ts
@@ -1,12 +1,23 @@
 import { Severity } from '@sap-devx/yeoman-ui-types';
-import { type ODataServiceInfo, ODataVersion, ServiceType, type V2CatalogService } from '@sap-ux/axios-extension';
+import {
+    type Annotations,
+    type ODataServiceInfo,
+    ODataVersion,
+    type ServiceProvider,
+    ServiceType,
+    type V2CatalogService
+} from '@sap-ux/axios-extension';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 import { initI18nOdataServiceInquirer, t } from '../../../../../src/i18n';
 import type { ConnectionValidator } from '../../../../../src/prompts/connectionValidator';
-import { getSelectedServiceMessage } from '../../../../../src/prompts/datasources/sap-system/service-selection/service-helper';
+import {
+    getSelectedServiceMessage,
+    validateService
+} from '../../../../../src/prompts/datasources/sap-system/service-selection/service-helper';
 import type { ServiceAnswer } from '../../../../../src/prompts/datasources/sap-system/service-selection/types';
 import * as sharedServiceHelpers from '../../../../../src/prompts/datasources/service-helpers/service-helpers';
+import { PromptState } from '../../../../../src/utils';
 
 const serviceV2a = {
     id: 'ZTRAVEL_DESK_SRV_0002',
@@ -57,6 +68,16 @@ const serviceChoices = [
 jest.mock('../../../../../src/prompts/connectionValidator', () => {
     return {
         ConnectionValidator: jest.fn().mockImplementation(() => connectionValidatorMock)
+    };
+});
+
+let catalogServiceMock = {};
+jest.mock('@sap-ux/axios-extension', () => {
+    return {
+        ...jest.requireActual('@sap-ux/axios-extension'),
+        createForAbap: jest.fn().mockImplementation(() => ({
+            catalog: jest.fn().mockImplementation(() => catalogServiceMock)
+        }))
     };
 });
 
@@ -145,5 +166,71 @@ describe('Test service-helper function `getSelectedServiceMessage`', () => {
             message: t('prompts.warnings.collaborativeDraftMessage'),
             severity: Severity.warning
         });
+    });
+});
+
+describe('Test service-helper function `validateService`', () => {
+    const v2Metadata =
+        '<?xml version="1.0" encoding="utf-8"?><edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">' +
+        '<edmx:DataServices m:DataServiceVersion="2.0">' +
+        '<Schema xmlns="http://schemas.microsoft.com/ado/2008/09/edm" Namespace="SEPMRA_PROD_MAN" xml:lang="en" sap:schema-version="1">' +
+        '<EntityContainer Name="SEPMRA_PROD_MAN_Entities" m:IsDefaultEntityContainer="true" sap:supported-formats="atom json xlsx">' +
+        '</EntityContainer>' +
+        '</Schema>' +
+        '</edmx:DataServices></edmx:Edmx>';
+
+    const v2Annotations = `<?xml version="1.0" encoding="utf-8"?>
+        <edmx:Edmx Version="1.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+            <edmx:Reference Uri="../../catalogservice;v=2/Vocabularies(TechnicalName=\'%2FIWBEP%2FVOC_COMMON\',Version=\'0001\',SAP__Origin=\'\')/$value">
+                <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common"/>
+            </edmx:Reference>
+        </edmx:Edmx>`;
+
+    beforeAll(async () => {
+        await initI18nOdataServiceInquirer();
+    });
+
+    test('Should get metadata and annotations for v2 services when using partial/full url destinations', async () => {
+        /**
+         * Partial/full URL destinations wont have a catalog defined in the connection validator.
+         * This test is to replicate that scenario.
+         */
+        const serviceAnswer = {
+            servicePath: '/sap/opu/odata/sap/ZTRAVEL_DESK_SRV_0002'
+        } as ServiceAnswer;
+
+        const connectionValidatorMockNoCatalogs = {
+            axiosConfig: {
+                auth: {
+                    username: 'anzeiger',
+                    password: 'display'
+                },
+                baseURL: 'https://uia_partial_url_host_only.dest',
+                url: '/sap/opu/odata/bobf/SB_TRAVEL_DESK/'
+            },
+            serviceProvider: {} as ServiceProvider,
+            odataService: {
+                metadata: jest.fn().mockResolvedValue(v2Metadata)
+            }
+        } as unknown as ConnectionValidator;
+
+        let validateServiceResult = await validateService(serviceAnswer, connectionValidatorMockNoCatalogs);
+        expect(validateServiceResult.hasAnnotations).toBe(false);
+
+        const mockAnnotations: Annotations[] = [
+            {
+                TechnicalName: 'SomeAnnotations',
+                Version: ODataVersion.v2,
+                Uri: 'https://annotations.url',
+                Definitions: v2Annotations
+            }
+        ];
+        catalogServiceMock = {
+            getAnnotations: jest.fn().mockResolvedValue(mockAnnotations),
+            interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } }
+        };
+
+        validateServiceResult = await validateService(serviceAnswer, connectionValidatorMockNoCatalogs);
+        expect(PromptState.odataService.annotations).toBe(mockAnnotations);
     });
 });


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3132

- Adds best-effort request to download backend annotations for v2 services
- Adds test to cover