### PR TITLE
fix: use memFs if passed while application access creation

### DIFF
--- a/.changeset/quick-rings-invite.md
+++ b/.changeset/quick-rings-invite.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+Use memFs if passed while application access creation

--- a/packages/project-access/src/project/access.ts
+++ b/packages/project-access/src/project/access.ts
@@ -189,7 +189,7 @@ class ApplicationAccessImp implements ApplicationAccess {
      * @param memFs - optional mem-fs-editor instance
      */
     async updatePackageJSON(packageJson: Package, memFs?: Editor): Promise<void> {
-        await updatePackageJSON(join(this.app.appRoot, FileName.Package), packageJson, memFs);
+        await updatePackageJSON(join(this.app.appRoot, FileName.Package), packageJson, memFs ?? this.options?.fs);
     }
 
     /**
@@ -199,7 +199,7 @@ class ApplicationAccessImp implements ApplicationAccess {
      * @param memFs - optional mem-fs-editor instance
      */
     async updateManifestJSON(manifest: Manifest, memFs?: Editor): Promise<void> {
-        await updateManifestJSON(this.app.manifest, manifest, memFs);
+        await updateManifestJSON(this.app.manifest, manifest, memFs ?? this.options?.fs);
     }
 
     /**

--- a/packages/project-access/test/project/access.test.ts
+++ b/packages/project-access/test/project/access.test.ts
@@ -298,6 +298,21 @@ describe('Test function createApplicationAccess()', () => {
         expect(result).toBe('{\n    "name": "two"\n}\n');
     });
 
+    test('Update package.json of app in CAP project - mem-fs-editor (mocked)', async () => {
+        // Mock setup
+        const projectRoot = join(sampleRoot, 'cap-project');
+        const appRoot = join(projectRoot, 'apps/one');
+        const updateFileContent = { name: 'two' } as unknown as Package;
+        const pckgPath = join(appRoot, 'package.json');
+        memFs.writeJSON(pckgPath, { name: 'one' }, undefined, 4);
+        // Test execution
+        const appAccess = await createApplicationAccess(appRoot, memFs);
+        await appAccess.updatePackageJSON(updateFileContent);
+        // Result check
+        const result = memFs.read(pckgPath);
+        expect(result).toBe('{\n    "name": "two"\n}\n');
+    });
+
     test('Update manifest.json of standalone app (mocked)', async () => {
         // Mock setup
         const appRoot = join(sampleRoot, 'fiori_elements');
@@ -320,6 +335,20 @@ describe('Test function createApplicationAccess()', () => {
         // Test execution
         const appAccess = await createApplicationAccess(appRoot);
         await appAccess.updateManifestJSON(updateFileContent, memFs);
+        // Result check
+        const result = memFs.read(manifestPath);
+        expect(result).toBe('{\n    "sap.app": {}\n}\n');
+    });
+
+    test('Update manifest.json of standalone app - mem-fs-editor passed when created', async () => {
+        // Mock setup
+        const appRoot = join(sampleRoot, 'fiori_elements');
+        const updateFileContent = { 'sap.app': {} } as unknown as Manifest;
+        const manifestPath = join(appRoot, 'webapp', 'manifest.json');
+        memFs.writeJSON(manifestPath, { 'sap.app': { id: 'single_apps-fiori_elements' } }, undefined, 4);
+        // Test execution
+        const appAccess = await createApplicationAccess(appRoot, memFs);
+        await appAccess.updateManifestJSON(updateFileContent);
         // Result check
         const result = memFs.read(manifestPath);
         expect(result).toBe('{\n    "sap.app": {}\n}\n');


### PR DESCRIPTION
Fix to use `memFs` in functions `updatePackageJSON()` and `updateManifestJSON()` in case it has been passed when `ApplicationAccess` instance was created using `createApplicationAccess()`.