### PR TITLE
Fix/preview middleware/cards generator with static flp html

### DIFF
--- a/.changeset/seven-rice-heal.md
+++ b/.changeset/seven-rice-heal.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix local flp file leading to error with virtual cards generator endpoint

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -423,8 +423,8 @@ export class FlpSandbox {
             return;
         }
         await this.setApplicationDependencies();
-        // inform the user if a html file exists on the filesystem
-        const filePath = 'query' in req ? req.path : new URL('http://dummyHost' + req.originalUrl!).pathname;
+        // get filepath from request. Use dummy url to extract it from originalUrl if needed
+        const filePath = 'query' in req ? req.path : new URL('http://dummyHost' + req.originalUrl!).pathname; //NOSONAR
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const file = await this.project.byPath(filePath);
         if (file) {

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -424,10 +424,11 @@ export class FlpSandbox {
         }
         await this.setApplicationDependencies();
         // inform the user if a html file exists on the filesystem
+        const filePath = 'query' in req ? req.path : new URL('http://dummyHost' + req.originalUrl!).pathname;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const file = await this.project.byPath(this.flpConfig.path);
+        const file = await this.project.byPath(filePath);
         if (file) {
-            this.logger.info(`HTML file returned at ${this.flpConfig.path} is loaded from the file system.`);
+            this.logger.info(`HTML file returned at ${filePath} is loaded from the file system.`);
             next();
         } else {
             const ui5Version = await this.getUi5Version(

--- a/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
+++ b/packages/preview-middleware/test/unit/base/__snapshots__/flp.test.ts.snap
@@ -583,6 +583,81 @@ exports[`FlpSandbox router - connect API GET default routes with connect API (us
 </html>"
 `;
 
+exports[`FlpSandbox router - connect API GET default routes with connect API (used by karma test runner) 5`] = `
+"<!DOCTYPE HTML>
+<html lang=\\"en\\">
+<!-- Copyright (c) 2015 SAP AG, All Rights Reserved -->
+
+<head>
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+    <meta charset=\\"UTF-8\\">
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+    <title>Local FLP Sandbox</title>
+
+    <!-- Bootstrap the unified shell in sandbox mode for standalone usage.
+
+         The renderer is specified in the global Unified Shell configuration object \\"sap-ushell-config\\".
+
+         The fiori2 renderer will render the shell header allowing, for instance,
+         testing of additional application setting buttons.
+
+         The navigation target resolution service is configured in a way that the empty URL hash is
+         resolved to our own application.
+
+         This example uses relative path references for the SAPUI5 resources and test-resources;
+         it might be necessary to adapt them depending on the target runtime platform.
+         The sandbox platform is restricted to development or demo use cases and must NOT be used
+         for productive scenarios.
+    -->
+    <script type=\\"text/javascript\\">
+        window[\\"sap-ushell-config\\"] = {
+            defaultRenderer: \\"fiori2\\",
+            renderers: {
+                fiori2: {
+                    componentData: {
+                        config: {
+                            search: \\"hidden\\",
+                            enableSearch: false
+                        }
+                    }
+                }
+            },
+            applications:  {\\"app-preview\\":{\\"title\\":\\"My Simple App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.app\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"..\\"},\\"testfev2other-preview\\":{\\"title\\":\\"My Other App\\",\\"description\\":\\"This is a very simple application.\\",\\"additionalInformation\\":\\"SAPUI5.Component=test.fe.v2.other\\",\\"applicationType\\":\\"URL\\",\\"url\\":\\"/yet/another/app\\"}}
+        };
+    </script>
+
+    <script type=\\"text/javascript\\">
+        window[\\"data-open-ux-preview-basePath\\"] = \\"..\\";
+    </script>
+
+    <script src=\\"../test-resources/sap/ushell/bootstrap/sandbox.js\\" id=\\"sap-ushell-bootstrap\\"></script>
+    <!-- Bootstrap the UI5 core library. 'data-sap-ui-frameOptions=\\"allow\\"' is a NON-SECURE setting for test environments -->
+    <script id=\\"sap-ui-bootstrap\\"
+        src=\\"../resources/sap-ui-core.js\\"
+        data-sap-ui-libs=\\"sap.m,sap.ui.core,sap.ushell,sap.f,sap.ui.comp,sap.ui.generic.app,sap.suite.ui.generic.template\\"
+        data-sap-ui-async=\\"true\\"
+        data-sap-ui-preload=\\"async\\"
+        data-sap-ui-theme=\\"sap_horizon_dark\\"
+        data-sap-ui-compatVersion=\\"edge\\"
+        data-sap-ui-language=\\"en\\"
+        data-sap-ui-bindingSyntax=\\"complex\\"
+        data-sap-ui-flexibilityServices='[{\\"connector\\":\\"LrepConnector\\",\\"layers\\":[],\\"url\\":\\"/sap/bc/lrep\\"},{\\"applyConnector\\":\\"open/ux/preview/client/flp/WorkspaceConnector\\",\\"writeConnector\\":\\"open/ux/preview/client/flp/WorkspaceConnector\\",\\"custom\\":true},{\\"connector\\":\\"LocalStorageConnector\\",\\"layers\\":[\\"CUSTOMER\\",\\"USER\\"]}]'
+        data-sap-ui-resourceroots='{\\"open.ux.preview.client\\":\\"../preview/client\\",\\"test.fe.v2.app\\":\\"..\\",\\"test.fe.v2.other\\":\\"/yet/another/app\\"}'
+        data-sap-ui-frameOptions=\\"allow\\"
+        data-sap-ui-xx-componentPreload=\\"off\\"
+        data-sap-ui-oninit=\\"module:open/ux/preview/client/flp/init\\">
+    </script>
+
+
+</head>
+
+<!-- UI Content -->
+<body class=\\"sapUiBody\\" id=\\"content\\">
+</body>
+
+</html>"
+`;
+
 exports[`FlpSandbox router - connect API GET default routes with connect API when enhancedHomePage is enabled 1`] = `
 "<!DOCTYPE HTML>
 <html lang=\\"en\\">

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -1046,6 +1046,8 @@ describe('FlpSandbox', () => {
             response = await server.get('/test/integration/opaTests.qunit.html').expect(200);
             expect(response.text).toMatchSnapshot();
             await server.get('/cdm.json').expect(404);
+            response = await server.get('/test/flp.html?sap-ui-xx-viewCache=false').expect(200);
+            expect(response.text).toMatchSnapshot();
         });
 
         test('GET default routes with connect API when enhancedHomePage is enabled', async () => {


### PR DESCRIPTION
Currently the virtual card generator endpoint does not work in case the preview uses a (non virtual) local flp html file. This is fixed in this PR.