### PR TITLE
fix(odata-service-inquirer): Set `ignoreCertError` to PromptState

### DIFF
--- a/.changeset/tricky-turkeys-smile.md
+++ b/.changeset/tricky-turkeys-smile.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix, adds `ignoreCertError` to prompt state

--- a/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
@@ -49,6 +49,7 @@ export async function validateService(
         // Remove all occurrences of the origin from the metadata to make backend uris relative
         PromptState.odataService.metadata = originToRelative(metadata);
         PromptState.odataService.odataVersion = serviceOdataVersion;
+        PromptState.odataService.ignoreCertError = ignoreCertError;
 
         // Extract sap-client and keep the rest of the query params as part of the url
         const fullUrl = new URL(url);

--- a/packages/odata-service-inquirer/test/unit/prompts/service-url/validators.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/service-url/validators.test.ts
@@ -123,7 +123,8 @@ describe('Test service url validators', () => {
                     Version: '0001',
                     Uri: 'https://some.host:1234/service/path'
                 }
-            ]
+            ],
+            ignoreCertError: false
         });
     });
 


### PR DESCRIPTION
Follow-up to fix for: https://github.com/SAP/open-ux-tools/issues/3228

- Add `ignoreCertError` property to prompt state in case if this is referenced by a caller instead of using `prompt()` function which returns the answers object including all prompt answers
- Updates test