### PR TITLE
feat(ui-components) export pivot

### DIFF
--- a/packages/ui-components/src/components/UITabs/UITabs.tsx
+++ b/packages/ui-components/src/components/UITabs/UITabs.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 
-import type { IPivotProps, IPivotStyles } from '@fluentui/react';
+import type { IPivotProps, IPivotStyles, IPivotItemProps } from '@fluentui/react';
 import { Pivot, PivotItem } from '@fluentui/react';
 
 export { PivotItem as UITabsItem };
+export { IPivotItemProps as UITabsItemProps };
+
+export { Pivot as UIPivot };
+export { IPivotProps as UIPivotProps };
+export { IPivotStyles as UIPivotStyle };
 
 export interface UITabsProps extends IPivotProps {
     items: string[];


### PR DESCRIPTION
export fluentUi pivot, props and styles to allow to build your own `Tab` as `UITabs` create the complete `Tab` without exporting all components.
It's needed in another extension as the design is completely different from `ui-components UITab`