### PR TITLE
fix: Space between empty table and add button

### DIFF
--- a/.changeset/real-emus-reply.md
+++ b/.changeset/real-emus-reply.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Fixes space between empty table and Add button.

--- a/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.scss
+++ b/packages/ui-components/src/components/UIFlexibleTable/UIFlexibleTable.scss
@@ -55,7 +55,6 @@ $readonly-labels-opacity: 0.4;
             .flexible-table-content-table-title-row {
                 border: 1px solid var(--vscode-editorWidget-border);
             }
-            margin-top: 0px;
         }
         &.empty-table-header {
             margin-top: 0px;


### PR DESCRIPTION
Fixes space between empty table and add button.
Occurs when `noDataText` is undefined and `rows` length is 0. 

From:
![1](https://github.com/user-attachments/assets/c3f8d6be-44ea-49e4-88af-c26549a857a6)

To:
![2](https://github.com/user-attachments/assets/4b257621-7ee6-406f-be42-eebdbaa8a3b6)
