### PR TITLE
fix(fiori-annotation-api): replace text content for cds paths

### DIFF
--- a/.changeset/smart-onions-mate.md
+++ b/.changeset/smart-onions-mate.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-annotation-api': patch
+---
+
+fix: [CDS] update change for path values does not replace `/` with `.`.

--- a/packages/fiori-annotation-api/src/cds/adapter.ts
+++ b/packages/fiori-annotation-api/src/cds/adapter.ts
@@ -885,10 +885,18 @@ export class CDSAnnotationServiceAdapter implements AnnotationServiceAdapter, Ch
                     });
                 }
             } else {
+                const text =
+                    // annotation paths are currently converted to strings and for those separators do not need to be replaced
+                    annotationFileNode?.type === ELEMENT_TYPE &&
+                    (annotationFileNode.name === Edm.Path ||
+                        annotationFileNode.name === Edm.PropertyPath ||
+                        annotationFileNode.name === Edm.NavigationPropertyPath)
+                        ? newValue.text.replaceAll('/', '.')
+                        : newValue.text;
                 writer.addChange({
                     type: 'update-primitive-value',
                     pointer: pointer,
-                    newValue: newValue.text
+                    newValue: text
                 });
             }
         } else {

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -3902,6 +3902,76 @@ exports[`fiori annotation service update property value complete EDMXBackend xml
 "
 `;
 
+exports[`fiori annotation service update property value replace paths with multiple segments CAPNodejs cap-start v4 1`] = `
+"using IncidentService as service from '../../srv/incidentservice';
+
+annotate service.Incidents with @(
+    UI.LineItem : [
+        {
+            $Type : 'UI.DataFieldForAnnotation',
+            Target : 'incidentFlow/@UI.LineItem',
+            ![@UI.Hidden] : incidentFlow.createdBy,
+        },
+        {
+            $Type : 'UI.DataFieldForIntentBasedNavigation',
+            Mapping : [
+                {
+                    $Type : 'Common.SemanticObjectMappingType',
+                    LocalProperty : incidentFlow.createdBy,
+                },
+            ],
+        },
+        {
+            $Type : 'UI.DataFieldWithNavigationPath',
+            Target : incidentFlow.createdBy,
+        },
+    ]
+);
+
+"
+`;
+
+exports[`fiori annotation service update property value replace paths with multiple segments EDMXBackend xml-start v4 1`] = `
+"<edmx:Edmx xmlns:edmx=\\"http://docs.oasis-open.org/odata/ns/edmx\\" Version=\\"4.0\\">
+    <edmx:Reference Uri=\\"https://sap.github.io/odata-vocabularies/vocabularies/Common.xml\\">
+        <edmx:Include Namespace=\\"com.sap.vocabularies.Common.v1\\" Alias=\\"Common\\"/>
+    </edmx:Reference>
+    <edmx:Reference Uri=\\"https://sap.github.io/odata-vocabularies/vocabularies/UI.xml\\">
+        <edmx:Include Namespace=\\"com.sap.vocabularies.UI.v1\\" Alias=\\"UI\\"/>
+    </edmx:Reference>
+    <edmx:Reference Uri=\\"/incident/$metadata\\">
+        <edmx:Include Namespace=\\"IncidentService\\"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns=\\"http://docs.oasis-open.org/odata/ns/edm\\" Namespace=\\"sap.fe.demo\\">
+            <Annotations Target=\\"IncidentService.Incidents\\">
+                <Annotation Term=\\"UI.LineItem\\">
+                    <Collection>
+                        <Record Type=\\"UI.DataFieldForAnnotation\\">
+                            <PropertyValue Property=\\"Target\\" AnnotationPath=\\"incidentFlow/@UI.LineItem\\"/>
+                            <Annotation Term=\\"UI.Hidden\\" Path=\\"incidentFlow/createdBy\\"/>
+                        </Record>
+                        <Record Type=\\"UI.DataFieldForIntentBasedNavigation\\">
+                            <PropertyValue Property=\\"Mapping\\">
+                                <Collection>
+                                    <Record Type=\\"Common.SemanticObjectMappingType\\">
+                                        <PropertyValue Property=\\"LocalProperty\\" PropertyPath=\\"incidentFlow/createdBy\\"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                        <Record Type=\\"UI.DataFieldWithNavigationPath\\">
+                            <PropertyValue Property=\\"Target\\" NavigationPropertyPath=\\"incidentFlow/createdBy\\"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>
+"
+`;
+
 exports[`fiori annotation service update qualifier value CAPNodejs cap-start v4 1`] = `
 "using IncidentService as service from '../../srv/incidentservice';
 

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -3910,7 +3910,7 @@ annotate service.Incidents with @(
         {
             $Type : 'UI.DataFieldForAnnotation',
             Target : 'incidentFlow/@UI.LineItem',
-            ![@UI.Hidden] : incidentFlow.createdBy,
+            ![@UI.Hidden] : incidentFlow.incident.createdBy,
         },
         {
             $Type : 'UI.DataFieldForIntentBasedNavigation',
@@ -3949,7 +3949,7 @@ exports[`fiori annotation service update property value replace paths with multi
                     <Collection>
                         <Record Type=\\"UI.DataFieldForAnnotation\\">
                             <PropertyValue Property=\\"Target\\" AnnotationPath=\\"incidentFlow/@UI.LineItem\\"/>
-                            <Annotation Term=\\"UI.Hidden\\" Path=\\"incidentFlow/createdBy\\"/>
+                            <Annotation Term=\\"UI.Hidden\\" Path=\\"incidentFlow/incident/createdBy\\"/>
                         </Record>
                         <Record Type=\\"UI.DataFieldForIntentBasedNavigation\\">
                             <PropertyValue Property=\\"Mapping\\">

--- a/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
+++ b/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
@@ -17,7 +17,7 @@ import type {
 } from '@sap-ux/vocabularies-types';
 import { getProject } from '@sap-ux/project-access';
 
-import type { Change, DeleteChange, InsertAnnotationChange, TextFile } from '../../src/types';
+import type { Change, DeleteChange, InsertAnnotationChange, TextFile, UpdateChange } from '../../src/types';
 import { ExpressionType, ChangeType } from '../../src/types';
 import { FioriAnnotationService } from '../../src/fiori-service';
 
@@ -3209,6 +3209,151 @@ rating : Rating;
                                     type: 'String',
                                     String: 'Test'
                                 }
+                            }
+                        }
+                    }
+                ]
+            });
+
+            createEditTestCase({
+                name: 'replace paths with multiple segments',
+                projectTestModels: TEST_TARGETS,
+                getInitialChanges: (files) => [
+                    {
+                        kind: ChangeType.InsertAnnotation,
+                        uri: files.annotations,
+                        content: {
+                            target: TARGET_INCIDENTS,
+                            type: 'annotation',
+                            value: {
+                                term: LINE_ITEM,
+                                collection: [
+                                    {
+                                        type: `${UI}.DataFieldForAnnotation`,
+                                        propertyValues: [
+                                            {
+                                                name: 'Target',
+                                                value: {
+                                                    type: 'AnnotationPath',
+                                                    AnnotationPath: `incidentFlow/@${UI}.Chart`
+                                                }
+                                            }
+                                        ],
+                                        annotations: [
+                                            {
+                                                term: `${UI}.Hidden`,
+                                                value: {
+                                                    type: 'Path',
+                                                    Path: 'priority'
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        type: `${UI}.DataFieldForIntentBasedNavigation`,
+                                        propertyValues: [
+                                            {
+                                                name: 'Mapping',
+                                                value: {
+                                                    type: 'Collection',
+                                                    Collection: [
+                                                        {
+                                                            type: `${COMMON}.SemanticObjectMappingType`,
+                                                            propertyValues: [
+                                                                {
+                                                                    name: 'LocalProperty',
+                                                                    value: {
+                                                                        type: 'PropertyPath',
+                                                                        PropertyPath: 'incidentFlow/processStep'
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        type: `${UI}.DataFieldWithNavigationPath`,
+                                        propertyValues: [
+                                            {
+                                                name: 'Target',
+                                                value: {
+                                                    type: 'NavigationPropertyPath',
+                                                    NavigationPropertyPath: `incidentFlow/incident`
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                getChanges: (files) => [
+                    {
+                        kind: ChangeType.Update,
+                        reference: {
+                            target: TARGET_INCIDENTS,
+                            term: LINE_ITEM
+                        },
+                        uri: files.annotations,
+                        pointer: `/collection/0/propertyValues/0/value`,
+                        content: {
+                            type: 'expression',
+                            value: {
+                                type: 'AnnotationPath',
+                                AnnotationPath: 'incidentFlow/@com.sap.vocabularies.UI.v1.LineItem'
+                            }
+                        }
+                    },
+                    // only certain paths are read as `PropertyPath` based on vocabulary definitions as CDS does not distinguish between different path types
+                    {
+                        kind: ChangeType.Update,
+                        reference: {
+                            target: TARGET_INCIDENTS,
+                            term: LINE_ITEM
+                        },
+                        uri: files.annotations,
+                        pointer: `/collection/1/propertyValues/0/value/Collection/0/propertyValues/0/value`,
+                        content: {
+                            type: 'expression',
+                            value: {
+                                type: 'PropertyPath',
+                                PropertyPath: 'incidentFlow/createdBy'
+                            }
+                        }
+                    },
+                    {
+                        kind: ChangeType.Update,
+                        reference: {
+                            target: TARGET_INCIDENTS,
+                            term: LINE_ITEM
+                        },
+                        uri: files.annotations,
+                        pointer: `/collection/2/propertyValues/0/value`,
+                        content: {
+                            type: 'expression',
+                            value: {
+                                type: 'NavigationPropertyPath',
+                                NavigationPropertyPath: 'incidentFlow/createdBy'
+                            }
+                        }
+                    },
+                    {
+                        kind: ChangeType.Update,
+                        reference: {
+                            target: TARGET_INCIDENTS,
+                            term: LINE_ITEM
+                        },
+                        uri: files.annotations,
+                        pointer: `/collection/0/annotations/0/value`,
+                        content: {
+                            type: 'expression',
+                            value: {
+                                type: 'Path',
+                                Path: 'incidentFlow/createdBy'
                             }
                         }
                     }

--- a/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
+++ b/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
@@ -17,7 +17,7 @@ import type {
 } from '@sap-ux/vocabularies-types';
 import { getProject } from '@sap-ux/project-access';
 
-import type { Change, DeleteChange, InsertAnnotationChange, TextFile, UpdateChange } from '../../src/types';
+import type { Change, DeleteChange, InsertAnnotationChange, TextFile } from '../../src/types';
 import { ExpressionType, ChangeType } from '../../src/types';
 import { FioriAnnotationService } from '../../src/fiori-service';
 

--- a/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
+++ b/packages/fiori-annotation-api/test/unit/fiori-service.test.ts
@@ -3353,7 +3353,7 @@ rating : Rating;
                             type: 'expression',
                             value: {
                                 type: 'Path',
-                                Path: 'incidentFlow/createdBy'
+                                Path: 'incidentFlow/incident/createdBy'
                             }
                         }
                     }


### PR DESCRIPTION
Correctly replace `/` with `.` for CDS paths when they are used for text replacement, because there conversion logic from `@sap-ux/cds-odata-annotation-converter` is not called.