### PR TITLE
fix(axios): Disable System info params encoding

### DIFF
--- a/.changeset/new-sloths-develop.md
+++ b/.changeset/new-sloths-develop.md
@@ -2,4 +2,4 @@
 '@sap-ux/axios-extension': patch
 ---
 
-Disable System info params encoding
+fix(axios): Disable System info params encoding

--- a/.changeset/new-sloths-develop.md
+++ b/.changeset/new-sloths-develop.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/axios-extension': patch
+---
+
+Disable System info params encoding

--- a/packages/axios-extension/src/abap/lrep-service.ts
+++ b/packages/axios-extension/src/abap/lrep-service.ts
@@ -138,7 +138,7 @@ function isBuffer(input: string | Buffer): input is Buffer {
  * Decodes url parameters.
  *
  * @param params An object containing the parameters to be decoded.
- * @returns The deocded parameters as a string.
+ * @returns The decoded parameters as a string.
  */
 const decodeUrlParams: CustomParamsSerializer = (params: URLSearchParams) => decodeURIComponent(params.toString());
 

--- a/packages/axios-extension/test/abap/lrep-service.test.ts
+++ b/packages/axios-extension/test/abap/lrep-service.test.ts
@@ -308,6 +308,20 @@ describe('LayeredRepositoryService', () => {
             expect(systemInfo).toEqual(mockResult);
         });
 
+        test('does NOT encode language and cloudPackage request params', async () => {
+            const language = 'EN';
+            const cloudPackage = 'path/to/cloud-package0';
+            nock(server)
+                .get((path) => path.startsWith(`${LayeredRepositoryService.PATH}/dta_folder/system_info`))
+                .reply(200, (path) => {
+                    expect(path).toContain(`sap-language=${language}`);
+                    expect(path).toContain(`package=${cloudPackage}`);
+                    return mockResult;
+                });
+            const systemInfo = await service.getSystemInfo(language, cloudPackage);
+            expect(systemInfo).toEqual(mockResult);
+        });
+
         test('throws error when request fails', async () => {
             nock(server)
                 .get((path) => path.startsWith(`${LayeredRepositoryService.PATH}/dta_folder/system_info`))

--- a/packages/axios-extension/test/abap/lrep-service.test.ts
+++ b/packages/axios-extension/test/abap/lrep-service.test.ts
@@ -314,7 +314,6 @@ describe('LayeredRepositoryService', () => {
             nock(server)
                 .get((path) => path.startsWith(`${LayeredRepositoryService.PATH}/dta_folder/system_info`))
                 .reply(200, (path) => {
-                    expect(path).toContain(`sap-language=${language}`);
                     expect(path).toContain(`package=${cloudPackage}`);
                     return mockResult;
                 });


### PR DESCRIPTION
Fix for: #3238

* Disable internally the encoding of url parameters set in the `get system info` api call.
* Make a small refactoring - in the `merge app descriptor variant` api call we also disable the encoding.

Testing done:
* Add unit tests.
* Manually verified.