### PR TITLE
feat(fiori-annotation-api): relax metadata reference check

### DIFF
--- a/.changeset/old-timers-greet.md
+++ b/.changeset/old-timers-greet.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-annotation-core': patch
+---
+
+fix: `toFullyQualifiedPath` replaces unknown namespace or alias with `undefined`.

--- a/.changeset/quiet-dolphins-shop.md
+++ b/.changeset/quiet-dolphins-shop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-annotation-api': minor
+---
+
+feat: for XML projects relax metadata reference check in annotation files.

--- a/packages/fiori-annotation-api/jest.setup.js
+++ b/packages/fiori-annotation-api/jest.setup.js
@@ -40,6 +40,6 @@ module.exports = function () {
     }
 
     for (const projectPath of CDS_PROJECTS) {
-        // npmInstall(projectPath);
+        npmInstall(projectPath);
     }
 };

--- a/packages/fiori-annotation-api/jest.setup.js
+++ b/packages/fiori-annotation-api/jest.setup.js
@@ -40,6 +40,6 @@ module.exports = function () {
     }
 
     for (const projectPath of CDS_PROJECTS) {
-        npmInstall(projectPath);
+        // npmInstall(projectPath);
     }
 };

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -2641,6 +2641,31 @@ Actions: []
 ActionImports: []"
 `;
 
+exports[`fiori annotation service read xml missing metadata alias 1`] = `
+"webapp/annotations/annotation.xml:
+    IncidentService.Incidents [(10,16)..(12,29),(13,16)..(15,29)]:
+        com.sap.vocabularies.UI.v1.LineItem#a (10,16)..(12,29): (Collection) []
+        com.sap.vocabularies.UI.v1.LineItem#b (13,16)..(15,29): (Collection) []
+"
+`;
+
+exports[`fiori annotation service read xml missing metadata reference  1`] = `
+"webapp/annotations/annotation.xml:
+    IncidentService.Incidents [(8,16)..(10,29),(11,16)..(13,29)]:
+        com.sap.vocabularies.UI.v1.LineItem#a (8,16)..(10,29): (Collection) []
+        com.sap.vocabularies.UI.v1.LineItem#b (11,16)..(13,29): (Collection) []
+"
+`;
+
+exports[`fiori annotation service read xml missing metadata reference (no alias in metadata) 1`] = `
+"webapp/annotations/annotation.xml:
+    IncidentService.Incidents [(8,16)..(10,29)]:
+        com.sap.vocabularies.UI.v1.LineItem#a (8,16)..(10,29): (Collection) []
+    Service.Incidents [(13,16)..(15,29)]:
+        com.sap.vocabularies.UI.v1.LineItem#b (13,16)..(15,29): (Collection) []
+"
+`;
+
 exports[`fiori annotation service read xml v2-app 1`] = `
 "webapp/localService/metadata.xml:
 webapp/annotations/annotation.xml:

--- a/packages/fiori-annotation-api/test/unit/raw-metadata-serializer.ts
+++ b/packages/fiori-annotation-api/test/unit/raw-metadata-serializer.ts
@@ -8,7 +8,8 @@ import type {
     AnnotationRecord,
     RawSchema,
     RawAction,
-    RawActionImport
+    RawActionImport,
+    AnnotationList
 } from '@sap-ux/vocabularies-types';
 import type { Range } from 'vscode-languageserver-textdocument';
 
@@ -35,11 +36,20 @@ function adaptedUrl(url: string, root: string): string {
 }
 
 export function serialize(schema: RawSchema, root: string): string {
+    return [
+        serializeAnnotations(schema.annotations, root),
+        'Actions: ' + serializeActions(schema.actions, 0),
+        'ActionImports: ' + serializeActionImports(schema.actionImports, 0)
+    ].join('\n');
+}
+export function serializeAnnotations(
+    annotations: {
+        [id: string]: AnnotationList[];
+    },
+    root: string
+): string {
     let result = '';
     let indent = 0;
-    const annotations = schema.annotations;
-    const actions = schema.actions;
-    const actionImports = schema.actionImports;
 
     const files = Object.keys(annotations);
     for (const uri of files) {
@@ -52,10 +62,6 @@ export function serialize(schema: RawSchema, root: string): string {
         }
         indent--;
     }
-
-    result += '\nActions: ' + serializeActions(actions, indent);
-
-    result += '\nActionImports: ' + serializeActionImports(actionImports, indent);
 
     return result;
 }

