### PR TITLE
Fix/remove UI theme belize label

### DIFF
--- a/.changeset/fuzzy-points-jam.md
+++ b/.changeset/fuzzy-points-jam.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-info': patch
+---
+
+update Belize theme label and add version checks for deprecation

--- a/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
@@ -287,11 +287,6 @@ describe('Filtering UI5 themes based on UI5 version', () => {
 
         const expectedChoices = getExpectedChoices(version);
 
-        // Debugging logs
-        console.log('Version:', version);
-        console.log('Expected Choices:', expectedChoices);
-        console.log('Actual Choices:', choices);
-
         expect(getUi5ThemesSpy).toHaveBeenCalledWith(version);
         expect(choices.length).toBeGreaterThan(0);
         expect(choices).toEqual(expectedChoices);

--- a/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
@@ -237,7 +237,7 @@ describe('ui5-application-inquirer API', () => {
 });
 
 describe('Filtering UI5 themes based on UI5 version', () => {
-    const versionsToTest = ['1.146.0', '1.136.0', '1.135.0', '1.133.0'];
+    const versionsToTest = ['1.119.0', '1.118.0', '1.146.0', '1.136.0', '1.135.0', '1.133.0', '1.120.0'];
 
     // Helper function to return the expected choices for each version
     function getExpectedChoices(version: string) {
@@ -250,14 +250,16 @@ describe('Filtering UI5 themes based on UI5 version', () => {
 
         if (gte(version, '1.136.0')) {
             return commonChoices;
-        }
-        if (lt(version, '1.136.0')) {
+        } else if (gte(version, '1.120.0') && lt(version, '1.136.0')) {
             return [{ name: 'Belize (deprecated)', value: 'sap_belize' }, ...commonChoices];
+        } else if (lt(version, '1.120.0')) {
+            return [{ name: 'Belize', value: 'sap_belize' }, ...commonChoices];
         }
         return [];
     }
 
     test.each(versionsToTest)('should call getUi5Themes with correct ui5Version: %s', async (version) => {
+        jest.restoreAllMocks();
         const getUi5ThemesSpy = jest.spyOn(ui5Info, 'getUi5Themes');
         const getUI5VersionsSpy = jest.spyOn(ui5Info, 'getUI5Versions').mockResolvedValue([{ version }]);
         const promptOpts: UI5ApplicationPromptOptions = {
@@ -283,9 +285,15 @@ describe('Filtering UI5 themes based on UI5 version', () => {
         const ui5ThemeQuestion = questions.find((q) => q.name === promptNames.ui5Theme);
         const choices = (ui5ThemeQuestion as any)?.choices({ ui5Version: version });
 
+        const expectedChoices = getExpectedChoices(version);
+
+        // Debugging logs
+        console.log('Version:', version);
+        console.log('Expected Choices:', expectedChoices);
+        console.log('Actual Choices:', choices);
+
         expect(getUi5ThemesSpy).toHaveBeenCalledWith(version);
         expect(choices.length).toBeGreaterThan(0);
-        const expectedChoices = getExpectedChoices(version);
         expect(choices).toEqual(expectedChoices);
     });
 });

--- a/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/ui5-application-inquirer.test.ts
@@ -237,7 +237,7 @@ describe('ui5-application-inquirer API', () => {
 });
 
 describe('Filtering UI5 themes based on UI5 version', () => {
-    const versionsToTest = ['1.119.0', '1.118.0', '1.146.0', '1.136.0', '1.135.0', '1.133.0', '1.120.0'];
+    const versionsToTest = ['1.146.0', '1.136.0', '1.135.0', '1.133.0', '1.120.0', '1.119.0', '1.118.0'];
 
     // Helper function to return the expected choices for each version
     function getExpectedChoices(version: string) {

--- a/packages/ui5-info/src/ui5-theme-info.ts
+++ b/packages/ui5-info/src/ui5-theme-info.ts
@@ -69,27 +69,26 @@ export function getUi5Themes(ui5Version: string = defaultVersion): UI5Theme[] {
     const ui5VersionSince = ui5Version.replace('snapshot-', '');
     const cleanSemVer = coerce(ui5VersionSince);
     if (cleanSemVer) {
-        return Object.values(ui5Themes).filter((ui5Theme) => {
-            // Check if the theme is deprecated and the UI5 version is within the deprecated range
-            if (
-                ui5Theme.id === ui5ThemeIds.SAP_BELIZE &&
-                gte(cleanSemVer, MIN_UI5_VER_BELIZE_DEPRECATED) &&
-                lt(cleanSemVer, MAX_UI5_VER_BELIZE_THEME)
-            ) {
-                ui5Theme.label = 'Belize (deprecated)';
-            }
+        return Object.values(ui5Themes)
+            .map((ui5Theme) => {
+                const theme = { ...ui5Theme };
 
-            // Check if the theme is within the valid version range
-            const isValidSinceVersion = ui5Theme.sinceVersion ? gte(cleanSemVer, ui5Theme.sinceVersion) : true;
-            const isValidUntilVersion = ui5Theme.untilVersion ? lt(cleanSemVer, ui5Theme.untilVersion) : true;
+                if (
+                    theme.id === ui5ThemeIds.SAP_BELIZE &&
+                    gte(cleanSemVer, MIN_UI5_VER_BELIZE_DEPRECATED) &&
+                    lt(cleanSemVer, MAX_UI5_VER_BELIZE_THEME)
+                ) {
+                    theme.label = 'Belize (deprecated)';
+                }
 
-            // Include themes that are within their version support range
-            if (isValidSinceVersion && isValidUntilVersion) {
-                return true;
-            }
+                return theme;
+            })
+            .filter((theme) => {
+                const isValidSinceVersion = theme.sinceVersion ? gte(cleanSemVer, theme.sinceVersion) : true;
+                const isValidUntilVersion = theme.untilVersion ? lt(cleanSemVer, theme.untilVersion) : true;
 
-            return false;
-        });
+                return isValidSinceVersion && isValidUntilVersion;
+            });
     }
 
     // If the UI5 version is not valid, return all themes

--- a/packages/ui5-info/src/ui5-theme-info.ts
+++ b/packages/ui5-info/src/ui5-theme-info.ts
@@ -5,6 +5,7 @@ import { coerce, gte, lt } from 'semver';
 const MIN_UI5_VER_DARK_THEME = '1.72.0';
 const MIN_UI5_VER_HORIZON_THEME = '1.102.0';
 const MAX_UI5_VER_BELIZE_THEME = '1.136.0';
+const MIN_UI5_VER_BELIZE_DEPRECATED = '1.120.0';
 
 export const enum ui5ThemeIds {
     SAP_BELIZE = 'sap_belize',
@@ -17,7 +18,7 @@ export const enum ui5ThemeIds {
 export const ui5Themes: Record<ui5ThemeIds, UI5Theme> = {
     [ui5ThemeIds.SAP_BELIZE]: {
         id: ui5ThemeIds.SAP_BELIZE,
-        label: 'Belize (deprecated)',
+        label: 'Belize',
         untilVersion: MAX_UI5_VER_BELIZE_THEME
     },
     [ui5ThemeIds.SAP_FIORI_3]: {
@@ -69,6 +70,15 @@ export function getUi5Themes(ui5Version: string = defaultVersion): UI5Theme[] {
     const cleanSemVer = coerce(ui5VersionSince);
     if (cleanSemVer) {
         return Object.values(ui5Themes).filter((ui5Theme) => {
+            // Check if the theme is deprecated and the UI5 version is within the deprecated range
+            if (
+                ui5Theme.id === ui5ThemeIds.SAP_BELIZE &&
+                gte(cleanSemVer, MIN_UI5_VER_BELIZE_DEPRECATED) &&
+                lt(cleanSemVer, MAX_UI5_VER_BELIZE_THEME)
+            ) {
+                ui5Theme.label = 'Belize (deprecated)';
+            }
+
             // Check if the theme is within the valid version range
             const isValidSinceVersion = ui5Theme.sinceVersion ? gte(cleanSemVer, ui5Theme.sinceVersion) : true;
             const isValidUntilVersion = ui5Theme.untilVersion ? lt(cleanSemVer, ui5Theme.untilVersion) : true;

--- a/packages/ui5-info/test/ui5-theme-info.test.ts
+++ b/packages/ui5-info/test/ui5-theme-info.test.ts
@@ -7,7 +7,7 @@ describe('getUi5Themes', () => {
     const allExpectedThemes = [
         {
             'id': 'sap_belize',
-            'label': 'Belize (deprecated)',
+            'label': 'Belize',
             'untilVersion': '1.136.0'
         },
         {
@@ -38,12 +38,46 @@ describe('getUi5Themes', () => {
         expect(getUi5Themes('1.72')).toEqual(allExpectedThemes.slice(0, 3));
         expect(getUi5Themes('1.101')).toEqual(allExpectedThemes.slice(0, 3));
         expect(getUi5Themes('1.102')).toEqual(allExpectedThemes);
-        expect(getUi5Themes('1.135.0')).toEqual(allExpectedThemes);
-        // Filter out sap_belize from allExpectedThemes
-        const allExpectedThemesExcludingBelize = allExpectedThemes.filter((theme) => theme.id !== 'sap_belize');
-        // expect sap_belize theme to be excluded when ui5 version is above 1.136.0
-        expect(getUi5Themes('1.136.0')).toEqual(allExpectedThemesExcludingBelize);
-        expect(getUi5Themes('1.155.0')).toEqual(allExpectedThemesExcludingBelize);
+    });
+
+    describe('Belize Theme Tests', () => {
+        const themesWithDeprecatedBelize = allExpectedThemes.map((theme) => {
+            if (theme.id === 'sap_belize') {
+                return {
+                    ...theme,
+                    label: 'Belize (deprecated)'
+                };
+            }
+            return theme;
+        });
+
+        const themesWithoutBelize = allExpectedThemes.filter((theme) => theme.id !== 'sap_belize');
+
+        beforeEach(() => {
+            // Restore the original ui5Themes before each test
+            Object.defineProperty(themeInfo, 'ui5Themes', {
+                value: allExpectedThemes
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should mark sap_belize as deprecated for versions between 1.120.0 and 1.136.0', () => {
+            expect(getUi5Themes('1.120.0')).toEqual(themesWithDeprecatedBelize);
+            expect(getUi5Themes('1.135.0')).toEqual(themesWithDeprecatedBelize);
+        });
+
+        test('should exclude sap_belize for versions above 1.136.0', () => {
+            expect(getUi5Themes('1.136.0')).toEqual(themesWithoutBelize);
+            expect(getUi5Themes('1.155.0')).toEqual(themesWithoutBelize);
+        });
+
+        test('should include sap_belize for versions below 1.120.0', () => {
+            expect(getUi5Themes('1.119.9')).toEqual(allExpectedThemes);
+            expect(getUi5Themes('1.105.0')).toEqual(allExpectedThemes);
+        });
     });
 
     test.each([


### PR DESCRIPTION
Related to [PR](https://github.com/SAP/open-ux-tools/pull/3189)


This PR updates the UI5 theme label based on the selected UI5 version:

- `Belize (deprecated)` is shown when `ui5Version >= 1.120 and < 1.136.0`
- `Belize` is shown when `ui5Version < 1.120`
