### PR TITLE
fix(ui5-app-inq): correct hide fn logic

### DIFF
--- a/.changeset/quick-jokes-arrive.md
+++ b/.changeset/quick-jokes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+---
+
+fix hide fn logic

--- a/packages/ui5-application-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompt-helpers.ts
@@ -78,13 +78,11 @@ export function hidePrompts(
             const promptKey = key as keyof typeof promptNames;
             // Narrow the type as we are only dealing with `hide` options
             const promptOpt = promptOptions?.[promptKey] as UI5ApplicationCommonPromptOptions | AddDeployPromptOptions;
-            let hidePrompt = false;
-            if (typeof promptOpt?.hide === 'function') {
-                hidePrompt = promptOpt.hide(isCapProject);
-            }
+
+            const hidePrompt =
+                typeof promptOpt?.hide === 'function' ? promptOpt.hide(isCapProject) : promptOpt?.hide ?? false;
             if (
                 !hidePrompt &&
-                !promptOpt?.hide &&
                 // Target directory is determined by the CAP project. `enableEsLint` and `targetFolder` are not available for CAP projects
                 !([promptNames.targetFolder, promptNames.enableEslint].includes(promptNames[promptKey]) && isCapProject)
             ) {

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompt-helpers.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompt-helpers.test.ts
@@ -133,20 +133,32 @@ describe('prompt-helpers', () => {
         };
         filteredPrompts = hidePrompts(prompts, promptOpts);
         expect(filteredPrompts.length).toEqual(12);
-        expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.addDeployConfig }]));
+        expect(filteredPrompts).toEqual(
+            expect.not.arrayContaining([{ name: promptNames.addDeployConfig, when: expect.any(Function) }])
+        );
         expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.skipAnnotations }]));
         expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.ui5Version }]));
 
         // More testing of prompt options (hide fn)
         promptOpts = {
             [promptNames.addDeployConfig]: {
-                hide: (isCap) => {
-                    return isCap;
+                hide: (isCap: boolean) => {
+                    return !isCap;
                 }
             }
         };
+        // show `addDeployConfig` prompt when isCap is true
         filteredPrompts = hidePrompts(prompts, promptOpts, true);
-        expect(filteredPrompts.length).toEqual(12);
-        expect(filteredPrompts).toEqual(expect.not.arrayContaining([{ name: promptNames.addDeployConfig }]));
+        expect(filteredPrompts.length).toEqual(13);
+        expect(filteredPrompts).toEqual(
+            expect.arrayContaining([{ name: promptNames.addDeployConfig, when: expect.any(Function) }])
+        );
+
+        // hide `addDeployConfig` prompt when isCap is false
+        filteredPrompts = hidePrompts(prompts, promptOpts, false);
+        expect(filteredPrompts.length).toEqual(14);
+        expect(filteredPrompts).toEqual(
+            expect.not.arrayContaining([{ name: promptNames.addDeployConfig, when: expect.any(Function) }])
+        );
     });
 });


### PR DESCRIPTION
When `promptOpt?.hide` is a function, the condition `!promptOpt?.hide` is returning false 

Correcting the condition to either check if it's a function or boolean value and assign it once 