### PR TITLE
fix(cf-deploy-config-writer): handle duplicate app frontend services

### DIFF
--- a/.changeset/rich-years-matter.md
+++ b/.changeset/rich-years-matter.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+Handle duplicate app-content for app frontend router

--- a/packages/cf-deploy-config-writer/src/cf-writer/app-config.ts
+++ b/packages/cf-deploy-config-writer/src/cf-writer/app-config.ts
@@ -277,6 +277,9 @@ async function updateMtaConfig(cfConfig: CFConfig, fs: Editor): Promise<void> {
         const appModule = cfConfig.appId;
         const appRelativePath = toPosixPath(relative(cfConfig.rootPath, cfConfig.appPath));
         await mtaInstance.addApp(appModule, appRelativePath ?? '.');
+        if (mtaInstance.hasAppFrontendRouter()) {
+            cfConfig.addAppFrontendRouter = true;
+        }
         await addMtaDeployParameters(mtaInstance);
         if ((cfConfig.addMtaDestination && cfConfig.isCap) || cfConfig.destinationName === DefaultMTADestination) {
             // If the destination instance identifier is passed, create a destination instance

--- a/packages/cf-deploy-config-writer/src/mta-config/mta.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/mta.ts
@@ -405,17 +405,19 @@ export class MtaConfig {
      */
     private async cleanupMissingResources(): Promise<void> {
         this.log?.debug(t('debug.addMissingModules'));
-        if (!this.modules.has('com.sap.application.content:resource')) {
-            await this.addAppContent();
-        }
+        if (!this.modules.has('com.sap.application.content:appfront')) {
+            if (!this.modules.has('com.sap.application.content:resource')) {
+                await this.addAppContent();
+            }
 
-        // For Approuter Configuration generators, the destination resource is missing for both Standalone | Managed
-        if (this.resources.get('destination')) {
-            // Ensure the resource is added
-            await this.updateDestinationResource(this.modules.has('com.sap.application.content:destination'));
-        } else {
-            // No destination resource found, add it, more common for standalone
-            await this.addDestinationResource(this.modules.has('com.sap.application.content:destination'));
+            // For Approuter Configuration generators, the destination resource is missing for both Standalone | Managed
+            if (this.resources.get('destination')) {
+                // Ensure the resource is added
+                await this.updateDestinationResource(this.modules.has('com.sap.application.content:destination'));
+            } else {
+                // No destination resource found, add it, more common for standalone
+                await this.addDestinationResource(this.modules.has('com.sap.application.content:destination'));
+            }
         }
     }
 
@@ -488,6 +490,15 @@ export class MtaConfig {
             }
         });
         return cloudServiceName;
+    }
+
+    /**
+     * Returns true if the MTA contains an approuter module of type App Frontend Service.
+     *
+     * @returns {boolean} true if the mta contains an App Frontend Service
+     */
+    public hasAppFrontendRouter(): boolean {
+        return this.modules.has('com.sap.application.content:appfront');
     }
 
     /**

--- a/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/package.json
+++ b/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "lrop",
+    "version": "0.0.1",
+    "private": true,
+    "description": "An SAP Fiori application.",
+    "keywords": [
+        "ui5",
+        "openui5",
+        "sapui5"
+    ],
+    "main": "webapp/index.html",
+    "dependencies": {},
+    "devDependencies": {
+        "@ui5/cli": "^3.0.0",
+        "@sap/ux-ui5-tooling": "1"
+    },
+    "scripts": {
+        "start": "fiori run --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#lrop-display\"",
+        "start-local": "fiori run --config ./ui5-local.yaml --open \"test/flpSandbox.html?sap-ui-xx-viewCache=false#lrop-display\"",
+        "build": "ui5 build --config=ui5.yaml --clean-dest --dest dist",
+        "deploy": "fiori verify",
+        "deploy-config": "fiori add deploy-config",
+        "start-noflp": "fiori run --open \"index.html?sap-ui-xx-viewCache=false\"",
+        "start-variants-management": "fiori run --open \"preview.html?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=true&sap-ui-rta-skip-flex-validation=true#preview-app\"",
+        "unit-tests": "fiori run --open 'test/unit/unitTests.qunit.html'",
+        "int-tests": "fiori run --open 'test/integration/opaTests.qunit.html'"
+    },
+    "sapuxLayer": "VENDOR"
+}

--- a/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/ui5.yaml
+++ b/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/ui5.yaml
@@ -1,0 +1,24 @@
+specVersion: '2.4'
+metadata:
+  name: 'lrop'
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        backend:
+          - path: /sap
+            url: https://example.net
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+          version:  # The UI5 version, for instance, 1.78.1. Empty means latest version
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp

--- a/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/webapp/manifest.json
+++ b/packages/cf-deploy-config-writer/test/sample/appfrontendbase/lrop/webapp/manifest.json
@@ -1,0 +1,164 @@
+{
+    "_version": "1.8.0",
+    "sap.app": {
+        "id": "com.fiori.tools.lrop",
+        "type": "application",
+        "i18n": "i18n/i18n.properties",
+        "applicationVersion": {
+            "version": "1.0.0"
+        },
+        "title": "{{appTitle}}",
+        "description": "{{appDescription}}",
+        "tags": {
+            "keywords": []
+        },
+        "ach": "",
+        "resources": "resources.json",
+        "dataSources": {
+            "mainService": {
+                "uri": "/sap/opu/odata/sap/ZUI_RAP_TRAVEL_M_U025/",
+                "type": "OData",
+                "settings": {
+                    "annotations": [
+                        "ZUI_RAP_TRAVEL_M_U025_VAN",
+                        "annotation"
+                    ],
+                    "localUri": "localService/metadata.xml"
+                }
+            },
+            "annotation": {
+                "type": "ODataAnnotation",
+                "uri": "annotations/annotation.xml",
+                "settings": {
+                    "localUri": "annotations/annotation.xml"
+                }
+            }
+        },
+        "offline": false,
+        "sourceTemplate": {
+            "id": "ui5template.smartTemplate",
+            "version": "1.40.12"
+        }
+    },
+    "sap.ui": {
+        "technology": "UI5",
+        "icons": {
+            "icon": "",
+            "favIcon": "",
+            "phone": "",
+            "phone@2": "",
+            "tablet": "",
+            "tablet@2": ""
+        },
+        "deviceTypes": {
+            "desktop": true,
+            "tablet": true,
+            "phone": true
+        },
+        "supportedThemes": [
+            "sap_hcb",
+            "sap_belize"
+        ]
+    },
+    "sap.ui5": {
+        "resources": {
+            "js": [],
+            "css": []
+        },
+        "dependencies": {
+            "minUI5Version": "1.65.0",
+            "libs": {},
+            "components": {}
+        },
+        "models": {
+            "i18n": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "uri": "i18n/i18n.properties"
+            },
+            "@i18n": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "uri": "i18n/i18n.properties"
+            },
+            "i18n|sap.suite.ui.generic.template.ListReport|Travel": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "uri": "i18n/ListReport/Travel/i18n.properties"
+            },
+            "i18n|sap.suite.ui.generic.template.ObjectPage|Travel": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "uri": "i18n/ObjectPage/Travel/i18n.properties"
+            },
+            "i18n|sap.suite.ui.generic.template.ObjectPage|Booking": {
+                "type": "sap.ui.model.resource.ResourceModel",
+                "uri": "i18n/ObjectPage/Booking/i18n.properties"
+            },
+            "": {
+                "dataSource": "mainService",
+                "preload": true,
+                "settings": {
+                    "defaultBindingMode": "TwoWay",
+                    "defaultCountMode": "Inline",
+                    "refreshAfterChange": false,
+                    "metadataUrlParams": {
+                        "sap-value-list": "none"
+                    }
+                }
+            }
+        },
+        "extends": {
+            "extensions": {}
+        },
+        "contentDensities": {
+            "compact": true,
+            "cozy": true
+        }
+    },
+    "sap.ui.generic.app": {
+        "_version": "1.3.0",
+        "settings": {
+            "forceGlobalRefresh": false,
+            "objectPageHeaderType": "Dynamic",
+            "showDraftToggle": false
+        },
+        "pages": {
+            "ListReport|Travel": {
+                "entitySet": "Travel",
+                "component": {
+                    "name": "sap.suite.ui.generic.template.ListReport",
+                    "list": true,
+                    "settings": {
+                        "condensedTableLayout": true,
+                        "smartVariantManagement": true,
+                        "enableTableFilterInPageVariant": true
+                    }
+                },
+                "pages": {
+                    "ObjectPage|Travel": {
+                        "entitySet": "Travel",
+                        "component": {
+                            "name": "sap.suite.ui.generic.template.ObjectPage"
+                        },
+                        "pages": {
+                            "ObjectPage|to_Booking": {
+                                "navigationProperty": "to_Booking",
+                                "entitySet": "Booking",
+                                "component": {
+                                    "name": "sap.suite.ui.generic.template.ObjectPage"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "sap.platform.abap": {
+        "uri": ""
+    },
+    "sap.fiori": {
+        "registrationIds": [],
+        "archeType": "transactional"
+    },
+    "sap.platform.hcp": {
+        "uri": ""
+    }
+}

--- a/packages/cf-deploy-config-writer/test/sample/appfrontendbase/mta.yaml
+++ b/packages/cf-deploy-config-writer/test/sample/appfrontendbase/mta.yaml
@@ -1,0 +1,35 @@
+_schema-version: '3.1'
+ID: rootmta
+description: Fiori elements app
+version: 0.0.1
+modules:
+  - name: rootmta-app-content
+    type: com.sap.application.content
+    path: .
+    requires:
+      - name: rootmta-app-front
+        parameters:
+          content-target: true
+      - name: rootmta-uaa
+    parameters:
+      config:
+        destinations:
+          - name: ui5
+            url: 'https://ui5.sap.com'
+resources:
+  - name: rootmta-uaa
+    type: org.cloudfoundry.managed-service
+    parameters:
+      path: ./xs-security.json
+      service: xsuaa
+      service-name: rootmta-xsuaa-service
+      service-plan: application
+  - name: rootmta-app-front
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: app-front
+      service-name: rootmta-app-front-service
+      service-plan: developer
+parameters:
+  deploy_mode: html5-repo
+  enable-parallel-deployments: true

--- a/packages/cf-deploy-config-writer/test/sample/appfrontendbase/xs-security.json
+++ b/packages/cf-deploy-config-writer/test/sample/appfrontendbase/xs-security.json
@@ -1,0 +1,7 @@
+{
+  "xsappname": "standalone",
+  "tenant-mode": "dedicated",
+  "description": "Security profile of called application",
+  "scopes": [],
+  "role-templates": []
+}

--- a/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-appfront.test.ts.snap
+++ b/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-appfront.test.ts.snap
@@ -149,6 +149,137 @@ parameters:
 "
 `;
 
+exports[`CF Writer App - Application Frontend Generate deployment configs - Append HTML5 to an existing app frontend router 1`] = `
+"{
+  \\"welcomeFile\\": \\"/index.html\\",
+  \\"authenticationMethod\\": \\"route\\",
+  \\"routes\\": [
+    {
+      \\"source\\": \\"^/sap/(.*)$\\",
+      \\"target\\": \\"/sap/$1\\",
+      \\"destination\\": \\"TestDestination\\",
+      \\"authenticationType\\": \\"ias\\",
+      \\"csrfProtection\\": false
+    },
+    {
+      \\"source\\": \\"^/resources/(.*)$\\",
+      \\"target\\": \\"/resources/$1\\",
+      \\"authenticationType\\": \\"none\\",
+      \\"destination\\": \\"ui5\\"
+    },
+    {
+      \\"source\\": \\"^/test-resources/(.*)$\\",
+      \\"target\\": \\"/test-resources/$1\\",
+      \\"authenticationType\\": \\"none\\",
+      \\"destination\\": \\"ui5\\"
+    },
+    {
+      \\"source\\": \\"^/logout-page.html$\\",
+      \\"service\\": \\"app-front\\",
+      \\"authenticationType\\": \\"none\\"
+    },
+    {
+      \\"source\\": \\"^/index.html$\\",
+      \\"service\\": \\"app-front\\",
+      \\"cacheControl\\": \\"no-cache, no-store, must-revalidate\\"
+    },
+    {
+      \\"source\\": \\"^(.*)$\\",
+      \\"target\\": \\"$1\\",
+      \\"service\\": \\"app-front\\",
+      \\"authenticationType\\": \\"ias\\"
+    }
+  ]
+}
+"
+`;
+
+exports[`CF Writer App - Application Frontend Generate deployment configs - Append HTML5 to an existing app frontend router 2`] = `
+"{
+  \\"xsappname\\": \\"standalone\\",
+  \\"tenant-mode\\": \\"dedicated\\",
+  \\"description\\": \\"Security profile of called application\\",
+  \\"scopes\\": [],
+  \\"role-templates\\": []
+}
+"
+`;
+
+exports[`CF Writer App - Application Frontend Generate deployment configs - Append HTML5 to an existing app frontend router 3`] = `
+"{
+  \\"name\\": \\"mta-project\\",
+  \\"version\\": \\"0.0.1\\",
+  \\"description\\": \\"Build and deployment scripts\\",
+  \\"scripts\\": {
+    \\"clean\\": \\"rimraf resources mta_archives mta-op*\\",
+    \\"build\\": \\"rimraf resources mta_archives && mbt build --mtar archive\\",
+    \\"deploy\\": \\"cf deploy mta_archives/archive.mtar --retries 1\\",
+    \\"undeploy\\": \\"cf undeploy rootmta --delete-services --delete-service-keys --delete-service-brokers\\"
+  },
+  \\"devDependencies\\": {
+    \\"mbt\\": \\"^1.2.29\\",
+    \\"rimraf\\": \\"^5.0.5\\"
+  }
+}
+"
+`;
+
+exports[`CF Writer App - Application Frontend Generate deployment configs - Append HTML5 to an existing app frontend router 4`] = `
+"_schema-version: '3.1'
+ID: rootmta
+description: Fiori elements app
+version: 0.0.1
+modules:
+  - name: rootmta-app-content
+    type: com.sap.application.content
+    path: .
+    requires:
+      - name: rootmta-app-front
+        parameters:
+          content-target: true
+      - name: rootmta-uaa
+    parameters:
+      config:
+        destinations:
+          - name: ui5
+            url: 'https://ui5.sap.com'
+    build-parameters:
+      build-result: resources
+      requires:
+        - name: basicapp
+          artifacts:
+            - basicapp.zip
+          target-path: resources/
+  - name: basicapp
+    type: html5
+    path: basicapp
+    build-parameters:
+      builder: custom
+      build-result: dist
+      commands:
+        - npm install
+        - 'npm run build:cf'
+      supported-platforms: []
+resources:
+  - name: rootmta-uaa
+    type: org.cloudfoundry.managed-service
+    parameters:
+      path: ./xs-security.json
+      service: xsuaa
+      service-name: rootmta-xsuaa-service
+      service-plan: application
+  - name: rootmta-app-front
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: app-front
+      service-name: rootmta-app-front-service
+      service-plan: developer
+parameters:
+  deploy_mode: html5-repo
+  enable-parallel-deployments: true
+"
+`;
+
 exports[`CF Writer App - Application Frontend Generate deployment configs - HTML5 App with app frontend service attached with no destination available 1`] = `
 "_schema-version: '3.2'
 ID: comfioritoolslrop

--- a/packages/cf-deploy-config-writer/test/unit/index-appfront.test.ts
+++ b/packages/cf-deploy-config-writer/test/unit/index-appfront.test.ts
@@ -83,4 +83,19 @@ describe('CF Writer App - Application Frontend', () => {
         expect(unitTestFs.read(join(rootPath, 'package.json'))).toMatchSnapshot();
         expect(fs.readFileSync(join(rootPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
     });
+
+    test('Generate deployment configs - Append HTML5 to an existing app frontend router', async () => {
+        const rootName = 'existingappfrontend';
+        const rootPath = join(outputDir, rootName);
+        const appPath = join(rootPath, 'basicapp');
+        fsExtra.mkdirSync(outputDir, { recursive: true });
+        fsExtra.mkdirSync(rootPath);
+        fsExtra.copySync(join(__dirname, `../sample/appfrontendbase`), rootPath); // Base mta
+        fsExtra.copySync(join(__dirname, `../sample/basicapp`), appPath); // Base -> App
+        await generateAppConfig({ appPath, addManagedAppRouter: false, addAppFrontendRouter: false }, unitTestFs);
+        expect(unitTestFs.read(join(appPath, 'xs-app.json'))).toMatchSnapshot();
+        expect(unitTestFs.read(join(rootPath, 'xs-security.json'))).toMatchSnapshot();
+        expect(unitTestFs.read(join(rootPath, 'package.json'))).toMatchSnapshot();
+        expect(fs.readFileSync(join(rootPath, 'mta.yaml'), { encoding: 'utf8' })).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
Fix for https://github.com/SAP/open-ux-tools/issues/3022

- issue found was related the ` name: appfrontend-app-content` being duplicated
- when an existing App Frontend project exists and you append a HTML5 app to the project the existing app frontend router should be udpated
- added tests to cover change
- complexity has increased by 1 but there is another PR coming with cleanups that will address this