### PR TITLE
fix(ui5-app-inquirer): remove typescript workspace warning for non cap

### DIFF
--- a/.changeset/short-snakes-exist.md
+++ b/.changeset/short-snakes-exist.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+---
+
+fix typescript workspace warning for non cap projects

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -194,7 +194,7 @@ export function getEnableTypeScriptPrompt(capCdsInfo?: CdsUi5PluginInfo): UI5App
         },
         additionalMessages: (val: boolean) => {
             let message;
-            if (val && !capCdsInfo?.isWorkspaceEnabled) {
+            if (val && capCdsInfo?.hasMinCdsVersion && !capCdsInfo?.isWorkspaceEnabled) {
                 message = { message: t('prompts.enableTypeScript.warningMsg'), severity: Severity.warning };
             }
             return message;

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -560,6 +560,7 @@ describe('getQuestions', () => {
         });
         enableTypeScriptQuestion = questions.find((question) => question.name === promptNames.enableTypeScript);
         expect(enableTypeScriptQuestion?.default()).toEqual(true);
+        expect(enableTypeScriptQuestion?.additionalMessages!(true)).toEqual(undefined);
 
         // when
         expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
@@ -574,10 +575,6 @@ describe('getQuestions', () => {
         );
         expect((enableTypeScriptQuestion?.when as Function)()).toEqual(false);
 
-        enableTypeScriptQuestion = getQuestions([], undefined, mockCdsInfoFalse).find(
-            (question) => question.name === promptNames.enableTypeScript
-        );
-
         enableTypeScriptQuestion = getQuestions([], undefined, {
             hasCdsUi5Plugin: true,
             isCdsUi5PluginEnabled: true,
@@ -585,6 +582,7 @@ describe('getQuestions', () => {
             hasMinCdsVersion: true
         }).find((question) => question.name === promptNames.enableTypeScript);
         expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
+        expect(enableTypeScriptQuestion?.additionalMessages!(true)).toEqual(undefined);
 
         enableTypeScriptQuestion = getQuestions([], undefined, {
             hasCdsUi5Plugin: false,


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3230

- remove workspace warning for non cap projects/data sources
- add additional tests