### PR TITLE
fix(odata-service-inquirer): Adds node TLS warn to password prompt

### DIFF
--- a/.changeset/fair-planes-hug.md
+++ b/.changeset/fair-planes-hug.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Adds node TLS setting warning to credentials prompt

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -100,11 +100,7 @@ export function getAbapOnPremSystemQuestions(
                 return valRes;
             }
         } as InputQuestion<AbapOnPremAnswers>,
-        ...getCredentialsPrompts<AbabpOnPremCredentialsAnswers>(
-            connectValidator,
-            abapOnPremPromptNamespace,
-            sapClientRef
-        )
+        ...getCredentialsPrompts<AbapOnPremAnswers>(connectValidator, abapOnPremPromptNamespace, sapClientRef)
     ];
 
     if (systemNamePromptOptions?.hide !== true) {

--- a/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
@@ -84,6 +84,7 @@ exports[`API tests getPrompts, i18n is loaded 1`] = `
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,
@@ -164,6 +165,7 @@ exports[`API tests getPrompts, i18n is loaded 1`] = `
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -88,6 +88,7 @@ exports[`getQuestions getQuestions 1`] = `
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,
@@ -172,6 +173,7 @@ exports[`getQuestions getQuestions 1`] = `
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
@@ -92,6 +92,7 @@ describe('questions', () => {
                 "when": [Function],
               },
               {
+                "additionalMessages": [Function],
                 "default": "",
                 "guiOptions": {
                   "applyDefaultWhenDirty": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/questions.test.ts
@@ -65,6 +65,7 @@ describe('questions', () => {
                 "when": [Function],
               },
               {
+                "additionalMessages": [Function],
                 "default": "",
                 "guiOptions": {
                   "applyDefaultWhenDirty": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/__snapshots__/questions.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/__snapshots__/questions.test.ts.snap
@@ -53,6 +53,7 @@ exports[`Test system selection prompts should return system selection prompts an
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,
@@ -162,6 +163,7 @@ exports[`Test system selection prompts should return system selection prompts an
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,
@@ -242,6 +244,7 @@ exports[`Test system selection prompts should return system selection prompts an
     "when": [Function],
   },
   {
+    "additionalMessages": [Function],
     "default": "",
     "guiOptions": {
       "applyDefaultWhenDirty": true,


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3264

- Adds the node tls cert warning to the password prompt for display in an edge scenario where credentials are being updated. Also prevents showing twice if new system flow for Abap on Prem
- Adds tests to cover