### PR TITLE
Refactor: Reuse handleWorkspaceConfig in ADT App Download

### DIFF
--- a/.changeset/spicy-cups-agree.md
+++ b/.changeset/spicy-cups-agree.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/repo-app-import-sub-generator': minor
+'@sap-ux/launch-config': minor
+---
+
+Export handleWorkspaceConfig from launch-config and use in adt app download sub generator

--- a/packages/launch-config/src/index.ts
+++ b/packages/launch-config/src/index.ts
@@ -7,3 +7,4 @@ export { updateLaunchConfig } from './launch-config-crud/update';
 export { getIndexOfArgument, getFioriOptions, generateNewFioriLaunchConfig } from './launch-config-crud/utils';
 export { updateLaunchJSON } from './launch-config-crud/writer';
 export { getDefaultLaunchConfigOptionsForProject } from './project-discovery/project';
+export { handleWorkspaceConfig } from './debug-config/workspaceManager';


### PR DESCRIPTION
Export `handleWorkspaceConfig` from launch-config and reuse in ADT App download sub-generator