### PR TITLE
fix to enable local preview for adt downloaded app

### DIFF
--- a/.changeset/friendly-countries-applaud.md
+++ b/.changeset/friendly-countries-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': patch
+---
+
+fix to enable local preview for adt downloaded app

--- a/packages/repo-app-import-sub-generator/src/app/app-config.ts
+++ b/packages/repo-app-import-sub-generator/src/app/app-config.ts
@@ -11,6 +11,7 @@ import type { AbapDeployConfig } from '@sap-ux/ui5-config';
 import RepoAppDownloadLogger from '../utils/logger';
 import { FileName } from '@sap-ux/project-access';
 import { join } from 'path';
+import { getUI5Versions, type UI5Version } from '@sap-ux/ui5-info';
 
 /**
  * Generates the deployment configuration for an ABAP application.
@@ -84,6 +85,11 @@ export async function getAppConfig(
             serviceProvider,
             manifest?.['sap.app']?.dataSources?.mainService.uri ?? ''
         );
+
+        // Fetch latest UI5 versions from npm
+        const ui5Versions: UI5Version[] = await getUI5Versions({ onlyNpmVersion: true });
+        const localVersion = ui5Versions[0]?.version;
+
         const appConfig: FioriElementsApp<LROPSettings> = {
             app: {
                 id: app.appId,
@@ -119,6 +125,9 @@ export async function getAppConfig(
             appOptions: {
                 addAnnotations: odataVersion === OdataVersion.v4,
                 addTests: true
+            },
+            ui5: {
+                localVersion
             }
         };
         return appConfig;

--- a/packages/repo-app-import-sub-generator/test/app-config.test.ts
+++ b/packages/repo-app-import-sub-generator/test/app-config.test.ts
@@ -176,7 +176,7 @@ describe('getAppConfig', () => {
         expect(result).toEqual(expectedAppConfig);
     });
 
-    it('should generate ui5 local', async () => {
+    it('should generate app config with the npm maintained UI5 local version for local preview', async () => {
         const mockManifest = {
             'sap.app': {
                 dataSources: {


### PR DESCRIPTION

Related to https://github.com/SAP/open-ux-tools/pull/3110

- Add logic to handle local UI5 version to ensure the downloaded app from ADT, works in local preview mode
- added test case