### PR TITLE
fix(app-config-writer): cards generator log message

### DIFF
--- a/.changeset/fair-toys-kiss.md
+++ b/.changeset/fair-toys-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': patch
+---
+
+fix card generator log message


### PR DESCRIPTION
Do not show warning in log in case the old card generator middleware has not been found