### PR TITLE
feat: Replace usage of cards-editor-config-writer with app-config-writer

### DIFF
--- a/.changeset/fluffy-jeans-look.md
+++ b/.changeset/fluffy-jeans-look.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/create': patch
+---
+
+Replace usage of cards-editor-config-writer with app-config-writer
+Added UI5.yaml config path option for cards-editor command

--- a/packages/create/src/cli/add/cards-editor.ts
+++ b/packages/create/src/cli/add/cards-editor.ts
@@ -1,16 +1,18 @@
 import type { Command } from 'commander';
-import { enableCardsEditor } from '@sap-ux/cards-editor-config-writer';
+import { enableCardGeneratorConfig } from '@sap-ux/app-config-writer';
 import { getLogger, traceChanges, setLogLevelVerbose } from '../../tracing';
 import { validateBasePath } from '../../validation';
 import { runNpmInstallCommand } from '../../common';
+import { isAbsolute, join } from 'path';
 
 /**
  * Add the cards-editor-config command.
  *
- * @param cmd - commander command for adding navigation inbounds config command
+ * @param cmd - commander command for adding cards editor config command
  */
 export function addCardsEditorConfigCommand(cmd: Command): void {
     cmd.command('cards-editor [path]')
+        .option('-c, --config <string>', 'Path to project configuration file in YAML format', 'ui5.yaml')
         .option('-n, --skip-install', 'skip npm install step')
         .option('-s, --simulate', 'simulate only do not write config; sets also --verbose')
         .option('-v, --verbose', 'show verbose information')
@@ -18,7 +20,12 @@ export function addCardsEditorConfigCommand(cmd: Command): void {
             if (options.verbose === true || options.simulate) {
                 setLogLevelVerbose();
             }
-            await addCardsEditorConfig(path || process.cwd(), !!options.simulate, !!options.skipInstall);
+            await addCardsEditorConfig(
+                path ?? process.cwd(), 
+                !!options.simulate, 
+                options.config,
+                !!options.skipInstall
+            );
         });
 }
 
@@ -27,15 +34,21 @@ export function addCardsEditorConfigCommand(cmd: Command): void {
  *
  * @param basePath - path to application root
  * @param simulate - if true, do not write but just show what would be changed; otherwise write
+ * @param yamlPath - path to the ui5*.yaml file passed by cli
  * @param skipInstall - if true, do not run npm install
  */
-async function addCardsEditorConfig(basePath: string, simulate: boolean, skipInstall: boolean): Promise<void> {
+async function addCardsEditorConfig(
+    basePath: string, 
+    simulate: boolean, 
+    yamlPath: string,
+    skipInstall: boolean): Promise<void> {
     const logger = getLogger();
     try {
-        logger.debug(`Called add cards-editor-config for path '${basePath}', simulate is '${simulate}'`);
-        await validateBasePath(basePath);
+        logger.debug(`Called add cards-generator-config for path '${basePath}', simulate is '${simulate}'`);
+        const ui5ConfigPath = isAbsolute(yamlPath) ? yamlPath : join(basePath, yamlPath);
+        await validateBasePath(basePath, ui5ConfigPath);
 
-        const fs = await enableCardsEditor(basePath);
+        const fs = await enableCardGeneratorConfig(basePath, ui5ConfigPath, logger);
         if (!simulate) {
             await new Promise((resolve) => fs.commit(resolve));
             if (!skipInstall) {

--- a/packages/create/test/unit/cli/add/cards-editor.test.ts
+++ b/packages/create/test/unit/cli/add/cards-editor.test.ts
@@ -1,6 +1,6 @@
 import * as tracer from '../../../../src/tracing/trace';
 import * as common from '../../../../src/common';
-import * as writer from '@sap-ux/cards-editor-config-writer';
+import { enableCardGeneratorConfig } from '@sap-ux/app-config-writer';
 import { addCardsEditorConfigCommand } from '../../../../src/cli/add/cards-editor';
 import { Command } from 'commander';
 import type { Store } from 'mem-fs';
@@ -19,13 +19,21 @@ jest.mock('mem-fs-editor', () => {
     };
 });
 
+jest.mock('@sap-ux/app-config-writer', () => {
+    return {
+        ...jest.requireActual('@sap-ux/app-config-writer'),
+        enableCardGeneratorConfig: jest.fn()
+    };
+});
+
+const enableCardGeneratorConfigMock = enableCardGeneratorConfig as jest.Mock;
+
 const appRoot = join(__dirname, '../../../fixtures/ui5-deploy-config');
 const testArgv = (args: string[]) => ['', '', 'cards-editor', appRoot, ...args];
 
 describe('add/cards-editor', () => {
     const traceSpy = jest.spyOn(tracer, 'traceChanges');
     const npmInstallSpy = jest.spyOn(common, 'runNpmInstallCommand').mockImplementation(() => undefined);
-    const generateSpy = jest.spyOn(writer, 'enableCardsEditor');
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -38,7 +46,7 @@ describe('add/cards-editor', () => {
         await command.parseAsync(testArgv([]));
 
         // Flow check
-        expect(generateSpy).toBeCalled();
+        expect(enableCardGeneratorConfigMock).toBeCalled();
         expect(traceSpy).not.toBeCalled();
         expect(npmInstallSpy).toBeCalled();
     });
@@ -50,7 +58,7 @@ describe('add/cards-editor', () => {
         await command.parseAsync(testArgv(['--simulate']));
 
         // Flow check
-        expect(generateSpy).toBeCalled();
+        expect(enableCardGeneratorConfigMock).toBeCalled();
         expect(traceSpy).toBeCalled();
         expect(npmInstallSpy).not.toBeCalled();
     });
@@ -62,7 +70,7 @@ describe('add/cards-editor', () => {
         await command.parseAsync(testArgv(['--skip-install']));
 
         // Flow check
-        expect(generateSpy).toBeCalled();
+        expect(enableCardGeneratorConfigMock).toBeCalled();
         expect(traceSpy).not.toBeCalled();
         expect(npmInstallSpy).not.toBeCalled();
     });


### PR DESCRIPTION
Replace usage of cards-editor-config-writer with app-config-writer.
Added UI5.yaml config path option for cards-editor command.

Issue: [1045](https://github.tools.sap/ux/sap.cards.ap/issues/1045)