### PR TITLE
fix(fiori-gen-shared): loop through workspace folders to find correct default

### DIFF
--- a/.changeset/serious-mice-leave.md
+++ b/.changeset/serious-mice-leave.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-generator-shared': patch
+---
+
+loop through workspace folders to find correct default

--- a/packages/fiori-generator-shared/src/vscode-helpers/vscode-helpers.ts
+++ b/packages/fiori-generator-shared/src/vscode-helpers/vscode-helpers.ts
@@ -24,9 +24,13 @@ export function getDefaultTargetFolder(vscode: any): string | undefined {
     }
     const workspace = vscode.workspace;
 
-    // If this is not a workspace default to the first folder (`rootPath` is deprecated)
-    if (workspace.workspaceFolders?.length > 0 && workspace.workspaceFolders[0].uri.scheme === 'file') {
-        return workspace.workspaceFolders[0].uri.fsPath;
+    // default to the first suitable folder found in the workspace folders
+    if (workspace.workspaceFolders?.length > 0) {
+        for (const folder of workspace.workspaceFolders) {
+            if (folder.uri.scheme === 'file') {
+                return folder.uri.fsPath;
+            }
+        }
     }
     // Otherwise use <home-dir>/projects,
     return existsSync(DEFAULT_PROJECTS_FOLDER) ? DEFAULT_PROJECTS_FOLDER : undefined;

--- a/packages/fiori-generator-shared/test/helpers.test.ts
+++ b/packages/fiori-generator-shared/test/helpers.test.ts
@@ -48,12 +48,12 @@ describe('getResourceUrlsForUi5Bootstrap', () => {
 });
 
 describe('getDefaultTargetFolder', () => {
-    // rootPath exists only in SBAS
     const vscodeMock = {
         workspace: {
             workspaceFolders: [
-                { uri: { fsPath: '/1st/workspace/path', scheme: 'file' } },
-                { uri: { fsPath: '/2nd/workspace/path', scheme: 'file' } }
+                { uri: { fsPath: '/1st/workspace/virtual/path', scheme: 'abapfs' } },
+                { uri: { fsPath: '/2nd/workspace/path', scheme: 'file' } },
+                { uri: { fsPath: '/3rd/workspace/path', scheme: 'file' } }
             ],
             workspaceFile: undefined,
             getConfiguration: (id: string): object => {
@@ -72,12 +72,12 @@ describe('getDefaultTargetFolder', () => {
         }
     };
 
-    test('getDefaultTargetFolder', () => {
-        expect(getDefaultTargetFolder(vscodeMock)).toBe('/1st/workspace/path');
+    test('should return correct default target folder', () => {
+        expect(getDefaultTargetFolder(vscodeMock)).toBe('/2nd/workspace/path');
 
         // Has a saved workspace, the first path is still used
         Object.assign(vscodeMock.workspace, { workspaceFile: 'workspace-file.json' });
-        expect(getDefaultTargetFolder(vscodeMock)).toBe('/1st/workspace/path');
+        expect(getDefaultTargetFolder(vscodeMock)).toBe('/2nd/workspace/path');
 
         // No folders added to workspace
         jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);


### PR DESCRIPTION
- Update `getDefaultTargetFolder` function to return the first folder found in the workspace which meets the criteria i.e `uri.scheme === 'file'`, rather than checking the first folder and going to the default if it is not suitable