### PR TITLE
fix(fiori-sub-gen): check enable typescript answer to determine use of npm workspaces

### DIFF
--- a/.changeset/nine-cows-tell.md
+++ b/.changeset/nine-cows-tell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-app-sub-generator': patch
+---
+
+check enable typescript answer to determine use of npm workspaces

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -408,6 +408,7 @@ export class FioriAppGenerator extends Generator {
                     enableCodeAssist: this.state.project?.enableCodeAssist ?? false,
                     // Assumption that npm workspaces will be enabled if cds ui5 plugin is a depenedency
                     useNpmWorkspaces: !!(
+                        this.state.project.enableTypeScript || // If typescript is enabled, it is required that the CAP project will be updated to use NPM workspaces
                         this.state.service.capService?.cdsUi5PluginInfo?.isCdsUi5PluginEnabled ||
                         this.state.service.capService?.cdsUi5PluginInfo?.hasCdsUi5Plugin ||
                         this.state.service.capService?.cdsUi5PluginInfo?.isWorkspaceEnabled

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
@@ -10,7 +10,7 @@ import {
 } from '@sap-ux/fiori-freestyle-writer';
 import type { BasicAppSettings } from '@sap-ux/fiori-freestyle-writer/dist/types';
 import { DefaultLogger, TelemetryHelper, sendTelemetry } from '@sap-ux/fiori-generator-shared';
-import { DatasourceType } from '@sap-ux/odata-service-inquirer';
+import { type CapService, DatasourceType } from '@sap-ux/odata-service-inquirer';
 import { ServiceType } from '@sap-ux/odata-service-writer';
 import { join } from 'path';
 import Generator from 'yeoman-generator';
@@ -354,6 +354,35 @@ describe('Test FioriAppGenerator', () => {
             expect.objectContaining({ debug: expect.any(Function) }) // Logger
         );
         (installDependencies as jest.Mock).mockClear();
+
+        // Should call installDependencies with useNpmWorkspaces as enableTypescript is true
+        fioriAppGen['state'] = {
+            ...mockState,
+            project: {
+                ...mockState.project,
+                enableTypeScript: true
+            },
+            service: {
+                ...mockState.service,
+                capService: {
+                    ...mockState.service.capService,
+                    cdsUi5PluginInfo: {
+                        isCdsUi5PluginEnabled: false,
+                        hasCdsUi5Plugin: false,
+                        hasMinCdsVersion: true,
+                        isWorkspaceEnabled: false
+                    }
+                } as CapService
+            }
+        };
+
+        await fioriAppGen.install();
+        expect(installDependencies).toHaveBeenCalledWith(
+            expect.objectContaining({ useNpmWorkspaces: true }),
+            expect.objectContaining({ debug: expect.any(Function) }) // Logger
+        );
+        (installDependencies as jest.Mock).mockClear();
+
         // Should skip installation if option specified
         fioriAppGen = new FioriAppGenerator([], { ...options, skipInstall: true });
         await fioriAppGen.install();


### PR DESCRIPTION
If enable typescript prompt is answered as true, it is required that the CAP project will be updated to use NPM workspaces