### PR TITLE
fix(ui-service-gen): adds descriptions for new transport requests

### DIFF
--- a/.changeset/kind-forks-guess.md
+++ b/.changeset/kind-forks-guess.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': minor
+'@sap-ux/ui-service-inquirer': patch
+---
+
+Adds new option to provide custom descriptions for new transport requests

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
@@ -54,15 +54,16 @@ export function getTransportRequestPrompts(
                 input: TransportChoices,
                 previousAnswers: AbapDeployConfigAnswersInternal
             ): Promise<boolean | string> => {
-                const result = validateTransportChoiceInput(
+                const result = validateTransportChoiceInput({
                     useStandalone,
                     input,
                     previousAnswers,
-                    true,
-                    transportInputChoice,
-                    options.backendTarget,
-                    options.ui5AbapRepo?.default
-                );
+                    validateInputChanged: true,
+                    prevTransportInputChoice: transportInputChoice,
+                    backendTarget: options.backendTarget,
+                    ui5AbapRepoName: options.ui5AbapRepo?.default,
+                    transportDescription: options.transportCreated?.description
+                });
                 transportInputChoice = input;
                 return result;
             }
@@ -72,15 +73,14 @@ export function getTransportRequestPrompts(
             // Use this hidden question for calling ADT services.
             when: async (previousAnswers: AbapDeployConfigAnswersInternal): Promise<boolean> => {
                 if (!PromptState.isYUI) {
-                    const result = await validateTransportChoiceInput(
+                    const result = await validateTransportChoiceInput({
                         useStandalone,
-                        previousAnswers.transportInputChoice,
+                        input: previousAnswers.transportInputChoice,
                         previousAnswers,
-                        false,
-                        undefined,
-                        options.backendTarget,
-                        options.ui5AbapRepo?.default
-                    );
+                        validateInputChanged: false,
+                        backendTarget: options.backendTarget,
+                        ui5AbapRepoName: options.ui5AbapRepo?.default
+                    });
                     if (result !== true) {
                         throw new Error(result as string);
                     }

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -436,6 +436,7 @@ function getPackageStartingPrefix(packageName: string): string {
  * @param params.prevTransportInputChoice - previous transport input choice
  * @param params.backendTarget - backend target
  * @param params.ui5AbapRepoName - ui5 app repository name derived from AbapDeployConfigPromptOptions[ui5AbapRepo]
+ * @param params.transportDescription - custom description for the transport request
  * @returns - boolean or error message as a string
  */
 async function handleCreateNewTransportChoice({
@@ -446,7 +447,8 @@ async function handleCreateNewTransportChoice({
     validateInputChanged,
     prevTransportInputChoice,
     backendTarget,
-    ui5AbapRepoName
+    ui5AbapRepoName,
+    transportDescription
 }: {
     packageAnswer: string;
     systemConfig: SystemConfig;
@@ -456,6 +458,7 @@ async function handleCreateNewTransportChoice({
     prevTransportInputChoice?: TransportChoices;
     backendTarget?: BackendTarget;
     ui5AbapRepoName?: string;
+    transportDescription?: string;
 }): Promise<boolean | string> {
     // Question is re-evaluated triggered by other user changes,
     // no need to create a new transport number
@@ -477,7 +480,10 @@ async function handleCreateNewTransportChoice({
             }
         }
     }
-    const description = `For ABAP repository ${previousAnswers?.ui5AbapRepo?.toUpperCase()}, created by SAP Fiori Tools`;
+    const description =
+        transportDescription ??
+        `For ABAP repository ${previousAnswers?.ui5AbapRepo?.toUpperCase()}, created by SAP Fiori Tools`;
+
     PromptState.transportAnswers.newTransportNumber = await createTransportNumber(
         {
             packageName: getPackageAnswer(previousAnswers, PromptState.abapDeployConfig.package),
@@ -536,24 +542,36 @@ async function handleListExistingTransportChoice(
 /**
  * Validates the transport choice input.
  *
- * @param useStandalone - if the transport prompts are used standalone
- * @param input - transport choice input
- * @param previousAnswers - previous answers
- * @param validateInputChanged - if the input has changed
- * @param prevTransportInputChoice - previous transport input choice
- * @param backendTarget - backend target
- * @param ui5AbapRepoName - ui5 app repository name derived from AbapDeployConfigPromptOptions[ui5AbapRepo]
+ * @param params - params for transport choice input
+ * @param params.useStandalone - if the transport prompts are used standalone
+ * @param params.input - transport choice input
+ * @param params.previousAnswers - previous answers
+ * @param params.validateInputChanged - if the input has changed
+ * @param params.prevTransportInputChoice - previous transport input choice
+ * @param params.backendTarget - backend target
+ * @param params.ui5AbapRepoName - ui5 app repository name derived from AbapDeployConfigPromptOptions[ui5AbapRepo]
+ * @param params.transportDescription - custom description for the transport request
  * @returns boolean or error message as a string
  */
-export async function validateTransportChoiceInput(
-    useStandalone: boolean,
-    input?: TransportChoices,
-    previousAnswers?: AbapDeployConfigAnswersInternal,
-    validateInputChanged?: boolean,
-    prevTransportInputChoice?: TransportChoices,
-    backendTarget?: BackendTarget,
-    ui5AbapRepoName?: string
-): Promise<boolean | string> {
+export async function validateTransportChoiceInput({
+    useStandalone,
+    input,
+    previousAnswers,
+    validateInputChanged,
+    prevTransportInputChoice,
+    backendTarget,
+    ui5AbapRepoName,
+    transportDescription
+}: {
+    useStandalone: boolean;
+    input?: TransportChoices;
+    previousAnswers?: AbapDeployConfigAnswersInternal;
+    validateInputChanged?: boolean;
+    prevTransportInputChoice?: TransportChoices;
+    backendTarget?: BackendTarget;
+    ui5AbapRepoName?: string;
+    transportDescription?: string;
+}): Promise<boolean | string> {
     const packageAnswer = getPackageAnswer(previousAnswers, PromptState.abapDeployConfig.package);
     const systemConfig = getSystemConfig(useStandalone, PromptState.abapDeployConfig, backendTarget);
 
@@ -576,7 +594,8 @@ export async function validateTransportChoiceInput(
                 validateInputChanged,
                 prevTransportInputChoice,
                 backendTarget,
-                ui5AbapRepoName
+                ui5AbapRepoName,
+                transportDescription
             });
         }
         case TransportChoices.EnterManualChoice:

--- a/packages/abap-deploy-config-inquirer/src/types.ts
+++ b/packages/abap-deploy-config-inquirer/src/types.ts
@@ -142,6 +142,13 @@ export type TransportManualPromptOptions = {
     default?: string;
 };
 
+export type TransportCreatedPromptOptions = {
+    /**
+     * Custom description for the new transport request.
+     */
+    description?: string;
+};
+
 export type OverwritePromptOptions = {
     /**
      * This option allows the prompt to be hidden and should be used when the overwrite prompt should not be shown.
@@ -186,6 +193,7 @@ type abapDeployConfigPromptOptions = Record<promptNames.ui5AbapRepo, UI5AbapRepo
     Record<promptNames.description, DescriptionPromptOptions> &
     Record<promptNames.packageManual, PackageManualPromptOptions> &
     Record<promptNames.transportManual, TransportManualPromptOptions> &
+    Record<promptNames.transportCreated, TransportCreatedPromptOptions> &
     Record<promptNames.overwrite, OverwritePromptOptions> &
     Record<promptNames.index, IndexPromptOptions> &
     Record<promptNames.packageAutocomplete, PackageAutocompletePromptOptions> &

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -526,16 +526,20 @@ describe('Test validators', () => {
         });
 
         it('should return error for invalid package / ui5 abap repo name', async () => {
-            let result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.ListExistingChoice,
+            let result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.ListExistingChoice,
                 previousAnswers
-            );
+            });
             expect(result).toBe(t('errors.validators.transportListPreReqs'));
 
-            result = await validateTransportChoiceInput(false, TransportChoices.ListExistingChoice, {
-                ...previousAnswers,
-                packageManual: 'ZPACKAGE'
+            result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.ListExistingChoice,
+                previousAnswers: {
+                    ...previousAnswers,
+                    packageManual: 'ZPACKAGE'
+                }
             });
             expect(result).toBe(t('errors.validators.transportListPreReqs'));
         });
@@ -544,41 +548,54 @@ describe('Test validators', () => {
             jest.spyOn(validatorUtils, 'getTransportList').mockResolvedValueOnce([
                 { transportReqNumber: 'K123456', transportReqDescription: 'Mock transport request' }
             ]);
-            const result = await validateTransportChoiceInput(false, TransportChoices.ListExistingChoice, {
-                ...previousAnswers,
-                packageManual: 'ZPACKAGE',
-                ui5AbapRepo: 'ZUI5REPO'
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.ListExistingChoice,
+                previousAnswers: {
+                    ...previousAnswers,
+                    packageManual: 'ZPACKAGE',
+                    ui5AbapRepo: 'ZUI5REPO'
+                }
             });
+
             expect(result).toBe(true);
         });
 
         it('should return errors messages for listing transport when transport request empty or undefined', async () => {
             jest.spyOn(validatorUtils, 'getTransportList').mockResolvedValueOnce([]);
 
-            let result = await validateTransportChoiceInput(false, TransportChoices.ListExistingChoice, {
-                ...previousAnswers,
-                packageManual: 'ZPACKAGE',
-                ui5AbapRepo: 'ZUI5REPO'
+            let result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.ListExistingChoice,
+                previousAnswers: {
+                    ...previousAnswers,
+                    packageManual: 'ZPACKAGE',
+                    ui5AbapRepo: 'ZUI5REPO'
+                }
             });
             expect(result).toBe(t('warnings.noTransportReqs'));
 
             jest.spyOn(validatorUtils, 'getTransportList').mockResolvedValueOnce(undefined);
-            result = await validateTransportChoiceInput(false, TransportChoices.ListExistingChoice, {
-                ...previousAnswers,
-                packageManual: 'ZPACKAGE',
-                ui5AbapRepo: 'ZUI5REPO'
+            result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.ListExistingChoice,
+                previousAnswers: {
+                    ...previousAnswers,
+                    packageManual: 'ZPACKAGE',
+                    ui5AbapRepo: 'ZUI5REPO'
+                }
             });
             expect(result).toBe(t('warnings.noExistingTransportReqList'));
         });
 
         it('should return true if transport request is same as previous', async () => {
-            const result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.CreateNewChoice,
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.CreateNewChoice,
                 previousAnswers,
-                true,
-                TransportChoices.CreateNewChoice
-            );
+                validateInputChanged: true,
+                prevTransportInputChoice: TransportChoices.CreateNewChoice
+            });
             expect(result).toBe(true);
         });
 
@@ -587,53 +604,61 @@ describe('Test validators', () => {
                 { transportReqNumber: 'K123456', transportReqDescription: 'Mock transport request' }
             ]);
 
-            const result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.CreateNewChoice,
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.CreateNewChoice,
                 previousAnswers,
-                true,
-                undefined
-            );
+                validateInputChanged: true
+            });
             expect(PromptState.transportAnswers.newTransportNumber).toBe('K123456');
             expect(result).toBe(true);
         });
 
         it('should return true if creating a new transport request is successful', async () => {
-            jest.spyOn(validatorUtils, 'createTransportNumber').mockResolvedValueOnce('TR1234');
+            const createTransportNumberSpy = jest
+                .spyOn(validatorUtils, 'createTransportNumber')
+                .mockResolvedValueOnce('TR1234');
 
-            const result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.CreateNewChoice,
-                previousAnswers,
-                false,
-                undefined
-            );
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.CreateNewChoice,
+                previousAnswers: {
+                    ...previousAnswers,
+                    packageManual: 'ZPACKAGE',
+                    ui5AbapRepo: 'ZUI5REPO'
+                },
+                validateInputChanged: false,
+                transportDescription: 'Mock description for new TR'
+            });
             expect(PromptState.transportAnswers.newTransportNumber).toBe('TR1234');
+            expect(createTransportNumberSpy.mock.calls[0][0]).toStrictEqual({
+                packageName: 'ZPACKAGE',
+                ui5AppName: 'ZUI5REPO',
+                description: 'Mock description for new TR'
+            });
             expect(result).toBe(true);
         });
 
         it('should return error if creating a new transport request returns undefined', async () => {
             jest.spyOn(validatorUtils, 'createTransportNumber').mockResolvedValueOnce(undefined);
 
-            const result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.CreateNewChoice,
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.CreateNewChoice,
                 previousAnswers,
-                false,
-                undefined
-            );
+                validateInputChanged: false
+            });
             expect(PromptState.transportAnswers.newTransportNumber).toBe(undefined);
             expect(result).toBe(t('errors.createTransportReqFailed'));
         });
 
         it('should return error if creating a new transport request returns undefined', async () => {
-            const result = await validateTransportChoiceInput(
-                false,
-                TransportChoices.EnterManualChoice,
+            const result = await validateTransportChoiceInput({
+                useStandalone: false,
+                input: TransportChoices.EnterManualChoice,
                 previousAnswers,
-                false,
-                undefined
-            );
+                validateInputChanged: false
+            });
             expect(result).toBe(true);
         });
     });

--- a/packages/ui-service-inquirer/src/prompts/configuration/questions.ts
+++ b/packages/ui-service-inquirer/src/prompts/configuration/questions.ts
@@ -52,6 +52,9 @@ export function getConfigQuestions(logger: Logger, options?: ServiceConfigOption
                 abapTarget: abapTarget,
                 serviceProvider: PromptState.systemSelection.connectedSystem?.serviceProvider
             },
+            transportCreated: {
+                description: t('prompts.options.transportDescription')
+            },
             transportInputChoice: {
                 showCreateDuringDeploy: false
             },

--- a/packages/ui-service-inquirer/src/translations/ui-service-inquirer.i18n.json
+++ b/packages/ui-service-inquirer/src/translations/ui-service-inquirer.i18n.json
@@ -7,7 +7,10 @@
         "serviceName": "Service Name (not editable)",
         "objectTypeLabel": "Object Type",
         "businessObjectInterfaceLabel": "Business Object Interface",
-        "abapCdsServiceLabel": "ABAP Core Data Service"
+        "abapCdsServiceLabel": "ABAP Core Data Service",
+        "options": {
+            "transportDescription": "Created by the UI service generator"
+        }
     },
     "error": {
         "validatingContent": "There was a back-end validation error for the service content and package provided. Service generation cannot continue. Please try again or contact an admin for the back-end system.",

--- a/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
@@ -8,7 +8,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "guiOptions": {
       "applyDefaultWhenDirty": true,
     },
-    "message": "prompts.config.package.packageInputChoice.message",
+    "message": "How do you want to enter the package?",
     "name": "packageInputChoice",
     "type": "list",
     "validate": [Function],
@@ -23,10 +23,10 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "default": [Function],
     "guiOptions": {
       "breadcrumb": true,
-      "hint": "prompts.config.package.packageManual.hint",
+      "hint": "Provide a package for the deployed application.",
       "mandatory": true,
     },
-    "message": "prompts.config.package.packageManual.message",
+    "message": "Package",
     "name": "packageManual",
     "type": "input",
     "validate": [Function],
@@ -36,10 +36,10 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "additionalInfo": [Function],
     "guiOptions": {
       "breadcrumb": true,
-      "hint": "prompts.config.package.packageAutocomplete.hint",
+      "hint": "Select a package for the deployed application.",
       "mandatory": true,
     },
-    "message": "prompts.config.package.packageAutocomplete.message",
+    "message": "Package",
     "name": "packageAutocomplete",
     "source": [Function],
     "type": "autocomplete",
@@ -52,7 +52,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "guiOptions": {
       "applyDefaultWhenDirty": true,
     },
-    "message": "prompts.config.transport.transportInputChoice.message",
+    "message": "How do you want to enter the transport request?",
     "name": "transportInputChoice",
     "type": "list",
     "validate": [Function],
@@ -65,7 +65,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
   },
   {
     "default": [Function],
-    "message": "prompts.config.transport.transportCreated.message",
+    "message": "Created new Transport Request",
     "name": "transportCreated",
     "type": "input",
     "when": [Function],
@@ -74,10 +74,10 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "choices": [Function],
     "default": [Function],
     "guiOptions": {
-      "breadcrumb": "prompts.config.transport.common.transportRequest",
-      "hint": "prompts.config.transport.common.provideTransportRequest",
+      "breadcrumb": "Transport Request",
+      "hint": "Provide a transport request for your application",
     },
-    "message": "prompts.config.transport.common.transportRequest",
+    "message": "Transport Request",
     "name": "transportFromList",
     "type": "list",
     "when": [Function],
@@ -86,8 +86,8 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "default": [Function],
     "filter": [Function],
     "guiOptions": {
-      "breadcrumb": "prompts.config.transport.common.transportRequest",
-      "hint": "prompts.config.transport.common.provideTransportRequest",
+      "breadcrumb": "Transport Request",
+      "hint": "Provide a transport request for your application",
     },
     "message": [Function],
     "name": "transportManual",
@@ -99,9 +99,9 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "choices": [Function],
     "default": [Function],
     "guiOptions": {
-      "breadcrumb": "prompts.serviceNameBreadcrumb",
+      "breadcrumb": "Service Name",
     },
-    "message": "prompts.serviceName",
+    "message": "Service Name (not editable)",
     "name": "serviceName",
     "type": "expand",
     "validate": [Function],
@@ -113,7 +113,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
       "breadcrumb": true,
       "mandatory": true,
     },
-    "message": "prompts.draftEnabled",
+    "message": "Draft Enabled",
     "name": "draftEnabled",
     "type": "confirm",
     "validate": [Function],
@@ -123,9 +123,9 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "additionalMessages": [Function],
     "default": false,
     "guiOptions": {
-      "breadcrumb": "prompts.launchAppGenBreadcrumb",
+      "breadcrumb": "Create SAP Fiori Application?",
     },
-    "message": "prompts.launchAppGen",
+    "message": "Do you want to create an SAP Fiori application with the newly generated service?",
     "name": "launchAppGen",
     "type": "confirm",
   },
@@ -135,15 +135,15 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
 exports[`getSystemQuestions getServiceConfigQuestions 2`] = `
 [
   {
-    "name": "choices.transport.enterManually",
+    "name": "Enter manually",
     "value": "EnterManualChoice",
   },
   {
-    "name": "choices.common.listExisting",
+    "name": "Choose from existing",
     "value": "ListExistingChoice",
   },
   {
-    "name": "choices.transport.createNew",
+    "name": "Create new",
     "value": "CreateNewChoice",
   },
 ]
@@ -153,10 +153,10 @@ exports[`getSystemQuestions getServiceConfigQuestions with error 1`] = `
 ValidationLink {
   "link": {
     "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzM0NTRfMTc4MDUpIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMSA3LjI0MjIzVjkuNUMxMSA5LjY4OTM5IDEwLjg5MyA5Ljg2MjUyIDEwLjcyMzYgOS45NDcyMUw3LjcyMzYxIDExLjQ0NzJDNy41OTkyNSAxMS41MDk0IDcuNDU0NjIgMTEuNTE3IDcuMzI0NDQgMTEuNDY4MkwzLjQ5MDE4IDEwLjAzMDNMMC42NTgxMTQgMTAuOTc0M0MwLjUwNTY0IDExLjAyNTIgMC4zMzgwMjkgMTAuOTk5NiAwLjIwNzY0NSAxMC45MDU2QzAuMDc3MjYwNiAxMC44MTE2IDAgMTAuNjYwNyAwIDEwLjVWMi41QzAgMi4yODQ3OCAwLjEzNzcxNSAyLjA5MzcyIDAuMzQxODg2IDIuMDI1NjZMMy4zNDE4OSAxLjAyNTY2QzMuNDQ3OTcgMC45OTAyOTYgMy41NjI4NiAwLjk5MTUxNyAzLjY2ODE3IDEuMDI5MTNMNC41NDkyNSAxLjM0MzhDNC4zOTAxOSAxLjYzNDYzIDQuMjYyMyAxLjk0NDk0IDQuMTcwMDkgMi4yNzAyNUw0IDIuMjA5NVY5LjE1MzVMNyAxMC4yNzg1VjcuNzQzOTRDNy4zMTg0MSA3Ljg1NjQ4IDcuNjUzMjcgNy45MzQyMSA4IDcuOTcyNTRWMTAuMTkxTDEwIDkuMTkwOThWNy43NDM5NEMxMC4zNTYgNy42MTgxIDEwLjY5MTUgNy40NDg3MyAxMSA3LjI0MjIzWk0xIDkuODA2MjlWMi44NjAzOEwzIDIuMTkzNzFWOS4xMzk2MkwxIDkuODA2MjlaIiBmaWxsPSIjQzVDNUM1Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNSAzLjQ2NjIyQzUgNC4yNTM4IDUuMjYyNjcgNC45ODAwMyA1LjcwNTE4IDUuNTYyMDlMNS4zNzc1OCA3LjQyTDcuMjg0NzEgNi43MjU4NkM3LjY1MzQ1IDYuODU5NTUgOC4wNTEzMiA2LjkzMjQ0IDguNDY2MjIgNi45MzI0NEMxMC4zODA2IDYuOTMyNDQgMTEuOTMyNCA1LjM4MDU2IDExLjkzMjQgMy40NjYyMkMxMS45MzI0IDEuNTUxODggMTAuMzgwNiAwIDguNDY2MjIgMEM2LjU1MTg4IDAgNSAxLjU1MTg4IDUgMy40NjYyMlpNOCAxLjVDOCAxLjIyMzg2IDguMjIzODYgMSA4LjUgMUM4Ljc3NjE0IDEgOSAxLjIyMzg2IDkgMS41QzkgMS43NzYxNCA4Ljc3NjE0IDIgOC41IDJDOC4yMjM4NiAyIDggMS43NzYxNCA4IDEuNVpNOC41IDNDOC4yMjM4NiAzIDggMy4yMjM4NiA4IDMuNVY1LjVDOCA1Ljc3NjE0IDguMjIzODYgNiA4LjUgNkM4Ljc3NjE0IDYgOSA1Ljc3NjE0IDkgNS41VjMuNUM5IDMuMjIzODYgOC43NzYxNCAzIDguNSAzWiIgZmlsbD0iI0M1QzVDNSIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzM0NTRfMTc4MDUiPgo8cmVjdCB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==",
-    "text": "guidedAnswers.validationErrorHelpText",
+    "text": "Need help with this error?",
     "url": "https://ga.support.sap.com/dtp/viewer/index.html#/tree/3046/actions/63068",
   },
-  "message": "error.validatingContent",
+  "message": "There was a back-end validation error for the service content and package provided. Service generation cannot continue. Please try again or contact an admin for the back-end system.",
 }
 `;
 
@@ -164,10 +164,10 @@ exports[`getSystemQuestions getServiceConfigQuestions with error in validateCont
 ValidationLink {
   "link": {
     "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzM0NTRfMTc4MDUpIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMSA3LjI0MjIzVjkuNUMxMSA5LjY4OTM5IDEwLjg5MyA5Ljg2MjUyIDEwLjcyMzYgOS45NDcyMUw3LjcyMzYxIDExLjQ0NzJDNy41OTkyNSAxMS41MDk0IDcuNDU0NjIgMTEuNTE3IDcuMzI0NDQgMTEuNDY4MkwzLjQ5MDE4IDEwLjAzMDNMMC42NTgxMTQgMTAuOTc0M0MwLjUwNTY0IDExLjAyNTIgMC4zMzgwMjkgMTAuOTk5NiAwLjIwNzY0NSAxMC45MDU2QzAuMDc3MjYwNiAxMC44MTE2IDAgMTAuNjYwNyAwIDEwLjVWMi41QzAgMi4yODQ3OCAwLjEzNzcxNSAyLjA5MzcyIDAuMzQxODg2IDIuMDI1NjZMMy4zNDE4OSAxLjAyNTY2QzMuNDQ3OTcgMC45OTAyOTYgMy41NjI4NiAwLjk5MTUxNyAzLjY2ODE3IDEuMDI5MTNMNC41NDkyNSAxLjM0MzhDNC4zOTAxOSAxLjYzNDYzIDQuMjYyMyAxLjk0NDk0IDQuMTcwMDkgMi4yNzAyNUw0IDIuMjA5NVY5LjE1MzVMNyAxMC4yNzg1VjcuNzQzOTRDNy4zMTg0MSA3Ljg1NjQ4IDcuNjUzMjcgNy45MzQyMSA4IDcuOTcyNTRWMTAuMTkxTDEwIDkuMTkwOThWNy43NDM5NEMxMC4zNTYgNy42MTgxIDEwLjY5MTUgNy40NDg3MyAxMSA3LjI0MjIzWk0xIDkuODA2MjlWMi44NjAzOEwzIDIuMTkzNzFWOS4xMzk2MkwxIDkuODA2MjlaIiBmaWxsPSIjQzVDNUM1Ii8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNSAzLjQ2NjIyQzUgNC4yNTM4IDUuMjYyNjcgNC45ODAwMyA1LjcwNTE4IDUuNTYyMDlMNS4zNzc1OCA3LjQyTDcuMjg0NzEgNi43MjU4NkM3LjY1MzQ1IDYuODU5NTUgOC4wNTEzMiA2LjkzMjQ0IDguNDY2MjIgNi45MzI0NEMxMC4zODA2IDYuOTMyNDQgMTEuOTMyNCA1LjM4MDU2IDExLjkzMjQgMy40NjYyMkMxMS45MzI0IDEuNTUxODggMTAuMzgwNiAwIDguNDY2MjIgMEM2LjU1MTg4IDAgNSAxLjU1MTg4IDUgMy40NjYyMlpNOCAxLjVDOCAxLjIyMzg2IDguMjIzODYgMSA4LjUgMUM4Ljc3NjE0IDEgOSAxLjIyMzg2IDkgMS41QzkgMS43NzYxNCA4Ljc3NjE0IDIgOC41IDJDOC4yMjM4NiAyIDggMS43NzYxNCA4IDEuNVpNOC41IDNDOC4yMjM4NiAzIDggMy4yMjM4NiA4IDMuNVY1LjVDOCA1Ljc3NjE0IDguMjIzODYgNiA4LjUgNkM4Ljc3NjE0IDYgOSA1Ljc3NjE0IDkgNS41VjMuNUM5IDMuMjIzODYgOC43NzYxNCAzIDguNSAzWiIgZmlsbD0iI0M1QzVDNSIvPgo8L2c+CjxkZWZzPgo8Y2xpcFBhdGggaWQ9ImNsaXAwXzM0NTRfMTc4MDUiPgo8cmVjdCB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIGZpbGw9IndoaXRlIi8+CjwvY2xpcFBhdGg+CjwvZGVmcz4KPC9zdmc+Cg==",
-    "text": "guidedAnswers.validationErrorHelpText",
+    "text": "Need help with this error?",
     "url": "https://ga.support.sap.com/dtp/viewer/index.html#/tree/3046/actions/63068",
   },
-  "message": "error.validatingContent",
+  "message": "There was a back-end validation error for the service content and package provided. Service generation cannot continue. Please try again or contact an admin for the back-end system.",
 }
 `;
 
@@ -198,7 +198,7 @@ exports[`getSystemQuestions getSystemQuestions 1`] = `
     "guiOptions": {
       "breadcrumb": true,
     },
-    "message": "prompts.objectTypeLabel",
+    "message": "Object Type",
     "name": "objectType",
     "type": "list",
     "when": [Function],
@@ -210,7 +210,7 @@ exports[`getSystemQuestions getSystemQuestions 1`] = `
       "applyDefaultWhenDirty": true,
       "breadcrumb": true,
     },
-    "message": "prompts.businessObjectInterfaceLabel",
+    "message": "Business Object Interface",
     "name": "businessObjectInterface",
     "type": "list",
     "validate": [Function],
@@ -223,7 +223,7 @@ exports[`getSystemQuestions getSystemQuestions 1`] = `
       "applyDefaultWhenDirty": true,
       "breadcrumb": true,
     },
-    "message": "prompts.abapCdsServiceLabel",
+    "message": "ABAP Core Data Service",
     "name": "abapCDSView",
     "type": "list",
     "validate": [Function],

--- a/packages/ui-service-inquirer/test/prompts.test.ts
+++ b/packages/ui-service-inquirer/test/prompts.test.ts
@@ -2,11 +2,12 @@ import { getSystemSelectionPrompts, getConfigPrompts } from '../src';
 import nock from 'nock';
 import type { Answers, Question as YoQuestion } from 'inquirer';
 import * as promptHelper from '../src/prompts/prompt-helper';
-import { genContent } from './fixtures/constants';
+import * as abapDeployConfigInquirer from '@sap-ux/abap-deploy-config-inquirer';
 import { PromptState } from '../src/prompts/prompt-state';
 import { ObjectType } from '../src/types';
 import type { YUIQuestion } from '@sap-ux/inquirer-common';
 import type { AbapServiceProvider } from '@sap-ux/axios-extension';
+import { initI18n, t } from '../src/i18n';
 
 jest.mock('../src/logger-helper');
 
@@ -128,7 +129,8 @@ const getContentMockDraftTrue = jest.fn().mockImplementation((pckg) => {
 });
 
 describe('getSystemQuestions', () => {
-    beforeAll(() => {
+    beforeAll(async () => {
+        await initI18n();
         nock.disableNetConnect();
     });
 
@@ -169,8 +171,8 @@ describe('getSystemQuestions', () => {
 
         expect(q.objectType.when!({ systemSelection: 'system1' })).toEqual(true);
         expect(q.objectType.choices!()).toEqual([
-            { name: 'prompts.businessObjectInterfaceLabel', value: ObjectType.BUSINESS_OBJECT },
-            { name: 'prompts.abapCdsServiceLabel', value: ObjectType.CDS_VIEW }
+            { name: t('prompts.businessObjectInterfaceLabel'), value: ObjectType.BUSINESS_OBJECT },
+            { name: t('prompts.abapCdsServiceLabel'), value: ObjectType.CDS_VIEW }
         ]);
 
         const businessObjectMock = {
@@ -188,12 +190,14 @@ describe('getSystemQuestions', () => {
         expect(await q.businessObjectInterface.when!({ objectType: ObjectType.CDS_VIEW })).toEqual(false);
         expect(await q.businessObjectInterface.choices!()).toEqual([businessObjectMockResp]);
         expect(await q.businessObjectInterface.validate!(businessObjectMock, answersMock)).toEqual(
-            'error.noGeneratorFoundBo'
+            t('error.noGeneratorFoundBo')
         );
 
         expect(await q.abapCDSView.when!({ objectType: ObjectType.CDS_VIEW })).toEqual(true);
         expect(await q.abapCDSView.choices!()).toEqual([abapCDSViewsMockResp]);
-        expect(await q.abapCDSView.validate!(abapCDSViewMock, answersMock)).toEqual('error.noGeneratorFoundCdsService');
+        expect(await q.abapCDSView.validate!(abapCDSViewMock, answersMock)).toEqual(
+            t('error.noGeneratorFoundCdsService')
+        );
 
         mockIsAppStudio.mockReturnValue(false);
         questions = (await getSystemSelectionPrompts()).prompts;
@@ -203,6 +207,7 @@ describe('getSystemQuestions', () => {
     });
 
     test('getServiceConfigQuestions', async () => {
+        const getTransportRequestPromptsSpy = jest.spyOn(abapDeployConfigInquirer, 'getTransportRequestPrompts');
         const genMock = {
             getContent: getContentMockDraftTrue,
             validateContent: jest.fn().mockResolvedValue({
@@ -212,7 +217,8 @@ describe('getSystemQuestions', () => {
         const systemSelectionAnswers = {
             connectedSystem: {
                 backendSystem: {
-                    name: 'system1'
+                    url: 'https://mock.sap.system/sap',
+                    client: '100'
                 },
                 destination: {
                     Name: 'system1'
@@ -233,6 +239,24 @@ describe('getSystemQuestions', () => {
             q[question.name] = question as Question;
         });
         expect(questions).toMatchSnapshot();
+        expect(getTransportRequestPromptsSpy.mock.calls[0][0]).toStrictEqual({
+            backendTarget: {
+                abapTarget: {
+                    url: 'https://mock.sap.system/sap',
+                    client: '100'
+                },
+                serviceProvider: systemSelectionAnswers.connectedSystem.serviceProvider
+            },
+            transportCreated: {
+                description: t('prompts.options.transportDescription')
+            },
+            transportInputChoice: {
+                showCreateDuringDeploy: false
+            },
+            ui5AbapRepo: {
+                default: 'ztestapp'
+            }
+        });
         expect(q.transportInputChoice.choices!()).toMatchSnapshot();
         expect(await q.serviceName.when!({ packageManual: '', packageAutocomplete: 'package' })).toEqual(true);
         expect(PromptState.serviceConfig.showDraftEnabled).toEqual(true);
@@ -244,7 +268,7 @@ describe('getSystemQuestions', () => {
         expect(await q.draftEnabled.validate!(false)).toEqual(true);
         expect((q.launchAppGen as YUIQuestion).additionalMessages!(false)).toBeUndefined();
         expect((q.launchAppGen as YUIQuestion).additionalMessages!(true)).toEqual({
-            message: 'info.appGenLaunch',
+            message: t('info.appGenLaunch'),
             severity: 2
         });
     });
@@ -300,7 +324,7 @@ describe('getSystemQuestions', () => {
             q[question.name] = question as Question;
         });
         expect(await q.serviceName.when!({ packageManual: 'package' })).toEqual(true);
-        expect(await q.draftEnabled.validate!(false)).toEqual('error.validatingContent');
+        expect(await q.draftEnabled.validate!(false)).toEqual(t('error.validatingContent'));
     });
 
     test('getServiceConfigQuestions with error in validateContent', async () => {


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3224

- Adds new option `description` for the `transportCreated` prompt. This allows a custom description to be passed in for consuming generators
- Updates the UI service generator to pass the new message 
- Updates tests