### PR TITLE
fix(odata-service-writer): avoid double slashes when adding new odata service 

### DIFF
--- a/.changeset/swift-pandas-juggle.md
+++ b/.changeset/swift-pandas-juggle.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Fix: Avoid double slashes when adding new OData service

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -232,6 +232,21 @@ function removeUnusedAnnotations(
 }
 
 /**
+ * Resolves the local service URI by joining the service name and technical name,
+ * ensuring that no double slashes appear.
+ *
+ * @param serviceName - the name of the service (may contain slashes).
+ * @param technicalName - the technical name or path of the service (may contain slashes).
+ * @returns The resolved local service URI in the format `localService/{serviceName}/{technicalName}.xml`.
+ */
+function resolveLocalServiceUri(serviceName: string, technicalName: string): string {
+    // Remove beginning and end forward slashes
+    serviceName = serviceName.replace(/^\/+|\/+$/g, '');
+    technicalName = technicalName.replace(/^\/+|\/+$/g, '');
+    return `localService/${serviceName}/${technicalName}.xml`;
+}
+
+/**
  * Adds remote annotations to manifest dataSources and removes unused annotations by the service.
  *
  * @param {Editor} fs - the memfs editor instance
@@ -260,7 +275,7 @@ function addRemoteAnnotationDataSources(
                     )}',Version='0001')/$value/`,
                     type: 'ODataAnnotation',
                     settings: {
-                        localUri: `localService/${serviceName}/${remoteAnnotation.technicalName}.xml`
+                        localUri: resolveLocalServiceUri(serviceName, remoteAnnotation.technicalName)
                     }
                 };
                 createdAnnotations.push(remoteAnnotation.name);
@@ -273,7 +288,7 @@ function addRemoteAnnotationDataSources(
             )}',Version='0001')/$value/`,
             type: 'ODataAnnotation',
             settings: {
-                localUri: `localService/${serviceName}/${serviceRemoteAnnotations.technicalName}.xml`
+                localUri: resolveLocalServiceUri(serviceName, serviceRemoteAnnotations.technicalName)
             }
         };
         createdAnnotations.push(serviceRemoteAnnotations.name);

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -232,20 +232,6 @@ function removeUnusedAnnotations(
 }
 
 /**
- * Resolves the local service URI by joining the service name and technical name,
- * ensuring that no double slashes appear.
- *
- * @param serviceName - the name of the service (may contain slashes).
- * @param technicalName - the technical name or path of the service (may contain slashes).
- * @returns The resolved local service URI in the format `localService/{serviceName}/{technicalName}.xml`.
- */
-function resolveLocalServiceUri(serviceName: string, technicalName: string): string {
-    // Remove beginning and end forward slashes
-    technicalName = technicalName.replace(/^\/+|\/+$/g, '');
-    return `localService/${serviceName}/${technicalName}.xml`;
-}
-
-/**
  * Adds remote annotations to manifest dataSources and removes unused annotations by the service.
  *
  * @param {Editor} fs - the memfs editor instance
@@ -274,7 +260,7 @@ function addRemoteAnnotationDataSources(
                     )}',Version='0001')/$value/`,
                     type: 'ODataAnnotation',
                     settings: {
-                        localUri: resolveLocalServiceUri(serviceName, remoteAnnotation.technicalName)
+                        localUri: `localService/${serviceName}/${trimSlashes(remoteAnnotation.technicalName)}.xml`
                     }
                 };
                 createdAnnotations.push(remoteAnnotation.name);
@@ -287,7 +273,7 @@ function addRemoteAnnotationDataSources(
             )}',Version='0001')/$value/`,
             type: 'ODataAnnotation',
             settings: {
-                localUri: resolveLocalServiceUri(serviceName, serviceRemoteAnnotations.technicalName)
+                localUri: `localService/${serviceName}/${trimSlashes(serviceRemoteAnnotations.technicalName)}.xml`
             }
         };
         createdAnnotations.push(serviceRemoteAnnotations.name);
@@ -539,4 +525,20 @@ export async function updateManifest(
     // Update manifest.json services
     enhanceManifest(service, convertedManifest, webappPath, fs, forceServiceUpdate);
     fs.writeJSON(manifestPath, convertedManifest);
+}
+
+/**
+ * Trims leading and trailing slashes from the input string.
+ *
+ * @param input - the string from which leading and trailing slashes will be removed.
+ * @returns The input string with leading and trailing slashes removed.
+ */
+function trimSlashes(input: string): string {
+    while (input.startsWith('/')) {
+        input = input.slice(1);
+    }
+    while (input.endsWith('/')) {
+        input = input.slice(0, -1);
+    }
+    return input;
 }

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -241,7 +241,6 @@ function removeUnusedAnnotations(
  */
 function resolveLocalServiceUri(serviceName: string, technicalName: string): string {
     // Remove beginning and end forward slashes
-    serviceName = serviceName.replace(/^\/+|\/+$/g, '');
     technicalName = technicalName.replace(/^\/+|\/+$/g, '');
     return `localService/${serviceName}/${technicalName}.xml`;
 }

--- a/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
@@ -2900,7 +2900,7 @@ Object {
         \\"uri\\": \\"/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/\\",
         \\"type\\": \\"ODataAnnotation\\",
         \\"settings\\": {
-          \\"localUri\\": \\"localService/mainService//SEPM_XYZ/SERVICE.xml\\"
+          \\"localUri\\": \\"localService/mainService/SEPM_XYZ/SERVICE.xml\\"
         }
       },
       \\"mainService\\": {

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -332,7 +332,7 @@ describe('manifest', () => {
                 type: ServiceType.EDMX,
                 annotations: [
                     {
-                        technicalName: '/dummy/myservice/aname/',
+                        technicalName: '//dummy/myservice/aname//',
                         xml: 'annotation1xml',
                         name: 'annotation1'
                     }

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -305,6 +305,50 @@ describe('manifest', () => {
             expect(manifestJson).toEqual(expectedEdmxManifestMultipleServices);
         });
 
+        test('Sanitize annotation local uri', async () => {
+            const testManifest = {
+                'sap.app': {
+                    id: 'test.update.manifest',
+                    dataSources: {
+                        'mainService': {
+                            type: 'OData'
+                        }
+                    }
+                },
+                'sap.ui5': {
+                    models: {
+                        '': {
+                            dataSource: 'mainService'
+                        }
+                    }
+                }
+            };
+            const service: OdataService = {
+                version: OdataVersion.v2,
+                client: '123',
+                model: 'amodel',
+                name: 'aname',
+                path: '/a/path',
+                type: ServiceType.EDMX,
+                annotations: [
+                    {
+                        technicalName: '/dummy/myservice/aname/',
+                        xml: 'annotation1xml',
+                        name: 'annotation1'
+                    }
+                ],
+                localAnnotationsName: 'localTest'
+            };
+
+            fs.writeJSON('./webapp/manifest.json', testManifest);
+            // Call updateManifest
+            await updateManifest('./', service, fs);
+            const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+            expect(manifestJson['sap.app']?.dataSources?.annotation1.settings).toEqual({
+                'localUri': 'localService/aname/dummy/myservice/aname.xml'
+            });
+        });
+
         test('Ensure manifest updates are updated as expected as in edmx projects with older services', async () => {
             // Test to basically check whether existing service definitions are updated (localUri attribute is modified)
             const testManifest = {


### PR DESCRIPTION
Problem happens if we pass service like:
```
{
  annotations: [
    {
      technicalName: '/TEST/DUMMY_SERVICE'
    }
  ]
}
```
then double forward slash is added here:
![image](https://github.com/user-attachments/assets/ea571379-ec3a-431d-abba-d35c4180ee1e)

As fix - sanitize trailing slashes before creating uri for `settings.localUri` - [trimSlashes](https://github.com/SAP/open-ux-tools/blob/fix/avoidDoubleSlashesWhenAddingNewDataSource/packages/odata-service-writer/src/data/manifest.ts#L536-L544)