### PR TITLE
fix: correct control aggregation for object page when fcl is enabled

### DIFF
--- a/.changeset/grumpy-olives-relate.md
+++ b/.changeset/grumpy-olives-relate.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Method "generateObjectPage": Incorrect 'controlAggregation' applied when a new Object Page is added and FCL is enabled

--- a/packages/fe-fpm-writer/src/page/object.ts
+++ b/packages/fe-fpm-writer/src/page/object.ts
@@ -15,9 +15,13 @@ function enhanceData(data: ObjectPage, manifest: Manifest): InternalObjectPage {
     const config: InternalObjectPage = {
         ...data,
         settings: initializeTargetSettings(data, data.settings),
-        name: PageType.ObjectPage,
-        ...getFclConfig(manifest)
+        name: PageType.ObjectPage
     };
+
+    // set FCL configuration
+    const fclConfig = getFclConfig(manifest, config.navigation);
+    config.fcl = fclConfig.fcl;
+    config.controlAggregation = fclConfig.controlAggregation;
 
     // set library dependencies
     config.libraries = getLibraryDependencies(PageType.ObjectPage);

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/object.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/object.test.ts.snap
@@ -1,5 +1,120 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ObjectPage FCL is enabled Create 2nd level page 1`] = `
+Object {
+  "config": Object {
+    "routerClass": "sap.f.routing.Router",
+  },
+  "routes": Array [
+    Object {
+      "name": "RootEntityObjectPage",
+      "pattern": "RootEntity({key}):?query:",
+      "target": Array [
+        "RootEntityObjectPage",
+      ],
+    },
+    Object {
+      "name": "ChildEntityObjectPage",
+      "pattern": "RootEntity({key})/navToChildEntity({navToChildEntityKey}):?query:",
+      "target": Array [
+        "RootEntityObjectPage",
+        "ChildEntityObjectPage",
+      ],
+    },
+  ],
+  "targets": Object {
+    "ChildEntityObjectPage": Object {
+      "controlAggregation": "midColumnPages",
+      "id": "ChildEntityObjectPage",
+      "name": "sap.fe.templates.ObjectPage",
+      "options": Object {
+        "settings": Object {
+          "contextPath": "/ChildEntity",
+          "navigation": Object {},
+        },
+      },
+      "type": "Component",
+    },
+    "RootEntityListReport": Object {},
+    "RootEntityObjectPage": Object {
+      "options": Object {
+        "settings": Object {
+          "navigation": Object {
+            "navToChildEntity": Object {
+              "detail": Object {
+                "route": "ChildEntityObjectPage",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`ObjectPage FCL is enabled Create 3rd level page 1`] = `
+Object {
+  "config": Object {
+    "routerClass": "sap.f.routing.Router",
+  },
+  "routes": Array [
+    Object {
+      "name": "RootEntityListReport",
+      "pattern": ":?query:",
+      "target": Array [
+        "TestListReport",
+      ],
+    },
+    Object {
+      "name": "RootEntityObjectPage",
+      "pattern": "RootEntity({RootEntityKey}):?query:",
+      "target": Array [
+        "TestListReport",
+        "RootEntityObjectPage",
+      ],
+    },
+    Object {
+      "name": "ChildEntityObjectPage",
+      "pattern": "RootEntity({RootEntityKey})/navToChildEntity({navToChildEntityKey}):?query:",
+      "target": Array [
+        "TestListReport",
+        "RootEntityObjectPage",
+        "ChildEntityObjectPage",
+      ],
+    },
+  ],
+  "targets": Object {
+    "ChildEntityObjectPage": Object {
+      "controlAggregation": "endColumnPages",
+      "id": "ChildEntityObjectPage",
+      "name": "sap.fe.templates.ObjectPage",
+      "options": Object {
+        "settings": Object {
+          "contextPath": "/ChildEntity",
+          "navigation": Object {},
+        },
+      },
+      "type": "Component",
+    },
+    "RootEntityListReport": Object {},
+    "RootEntityObjectPage": Object {
+      "options": Object {
+        "settings": Object {
+          "navigation": Object {
+            "navToChildEntity": Object {
+              "detail": Object {
+                "route": "ChildEntityObjectPage",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`ObjectPage generate Add library dependency \`sap.fe.templates\`  1`] = `
 Object {
   "libs": Object {


### PR DESCRIPTION
Issue #3170

Scenario:
1. Use `manifest.json` with routing like:
```
"routing": {
            "config": {
                "flexibleColumnLayout": {
                    "defaultTwoColumnLayoutType": "TwoColumnsBeginExpanded",
                    "defaultThreeColumnLayoutType": "ThreeColumnsMidExpanded"
                },
                "routerClass": "sap.f.routing.Router"
            },
            "routes": [
                {
                    "pattern": ":?query:",
                    "name": "TripsList",
                    "target": [
                        "TripsList"
                    ]
                },
                {
                    "name": "TripsObjectPage",
                    "pattern": "Trips({TripsKey}):?query:",
                    "target": [
                        "TripsList",
                        "TripsObjectPage"
                    ]
                }
            ],
            "targets": {
                "TripsList": {
                    "type": "Component",
                    "id": "TripsList",
                    "name": "sap.fe.templates.ListReport",
                    "options": {
                        "settings": {
                            "contextPath": "/Trips",
                            "variantManagement": "Page",
                            "initialLoad": "Enabled",
                            "navigation": {
                                "Trips": {
                                    "detail": {
                                        "route": "TripsObjectPage"
                                    }
                                }
                            }
                        }
                    },
                    "controlAggregation": "beginColumnPages",
                    "contextPattern": ""
                },
                "TripsObjectPage": {
                    "type": "Component",
                    "id": "TripsObjectPage",
                    "name": "sap.fe.templates.ObjectPage",
                    "controlAggregation": "midColumnPages",
                    "options": {
                        "settings": {
                            "navigation": {},
                            "contextPath": "/Trips"
                        }
                    },
                    "contextPattern": "/Trips({TripsKey})"
                }
            }
        },
```
2. Add new object page to `TripsObjectPage` while FCL is enabled.


Problem - `controlAggregation` of new Object Page is `beginColumnPages` instead of `endColumnPages`

Issue `navigation` was not passed to method `getFclConfig`