### PR TITLE
Removed Jest timeout from test and mocked _runNpmInstall method when skipInstall is false

### DIFF
--- a/.changeset/smooth-rules-pump.md
+++ b/.changeset/smooth-rules-pump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': minor
+---
+
+Removed Jest timeout from test and mocked \_runNpmInstall method when skipInstall is false

--- a/packages/repo-app-import-sub-generator/test/app.test.ts
+++ b/packages/repo-app-import-sub-generator/test/app.test.ts
@@ -230,10 +230,12 @@ describe('Repo App Download', () => {
         mockPrompts(testOutputDir);
 		mockVSCode = {
 			workspace: {
+                workspaceFolders: [],
+                updateWorkspaceFolders: jest.fn(),
 				getConfiguration: jest.fn().mockReturnValue({
 					get: jest.fn().mockReturnValue(undefined)
 				})
-			},
+            },
 			Uri: {
 				file: jest.fn((path) => ({ fsPath: path }))
 			}
@@ -329,7 +331,7 @@ describe('Repo App Download', () => {
 					systemSelection: 'system3',
 					selectedApp: {
 						appId: appConfig.app.id,
-						title: appConfig.app.id,
+						title: appConfig.app.title,
 						description: appConfig.app.description,
 						repoName: 'app-1-repo',
 						url: 'url-1'
@@ -347,8 +349,7 @@ describe('Repo App Download', () => {
 		const generator = new RepoAppDownloadGenerator([], {
 			env: yeomanEnv,
 			appWizard: mockAppWizard as AppWizard,
-			logWrapper: console,
-			logger: console,
+			logger: {},
 			vscode: mockVSCode,
 			data: {
 				quickDeployedAppConfig: {
@@ -356,7 +357,7 @@ describe('Repo App Download', () => {
 					serviceProviderInfo: { name: 'system3' }
 				}
 			}
-		} as any);
+		});
 		
 		// mock _runNpmInstall 
 		(generator as any)._runNpmInstall = jest.fn().mockResolvedValue(undefined);

--- a/packages/repo-app-import-sub-generator/test/app.test.ts
+++ b/packages/repo-app-import-sub-generator/test/app.test.ts
@@ -16,9 +16,6 @@ import { hostEnvironment, sendTelemetry } from '@sap-ux/fiori-generator-shared';
 import { FileName, DirName, type Manifest } from '@sap-ux/project-access';
 import RepoAppDownloadLogger from '../src/utils/logger';
 import { t } from '../src/utils/i18n';
-import { type AbapServiceProvider } from '@sap-ux/axios-extension';
-import { fetchAppListForSelectedSystem } from '../src/prompts/prompt-helpers';
-import { App } from '../../adp-tooling/src';
 import env from 'yeoman-environment';
 
 jest.mock('../src/prompts/prompt-helpers', () => ({


### PR DESCRIPTION
related to [PR](https://github.com/SAP/open-ux-tools/pull/3110) 

Address the test timeout [issue](https://github.com/SAP/open-ux-tools/actions/runs/14490944433/job/40647049641?pr=3135) during the installation phase

- the Jest timeout was removed
- the `_runNpmInstall` method is mocked when `skipInstall` is false. 
