### PR TITLE
fix(abap-deploy-config-inquirer): Re-auth should not be required

### DIFF
--- a/.changeset/loud-beers-know.md
+++ b/.changeset/loud-beers-know.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+Fix for re-authentication should not be required

--- a/.changeset/loud-beers-know.md
+++ b/.changeset/loud-beers-know.md
@@ -2,4 +2,4 @@
 '@sap-ux/abap-deploy-config-inquirer': patch
 ---
 
-Fix for re-authentication should not be required
+Fixes re-authentication should not be required

--- a/packages/abap-deploy-config-inquirer/src/utils.ts
+++ b/packages/abap-deploy-config-inquirer/src/utils.ts
@@ -82,7 +82,7 @@ export function isSameSystem(abapSystem?: SystemConfig, url?: string, client?: s
     return Boolean(
         (abapSystem?.url &&
             abapSystem.url.trim()?.replace(/\/$/, '') === url?.trim()?.replace(/\/$/, '') &&
-            abapSystem.client === client) ??
+            abapSystem.client === client) ||
             (!!abapSystem?.destination && destination === abapSystem?.destination)
     );
 }

--- a/packages/abap-deploy-config-inquirer/test/utils.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/utils.test.ts
@@ -104,7 +104,9 @@ describe('Test utils', () => {
         // destination
         const destination = mockDestinations.Dest1;
         const abapSystemDest = {
-            destination: 'Dest1'
+            destination: 'Dest1',
+            client: '100', // should be ignored since dest is defined
+            url: 'http://dest.btp.url' // should be ignored since dest is defined
         };
         expect(isSameSystem(abapSystemDest, undefined, undefined, destination.Name)).toBe(true);
     });


### PR DESCRIPTION
#3194 

- Replace `??` with logical OR `||` for correct behaviour (thx Sonar 😞  )
- Update test to replicate real world scenario where the bug occurred