### PR TITLE
fix(fiori-app-sub-generator): Flp App Id form is incorrect

### DIFF
--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -258,12 +258,13 @@ export class FioriAppGenerator extends Generator {
                     );
                 this.state.project = Object.assign(this.state.project ?? {}, ui5AppAnswers, {
                     ui5Version: ui5AppAnswers?.ui5Version || localUI5Version,
-                    localUI5Version,
-                    flpAppId: getFlpId(
-                        getAppId(ui5AppAnswers.namespace ?? '', ui5AppAnswers?.name),
-                        this.state.floorplan === FloorplanFF.FF_SIMPLE ? defaultNavActionDisplay : defaultNavActionTile
-                    )
+                    localUI5Version
                 });
+                // Some extensions may reference this before the writing phase where normally the flpAppId is set
+                this.state.project.flpAppId = getFlpId(
+                    getAppId(this.state.project.name, ui5AppAnswers.namespace ?? ''),
+                    this.state.floorplan === FloorplanFF.FF_SIMPLE ? defaultNavActionDisplay : defaultNavActionTile
+                );
             }
 
             if (this.state.project?.addDeployConfig) {

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle1.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle1.test.ts
@@ -452,7 +452,7 @@ describe('Test FioriAppGenerator', () => {
             namespace: ui5ApplicationAnswers.namespace,
             description: ui5ApplicationAnswers.description,
             localUI5Version: '3.2.1',
-            flpAppId: 'testAppNametestNamespace-display'
+            flpAppId: 'testNamespacetestAppName-display'
         });
     });
 
@@ -522,7 +522,7 @@ describe('Test FioriAppGenerator', () => {
             description: ui5ApplicationAnswers.description,
             enableNpmWorkspaces: undefined,
             localUI5Version: '3.2.1',
-            flpAppId: 'testAppNametestNamespace-display'
+            flpAppId: 'testNamespacetestAppName-display'
         });
     });
 
@@ -563,7 +563,7 @@ describe('Test FioriAppGenerator', () => {
             localUI5Version: '3.2.1',
             addDeployConfig: true,
             addFlpConfig: true,
-            flpAppId: 'testAppNametestNamespace-display'
+            flpAppId: 'testNamespacetestAppName-display'
         });
 
         expect(addDeployGen).toHaveBeenCalledWith(


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3136

- Reverses namespace/name to be correctly ordered in flp app id string.
- Updates test