### PR TITLE
fix(odata-service-writer): Write service annotations using `name` instead of `technicalName` to avoid sub folders

### DIFF
--- a/.changeset/light-dryers-jump.md
+++ b/.changeset/light-dryers-jump.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Write service annotations using `name` instead of `technicalName` to avoid sub folders

--- a/packages/odata-service-writer/src/data/annotations.ts
+++ b/packages/odata-service-writer/src/data/annotations.ts
@@ -262,14 +262,14 @@ export async function writeRemoteServiceAnnotationXmlFiles(
             const annotation = edmxAnnotations[annotationName];
             if (annotation?.xml) {
                 fs.write(
-                    join(webappPath, DirName.LocalService, serviceName, `${annotation.technicalName}.xml`),
+                    join(webappPath, DirName.LocalService, serviceName, `${annotation.name}.xml`),
                     prettifyXml(annotation.xml, { indent: 4 })
                 );
             }
         }
     } else if (edmxAnnotations?.xml) {
         fs.write(
-            join(webappPath, DirName.LocalService, serviceName, `${edmxAnnotations.technicalName}.xml`),
+            join(webappPath, DirName.LocalService, serviceName, `${edmxAnnotations.name}.xml`),
             prettifyXml(edmxAnnotations.xml, { indent: 4 })
         );
     }

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -260,7 +260,7 @@ function addRemoteAnnotationDataSources(
                     )}',Version='0001')/$value/`,
                     type: 'ODataAnnotation',
                     settings: {
-                        localUri: `localService/${serviceName}/${remoteAnnotation.technicalName}.xml`
+                        localUri: `localService/${serviceName}/${remoteAnnotation.name}.xml`
                     }
                 };
                 createdAnnotations.push(remoteAnnotation.name);
@@ -273,7 +273,7 @@ function addRemoteAnnotationDataSources(
             )}',Version='0001')/$value/`,
             type: 'ODataAnnotation',
             settings: {
-                localUri: `localService/${serviceName}/${serviceRemoteAnnotations.technicalName}.xml`
+                localUri: `localService/${serviceName}/${serviceRemoteAnnotations.name}.xml`
             }
         };
         createdAnnotations.push(serviceRemoteAnnotations.name);

--- a/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
@@ -2821,7 +2821,7 @@ Object {
             mockdataPath: ./webapp/localService/mainService/data
             generateMockData: true
         annotations:
-          - localPath: ./webapp/localService/mainService/SEPM_XYZ/SERVICE.xml
+          - localPath: ./webapp/localService/mainService/SEPM_XYZ_SERVICE.xml
             urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/
 ",
     "state": "modified",
@@ -2851,7 +2851,7 @@ Object {
             mockdataPath: ./webapp/localService/mainService/data
             generateMockData: true
         annotations:
-          - localPath: ./webapp/localService/mainService/SEPM_XYZ/SERVICE.xml
+          - localPath: ./webapp/localService/mainService/SEPM_XYZ_SERVICE.xml
             urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/
 ",
     "state": "modified",
@@ -2874,7 +2874,7 @@ Object {
 ",
     "state": "modified",
   },
-  "webapp/localService/mainService/SEPM_XYZ/SERVICE.xml": Object {
+  "webapp/localService/mainService/SEPM_XYZ_SERVICE.xml": Object {
     "contents": "<HELLO>
     <ANNOTATION>
     </ANNOTATION>
@@ -2900,7 +2900,7 @@ Object {
         \\"uri\\": \\"/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/\\",
         \\"type\\": \\"ODataAnnotation\\",
         \\"settings\\": {
-          \\"localUri\\": \\"localService/mainService//SEPM_XYZ/SERVICE.xml\\"
+          \\"localUri\\": \\"localService/mainService/SEPM_XYZ_SERVICE.xml\\"
         }
       },
       \\"mainService\\": {

--- a/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-multiple-annotations.ts
+++ b/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-multiple-annotations.ts
@@ -14,14 +14,14 @@ export const expectedEdmxManifestMultipleAnnotations = {
                 uri: `/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='annotation1Technical',Version='0001')/$value/`,
                 type: 'ODataAnnotation',
                 settings: {
-                    localUri: 'localService/aname/annotation1Technical.xml'
+                    localUri: 'localService/aname/annotation1.xml'
                 }
             },
             annotation2: {
                 uri: `/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='annotation2Technical',Version='0001')/$value/`,
                 type: 'ODataAnnotation',
                 settings: {
-                    localUri: 'localService/aname/annotation2Technical.xml'
+                    localUri: 'localService/aname/annotation2.xml'
                 }
             },
             localTest: {

--- a/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-multiple-services.ts
+++ b/packages/odata-service-writer/test/test-data/manifest-json/edmx-manifest-multiple-services.ts
@@ -17,7 +17,7 @@ export const expectedEdmxManifestMultipleServices = {
                 uri: "/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='annotation1Technical',Version='0001')/$value/",
                 type: 'ODataAnnotation',
                 settings: {
-                    localUri: 'localService/aname/annotation1Technical.xml'
+                    localUri: 'localService/aname/annotation1.xml'
                 }
             },
             localTest: {


### PR DESCRIPTION
We noticed that service annotation files are written with sub folder like:
![image](https://github.com/user-attachments/assets/ef758f59-ef1d-4b45-a67f-46d9d7891b88)

after correction it looks following:
![image](https://github.com/user-attachments/assets/656dc777-6d26-4984-b7bb-e06053ec6ca8)

