### PR TITLE
fix(ui5-app-inquirer): fix 'when' condition for Typescript prompt

### DIFF
--- a/.changeset/weak-planets-mix.md
+++ b/.changeset/weak-planets-mix.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+---
+
+fix when condition for typescript prompt

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -188,7 +188,7 @@ export function getEnableTypeScriptPrompt(capCdsInfo?: CdsUi5PluginInfo): UI5App
     return {
         when: (): boolean => {
             if (capCdsInfo) {
-                return capCdsInfo.isCdsUi5PluginEnabled || capCdsInfo.hasMinCdsVersion;
+                return capCdsInfo.hasMinCdsVersion;
             }
             return true;
         },

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -188,13 +188,13 @@ export function getEnableTypeScriptPrompt(capCdsInfo?: CdsUi5PluginInfo): UI5App
     return {
         when: (): boolean => {
             if (capCdsInfo) {
-                return capCdsInfo.isCdsUi5PluginEnabled || (capCdsInfo.hasMinCdsVersion && !capCdsInfo.hasCdsUi5Plugin);
+                return capCdsInfo.isCdsUi5PluginEnabled || capCdsInfo.hasMinCdsVersion;
             }
             return true;
         },
         additionalMessages: (val: boolean) => {
             let message;
-            if (val && capCdsInfo?.hasMinCdsVersion && !capCdsInfo?.hasCdsUi5Plugin) {
+            if (val && !capCdsInfo?.isWorkspaceEnabled) {
                 message = { message: t('prompts.enableTypeScript.warningMsg'), severity: Severity.warning };
             }
             return message;

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -592,6 +592,7 @@ describe('getQuestions', () => {
             isWorkspaceEnabled: false,
             hasMinCdsVersion: true
         }).find((question) => question.name === promptNames.enableTypeScript);
+        expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
         expect(enableTypeScriptQuestion?.additionalMessages!(true)).toEqual({
             message:
                 'The CAP project will be updated to use NPM workspaces (this is a requirement for generating with TypeScript)',


### PR DESCRIPTION
- there was a bug when a project has the CdsUi5Plugin installed and hasMinCdsVersion but was not getting the option for Typescript
- update typescript prompt condition to show prompt when only hasMinCdsVersion is true
- current logic was hiding the prompt when the CdsUi5Plugin was installed but workspaces were not enabled. User should be given the option to select Typescript here as they have the plugin and we enable workspaces at generation.
- Warning is still shown to state we enable workspaces when Typescript is selected, if workspaces are not already enabled.
- Tests mostly cover the flow already, added an explicit test for `when` if only `hasMinCdsVersion ` is true (the flow for the bug)