### PR TITLE
feat: Option to only update annotation and metadata files

### DIFF
--- a/.changeset/two-mirrors-travel.md
+++ b/.changeset/two-mirrors-travel.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-writer': patch
+---
+
+Allow to only update annotation and metada files without YAML file changes.

--- a/packages/odata-service-writer/src/index.ts
+++ b/packages/odata-service-writer/src/index.ts
@@ -123,8 +123,8 @@ async function update(basePath: string, service: OdataService, fs?: Editor, upda
     const isServiceTypeEdmx = service.type === ServiceType.EDMX;
     await updateManifest(basePath, service, fs, true);
     // Dont extend/update backend and mockserver middlewares if service type is CDS
-    if (isServiceTypeEdmx && updateMiddlewares) {
-        await updateServicesData(basePath, paths, service as EdmxOdataService, fs);
+    if (isServiceTypeEdmx) {
+        await updateServicesData(basePath, paths, service as EdmxOdataService, fs, updateMiddlewares);
     }
     return fs;
 }

--- a/packages/odata-service-writer/src/update.ts
+++ b/packages/odata-service-writer/src/update.ts
@@ -198,13 +198,13 @@ export async function updateServicesData(
                 ui5MockConfig = await UI5Config.newInstance(fs.read(paths.ui5MockYaml));
                 extendBackendMiddleware(fs, service, ui5MockConfig, paths.ui5MockYaml, true);
             }
-            if (paths.ui5LocalYaml && ui5LocalConfig) {
-                // write ui5 local yaml if service type is not CDS
-                fs.write(paths.ui5LocalYaml, ui5LocalConfig.toString());
-            }
         }
         // Write metadata.xml file
         await writeMetadata(fs, webappPath, service);
+    }
+    if (paths.ui5LocalYaml && ui5LocalConfig) {
+        // write ui5 local yaml if service type is not CDS
+        fs.write(paths.ui5LocalYaml, ui5LocalConfig.toString());
     }
     // Write new annotations files
     await writeRemoteServiceAnnotationXmlFiles(fs, basePath, service.name ?? 'mainService', service.annotations);

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -1285,6 +1285,10 @@ describe('update', () => {
     });
 
     it('Update an existing service without YAML updates, only update service files in localService', async () => {
+        // Write dummy YAML files that could potentially be updated
+        fs.write(join(testDir, 'ui5.yaml'), '');
+        fs.write(join(testDir, 'ui5-mock.yaml'), '');
+        fs.write(join(testDir, 'ui5-local.yaml'), '');
         // Delete metadata and annotation file from service folder
         fs.delete(join(testDir, 'webapp', 'localService', 'mainService', 'metadata.xml'));
         fs.delete(join(testDir, 'webapp', 'localService', 'mainService', 'SEPMRA_PROD_MAN.xml'));
@@ -1308,6 +1312,11 @@ describe('update', () => {
             fs,
             false
         );
+        // Check that YAML are not updated with backend and mockserver middlewares
+        expect(fs.read(join(testDir, 'ui5.yaml'))).toBe('');
+        expect(fs.read(join(testDir, 'ui5-mock.yaml'))).toBe('');
+        expect(fs.read(join(testDir, 'ui5-local.yaml'))).toBe('');
+        // Check that annotation and metadata files are created
         expect(fs.exists(join(testDir, 'webapp', 'localService', 'mainService', 'metadata.xml'))).toBe(true);
         expect(fs.exists(join(testDir, 'webapp', 'localService', 'mainService', 'SEPMRA_PROD_MAN.xml'))).toBe(true);
     });

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -1284,6 +1284,34 @@ describe('update', () => {
         expect(fs.exists(join(testDir, 'webapp', 'localService', 'mainService', 'metadata.xml'))).toBe(true);
     });
 
+    it('Update an existing service without YAML updates, only update service files in localService', async () => {
+        // Delete metadata and annotation file from service folder
+        fs.delete(join(testDir, 'webapp', 'localService', 'mainService', 'metadata.xml'));
+        fs.delete(join(testDir, 'webapp', 'localService', 'mainService', 'SEPMRA_PROD_MAN.xml'));
+        await update(
+            testDir,
+            {
+                name: 'mainService',
+                url: 'https://localhost',
+                path: '/sap',
+                type: ServiceType.EDMX,
+                annotations: [
+                    {
+                        technicalName: 'SEPMRA_PROD_MAN',
+                        xml: '<edmx:Edmx><?xml version="1.0" encoding="utf-8"?></edmx:Edmx>'
+                    }
+                ] as EdmxAnnotationsInfo[],
+                metadata: '<edmx:Edmx><?xml version="1.0" encoding="utf-8"?></edmx:Edmx>',
+                version: OdataVersion.v4,
+                localAnnotationsName: 'annotation'
+            },
+            fs,
+            false
+        );
+        expect(fs.exists(join(testDir, 'webapp', 'localService', 'mainService', 'metadata.xml'))).toBe(true);
+        expect(fs.exists(join(testDir, 'webapp', 'localService', 'mainService', 'SEPMRA_PROD_MAN.xml'))).toBe(true);
+    });
+
     it('Update an existing service with changed annotations', async () => {
         await update(
             testDir,


### PR DESCRIPTION
Adds option to only update annotation and metadata XML files (service refresh) without any changes to the YAML files.