### PR TITLE
fix(ui-service-generator): use accept header for content request from generator config

### DIFF
--- a/.changeset/stale-carrots-think.md
+++ b/.changeset/stale-carrots-think.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui-service-inquirer': patch
+'@sap-ux/axios-extension': patch
+---
+
+use accept header for service generator content request from config

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -250,7 +250,7 @@ export class AbapServiceProvider extends ServiceProvider {
      * @returns the type of the config link from config
      */
     private getContentAcceptType(config: GeneratorEntry): string {
-        const found = config.link.find((link) => typeof link.href === 'string' && link.href.endsWith('/content'));
+        const found = config.link.find((link) => typeof link.href === 'string' && link.href.includes('/content'));
         return found.type;
     }
 

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -224,7 +224,7 @@ export class AbapServiceProvider extends ServiceProvider {
         }
         const config = await generatorService.getUIServiceGeneratorConfig(referencedObject.uri);
         const gen = this.createService<UiServiceGenerator>(this.getServiceUrlFromConfig(config), UiServiceGenerator);
-        gen.configure(config, referencedObject, this.getContentAcceptType(config));
+        gen.configure(config, referencedObject, this.getContentType(config));
         return gen;
     }
 
@@ -244,12 +244,12 @@ export class AbapServiceProvider extends ServiceProvider {
     }
 
     /**
-     * Get the content accept type from the generator config.
+     * Get the content type from the generator config.
      *
      * @param config - generator config
-     * @returns the type of the config link from config
+     * @returns the type of the content link from service generator config
      */
-    private getContentAcceptType(config: GeneratorEntry): string {
+    private getContentType(config: GeneratorEntry): string {
         const found = config.link.find((link) => typeof link.href === 'string' && link.href.includes('/content'));
         return found.type;
     }

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -224,7 +224,7 @@ export class AbapServiceProvider extends ServiceProvider {
         }
         const config = await generatorService.getUIServiceGeneratorConfig(referencedObject.uri);
         const gen = this.createService<UiServiceGenerator>(this.getServiceUrlFromConfig(config), UiServiceGenerator);
-        gen.configure(config, referencedObject);
+        gen.configure(config, referencedObject, this.getContentAcceptType(config));
         return gen;
     }
 
@@ -241,6 +241,17 @@ export class AbapServiceProvider extends ServiceProvider {
         }
         const endIndex = config.link[0].href.indexOf(config.id) + config.id.length;
         return config.link[0].href.substring(0, endIndex);