--- a/packages/odata-annotation-core/src/paths/normalization.ts
+++ b/packages/odata-annotation-core/src/paths/normalization.ts
@@ -4,11 +4,12 @@ import type { ParsedPath, ParsedPathSegment } from './parse';
 import { PATH_SEPARATOR } from './parse';
 
 /**
+ * Converts path to fully qualified representation.
  *
- * @param namespaceMap
- * @param currentNamespace
- * @param path
- * @returns
+ * @param namespaceMap namespace map
+ * @param currentNamespace namespace
+ * @param path path
+ * @returns fully qualified path string
  */
 export function toFullyQualifiedPath(
     namespaceMap: { [aliasOrNamespace: string]: string },
@@ -42,13 +43,13 @@ function toFullyQualifiedPathSegment(
                 .filter((parameter): parameter is string => !!parameter)
                 .join(',');
 
-            return `${namespace}.${segment.name}(${parameters})`;
+            return `${namespace ?? segment.namespaceOrAlias}.${segment.name}(${parameters})`;
         }
         case 'identifier':
             if (segment.namespaceOrAlias === undefined) {
                 return segment.name;
             }
-            return `${namespace}.${segment.name}`;
+            return `${namespace ?? segment.namespaceOrAlias}.${segment.name}`;
         case 'term-cast':
             return `@${toFullyQualifiedName(namespaceMap, currentNamespace, { ...segment, type: 'identifier' }) ?? ''}${
                 segment.qualifier ? '#' + segment.qualifier : ''

--- a/packages/odata-annotation-core/test/paths/normalization.test.ts
+++ b/packages/odata-annotation-core/test/paths/normalization.test.ts
@@ -15,30 +15,40 @@ describe('path normalization', () => {
 
     test('nav prop annotation', () => {
         const result = testPath('MySchema.MyEntityType/MyNavigationProperty@Common.Label');
-        expect(result).toMatchInlineSnapshot(
-            `"MyNamespace.MyEntityType/MyNamespace.MyNavigationProperty@com.sap.vocabularies.Common.v1.Label"`
+        expect(result).toStrictEqual(
+            'MyNamespace.MyEntityType/MyNamespace.MyNavigationProperty@com.sap.vocabularies.Common.v1.Label'
         );
     });
 
     test('nav prop annotation with qualifier', () => {
         const result = testPath('MySchema.MyEntityType/MyNavigationProperty@Common.Label#q1');
-        expect(result).toMatchInlineSnapshot(
-            `"MyNamespace.MyEntityType/MyNamespace.MyNavigationProperty@com.sap.vocabularies.Common.v1.Label#q1"`
+        expect(result).toStrictEqual(
+            'MyNamespace.MyEntityType/MyNamespace.MyNavigationProperty@com.sap.vocabularies.Common.v1.Label#q1'
         );
     });
 
     test('action', () => {
         const result = testPath('testAction(MySchema.MyEntityType)');
-        expect(result).toMatchInlineSnapshot(`"MyNamespace.testAction(MyNamespace.MyEntityType)"`);
+        expect(result).toStrictEqual('MyNamespace.testAction(MyNamespace.MyEntityType)');
+    });
+
+    test('action with unknown namespace', () => {
+        const result = testPath('unknown.testAction(MySchema.MyEntityType)');
+        expect(result).toStrictEqual('unknown.testAction(MyNamespace.MyEntityType)');
     });
 
     test('identifier alone', () => {
         const result = testPath('MyEntityType');
-        expect(result).toMatchInlineSnapshot(`"MyEntityType"`);
+        expect(result).toStrictEqual('MyEntityType');
+    });
+
+    test('unknown namespace in identifier', () => {
+        const result = testPath('unknown.MyEntityType');
+        expect(result).toStrictEqual('unknown.MyEntityType');
     });
 
     test('term-cast', () => {
         const result = testPath('@Common.Label#q1');
-        expect(result).toMatchInlineSnapshot(`"@com.sap.vocabularies.Common.v1.Label#q1"`);
+        expect(result).toStrictEqual('@com.sap.vocabularies.Common.v1.Label#q1');
     });
 });


### PR DESCRIPTION
UI5 runtime also works with annotations files without references to the metadata, so we should not prevent tools from working in such cases either. We should still report this as warning since it does not conform with the OData spec, but currently we can only throw errors.