### PR TITLE
feat(odata-inq): service filter prompt option

### DIFF
--- a/.changeset/lazy-colts-shave.md
+++ b/.changeset/lazy-colts-shave.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+adds new service filter prompt option

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -85,7 +85,8 @@ export function getSystemServiceQuestion(
                 if (connectValidator.catalogs[OdataVersion.v2] || connectValidator.catalogs[OdataVersion.v4]) {
                     serviceChoices = await createServiceChoicesFromCatalog(
                         connectValidator.catalogs,
-                        requiredOdataVersion
+                        requiredOdataVersion,
+                        promptOptions?.serviceFilter
                     );
                     previousSystemUrl = connectValidator.validatedUrl;
                     previousClient = connectValidator.validatedClient;
@@ -208,11 +209,13 @@ export function getSystemServiceQuestion(
  *
  * @param availableCatalogs catalogs that can be used to list services
  * @param requiredOdataVersion the required OData version to list services for, if not provided all available catalogs will be used
+ * @param serviceFilter list of service ids used for filtering the choices
  * @returns service choices
  */
 async function createServiceChoicesFromCatalog(
     availableCatalogs: Record<ODataVersion, CatalogService | undefined>,
-    requiredOdataVersion?: OdataVersion
+    requiredOdataVersion?: OdataVersion,
+    serviceFilter?: string[]
 ): Promise<ListChoiceOptions<ServiceAnswer>[]> {
     let catalogs: CatalogService[] = [];
     if (requiredOdataVersion && availableCatalogs[requiredOdataVersion]) {
@@ -220,5 +223,5 @@ async function createServiceChoicesFromCatalog(
     } else {
         catalogs = Object.values(availableCatalogs).filter((cat): cat is CatalogService => cat !== undefined);
     }
-    return await getServiceChoices(catalogs);
+    return await getServiceChoices(catalogs, serviceFilter);
 }

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -331,7 +331,7 @@ export type ServiceSelectionPromptOptions = {
      */
     showCollaborativeDraftWarning?: boolean;
     /**
-     * A list of service ids which will be used to filter the service returned from the catalog service
+     * A list of service ids used to filter the catalog results
      */
     serviceFilter?: string[];
 } & Pick<CommonPromptOptions, 'additionalMessages'>; // Service selection prompts allow extension with additional messages;

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -330,6 +330,10 @@ export type ServiceSelectionPromptOptions = {
      * This is used to indicate that the service does not support collaborative draft.
      */
     showCollaborativeDraftWarning?: boolean;
+    /**
+     * A list of service ids which will be used to filter the service returned from the catalog service
+     */
+    serviceFilter?: string[];
 } & Pick<CommonPromptOptions, 'additionalMessages'>; // Service selection prompts allow extension with additional messages;
 
 export type SystemNamePromptOptions = {

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -1,4 +1,4 @@
-import type { Annotations, ServiceProvider } from '@sap-ux/axios-extension';
+import type { Annotations, ServiceProvider, ODataServiceInfo } from '@sap-ux/axios-extension';
 import type { Destination } from '@sap-ux/btp-utils';
 import type { CommonPromptOptions, YUIQuestion } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
@@ -331,7 +331,7 @@ export type ServiceSelectionPromptOptions = {
      */
     showCollaborativeDraftWarning?: boolean;
     /**
-     * A list of service ids used to filter the catalog results
+     * A list of service ids ({@link ODataServiceInfo.id}), used to filter the catalog results
      */
     serviceFilter?: string[];
 } & Pick<CommonPromptOptions, 'additionalMessages'>; // Service selection prompts allow extension with additional messages;

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/questions.test.ts
@@ -189,6 +189,26 @@ describe('Test new system prompt', () => {
             }
         ]);
 
+        // The service choices should be restricted based on the service filter prompt option
+        systemServiceQuestions = getSystemServiceQuestion(connectValidator, promptNamespace, {
+            serviceFilter: ['/DMO/FLIGHT']
+        });
+        serviceSelectionPrompt = systemServiceQuestions.find(
+            (question) => question.name === `${promptNamespace}:${promptNames.serviceSelection}`
+        );
+
+        expect(await ((serviceSelectionPrompt as ListQuestion)?.choices as Function)()).toEqual([
+            {
+                name: 'DMO_GRP > /DMO/FLIGHT (0001) - OData V4',
+                value: {
+                    serviceODataVersion: '4',
+                    servicePath: '/sap/opu/odata4/dmo/flight/0001/?sap-client=000',
+                    serviceType: 'WEB_API',
+                    toString: expect.any(Function)
+                }
+            }
+        ]);
+
         // The services choices should be restricted to the specified required odata version
         systemServiceQuestions = getSystemServiceQuestion(connectValidator, promptNamespace, {
             requiredOdataVersion: OdataVersion.v2


### PR DESCRIPTION
- In some cases, the list of services returned from the catalog may require filtering, the new property `serviceFilter` on `ServiceSelectionPromptOptions` will facilitate the filtering of services returned from the catalog, based on the service ID. 
