### PR TITLE
fix(preview-middleware): new column is not visible after using `Add Custom Table Column` Quick Action

### DIFF
--- a/.changeset/fresh-boxes-kneel.md
+++ b/.changeset/fresh-boxes-kneel.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: new column is not visible after using `Add Custom Table Column` Quick Action

--- a/packages/preview-middleware-client/src/adp/controllers/AddTableColumnFragments.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/AddTableColumnFragments.controller.ts
@@ -39,6 +39,7 @@ import Input from 'sap/m/Input';
 import Control from 'sap/ui/core/Control';
 import ManagedObject from 'sap/ui/base/ManagedObject';
 import { QuickActionTelemetryData } from '../../cpe/quick-actions/quick-action-definition';
+import { setAdditionalChangeInfoForChangeFile } from '../../utils/additional-change-info';
 
 const radix = 10;
 
@@ -60,7 +61,6 @@ interface CreateFragmentProps {
  * @namespace open.ux.preview.client.adp.controllers
  */
 export default class AddTableColumnFragments extends BaseDialog<AddTableColumnsFragmentsModel> {
-
     constructor(
         name: string,
         overlays: UI5Element,
@@ -255,15 +255,13 @@ export default class AddTableColumnFragments extends BaseDialog<AddTableColumnsF
      *
      * @param fragmentData Fragment Data
      */
-    private async createFragmentChange(fragmentData: CreateFragmentProps): Promise<string[] | undefined> {
+    private async createFragmentChange(fragmentData: CreateFragmentProps): Promise<void> {
         const { fragments, index } = fragmentData;
 
         const flexSettings = this.rta.getFlexSettings();
 
         const overlay = OverlayRegistry.getOverlay(this.runtimeControl as UI5Element);
         const designMetadata = overlay.getDesignTimeMetadata();
-
-        const result: string[] = [];
 
         const compositeCommand = await this.commandExecutor.createCompositeCommand(this.runtimeControl);
 
@@ -292,15 +290,11 @@ export default class AddTableColumnFragments extends BaseDialog<AddTableColumnsF
             const templateName =
                 fragment.targetAggregation === COLUMNS_AGGREGATION ? `V2_SMART_TABLE_COLUMN` : 'V2_SMART_TABLE_CELL';
             const preparedChange = command.getPreparedChange();
-            const content = { ...preparedChange.getContent(), templateName };
-            preparedChange.setContent(content);
+            setAdditionalChangeInfoForChangeFile(preparedChange.getDefinition().fileName, { templateName });
             compositeCommand.addCommand(command, false);
-            result.push(templateName);
         }
 
         await this.commandExecutor.pushAndExecuteCommand(compositeCommand);
         CommunicationService.sendAction(setApplicationRequiresReload(true));
-
-        return result;
     }
 }

--- a/packages/preview-middleware-client/src/utils/additional-change-info.ts
+++ b/packages/preview-middleware-client/src/utils/additional-change-info.ts
@@ -47,3 +47,10 @@ export function setAdditionalChangeInfoForChangeFile(
 export function getAdditionalChangeInfo(change: Change): AdditionalChangeInfo {
     return additionalChangeInfoMap.get(change.fileName);
 }
+
+/**
+ * Should only be used in tests.
+ */
+export function clearAdditionalChangeInfo(): void {
+    additionalChangeInfoMap.clear();
+}

--- a/packages/preview-middleware-client/src/utils/additional-change-info.ts
+++ b/packages/preview-middleware-client/src/utils/additional-change-info.ts
@@ -6,28 +6,35 @@ import {
 } from '../cpe/additional-change-info/add-xml-additional-info';
 import { FlexChange as Change } from '../flp/common';
 
-const additionalChangeInfoMap = new Map<string, AddXMLAdditionalInfo>();
+export type AdditionalChangeInfo = AddXMLAdditionalInfo | undefined;
 
-export type AdditionalChangeInfo = AddXMLAdditionalInfo | undefined
+const additionalChangeInfoMap = new Map<string, AdditionalChangeInfo>();
 
 /**
-* This function is used to set additional change information for a given change.
-* 
-* @param change - The change object for which additional information is to be set.
-*/
+ * This function is used to set additional change information for a given change.
+ *
+ * @param change - The change object for which additional information is to be set.
+ */
 export function setAdditionalChangeInfo(change: FlexChange<AddXMLChangeContent> | undefined): void {
     if (!change) {
         return;
     }
 
     let additionalChangeInfo;
-    if(change?.getChangeType?.() === 'addXML') {
+    if (change?.getChangeType?.() === 'addXML') {
         additionalChangeInfo = getAddXMLAdditionalInfo(change);
     }
 
     if (additionalChangeInfo) {
         additionalChangeInfoMap.set(change.getDefinition().fileName, additionalChangeInfo);
     }
+}
+
+export function setAdditionalChangeInfoForChangeFile(
+    fileName: string,
+    additionalChangeInfo: AdditionalChangeInfo
+): void {
+    additionalChangeInfoMap.set(fileName, additionalChangeInfo);
 }
 
 /**
@@ -38,5 +45,5 @@ export function setAdditionalChangeInfo(change: FlexChange<AddXMLChangeContent> 
  *          or `undefined` if no additional information is available.
  */
 export function getAdditionalChangeInfo(change: Change): AdditionalChangeInfo {
-    return additionalChangeInfoMap.get(change.fileName);              
+    return additionalChangeInfoMap.get(change.fileName);
 }

--- a/packages/preview-middleware-client/test/__mock__/sap/ui/fl/Change.ts
+++ b/packages/preview-middleware-client/test/__mock__/sap/ui/fl/Change.ts
@@ -1,7 +1,10 @@
 import type Selector from 'sap/ui/fl/Selector';
 import type { Layer } from 'sap/ui/fl';
 export default class Change<ContentType> {
-    constructor(private change: { selector: Selector; changeType: string; layer: Layer }) {}
+    public get fileName(): string | undefined {
+        return this.change.fileName;
+    }
+    constructor(private change: { selector: Selector; changeType: string; layer: Layer; fileName?: string }) {}
     public getSelector = jest.fn().mockImplementation(() => {
         return this.change.selector;
     });
@@ -11,7 +14,9 @@ export default class Change<ContentType> {
     public getLayer = jest.fn().mockImplementation(() => {
         return this.change.layer;
     });
-    public getDefinition = jest.fn();
+    public getDefinition = jest.fn().mockImplementation(() => {
+        return { fileName: this.change.fileName };
+    });
     public getContent = jest.fn().mockImplementation(() => {
         return {
             selector: this.change.selector,

--- a/packages/preview-middleware-client/test/unit/adp/controllers/AddTableColumnFragments.controller.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/controllers/AddTableColumnFragments.controller.test.ts
@@ -16,6 +16,8 @@ import type ManagedObject from 'sap/ui/base/ManagedObject';
 import AddTableColumnFragments from 'open/ux/preview/client/adp/controllers/AddTableColumnFragments.controller';
 import SimpleForm from 'sap/ui/layout/form';
 import Control from 'sap/ui/core/Control';
+import { getAdditionalChangeInfo } from '../../../../src/utils/additional-change-info';
+import { FlexChange } from 'open/ux/preview/client/flp/common';
 
 const mocks = {
     setValueStateMock: jest.fn(),
@@ -634,7 +636,8 @@ describe('AddTableColumnsFragments controller', () => {
                     },
                     getPreparedChange: jest.fn().mockReturnValue({
                         getContent: () => content1,
-                        setContent: setContentMock
+                        setContent: setContentMock,
+                        getDefinition: jest.fn().mockReturnValue({ fileName: 'change1' })
                     })
                 },
                 {
@@ -644,7 +647,8 @@ describe('AddTableColumnsFragments controller', () => {
                     },
                     getPreparedChange: jest.fn().mockReturnValue({
                         getContent: () => content2,
-                        setContent: setContentMock
+                        setContent: setContentMock,
+                        getDefinition: jest.fn().mockReturnValue({ fileName: 'change2' })
                     })
                 }
             ]);
@@ -680,14 +684,15 @@ describe('AddTableColumnsFragments controller', () => {
             expect(commandStack[0]._oPreparedChange._oDefinition.moduleName).toBe(
                 'adp/app/changes/fragments/Name1.fragment.xml'
             );
-            expect(setContentMock.mock.calls[0][0]).toStrictEqual({
-                ...content1,
+            expect(getAdditionalChangeInfo({ fileName: 'change1' } as unknown as FlexChange)).toStrictEqual({
                 templateName: 'V2_SMART_TABLE_COLUMN'
             });
             expect(commandStack[1]._oPreparedChange._oDefinition.moduleName).toBe(
                 'adp/app/changes/fragments/Name2.fragment.xml'
             );
-            expect(setContentMock.mock.calls[1][0]).toStrictEqual({ ...content2, templateName: 'V2_SMART_TABLE_CELL' });
+            expect(getAdditionalChangeInfo({ fileName: 'change2' } as unknown as FlexChange)).toStrictEqual({
+                templateName: 'V2_SMART_TABLE_CELL'
+            });
             expect(CommandFactory.getCommandFor.mock.calls[0][1]).toBe('composite');
 
             expect(CommandFactory.getCommandFor.mock.calls[1][0].dummyAggregation).toBeUndefined();

--- a/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
+++ b/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
@@ -1,27 +1,37 @@
 import {
     setAdditionalChangeInfo,
     getAdditionalChangeInfo,
+    clearAdditionalChangeInfo,
+    setAdditionalChangeInfoForChangeFile
 } from '../../../src/utils/additional-change-info';
 import FlexChange from 'mock/sap/ui/fl/Change';
 import * as xmlAdditionalInfo from '../../../src/cpe/additional-change-info/add-xml-additional-info';
 import type { FlexChange as Change } from '../../../src/flp/common';
 
 describe('additional-change-info.ts', () => {
-    const mockChange = new FlexChange({selector: { id: 'mockSelectorId', idIsLocal: false }, changeType: 'addXML', layer: 'CUSTOMER_BASE'}) as FlexChange<any> & { fileName: string };
     const mockAdditionalInfo = {
         someKey: 'someValue'
     } as unknown as xmlAdditionalInfo.AddXMLAdditionalInfo;
 
-    beforeEach(() => {
-        mockChange.fileName = 'mockFileName';
+    afterEach(() => {
         jest.clearAllMocks();
+        clearAdditionalChangeInfo();
     });
 
     describe('setAdditionalChangeInfo', () => {
-        const getAddXMLAdditionalInfoSpy = jest.spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo').mockReturnValue(undefined);
+        const getAddXMLAdditionalInfoSpy = jest
+            .spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo')
+            .mockReturnValue(undefined);
         it('should set additional change info for addXML change type', () => {
-            mockChange.getDefinition.mockReturnValueOnce({ fileName: 'mockFileName' });
-            const getAddXMLAdditionalInfoSpy = jest.spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo').mockReturnValueOnce(mockAdditionalInfo);
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'addXML',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'mockFileName'
+            });
+            const getAddXMLAdditionalInfoSpy = jest
+                .spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo')
+                .mockReturnValueOnce(mockAdditionalInfo);
 
             setAdditionalChangeInfo(mockChange);
 
@@ -31,9 +41,12 @@ describe('additional-change-info.ts', () => {
         });
 
         it('should not set additional change info for unsupported change type', () => {
-            mockChange.fileName = 'mockFileName1';
-            mockChange.getChangeType.mockReturnValueOnce('unsupportedType');
-            mockChange.getDefinition.mockReturnValueOnce({ fileName: 'mockFileName' });
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'unsupportedType',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'mockFileName'
+            });
 
             setAdditionalChangeInfo(mockChange);
 
@@ -49,9 +62,30 @@ describe('additional-change-info.ts', () => {
         });
     });
 
+    describe('setAdditionalChangeInfoForChangeFile', () => {
+        it('should set additional change info for templateName', () => {
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'addXML',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'mockFileName'
+            });
+
+            setAdditionalChangeInfoForChangeFile('mockFileName', { templateName: 'template' });
+
+            const result = getAdditionalChangeInfo(mockChange as unknown as Change);
+            expect(result).toEqual({ templateName: 'template' });
+        });
+    });
+
     describe('getAdditionalChangeInfo', () => {
         it('should return additional change info if it exists in the map', () => {
-            mockChange.fileName = 'mockFileName';
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'addXML',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'mockFileName'
+            });
             jest.spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo').mockReturnValueOnce(mockAdditionalInfo);
 
             setAdditionalChangeInfo(mockChange);
@@ -61,7 +95,12 @@ describe('additional-change-info.ts', () => {
         });
 
         it('should return undefined if additional change info does not exist in the map', () => {
-            mockChange.fileName = 'nonExistentFileName';
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'addXML',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'nonExistentFileName'
+            });
 
             const result = getAdditionalChangeInfo(mockChange as unknown as Change);
             expect(result).toBeUndefined();


### PR DESCRIPTION
Fix regression introduced by #3091.

Move `templateName` data to the new data transfer mechanism also for adding table column dialog.

We can't use plugin, because it only creates one fragment, but we need to create two at the same time.