### PR TITLE
fix(cf-deploy-config-writer): ensure package.json is created using mta ID

### DIFF
--- a/.changeset/wise-kids-unite.md
+++ b/.changeset/wise-kids-unite.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+Ensure missing package.json id matches the mta ID

--- a/packages/cf-deploy-config-sub-generator/test/fixtures/sap-ux-test/package.json
+++ b/packages/cf-deploy-config-sub-generator/test/fixtures/sap-ux-test/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "mta-project",
+    "name": "sap-ux-test",
     "version": "0.0.1",
     "description": "Build and deployment scripts",
     "scripts": {

--- a/packages/cf-deploy-config-writer/src/mta-config/mta.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/mta.ts
@@ -914,8 +914,9 @@ export class MtaConfig {
      * Add a destination to the approuter.
      *
      * @param cfDestination The name of the destination to be appended
+     * @returns {void}
      */
-    public async addDestinationToAppRouter(cfDestination: string | undefined) {
+    public async addDestinationToAppRouter(cfDestination: string | undefined): Promise<void> {
         if (this.hasAppFrontendRouter()) {
             // Append destination directly to app frontend
             await this.appendAppfrontCAPDestination(cfDestination);

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -132,7 +132,7 @@ export function validateVersion(mtaVersion?: string): boolean {
  * @param {string} config.mtaPath - Path to the MTA project
  * @param {string} config.mtaId - MTA ID
  * @param {Editor} fs - Reference to a mem-fs editor
- * @param {boolean} [addTenant=true] - If true, append tenant to the xs-security.json file
+ * @param {boolean} [addTenant] - If true, append tenant to the xs-security.json file
  * @returns {void}
  */
 export function addXSSecurityConfig({ mtaPath, mtaId }: MTABaseConfig, fs: Editor, addTenant: boolean = true): void {

--- a/packages/cf-deploy-config-writer/src/utils.ts
+++ b/packages/cf-deploy-config-writer/src/utils.ts
@@ -126,13 +126,14 @@ export function validateVersion(mtaVersion?: string): boolean {
 }
 
 /**
- *  Append xs-security.json to project folder.
+ * Appends xs-security.json to the project folder.
  *
- * @param root0 MTA base configuration
- * @param root0.mtaPath Path to the MTA project
- * @param root0.mtaId MTA ID
- * @param fs reference to a mem-fs editor
- * @param addTenant If true, append tenant to the xs-security.json file
+ * @param {MTABaseConfig} config - MTA base configuration
+ * @param {string} config.mtaPath - Path to the MTA project
+ * @param {string} config.mtaId - MTA ID
+ * @param {Editor} fs - Reference to a mem-fs editor
+ * @param {boolean} [addTenant=true] - If true, append tenant to the xs-security.json file
+ * @returns {void}
  */
 export function addXSSecurityConfig({ mtaPath, mtaId }: MTABaseConfig, fs: Editor, addTenant: boolean = true): void {
     fs.copyTpl(getTemplatePath(`common/${FileName.XSSecurityJson}`), join(mtaPath, FileName.XSSecurityJson), {
@@ -152,16 +153,17 @@ export function addGitIgnore(targetPath: string, fs: Editor): void {
 }
 
 /**
- * Append server package.json to project folder.
+ * Appends server package.json to the project folder.
  *
- * @param root0 MTA base configuration
- * @param root0.mtaPath Path to the MTA project
- * @param root0.mtaId MTA ID
- * @param fs reference to a mem-fs editor
+ * @param {MTABaseConfig} config - MTA base configuration
+ * @param {string} config.mtaPath - Path to the MTA project
+ * @param {string} config.mtaId - MTA ID
+ * @param {Editor} fs - Reference to a mem-fs editor
+ * @returns {void}
  */
 export function addRootPackage({ mtaPath, mtaId }: MTABaseConfig, fs: Editor): void {
     fs.copyTpl(getTemplatePath(FileName.Package), join(mtaPath, FileName.Package), {
-        mtaId: mtaId
+        mtaId
     });
 }
 

--- a/packages/cf-deploy-config-writer/templates/package.json
+++ b/packages/cf-deploy-config-writer/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mta-project",
+  "name": "<%- mtaId %>",
   "version": "0.0.1",
   "description": "Build and deployment scripts",
   "scripts": {

--- a/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-app.test.ts.snap
+++ b/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-app.test.ts.snap
@@ -1368,7 +1368,7 @@ builder:
 
 exports[`CF Writer App Generate deployment configs - generateSupportingConfig read mtaId read from file 1`] = `
 "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"captestproject\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {
@@ -1411,7 +1411,7 @@ exports[`CF Writer App Generate deployment configs - generateSupportingConfig re
 
 exports[`CF Writer App Generate deployment configs - generateSupportingConfig with mtaId passed in 1`] = `
 "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"testMtaId\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {

--- a/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-appfront.test.ts.snap
+++ b/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-appfront.test.ts.snap
@@ -209,7 +209,7 @@ exports[`CF Writer App - Application Frontend Generate deployment configs - Appe
 
 exports[`CF Writer App - Application Frontend Generate deployment configs - Append HTML5 to an existing app frontend router 3`] = `
 "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"rootmta\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {

--- a/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-base.test.ts.snap
+++ b/packages/cf-deploy-config-writer/test/unit/__snapshots__/index-base.test.ts.snap
@@ -17,7 +17,7 @@ archive.zip
   },
   "package.json": Object {
     "contents": "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"appfrontend\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {
@@ -104,7 +104,7 @@ archive.zip
   },
   "package.json": Object {
     "contents": "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"managed\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {
@@ -226,7 +226,7 @@ archive.zip
   },
   "package.json": Object {
     "contents": "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"standalonewithabapserviceprovider\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {
@@ -393,7 +393,7 @@ archive.zip
   },
   "package.json": Object {
     "contents": "{
-  \\"name\\": \\"mta-project\\",
+  \\"name\\": \\"standalone-with-connectivity-service\\",
   \\"version\\": \\"0.0.1\\",
   \\"description\\": \\"Build and deployment scripts\\",
   \\"scripts\\": {


### PR DESCRIPTION

Fix for https://github.com/SAP/open-ux-tools/issues/3097

Ensure the `package.json` created references the mta ID used to generate the mta configuration, these are normally aligned. 

Note, this is part of cleanup job and its a rare situation to have a HTML5 app without a package.json
 
- updated snapshots
- updated jsdoc
- updated template