### PR TITLE
Fix App Select Prompt Display Issue When Switching Systems

### DIFF
--- a/.changeset/dull-cheetahs-float.md
+++ b/.changeset/dull-cheetahs-float.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': patch
+---
+
+refactor: update logging for missing required fields and enhance prompt options

--- a/packages/repo-app-import-sub-generator/src/prompts/prompt-helpers.ts
+++ b/packages/repo-app-import-sub-generator/src/prompts/prompt-helpers.ts
@@ -57,7 +57,7 @@ export const formatAppChoices = (appList: AppIndex): Array<{ name: string; value
         .filter((app: AppItem) => {
             const hasRequiredFields = app['sap.app/id'] && app['sap.app/title'] && app['repoName'] && app['url'];
             if (!hasRequiredFields) {
-                RepoAppDownloadLogger.logger?.error(t('error.requiredFieldsMissing', { app: JSON.stringify(app) }));
+                RepoAppDownloadLogger.logger?.warn(t('warn.requiredFieldsMissing', { app: app.appId }));
             }
             return hasRequiredFields;
         })

--- a/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
+++ b/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
@@ -89,7 +89,8 @@ export async function getPrompts(
                 default: () => (quickDeployedAppConfig?.appId ? 0 : undefined),
                 guiOptions: {
                     mandatory: !!appList.length,
-                    breadcrumb: t('prompts.appSelection.breadcrumb')
+                    breadcrumb: t('prompts.appSelection.breadcrumb'),
+                    applyDefaultWhenDirty: true
                 },
                 message: t('prompts.appSelection.message'),
                 choices: (): { name: string; value: AppInfo }[] => (appList.length ? formatAppChoices(appList) : []),

--- a/packages/repo-app-import-sub-generator/src/translations/repo-app-import-sub-generator.i18n.json
+++ b/packages/repo-app-import-sub-generator/src/translations/repo-app-import-sub-generator.i18n.json
@@ -3,7 +3,6 @@
         "telemetry": "Failed to send telemetry data after downloading the application from the SAPUI5 ABAP Repository. {{- error}}",
         "qfaJsonNotFound": "{{- jsonFileName }} not found in the downloaded application. Ensure the downloaded application is properly deployed to the ABAP repository.",
         "replaceWebappFilesError": "An error occurred when replacing files in the downloaded application: {{- error}}. For more information, view the logs.",
-        "requiredFieldsMissing": "Required fields are missing for the {{- app }} application. Check if the application is deployed correctly.",
         "applicationListFetchError": "An error occurred when fetching the application list: {{- error}}. Check if your application is available in the system.",
         "metadataFetchError": "An error occurred when fetching metadata: {{- error}}. For more information, view the logs.",
         "appConfigGenError": "An error occurred when generating the application configuration: {{- error}}. For more information, view the logs.",
@@ -44,7 +43,8 @@
         }
     },
     "warn": {
-        "extractedFileNotFound": "Extracted file not found - {{- extractedFilePath}}. For more information, view the logs."
+        "extractedFileNotFound": "Extracted file not found - {{- extractedFilePath}}. For more information, view the logs.",
+        "requiredFieldsMissing": "Required fields are missing for the {{- appId }} application. Check if the application is deployed correctly."
     },
     "prompts": {
         "appSelection": {

--- a/packages/repo-app-import-sub-generator/test/prompts/prompt-helpers.test.ts
+++ b/packages/repo-app-import-sub-generator/test/prompts/prompt-helpers.test.ts
@@ -8,7 +8,8 @@ import RepoAppDownloadLogger from '../../src/utils/logger';
 
 jest.mock('../../src/utils/logger', () => ({
     logger: {
-        error: jest.fn()
+        error: jest.fn(),
+        warn: jest.fn()
     }
 }));
 
@@ -99,13 +100,13 @@ describe('formatAppChoices', () => {
     it('should log error if required fields are missing', () => {
         const appList: AppIndex = [invalidApp];
         const result = formatAppChoices(appList);
-        expect(RepoAppDownloadLogger.logger.error).toBeCalledWith( t('error.requiredFieldsMissing', { app: JSON.stringify(appList) }) );
+        expect(RepoAppDownloadLogger.logger.warn).toBeCalledWith( t('warn.requiredFieldsMissing', { app: JSON.stringify(appList) }) );
     });
 
     it('should handle a mix of valid and invalid apps by throwing an error', () => {
         const appList: AppIndex = [validApp, invalidApp];
         const result = formatAppChoices(appList);
-        expect(RepoAppDownloadLogger.logger.error).toBeCalledWith( t('error.requiredFieldsMissing', { app: JSON.stringify(appList) }) );
+        expect(RepoAppDownloadLogger.logger.warn).toBeCalledWith( t('warn.requiredFieldsMissing', { app: JSON.stringify(appList) }) );
     });
 
     it('should return an empty array if the app list is empty', () => {

--- a/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
+++ b/packages/repo-app-import-sub-generator/test/prompts/prompts.test.ts
@@ -100,7 +100,8 @@ describe('getPrompts', () => {
         expect(appSelectionPrompt).toHaveProperty('message', t('prompts.appSelection.message'));
         expect(appSelectionPrompt).toHaveProperty('guiOptions', {
             mandatory: false,
-            breadcrumb: t('prompts.appSelection.breadcrumb')
+            breadcrumb: t('prompts.appSelection.breadcrumb'),
+            applyDefaultWhenDirty: true
         });
         expect(await (appSelectionPrompt as any)?.validate(appValue)).toBe(true);
         expect((appSelectionPrompt as any)?.default()).toBe(undefined);
@@ -165,7 +166,8 @@ describe('getPrompts', () => {
         expect(appSelectionPrompt).toHaveProperty('message', t('prompts.appSelection.message'));
         expect(appSelectionPrompt).toHaveProperty('guiOptions', {
             mandatory: false,
-            breadcrumb: t('prompts.appSelection.breadcrumb')
+            breadcrumb: t('prompts.appSelection.breadcrumb'),
+            applyDefaultWhenDirty: true
         });
         expect(await (appSelectionPrompt as any)?.validate(appValue)).toBe(true);
         expect((appSelectionPrompt as any)?.default()).toBe(0);


### PR DESCRIPTION
This PR fixes an issue in the `@sap-ux/repo-import-app-sub-generator` package where the App Select Prompt incorrectly displays `[Object] [Object]` instead of Click to Display List when switching systems after selecting an app. The issue occurs because the prompt state is not properly reset when switching systems.