+    }
+
+    /**
+     * Get the content accept type from the generator config.
+     *
+     * @param config - generator config
+     * @returns the type of the config link from config
+     */
+    private getContentAcceptType(config: GeneratorEntry): string {
+        const found = config.link.find((link) => typeof link.href === 'string' && link.href.endsWith('/content'));
+        return found.type;
     }
 
     /**

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -250,8 +250,10 @@ export class AbapServiceProvider extends ServiceProvider {
      * @returns the type of the content link from service generator config
      */
     private getContentType(config: GeneratorEntry): string {
-        const found = config.link.find((link) => typeof link.href === 'string' && link.href.includes('/content'));
-        return found.type;
+        const contentEndpoint = config.link.find(
+            (link) => typeof link.href === 'string' && link.href.includes('/content')
+        );
+        return contentEndpoint.type;
     }
 
     /**

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -250,7 +250,7 @@ export class AbapServiceProvider extends ServiceProvider {
      * @returns the type of the content link from service generator config
      */
     private getContentType(config: GeneratorEntry): string {
-        const contentEndpoint = config.link.find(
+        const contentEndpoint = config.link?.find(
             (link) => typeof link.href === 'string' && link.href.includes('/content')
         );
         return contentEndpoint.type;

--- a/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
@@ -7,15 +7,22 @@ import { AdtService } from '../services';
  */
 export class UiServiceGenerator extends AdtService {
     protected referencedObject!: BusinessObject | AbapCDSView;
+    protected contentAcceptType!: string;
 
     /**
      * Configure the UI service generator.
      *
      * @param _config - The generator configuration.
      * @param referencedObject - The referenced object (business object or abap cds view).
+     * @param acceptType - The header accept type for the request.
      */
-    public configure(_config: GeneratorEntry, referencedObject: BusinessObject | AbapCDSView) {
+    public configure(
+        _config: GeneratorEntry,
+        referencedObject: BusinessObject | AbapCDSView,
+        acceptType: string
+    ): void {
         this.referencedObject = referencedObject;
+        this.contentAcceptType = acceptType;
     }
 
     /**
@@ -44,7 +51,7 @@ export class UiServiceGenerator extends AdtService {
     public async getContent(pckg: string): Promise<string> {
         const response = await this.get('/content', {
             headers: {
-                Accept: 'application/vnd.sap.adt.repository.generator.content.v1+json'
+                Accept: this.contentAcceptType
             },
             params: {
                 referencedObject: this.referencedObject.uri,
@@ -91,7 +98,7 @@ export class UiServiceGenerator extends AdtService {
     public async validateContent(content: string): Promise<ValidationResponse> {
         const response = await this.post('/validation', content, {
             headers: {
-                'Content-Type': 'application/vnd.sap.adt.repository.generator.content.v1+json',
+                'Content-Type': this.contentAcceptType,
                 Accept: 'application/vnd.sap.adt.validationMessages.v1+xml'
             },
             params: {

--- a/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/generators/ui-service-generator.ts
@@ -7,22 +7,22 @@ import { AdtService } from '../services';
  */
 export class UiServiceGenerator extends AdtService {
     protected referencedObject!: BusinessObject | AbapCDSView;
-    protected contentAcceptType!: string;
+    protected contentType!: string;
 
     /**
      * Configure the UI service generator.
      *
      * @param _config - The generator configuration.
      * @param referencedObject - The referenced object (business object or abap cds view).
-     * @param acceptType - The header accept type for the request.
+     * @param contentType - The header accept type for content.
      */
     public configure(
         _config: GeneratorEntry,
         referencedObject: BusinessObject | AbapCDSView,
-        acceptType: string
+        contentType: string
     ): void {
         this.referencedObject = referencedObject;
-        this.contentAcceptType = acceptType;
+        this.contentType = contentType;
     }
 
     /**
@@ -51,7 +51,7 @@ export class UiServiceGenerator extends AdtService {
     public async getContent(pckg: string): Promise<string> {
         const response = await this.get('/content', {
             headers: {
-                Accept: this.contentAcceptType
+                Accept: this.contentType
             },
             params: {
                 referencedObject: this.referencedObject.uri,
@@ -98,7 +98,7 @@ export class UiServiceGenerator extends AdtService {
     public async validateContent(content: string): Promise<ValidationResponse> {
         const response = await this.post('/validation', content, {
             headers: {
-                'Content-Type': this.contentAcceptType,
+                'Content-Type': this.contentType,
                 Accept: 'application/vnd.sap.adt.validationMessages.v1+xml'
             },
             params: {
@@ -120,7 +120,7 @@ export class UiServiceGenerator extends AdtService {
     public async generate(content: string, transport: string): Promise<unknown> {
         const response = await this.post('', content, {
             headers: {
-                'Content-Type': 'application/vnd.sap.adt.repository.generator.content.v1+json',
+                'Content-Type': this.contentType,
                 Accept: 'application/vnd.sap.adt.repository.generator.v1+json, application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.StatusMessage'
             },
             params: {

--- a/packages/ui-service-sub-generator/src/app/utils.ts
+++ b/packages/ui-service-sub-generator/src/app/utils.ts
@@ -35,6 +35,8 @@ export async function generateService(
         appWizard.showError(`${t('error.generatingService')}`, MessageType.notification);
         UiServiceGenLogger.logger.error(`Error generating service: ${error.message}`);
         UiServiceGenLogger.logger.error(`${error.code} ${error.response?.status} ${error.response?.data}`);
+        UiServiceGenLogger.logger?.error(JSON.stringify(error, null, 2));
+        UiServiceGenLogger.logger?.error(JSON.stringify(error.response, null, 2));
 
         TelemetryHelper.createTelemetryData({
             ErrorMessage: error.message,


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3291

- hardcoded content type is no longer valid and has changed
- use content type from generator config retrieved in generator flow