### PR TITLE
Repo App Import Invalid dest Fix

### DIFF
--- a/.changeset/tame-frogs-remain.md
+++ b/.changeset/tame-frogs-remain.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': patch
+---
+
+Handle adt app download generator crash due to invalid destinations

--- a/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
+++ b/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
@@ -64,13 +64,16 @@ export async function getPrompts(
                 serviceSelection: { hide: true },
                 systemSelection: { defaultChoice: quickDeployedAppConfig?.serviceProviderInfo?.name }
             },
-            false
+            true
         );
         let appList: AppIndex = [];
         const appSelectionPrompt = [
             {
                 when: async (answers: RepoAppDownloadAnswers): Promise<boolean> => {
-                    if (answers[PromptNames.systemSelection]) {
+                    if (
+                        answers[PromptNames.systemSelection] &&
+                        systemQuestions.answers.connectedSystem?.serviceProvider
+                    ) {
                         appList = await fetchAppListForSelectedSystem(
                             systemQuestions.answers.connectedSystem?.serviceProvider as AbapServiceProvider,
                             quickDeployedAppConfig?.appId

--- a/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
+++ b/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
@@ -76,28 +76,6 @@ describe('getPrompts', () => {
         expect(prompts.find(p => p.name === PromptNames.targetFolder)).toBeTruthy();
     });
 
-    it('should return prompts including system, app, and target folder', async () => {
-        mockGetSystemSelectionQuestions.mockResolvedValue({
-            prompts: [{
-                name: PromptNames.systemSelection,
-                type: 'list',
-                choices: [{ name: 'System 1', value: { system: { name: 'MockSystem' } } }]
-            }],
-            answers: {
-                connectedSystem: { serviceProvider: {} }
-            }
-        });
-
-        mockFetchAppList.mockResolvedValue([{ appId: 'app1', repoName: 'repo1' }]);
-        mockDownloadApp.mockResolvedValue(undefined);
-
-        const prompts = await getPrompts('/app/path');
-        expect(prompts).toBeInstanceOf(Array);
-        expect(prompts.find(p => p.name === PromptNames.systemSelection)).toBeTruthy();
-        expect(prompts.find(p => p.name === PromptNames.selectedApp)).toBeTruthy();
-        expect(prompts.find(p => p.name === PromptNames.targetFolder)).toBeTruthy();
-    });
-
     it('should preselect default system if quickDeployedAppConfig is provided', async () => {
         const quickDeployedAppConfig = {
             appId: 'app1',

--- a/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
+++ b/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
@@ -76,6 +76,28 @@ describe('getPrompts', () => {
         expect(prompts.find(p => p.name === PromptNames.targetFolder)).toBeTruthy();
     });
 
+    it('should return prompts including system, app, and target folder', async () => {
+        mockGetSystemSelectionQuestions.mockResolvedValue({
+            prompts: [{
+                name: PromptNames.systemSelection,
+                type: 'list',
+                choices: [{ name: 'System 1', value: { system: { name: 'MockSystem' } } }]
+            }],
+            answers: {
+                connectedSystem: { serviceProvider: {} }
+            }
+        });
+
+        mockFetchAppList.mockResolvedValue([{ appId: 'app1', repoName: 'repo1' }]);
+        mockDownloadApp.mockResolvedValue(undefined);
+
+        const prompts = await getPrompts('/app/path');
+        expect(prompts).toBeInstanceOf(Array);
+        expect(prompts.find(p => p.name === PromptNames.systemSelection)).toBeTruthy();
+        expect(prompts.find(p => p.name === PromptNames.selectedApp)).toBeTruthy();
+        expect(prompts.find(p => p.name === PromptNames.targetFolder)).toBeTruthy();
+    });
+
     it('should preselect default system if quickDeployedAppConfig is provided', async () => {
         const quickDeployedAppConfig = {
             appId: 'app1',
@@ -166,6 +188,27 @@ describe('getPrompts', () => {
         if (targetFolderPrompt) {
             expect(targetFolderPrompt.when).toBeTruthy();
         }
+    });
+
+    it('should call getSystemSelectionQuestions with expected args when invalid destination is selecte by user', async () => {
+        mockGetSystemSelectionQuestions.mockResolvedValue({
+            prompts: [{
+                name: PromptNames.systemSelection,
+                type: 'list',
+                choices: [{ name: 'System 1', value: { system: { name: 'MockSystem' } } }]
+            }],
+            answers: {}
+        });
+    
+        const prompts = await getPrompts('/app/path');
+        expect(mockGetSystemSelectionQuestions).toHaveBeenCalledWith(
+            {
+                serviceSelection: { hide: true },
+                systemSelection: { defaultChoice: undefined }
+            },
+            true
+        );
+        expect(prompts.find(p => p.name === PromptNames.systemSelection)).toBeTruthy();
     });
 });
 


### PR DESCRIPTION
This PR addresses a crash in the generator occurring when invalid destinations are encountered in BAS.

