### PR TITLE
feat(fiori-annotation-api): write using new annotation syntax

### DIFF
--- a/packages/cds-odata-annotation-converter/src/index.ts
+++ b/packages/cds-odata-annotation-converter/src/index.ts
@@ -5,14 +5,7 @@ export {
     CdsAnnotationFile,
     toAbsoluteUriString
 } from './transforms';
-export {
-    print,
-    PrintPattern,
-    resolveTarget,
-    printTarget,
-    printPrimitiveValue,
-    printCsdlNode
-} from './printer/csdl-to-cds';
+export { print, PrintPattern, resolveTarget, printTarget, printPrimitiveValue, printKey } from './printer/csdl-to-cds';
 export { indent } from './printer';
 export { printEdmJson } from './printer/edm-json';
 export type { Target } from './transforms/annotation-file';

--- a/packages/cds-odata-annotation-converter/src/printer/index.ts
+++ b/packages/cds-odata-annotation-converter/src/printer/index.ts
@@ -1,2 +1,2 @@
 export { indent } from './indent';
-export { print, printCsdlNode, printPrimitiveValue, printTarget } from './csdl-to-cds';
+export { print, printCsdlNode, printPrimitiveValue, printTarget, printKey } from './csdl-to-cds';

--- a/packages/cds-odata-annotation-converter/test/printer/__snapshots__/csdl-to-cds.test.ts.snap
+++ b/packages/cds-odata-annotation-converter/test/printer/__snapshots__/csdl-to-cds.test.ts.snap
@@ -12,6 +12,22 @@ exports[`csdlToCds print Annotation content.length > 0 1`] = `
 ]"
 `;
 
+exports[`csdlToCds print Annotation multiple levels of primitive annotation values 1`] = `
+"Annotation1 : 'Value1',
+Annotation1.@Annotation2 : {
+    Property1 : {
+        Property : 'My Value',
+        Property.@Core.Description : 'on property',
+    },
+    @Core.Description : 'on record',
+},
+Annotation1.@Annotation2.@Annotation3 : 'Value3'"
+`;
+
+exports[`csdlToCds print Annotation no placeholders 1`] = `"UI.TextArrangement : #TextLast"`;
+
+exports[`csdlToCds print Annotation with prefix 1`] = `"Common.Text.@UI.TextArrangement : #TextLast"`;
+
 exports[`csdlToCds print Collection 1`] = `
 "[
     {
@@ -178,39 +194,36 @@ exports[`csdlToCds printTarget Annotating unbound Action/Function parameter 1`] 
 
 exports[`csdlToCds printTarget Embedded annotation collection 1`] = `
 "annotate AdminService.Books with {
-    Autor @UI.Facets : {
-        $value : [
+    Author @(
+        UI.Facets : [
             {
                 $Type : 'UI.ReferenceFacet',
                 Label : 'Sales',
             },
         ],
-        ![@UI.Importance] : #High,
-    }
-};
+        UI.Facets.@UI.Importance : #High,
+)};
 "
 `;
 
 exports[`csdlToCds printTarget Embedded annotation record 1`] = `
 "annotate AdminService.Books with {
-    Autor @UI.HeaderInfo : {
-        $value : {
+    Author @(
+        UI.HeaderInfo : {
             $Type : 'UI.HeaderInfo',
-            TypeName : {
-                $value : 'My Book',
-                ![@Core.Description] #something : 'PropertyValue annotation',
-            },
-            ![@Core.Description] : 'Record annotation',
+            TypeName : 'My Book',
+            TypeName.@Core.Description #something : 'PropertyValue annotation',
+            TypeName.![@Core.Description#something].@Core.Description : 'of Description',
+            @Core.Description : 'Record annotation',
         },
-        ![@UI.Importance] : #High,
-    }
-};
+        UI.HeaderInfo.@UI.Importance : #High,
+)};
 "
 `;
 
 exports[`csdlToCds printTarget childSegments.length === 1] 1`] = `
 "annotate AdminService.Books with {
-    Autor @UI.Facets : [
+    Author @UI.Facets : [
         {
             $Type : 'UI.ReferenceFacet',
             Label : 'Sales',
@@ -224,7 +237,8 @@ exports[`csdlToCds printTarget childSegments.length === 1] 1`] = `
 
 exports[`csdlToCds printTarget childSegments.length > 1] 1`] = `
 "annotate AdminService.Books with {
-    Autor @(UI.Facets : [
+    Author @(
+        UI.Facets : [
             {
                 $Type : 'UI.ReferenceFacet',
                 Label : 'Sales',
@@ -239,7 +253,7 @@ exports[`csdlToCds printTarget childSegments.length > 1] 1`] = `
                 ID : 'Sales',
                 Target : 'to_ProductSalesData/@UI.Chart',
             },
-        ]
+        ],
 )};
 "
 `;
@@ -249,7 +263,7 @@ exports[`csdlToCds printTarget multiple terms in single target 1`] = `
     UI.Facets : [
     ],
     UI.Facets #MyQualifierName : [
-    ]
+    ],
 );
 "
 `;

--- a/packages/cds-odata-annotation-converter/test/printer/csdl-to-cds.test.ts
+++ b/packages/cds-odata-annotation-converter/test/printer/csdl-to-cds.test.ts
@@ -1,5 +1,11 @@
 import { print, printTarget } from '../../src/printer/csdl-to-cds';
-import { printOptions as defaultPrintOptions, Edm } from '@sap-ux/odata-annotation-core';
+import {
+    createAttributeNode,
+    createElementNode,
+    createTextNode,
+    printOptions as defaultPrintOptions,
+    Edm
+} from '@sap-ux/odata-annotation-core';
 import type { Element, Target, TextNode, Attribute } from '@sap-ux/odata-annotation-core';
 
 describe('csdlToCds', () => {
@@ -448,7 +454,7 @@ describe('csdlToCds', () => {
             // arrange
             const target: Target = {
                 type: 'target',
-                name: 'AdminService.Books/Autor',
+                name: 'AdminService.Books/Author',
                 terms: [
                     {
                         type: 'element',
@@ -539,7 +545,7 @@ describe('csdlToCds', () => {
             // assert
             expect(result).toMatchSnapshot();
             /* "annotate AdminService.Books with {
-                Autor @UI.Facets: [
+                Author @UI.Facets: [
                         {
                             $Type:'UI.ReferenceFacet',
                             Label : 'Sales',
@@ -555,7 +561,7 @@ describe('csdlToCds', () => {
             // arrange
             const target: Target = {
                 type: 'target',
-                name: 'AdminService.Books/Autor',
+                name: 'AdminService.Books/Author',
                 terms: [
                     {
                         type: 'element',
@@ -731,7 +737,7 @@ describe('csdlToCds', () => {
             // assert
             expect(result).toMatchSnapshot();
             /* "annotate AdminService.Books with {
-                Autor @(UI.Facets : [
+                Author @(UI.Facets : [
                     {
                       $Type : 'UI.ReferenceFacet',
                       Label : 'Sales',
@@ -949,7 +955,7 @@ describe('csdlToCds', () => {
             test('collection', () => {
                 const target: Target = {
                     type: 'target',
-                    name: 'AdminService.Books/Autor',
+                    name: 'AdminService.Books/Author',
                     terms: [
                         {
                             type: 'element',
@@ -1026,7 +1032,7 @@ describe('csdlToCds', () => {
             test('record', () => {
                 const target: Target = {
                     type: 'target',
-                    name: 'AdminService.Books/Autor',
+                    name: 'AdminService.Books/Author',
                     terms: [
                         {
                             type: 'element',
@@ -1079,7 +1085,21 @@ describe('csdlToCds', () => {
                                                             value: 'PropertyValue annotation'
                                                         }
                                                     },
-                                                    content: []
+                                                    content: [
+                                                        createElementNode({
+                                                            name: Edm.Annotation,
+                                                            attributes: {
+                                                                [Edm.Term]: createAttributeNode(
+                                                                    Edm.Term,
+                                                                    'Core.Description'
+                                                                ),
+                                                                [Edm.String]: createAttributeNode(
+                                                                    Edm.String,
+                                                                    'of Description'
+                                                                )
+                                                            }
+                                                        })
+                                                    ]
                                                 }
                                             ]
                                         },
@@ -1129,7 +1149,6 @@ describe('csdlToCds', () => {
 
                 // act
                 const result = printTarget(target);
-
                 // assert
                 expect(result).toMatchSnapshot();
             });
@@ -1168,27 +1187,6 @@ describe('csdlToCds', () => {
                 // assert
                 expect(result).toMatchSnapshot();
             });
-
-            /*test("attributes['String']", () => {
-        // arrange
-        const element: Element = {};
-
-        // act
-        const result = print(element );
-
-        // assert
-        expect(result).toMatchSnapshot();
-    });*/
-            /*test("attributes['EnumMember']", () => {
-        // arrange
-        const element: Element = 
-
-        // act
-        const result = print(element );
-
-        // assert
-        expect(result).toMatchSnapshot();
-    });*/
 
             test('content.length', () => {
                 // arrange
@@ -1733,6 +1731,128 @@ describe('csdlToCds', () => {
                 const result = print(element);
 
                 // assert
+                expect(result).toMatchSnapshot();
+            });
+
+            test('no placeholders', () => {
+                const node: Element = createElementNode({
+                    name: Edm.Annotation,
+                    attributes: {
+                        [Edm.Term]: createAttributeNode(Edm.Term, 'UI.TextArrangement'),
+                        [Edm.EnumMember]: createAttributeNode(Edm.EnumMember, 'UI.TextArrangement/TextLast')
+                    }
+                });
+
+                const result = print(node);
+
+                expect(result).toMatchSnapshot();
+            });
+
+            test('with prefix', () => {
+                const node: Element = createElementNode({
+                    name: Edm.Annotation,
+                    attributes: {
+                        [Edm.Term]: createAttributeNode(Edm.Term, 'UI.TextArrangement'),
+                        [Edm.EnumMember]: createAttributeNode(Edm.EnumMember, 'UI.TextArrangement/TextLast')
+                    }
+                });
+
+                const result = print(node, defaultPrintOptions, {
+                    annotationContext: [
+                        createElementNode({
+                            name: Edm.Annotation,
+                            attributes: {
+                                [Edm.Term]: createAttributeNode(Edm.Term, 'Common.Text')
+                            }
+                        })
+                    ]
+                });
+
+                expect(result).toMatchSnapshot();
+            });
+
+            test('multiple levels of primitive annotation values', () => {
+                const node: Element = createElementNode({
+                    name: Edm.Annotation,
+                    attributes: {
+                        [Edm.Term]: createAttributeNode(Edm.Term, 'Annotation1'),
+                        [Edm.String]: createAttributeNode(Edm.String, 'Value1')
+                    },
+                    content: [
+                        createElementNode({
+                            name: Edm.Annotation,
+                            attributes: {
+                                [Edm.Term]: createAttributeNode(Edm.Term, 'Annotation2')
+                            },
+                            content: [
+                                createElementNode({
+                                    name: Edm.Record,
+                                    content: [
+                                        createElementNode({
+                                            name: Edm.PropertyValue,
+                                            attributes: {
+                                                [Edm.Property]: createAttributeNode(Edm.Property, 'Property1')
+                                            },
+                                            content: [
+                                                createElementNode({
+                                                    name: Edm.Record,
+                                                    content: [
+                                                        createElementNode({
+                                                            name: Edm.PropertyValue,
+                                                            attributes: {
+                                                                [Edm.Property]: createAttributeNode(
+                                                                    Edm.Property,
+                                                                    'Property'
+                                                                )
+                                                            },
+                                                            content: [
+                                                                createElementNode({
+                                                                    name: Edm.String,
+                                                                    content: [createTextNode('My Value')]
+                                                                }),
+                                                                createElementNode({
+                                                                    name: Edm.Annotation,
+                                                                    attributes: {
+                                                                        [Edm.Term]: createAttributeNode(
+                                                                            Edm.Term,
+                                                                            'Core.Description'
+                                                                        ),
+                                                                        [Edm.String]: createAttributeNode(
+                                                                            Edm.String,
+                                                                            'on property'
+                                                                        )
+                                                                    }
+                                                                })
+                                                            ]
+                                                        })
+                                                    ]
+                                                })
+                                            ]
+                                        }),
+                                        createElementNode({
+                                            name: Edm.Annotation,
+                                            attributes: {
+                                                [Edm.Term]: createAttributeNode(Edm.Term, 'Core.Description'),
+                                                [Edm.String]: createAttributeNode(Edm.String, 'on record')
+                                            }
+                                        })
+                                    ]
+                                }),
+                                createElementNode({
+                                    name: Edm.Annotation,
+                                    attributes: {
+                                        [Edm.Term]: createAttributeNode(Edm.Term, 'Annotation3'),
+                                        [Edm.String]: createAttributeNode(Edm.String, 'Value3')
+                                    },
+                                    content: []
+                                })
+                            ]
+                        })
+                    ]
+                });
+
+                const result = print(node, defaultPrintOptions);
+
                 expect(result).toMatchSnapshot();
             });
         });
@@ -2395,7 +2515,7 @@ describe('csdlToCds', () => {
         expect(result).toMatchInlineSnapshot(`
             "UI.SelectionVariant #Expensive : {
                 Text : 'Expensive',
-                ![@UI.Importance],
+                @UI.Importance,
             }"
         `);
     });

--- a/packages/fiori-annotation-api/src/cds/deletion.ts
+++ b/packages/fiori-annotation-api/src/cds/deletion.ts
@@ -920,9 +920,19 @@ function includeSiblingSeparator(
     const endTokenIndex = deletionRange.tokenRange.end;
     const nextTokenIndex = getNeighboringTokenIndex(tokens, endTokenIndex, +1);
     const nextToken = tokens[nextTokenIndex];
+
+    const startTokenIndex = deletionRange.tokenRange.start;
+    const previousTokenIndex = getNeighboringTokenIndex(tokens, startTokenIndex, -1);
+    const previousToken = tokens[previousTokenIndex];
+
     let siblingSeparatorFound = false;
     let previousSeparatorIncluded = false;
-    if (nextToken && nextToken.text === separator) {
+    if (previousToken?.text === separator && deletionRange.kind !== DeletionRangeKind.TARGET_ARTIFACT) {
+        // extend deletion range to include separator (except for whole annotate statement, there ';' might be needed)
+        deletionRange.tokenRange.start = previousTokenIndex;
+        previousSeparatorIncluded = true;
+    }
+    if (!previousSeparatorIncluded && nextToken && nextToken.text === separator) {
         // extend deletion range to include separator
         deletionRange.tokenRange.end = nextTokenIndex;
         siblingSeparatorFound = true;
@@ -934,15 +944,6 @@ function includeSiblingSeparator(
             }
         }
     }
-    if (!siblingSeparatorFound) {
-        const startTokenIndex = deletionRange.tokenRange.start;
-        const previousTokenIndex = getNeighboringTokenIndex(tokens, startTokenIndex, -1);
-        const previousToken = tokens[previousTokenIndex];
-        if (previousToken.text === separator && deletionRange.kind !== DeletionRangeKind.TARGET_ARTIFACT) {
-            // extend deletion range to include separator (except for whole annotate statement, there ';' might be needed)
-            deletionRange.tokenRange.start = previousTokenIndex;
-            previousSeparatorIncluded = true;
-        }
-    }
+
     return { deletionRange, siblingSeparatorFound, previousSeparatorIncluded };
 }

--- a/packages/fiori-annotation-api/src/cds/pointer.ts
+++ b/packages/fiori-annotation-api/src/cds/pointer.ts
@@ -379,7 +379,7 @@ class Visitor {
     }
 
     private flattenedAnnotation(astNode: Annotation, node: ElementChild, pointer: string[]): ReturnValue | undefined {
-        if (node.type !== ELEMENT_TYPE || node.name !== Edm.Record) {
+        if (node.type !== ELEMENT_TYPE || (node.name !== Edm.Record && node.name !== Edm.Annotation)) {
             return undefined;
         }
         const [segment, indexSegment, ...segments] = pointer;
@@ -392,7 +392,11 @@ class Visitor {
                 if (segment.length === 0) {
                     return undefined;
                 }
-                return this.flattenedAnnotationPropertyValue(astNode, propertyValue, segments);
+                if (node.name === Edm.Record) {
+                    return this.flattenedAnnotationPropertyValue(astNode, propertyValue, segments);
+                } else if (node.name === Edm.Annotation) {
+                    return this.flattenedAnnotationValue(astNode, propertyValue, segments);
+                }
             }
         }
         return undefined;
@@ -428,6 +432,22 @@ class Visitor {
                 pointer: ['term', 'segments', this.currentFlattenedSegmentIndexInPath.toString()]
             };
         }
+        return undefined;
+    }
+    private flattenedAnnotationValue(
+        astNode: Annotation,
+        node: ElementChild,
+        pointer: string[]
+    ): ReturnValue | undefined {
+        if (node?.type !== ELEMENT_TYPE || !astNode.value) {
+            return undefined;
+        }
+        if (pointer.length === 0) {
+            return {
+                pointer: ['value']
+            };
+        }
+        // flattened structures after annotation are not supported
         return undefined;
     }
 }

--- a/packages/fiori-annotation-api/src/cds/preprocessor.ts
+++ b/packages/fiori-annotation-api/src/cds/preprocessor.ts
@@ -1,5 +1,6 @@
-import { TARGET_TYPE } from '@sap-ux/odata-annotation-core-types';
-import type { Target } from '@sap-ux/cds-odata-annotation-converter';
+import type { Element } from '@sap-ux/odata-annotation-core-types';
+import { createAttributeNode, createElementNode, Edm, TARGET_TYPE } from '@sap-ux/odata-annotation-core-types';
+import { printKey, type Target } from '@sap-ux/cds-odata-annotation-converter';
 
 import type { AnnotationGroup, AnnotationGroupItems, Record as RecordNode } from '@sap-ux/cds-annotation-parser';
 import {
@@ -40,6 +41,9 @@ import {
 import type { Deletes, CDSDocumentChange, InsertRecord } from './change';
 import { getChildCount, type AstNode, type CDSDocument } from './document';
 import { getAstNodesFromPointer } from './pointer';
+import type { CompilerToken } from './cds-compiler-tokens';
+import { findLastTokenBeforePosition } from './cds-compiler-tokens';
+import { getElementAttribute } from '@sap-ux/odata-annotation-core';
 
 /**
  *
@@ -51,8 +55,9 @@ class ChangePreprocessor {
      *
      * @param document - CDS document object.
      * @param input - CDS document changes.
+     * @param tokens - All tokens in the document.
      */
-    constructor(private document: CDSDocument, private input: CDSDocumentChange[]) {}
+    constructor(private document: CDSDocument, private input: CDSDocumentChange[], private tokens: CompilerToken[]) {}
 
     /**
      * Optimizes changes to remove duplicates and conflicting changes.
@@ -86,7 +91,7 @@ class ChangePreprocessor {
      * Makes sure that inserts in an empty container have the same insert positions.
      */
 
-    private normalizeInsertIndex() {
+    private normalizeInsertIndex(): void {
         for (let i = 0; i < this.input.length; i++) {
             const change = this.input[i];
             const [parent] = getAstNodesFromPointer(this.document, change.pointer).reverse();
@@ -121,7 +126,7 @@ class ChangePreprocessor {
         }
     }
 
-    private removeDuplicates() {
+    private removeDuplicates(): void {
         for (let index = this.input.length - 1; index >= 0; index--) {
             const currentChange = this.input[index];
             if (
@@ -163,7 +168,7 @@ class ChangePreprocessor {
         deletionMap: Record<string, DeletionIndex[]>,
         insertionMap: Record<string, boolean>,
         index: number
-    ) {
+    ): void {
         const command = this.commands.get(index);
         if (command?.type === 'drop') {
             // if the change is already dropped it is not relevant for further processing
@@ -208,7 +213,7 @@ class ChangePreprocessor {
         }
     }
 
-    private mergeDeletes() {
+    private mergeDeletes(): void {
         const deletionMap: Record<string, DeletionIndex[]> = {};
         const insertionMap: Record<string, boolean> = {};
         // optimize deletion changes
@@ -218,7 +223,10 @@ class ChangePreprocessor {
         this.processDeletionMap(deletionMap, insertionMap);
     }
 
-    private processDeletionMap(deletionMap: Record<string, DeletionIndex[]>, insertionMap: Record<string, boolean>) {
+    private processDeletionMap(
+        deletionMap: Record<string, DeletionIndex[]>,
+        insertionMap: Record<string, boolean>
+    ): void {
         while (Object.keys(deletionMap).length > 0) {
             // picking longest pointer ensures that the deletion changes are bubbling up
             const parentPointer = Object.keys(deletionMap).reduce(
@@ -261,7 +269,7 @@ class ChangePreprocessor {
         parentPointer: string,
         deletionMap: Record<string, DeletionIndex[]>,
         insertionMap: Record<string, boolean>
-    ) {
+    ): void {
         const childPointers = new Set([
             ...parent.properties.map((_, i) => `${parentPointer}/properties/${i}`),
             ...(parent.annotations ?? []).map((_, i) => `${parentPointer}/annotations/${i}`)
@@ -279,7 +287,7 @@ class ChangePreprocessor {
         parentPointer: string,
         deletionMap: Record<string, DeletionIndex[]>,
         insertionMap: Record<string, boolean>
-    ) {
+    ): void {
         const childPointers = new Set([...parent.assignments.map((_, i) => `${parentPointer}/assignments/${i}`)]);
         for (const indexedValue of deletionMap[parentPointer]) {
             childPointers.delete(indexedValue.change.pointer);
@@ -295,7 +303,7 @@ class ChangePreprocessor {
         parentPointer: string,
         deletionMap: Record<string, DeletionIndex[]>,
         insertionMap: Record<string, boolean>
-    ) {
+    ): void {
         if (!insertionMap[parentPointer]) {
             // most probably this if-check is redundant but is left just for safety reasons
             this.bubbleUpDeleteChange(deletionMap, parent, grandParent, parentPointer);
@@ -308,7 +316,7 @@ class ChangePreprocessor {
         parentPointer: string,
         deletionMap: Record<string, DeletionIndex[]>,
         insertionMap: Record<string, boolean>
-    ) {
+    ): void {
         const childPointers = new Set([...parent.items.map((_, i) => `${parentPointer}/items/${i}`)]);
         for (const indexedValue of deletionMap[parentPointer]) {
             childPointers.delete(indexedValue.change.pointer);
@@ -328,7 +336,7 @@ class ChangePreprocessor {
         grandParent: AstNode | undefined,
         greatGrandParent: AstNode | undefined,
         parentPointer: string
-    ) {
+    ): void {
         // no more children => delete record
         // propagate change of the parent up (if required)
         // only skip for collection entries
@@ -412,40 +420,148 @@ class ChangePreprocessor {
         // Inserts are usually merged together, so we need to replace the last insert of the batch for the same index
         for (let i = 0; i < this.input.length; i++) {
             const change = this.input[i];
-            const [parent] = getAstNodesFromPointer(this.document, change.pointer).reverse();
-            if (change.type !== INSERT_ANNOTATION_CHANGE_TYPE || parent?.type !== TARGET_TYPE) {
-                continue;
-            }
-            // merge inserts and deletions
-            const index = change.index ?? parent.assignments.length - 1;
-            const pointer = `${change.pointer}/assignments/${index}`;
-            const deletionChangeIndex = this.input.findIndex(
-                (c) => c.pointer === pointer && c.type === DELETE_ANNOTATION_CHANGE_TYPE
-            );
-            const command = this.commands.get(deletionChangeIndex);
-            if (command?.type === 'drop') {
-                continue;
-            }
-            if (deletionChangeIndex !== -1) {
-                this.commands.set(i, {
-                    type: 'replace',
-                    changes: [createReplaceNodeChange(pointer, change.element)]
-                });
-                this.commands.set(deletionChangeIndex, {
-                    type: 'drop'
-                });
+            const [parent, grandParent] = getAstNodesFromPointer(this.document, change.pointer).reverse();
+            if (
+                change.type === INSERT_ANNOTATION_CHANGE_TYPE &&
+                (parent?.type === TARGET_TYPE || parent?.type === ANNOTATION_GROUP_ITEMS_TYPE)
+            ) {
+                if (parent.type === ANNOTATION_GROUP_ITEMS_TYPE) {
+                    // merge inserts and deletions
+                    const index = change.index ?? parent.items.length - 1;
+                    const pointer = `${change.pointer}/${index}`;
+                    const deletionChangeIndex = this.input.findIndex(
+                        (c) => c.pointer === pointer && c.type === DELETE_ANNOTATION_CHANGE_TYPE
+                    );
+                    const command = this.commands.get(deletionChangeIndex);
+                    if (command?.type === 'drop') {
+                        continue;
+                    }
+                    if (deletionChangeIndex !== -1) {
+                        this.commands.set(i, {
+                            type: 'replace',
+                            changes: [createReplaceNodeChange(pointer, change.element)]
+                        });
+                        this.commands.set(deletionChangeIndex, {
+                            type: 'drop'
+                        });
+                    }
+                } else {
+                    // merge inserts and deletions
+                    const index = change.index ?? parent.assignments.length - 1;
+                    const pointer = `${change.pointer}/assignments/${index}`;
+                    const deletionChangeIndex = this.input.findIndex(
+                        (c) => c.pointer === pointer && c.type === DELETE_ANNOTATION_CHANGE_TYPE
+                    );
+                    const command = this.commands.get(deletionChangeIndex);
+                    if (command?.type === 'drop') {
+                        continue;
+                    }
+                    if (deletionChangeIndex !== -1) {
+                        this.commands.set(i, {
+                            type: 'replace',
+                            changes: [createReplaceNodeChange(pointer, change.element)]
+                        });
+                        this.commands.set(deletionChangeIndex, {
+                            type: 'drop'
+                        });
+                    }
+                }
+            } else if (
+                change.type === INSERT_EMBEDDED_ANNOTATION_CHANGE_TYPE &&
+                (grandParent?.type === TARGET_TYPE || grandParent?.type === ANNOTATION_GROUP_ITEMS_TYPE)
+            ) {
+                // currently this is not supported for longer deeper structures
+                // e.g multiple levels of annotations on an annotation with a primitive value
+                // const elementName = parent.type === RECORD_PROPERTY_TYPE ? Edm.PropertyValue : Edm.Annotation;
+
+                if (grandParent.type === ANNOTATION_GROUP_ITEMS_TYPE) {
+                    // merge inserts and deletions
+                    const index = change.index ?? grandParent.items.length - 1;
+                    const pointer = `${change.pointer.split('/').slice(0, -1).join('/')}/${index}`;
+                    const deletionChangeIndex = this.input.findIndex(
+                        (c) => c.pointer === pointer && c.type === DELETE_ANNOTATION_CHANGE_TYPE
+                    );
+                    const command = this.commands.get(deletionChangeIndex);
+                    if (command?.type === 'drop') {
+                        continue;
+                    }
+                    if (deletionChangeIndex !== -1) {
+                        const element = createReferenceElement(parent);
+                        const last = structuredClone(change.element);
+                        delete last.attributes[Edm.Qualifier];
+                        const context = [last];
+                        if (element) {
+                            context.unshift(element);
+                            const term = getElementAttribute(change.element, Edm.Term);
+                            if (term) {
+                                term.value = printKey(context);
+                            }
+                        }
+                        this.commands.set(i, {
+                            type: 'replace',
+                            changes: [createReplaceNodeChange(pointer, change.element)]
+                        });
+                        this.commands.set(deletionChangeIndex, {
+                            type: 'drop'
+                        });
+                    }
+                } else {
+                    // merge inserts and deletions
+                    const index = change.index ?? grandParent.assignments.length - 1;
+                    const pointer = `${change.pointer.split('/').slice(0, -1).join('/')}/${index}`;
+                    const deletionChangeIndex = this.input.findIndex(
+                        (c) => c.pointer === pointer && c.type === DELETE_ANNOTATION_CHANGE_TYPE
+                    );
+                    const command = this.commands.get(deletionChangeIndex);
+                    if (command?.type === 'drop') {
+                        continue;
+                    }
+                    if (deletionChangeIndex !== -1) {
+                        const element = createReferenceElement(parent);
+                        const last = structuredClone(change.element);
+                        delete last.attributes[Edm.Qualifier];
+                        const context = [last];
+                        if (element) {
+                            context.unshift(element);
+                            const term = getElementAttribute(change.element, Edm.Term);
+                            if (term) {
+                                term.value = printKey(context);
+                            }
+                        }
+                        this.commands.set(i, {
+                            type: 'replace',
+                            changes: [createReplaceNodeChange(pointer, change.element)]
+                        });
+                        this.commands.set(deletionChangeIndex, {
+                            type: 'drop'
+                        });
+                    }
+                }
             }
         }
     }
 
-    private expandToCompoundAnnotations() {
+    private expandToCompoundAnnotations(): void {
         // Inserts are usually merged together, so we need to replace the last insert of the batch for the same index
         const handledAssignments = new Set<string>();
         // we need to start from the end because the conversion change should come after last insert
         for (let i = this.input.length - 1; i >= 0; i--) {
             const change = this.input[i];
-            const [parent] = getAstNodesFromPointer(this.document, change.pointer).reverse();
-            if (change.type !== INSERT_ANNOTATION_CHANGE_TYPE || parent?.type !== TARGET_TYPE) {
+            const path = getAstNodesFromPointer(this.document, change.pointer);
+            const [parent, grandParent] = path.reverse();
+            let pointer = change.pointer;
+            let target = parent;
+            if (
+                change.type === INSERT_EMBEDDED_ANNOTATION_CHANGE_TYPE &&
+                parent.type === ANNOTATION_TYPE &&
+                grandParent.type === TARGET_TYPE &&
+                path.length === 2
+            ) {
+                // annotations on top level annotations will be appended to the current assignment
+                // update pointer to target
+                target = grandParent;
+                pointer = change.pointer.split('/').slice(0, -2).join('/');
+            } else if (change.type !== INSERT_ANNOTATION_CHANGE_TYPE || target?.type !== TARGET_TYPE) {
                 continue;
             }
             const command = this.commands.get(i);
@@ -453,16 +569,30 @@ class ChangePreprocessor {
                 // if the change is replaced or dropped we shouldn't do anything
                 continue;
             }
-            if (!handledAssignments.has(change.pointer)) {
-                handledAssignments.add(change.pointer);
+            if (!handledAssignments.has(pointer)) {
+                handledAssignments.add(pointer);
+
+                // make sure that the assignment isn't already a compound assignment
+                const startPosition =
+                    target.assignments[target.assignments.length - 1]?.range?.start ?? target.range?.start;
+                if (!startPosition) {
+                    continue;
+                }
+                const startToken = findLastTokenBeforePosition(/^@/i, this.tokens, startPosition);
+                if (!startToken) {
+                    continue;
+                }
+                const nextToken = this.tokens[startToken.tokenIndex + 1];
+                if (!nextToken || nextToken.text === '(') {
+                    continue;
+                }
                 const deletion = this.input.find(
                     (c) =>
-                        (c.type.startsWith('delete') || c.type.startsWith('replace')) &&
-                        c.pointer.startsWith(change.pointer)
+                        (c.type.startsWith('delete') || c.type.startsWith('replace')) && c.pointer.startsWith(pointer)
                 );
                 this.commands.set(i, {
                     type: 'replace',
-                    changes: [change, createConvertToCompoundAnnotationChange(change.pointer, deletion === undefined)]
+                    changes: [change, createConvertToCompoundAnnotationChange(pointer, deletion === undefined)]
                 });
             }
         }
@@ -537,10 +667,45 @@ function isChildOf(child: JsonPointer, parent: JsonPointer): boolean {
  *
  * @param document - CDS document.
  * @param changes - CDS document changes.
+ * @param tokens - All tokens in the document.
  * @returns Optimized CDS document changes.
  */
-export function preprocessChanges(document: CDSDocument, changes: CDSDocumentChange[]): CDSDocumentChange[] {
+export function preprocessChanges(
+    document: CDSDocument,
+    changes: CDSDocumentChange[],
+    tokens: CompilerToken[]
+): CDSDocumentChange[] {
     //
-    const preprocessor = new ChangePreprocessor(document, changes);
+    const preprocessor = new ChangePreprocessor(document, changes, tokens);
     return preprocessor.run();
+}
+
+/**
+ * Creates a reference element used for building flattened annotation keys.
+ *
+ * @param astNode - AST node to be converted to a reference element.
+ * @returns Reference element.
+ */
+export function createReferenceElement(astNode?: AstNode): Element | undefined {
+    if (astNode?.type === ANNOTATION_TYPE) {
+        const element = createElementNode({
+            name: Edm.Annotation,
+            attributes: {
+                [Edm.Term]: createAttributeNode(Edm.Term, astNode.term.value)
+            }
+        });
+        if (astNode.qualifier) {
+            element.attributes[Edm.Qualifier] = createAttributeNode(Edm.Qualifier, astNode.qualifier.value);
+        }
+        return element;
+    } else if (astNode?.type === RECORD_PROPERTY_TYPE) {
+        const element = createElementNode({
+            name: Edm.PropertyValue,
+            attributes: {
+                [Edm.Property]: createAttributeNode(Edm.Property, astNode.name.value)
+            }
+        });
+        return element;
+    }
+    return undefined;
 }

--- a/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/__snapshots__/fiori-service.test.ts.snap
@@ -60,7 +60,7 @@ exports[`fiori annotation service delete annotation embedded annotation from roo
 
 annotate service.test with @(
     UI.LineItem : [
-        ]
+    ],
 );
 
 "
@@ -93,7 +93,8 @@ using from '../../srv/common';
 
 
 annotate service.Incidents with {
-    category @(Common.ValueListWithFixedValues : true
+    category @(
+        Common.ValueListWithFixedValues : true,
 )};
 
 "
@@ -126,7 +127,7 @@ exports[`fiori annotation service delete annotation with cds annotation group 1`
                 annotate service.Incidents with {
                     priority @Common : {
                         Text : priority.name,
-                        }
+                    }
                 };
                 "
 `;
@@ -136,7 +137,7 @@ exports[`fiori annotation service delete annotation with no qualifier CAPNodejs 
 
 annotate service.test with @(
     UI.LineItem #qualifier : [
-    ]
+    ],
 );
 
 "
@@ -186,7 +187,7 @@ exports[`fiori annotation service delete annotation with qualifier CAPNodejs cap
 
 annotate service.test with @(
     UI.LineItem : [
-    ]
+    ],
 );
 
 "
@@ -598,7 +599,8 @@ exports[`fiori annotation service insert SAP annotations for CDS projects UI.Fac
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.Incidents with {
-    path @(UI.fieldGroup : [
+    path @(
+        UI.fieldGroup : [
             {
                 position : 10,
                 qualifier : 'GeneralInformation',
@@ -612,7 +614,7 @@ annotate service.Incidents with {
                 targetQualifier : 'GeneralInformation',
                 position : 10,
             },
-        ]
+        ],
 )};
 
 "
@@ -622,13 +624,14 @@ exports[`fiori annotation service insert SAP annotations for CDS projects UI.Lin
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.Incidents with {
-    path @(UI.lineItem : [
+    path @(
+        UI.lineItem : [
             {
                 position : 10,
                 importance : #HIGH,
             },
         ],
-        EndUserText.label : 'Test Label'
+        EndUserText.label : 'Test Label',
 )};
 
 "
@@ -637,13 +640,14 @@ annotate service.Incidents with {
 exports[`fiori annotation service insert SAP annotations for CDS projects external cds file CAPNodejs cap-start v4 1`] = `
 "using from '../data/cds/cap-start/srv/incidentservice';
 annotate IncidentService.Incidents with {
-    path @(UI.lineItem : [
+    path @(
+        UI.lineItem : [
             {
                 position : 10,
                 importance : #HIGH,
             },
         ],
-        EndUserText.label : 'Test Label'
+        EndUserText.label : 'Test Label',
 )};
 
 "
@@ -820,14 +824,12 @@ exports[`fiori annotation service insert embedded annotation and update collecti
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.test with @(
-    UI.LineItem : {
-        $value : [
-            {
-                $Type : 'UI.DataFieldForAnnotation',
-            },
-        ],
-        ![@UI.Criticality] : value
-    }
+    UI.LineItem : [
+        {
+            $Type : 'UI.DataFieldForAnnotation',
+        },
+    ],
+    UI.LineItem.@UI.Criticality : value,
 );
 
 "
@@ -864,8 +866,8 @@ annotate service.test with @(
     UI.FieldGroup : {
         Data : [
         ],
-        ![@UI.Hidden],
-    }
+    },
+    UI.FieldGroup.@UI.Hidden,
 );
 
 "
@@ -904,7 +906,7 @@ annotate service.test with @(
     UI.LineItem : [
         {
             $Type : 'UI.DataField',
-            ![@UI.Hidden] : true,
+            @UI.Hidden : true,
         },
     ]
 );
@@ -941,11 +943,9 @@ exports[`fiori annotation service insert embedded annotation in root CAPNodejs c
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.test with @(
-    UI.LineItem : {
-        $value : [
-        ],
-        ![@UI.Hidden] : true
-    }
+    UI.LineItem : [
+    ],
+    UI.LineItem.@UI.Hidden : true,
 );
 
 "
@@ -973,19 +973,21 @@ exports[`fiori annotation service insert embedded annotation in root EDMXBackend
 "
 `;
 
+exports[`fiori annotation service insert embedded annotation no existing annotation CAPNodejs cap-start v4 1`] = `"Term 'IncidentService.test/com.sap.vocabularies.UI.v1.LineItem' does not exist"`;
+
+exports[`fiori annotation service insert embedded annotation no existing annotation EDMXBackend xml-start v4 1`] = `"Term 'IncidentService.test/com.sap.vocabularies.UI.v1.LineItem' does not exist"`;
+
 exports[`fiori annotation service insert embedded annotation subsequent inserts CAPNodejs cap-start v4 1`] = `
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.test with @(
-    UI.LineItem : {
-        $value : [
-            {
-                $Type : 'UI.DataField',
-                Value : a,
-            },
-        ],
-        ![@UI.Hidden] : true,
-    }
+    UI.LineItem : [
+        {
+            $Type : 'UI.DataField',
+            Value : a,
+        },
+    ],
+    UI.LineItem.@UI.Hidden : true,
 );
 
 "
@@ -1023,10 +1025,10 @@ using from '../../srv/common';
 
 
 annotate service.Incidents with {
-    category @Common.Text : {
-        $value : descr,
-        ![@UI.TextArrangement] : #TextFirst
-    }
+    category @(
+        Common.Text : descr,
+        Common.Text.@UI.TextArrangement : #TextFirst,
+    )
 };
 
 "
@@ -1098,7 +1100,7 @@ annotate service.Incidents with @(
     UI.LineItem : [
         {
             $Type : 'UI.DataField',
-            ![@UI.Hidden] : Test,
+            @UI.Hidden : Test,
         },
     ]
 );
@@ -1406,7 +1408,7 @@ annotate service.test with @(
         },
         {
             $Type : 'UI.DataField',
-            ![@UI.Importance] : 'Test',
+            @UI.Importance : 'Test',
             Value : path,
         },
     ]
@@ -1425,7 +1427,7 @@ annotate service.test with @(
             Value : path,
         },
         {
-            ![@UI.Importance] : 'Test',
+            @UI.Importance : 'Test',
             Value : path,
         },
     ]
@@ -1815,7 +1817,7 @@ annotate service.test with @(
     UI.LineItem : [
     ],
     UI.LineItem #second : [
-    ]
+    ],
 );
 
 annotate service.test with {
@@ -2179,7 +2181,7 @@ annotate service.test with @(
             $Type : 'UI.DataField',
             Value : test1,
         },
-    ]
+    ],
 );
 
 "
@@ -3385,19 +3387,17 @@ exports[`fiori annotation service update collection collection with annotation C
 "using IncidentService as service from '../../srv/incidentservice';
 
 annotate service.test with @(
-    UI.LineItem : {
-        $value : [
-            {
-                $Type : 'UI.DataField',
-                Value : path,
-            },
-            {
-                $Type : 'UI.DataField',
-                Value : path2,
-            },
-        ],
-        ![@UI.Criticality] : criticality,
-    }
+    UI.LineItem : [
+        {
+            $Type : 'UI.DataField',
+            Value : path,
+        },
+        {
+            $Type : 'UI.DataField',
+            Value : path2,
+        },
+    ],
+    UI.LineItem.@UI.Criticality : criticality,
 );
 
 "
@@ -3706,7 +3706,7 @@ annotate service.test with @(
         {
             $Type : 'UI.DataField',
             Value : path,
-            ![@UI.Importance] : #Medium,
+            @UI.Importance : #Medium,
         },
     ]
 );
@@ -4089,13 +4089,24 @@ using from '../../srv/common';
 
 
 annotate service.Individual with {
-    createdAt @Common.Text : {
-        $value : undefined,
-        ![@UI.TextArrangement] : #TextFirst,
-    }
-};
+    createdAt @(
+        Common.Text,
+        Common.Text.@UI.TextArrangement : #TextFirst,
+)};
 
 "
+`;
+
+exports[`fiori annotation service using change embedded annotation with update 1`] = `
+"using IncidentService as service from '../../srv/incidentservice';
+
+
+            annotate service.Individual with {
+                createdAt @(
+                    Common.Text            : createdBy,
+                    Common.Text.@UI.TextArrangement : #TextFirst,
+                )
+            };"
 `;
 
 exports[`serializeTarget cds Delete Criticality and criticality Representation 1`] = `

--- a/packages/fiori-annotation-api/test/unit/cds/indent.test.ts
+++ b/packages/fiori-annotation-api/test/unit/cds/indent.test.ts
@@ -91,4 +91,11 @@ annotate S.E with @(
         );
         expect(indent).toStrictEqual(2);
     });
+    test('single line assignment for element', async () => {
+        const fixture = `Service S { entity E { description: String; }; };
+annotate S.E with { description @Common.Text: title };`;
+        const [, document] = await getCDSDocument(PROJECTS.V4_CDS_START.root, fixture);
+        const indent = getIndentLevelFromPointer(document.ast, document.tokens, '/targets/0');
+        expect(indent).toStrictEqual(0);
+    });
 });

--- a/packages/fiori-annotation-api/test/unit/cds/pointer.test.ts
+++ b/packages/fiori-annotation-api/test/unit/cds/pointer.test.ts
@@ -167,6 +167,19 @@ describe('convertPointerX - Ast Paths', () => {
                 '/targets/0/assignments/0/value/annotations/0'
             );
         });
+        test('new annotation syntax', async () => {
+            await testPointerWithFixture(
+                `using IncidentService as service from '../../srv/incidentservice';
+annotate service.Individual with {
+    createdAt @(
+        Common.Text            : createdBy,
+        Common.Text.@UI.TextArrangement : null,
+    )
+};`,
+                '/targets/0/terms/1/content/0/content/0',
+                '/targets/0/assignments/1/value'
+            );
+        });
         test('record property value', () => {
             testPointer(
                 '/targets/2/terms/0/content/0/content/0/content/3/content/0/content/0/content/0/content/0/text',

--- a/packages/fiori-annotation-api/test/unit/cds/writer.test.ts
+++ b/packages/fiori-annotation-api/test/unit/cds/writer.test.ts
@@ -676,6 +676,45 @@ annotate S.E with {
                 );
             });
 
+            test('delete existing annotation in group and insert multiple annotation on the same element', async () => {
+                function createTestNode(qualifier: string) {
+                    return createElementNode({
+                        name: Edm.Annotation,
+                        attributes: {
+                            [Edm.Term]: createAttributeNode(Edm.Term, 'Hidden'),
+                            [Edm.Qualifier]: createAttributeNode(Edm.Qualifier, qualifier),
+                            [Edm.Bool]: createAttributeNode(Edm.Bool, 'true')
+                        },
+                        content: []
+                    });
+                }
+                const fixture = `Service S { entity E { name: String; }; };
+annotate S.E with {
+    name @UI : {
+        Label : 'label',
+        Label #two : 'label2',
+    };
+};`;
+                await testWriter(
+                    fixture,
+                    [
+                        createInsertAnnotationChange('/targets/0/assignments/0/items/items', createTestNode('one')),
+                        createInsertAnnotationChange('/targets/0/assignments/0/items/items', createTestNode('two')),
+                        createInsertAnnotationChange('/targets/0/assignments/0/items/items', createTestNode('three')),
+                        createDeleteAnnotationChange('/targets/0/assignments/0/items/items/1')
+                    ],
+                    `Service S { entity E { name: String; }; };
+annotate S.E with {
+    name @UI : {
+        Label : 'label',
+        Hidden #one : true,
+        Hidden #two : true,
+        Hidden #three : true,
+    };
+};`
+                );
+            });
+
             test('delete multiple annotations and insert multiple annotations on the same element', async () => {
                 const fixture = `Service S { entity E { name: String; }; };
 annotate S.E with {
@@ -2380,12 +2419,83 @@ annotate S.E with @UI.LineItem: [
                     `
                     Service S { entity E {}; };
                     annotate S.E with @(
-                        Common.Text : {
-                            $value : 'abc',
-                            ![@UI.TextArrangement] : #TextFirst
-                        }
+                        Common.Text : 'abc',
+                        Common.Text.@UI.TextArrangement : #TextFirst,
                     );
                     `
+                );
+            });
+
+            test('first embedded annotation', async () => {
+                const fixture = `
+                    Service S { entity E {}; };
+                    annotate S.E with @(
+                        Common.Text : 'abc'
+                    );
+                    `;
+                await testWriter(
+                    fixture,
+                    [
+                        {
+                            type: 'insert-embedded-annotation',
+                            pointer: '/targets/0/assignments/0',
+                            element: createElementNode({
+                                name: Edm.Annotation,
+                                attributes: {
+                                    [Edm.Term]: createAttributeNode(Edm.Term, 'UI.TextArrangement'),
+                                    [Edm.EnumMember]: createAttributeNode(Edm.EnumMember, 'TextFirst')
+                                }
+                            })
+                        }
+                    ],
+                    `
+                    Service S { entity E {}; };
+                    annotate S.E with @(
+                        Common.Text : 'abc',
+                        Common.Text.@UI.TextArrangement : #TextFirst,
+                    );
+                    `
+                );
+            });
+
+            test('replace Common.TextArrangement', async () => {
+                const fixture = `
+Service S { entity E { prop: String;}; };
+annotate S.E with {
+    prop @Common: {
+        Text : 'abc',
+        TextArrangement : #TextLast,
+    }
+};
+`;
+                await testWriter(
+                    fixture,
+                    [
+                        {
+                            type: 'insert-embedded-annotation',
+                            pointer: '/targets/0/assignments/0/items/items/0',
+                            element: createElementNode({
+                                name: Edm.Annotation,
+                                attributes: {
+                                    [Edm.Term]: createAttributeNode(Edm.Term, 'UI.TextArrangement'),
+                                    [Edm.EnumMember]: createAttributeNode(Edm.EnumMember, 'TextFirst')
+                                }
+                            })
+                        },
+                        {
+                            type: 'delete-annotation',
+                            pointer: '/targets/0/assignments/0/items/items/1'
+                        }
+                    ],
+                    `
+Service S { entity E { prop: String;}; };
+annotate S.E with {
+    prop @Common: {
+        Text : 'abc',
+        Text.@UI.TextArrangement : #TextFirst,
+    }
+};
+`
                 );
             });
 
@@ -2421,17 +2531,15 @@ annotate S.E with @UI.LineItem: [
                     `
                     Service S { entity E {}; };
                     annotate S.E with @(
-                        UI.LineItem : {
-                            $value : [
-                                {
-                                    Value: a
-                                },
-                                {
-                                    Value: b
-                                },
-                            ],
-                            ![@UI.TextArrangement] : #TextFirst
-                        }
+                        UI.LineItem : [
+                            {
+                                Value: a
+                            },
+                            {
+                                Value: b
+                            },
+                        ],
+                        UI.LineItem.@UI.TextArrangement : #TextFirst,
                     );
                     `
                 );
@@ -2484,14 +2592,12 @@ annotate S.E with @UI.LineItem: [
                     `
                     Service S { entity E {}; };
                     annotate S.E with @(
-                        UI.LineItem : {
-                            $value : [
-                                {
-                                    $Type : 'UI.DataFieldForAnnotation',
-                                },
-                            ],
-                            ![@UI.Criticality] : true
-                        }
+                        UI.LineItem : [
+                            {
+                                $Type : 'UI.DataFieldForAnnotation',
+                            },
+                        ],
+                        UI.LineItem.@UI.Criticality : true,
                     );`
                 );
             });
@@ -2524,9 +2630,9 @@ annotate S.E with @UI.LineItem: [
                     Service S { entity E {}; };
                     annotate S.E with @(
                         Common.Text : {
-                            $value : 'abc',
-                            ![@UI.TextArrangement] : #TextFirst,
-                        }
+                            $value : 'abc'
+                        },
+                        Common.Text.@UI.TextArrangement : #TextFirst,
                     );
                     `
                 );
@@ -2562,8 +2668,8 @@ annotate S.E with @UI.LineItem: [
                         UI.LineItem : {
                             $value : [],
                             ![@UI.Importance] : #Low,
-                            ![@UI.Criticality] : criticality,
-                        }
+                        },
+                        UI.LineItem.@UI.Criticality : criticality,
                     );`
                 );
             });
@@ -2600,7 +2706,7 @@ annotate S.E with @UI.LineItem: [
                             Criticality : #Critical,
                             ![@UI.Hidden] : true,
                             Value : 'test',
-                            ![@UI.Criticality] : criticality,
+                            @UI.Criticality : criticality,
                         }
                     );`
                 );
@@ -2612,8 +2718,8 @@ annotate S.E with @UI.LineItem: [
                     annotate S.E with @(
                         Common.Text : {
                             $value : 'abc',
-                            ![@UI.Hidden],
-                        }
+                        },
+                        Common.Text.@UI.Hidden,
                     );`;
                 await testWriter(
                     fixture,
@@ -2636,9 +2742,9 @@ annotate S.E with @UI.LineItem: [
                     annotate S.E with @(
                         Common.Text : {
                             $value : 'abc',
-                            ![@UI.TextArrangement] : #TextFirst,
-                            ![@UI.Hidden],
-                        }
+                        },
+                        Common.Text.@UI.TextArrangement : #TextFirst,
+                        Common.Text.@UI.Hidden,
                     );`
                 );
             });
@@ -2683,10 +2789,10 @@ annotate S.E with @UI.LineItem: [
                     `
                     Service S { entity E { name: String; }; };
                     annotate S.E with {
-                        name @Common.Text : {
-                            $value : updated,
-                            ![@UI.TextArrangement] : #TextFirst
-                        }
+                        name @(
+                            Common.Text : updated,
+                            Common.Text.@UI.TextArrangement : #TextFirst,
+                        )
                     };`
                 );
             });
@@ -2697,7 +2803,8 @@ annotate S.E with @UI.LineItem: [
                         Common.Text : {
                             $value : 'abc',
                             ![@UI.Hidden],
-                        }
+                        },
+                        Common.Text.@UI.Hidden,
                     );`;
                 await testWriter(
                     fixture,
@@ -2720,9 +2827,10 @@ annotate S.E with @UI.LineItem: [
                     annotate S.E with @(
                         Common.Text : {
                             $value : 'abc',
-                            ![@UI.TextArrangement] : #TextFirst,
                             ![@UI.Hidden],
-                        }
+                        },
+                        Common.Text.@UI.TextArrangement : #TextFirst,
+                        Common.Text.@UI.Hidden,
                     );`
                 );
             });
@@ -2842,16 +2950,43 @@ annotate S.E with @UI.LineItem: [];`;
                     ],
                     `Service S { entity E {}; };
 annotate S.E with @(
-    UI.LineItem: {
-        $value : [
-            {
-                Value : some_path,
-            },
-        ],
-        ![@UI.Hidden] : true
-    },
+    UI.LineItem: [
+        {
+            Value : some_path,
+        },
+    ],
+    UI.LineItem.@UI.Hidden : true,
     UI.Hidden : true,
 );`
+                );
+            });
+            test('single line annotate statement', async () => {
+                const fixture = `Service S { entity E { description String; }; };
+annotate S.E with { description @Common.Text: title };`;
+                await testWriter(
+                    fixture,
+                    [
+                        {
+                            type: 'insert-embedded-annotation',
+                            pointer: '/targets/0/assignments/0',
+                            element: createElementNode({
+                                name: Edm.Annotation,
+                                attributes: {
+                                    [Edm.Term]: createAttributeNode(Edm.Term, 'UI.TextArrangement'),
+                                    [Edm.EnumMember]: createAttributeNode(
+                                        Edm.EnumMember,
+                                        'UI.TextArrangementType/TextFirst'
+                                    )
+                                },
+                                content: []
+                            })
+                        }
+                    ],
+                    `Service S { entity E { description String; }; };
+annotate S.E with { description @(
+    Common.Text: title,
+    Common.Text.@UI.TextArrangement : #TextFirst,
+)};`
                 );
             });
             test('annotation and embedded annotation', async () => {
@@ -2887,10 +3022,8 @@ annotate S.E with @UI.LineItem: [];`;
                     ],
                     `Service S { entity E {}; };
 annotate S.E with @(
-    UI.LineItem: {
-        $value : [],
-        ![@UI.Hidden] : true
-    },
+    UI.LineItem: [],
+    UI.LineItem.@UI.Hidden : true,
     UI.Hidden : true,
 );`
                 );
@@ -2898,8 +3031,34 @@ annotate S.E with @(
         });
 
         describe('delete', () => {
+            describe('annotation', () => {
+                test('last value in compound annotation', async () => {
+                    const fixture = `
+                        Service S { entity E {}; };
+                        annotate S.E with @(
+                            Common.Text : 'abc',
+                            UI.LineItem: [],
+                        );
+                        `;
+                    await testWriter(
+                        fixture,
+                        [
+                            {
+                                type: 'delete-annotation',
+                                pointer: '/targets/0/assignments/1'
+                            }
+                        ],
+                        `
+                        Service S { entity E {}; };
+                        annotate S.E with @(
+                            Common.Text : 'abc',
+                        );
+                        `
+                    );
+                });
+            });
             describe('embedded annotation', () => {
-                test('delete single embedded annotation', async () => {
+                test('delete single embedded annotation ($value)', async () => {
                     const fixture = `
                         Service S { entity E {}; };
                         annotate S.E with @(
@@ -2921,6 +3080,31 @@ annotate S.E with @(
                         Service S { entity E {}; };
                         annotate S.E with @(
                             Common.Text : 'abc'
+                        );
+                        `
+                    );
+                });
+                test('delete single embedded annotation', async () => {
+                    // TODO: add similar test in fiori-service
+                    const fixture = `
+                        Service S { entity E {}; };
+                        annotate S.E with @(
+                            Common.Text : 'abc',
+                            Common.Text.@UI.Hidden,
+                        );
+                        `;
+                    await testWriter(
+                        fixture,
+                        [
+                            {
+                                type: 'delete-embedded-annotation',
+                                pointer: '/targets/0/assignments/1'
+                            }
+                        ],
+                        `
+                        Service S { entity E {}; };
+                        annotate S.E with @(
+                            Common.Text : 'abc',
                         );
                         `
                     );
@@ -2950,7 +3134,7 @@ annotate S.E with @(
                         annotate S.E with {
                             name @Common : {
                                 Text : 'abc',
-                                }
+                            }
                         );
                         `
                     );
@@ -3151,6 +3335,52 @@ annotate S.E with @Aggregation: { ApplySupported: {$value : {AggregatablePropert
                     `Service S { entity E {}; };
 annotate S.E with @Aggregation: { ApplySupported, };
 `
+                );
+            });
+            test('when there are two annotations in compound annotation', async () => {
+                const fixture = `Service S { entity E { description: String; }; };
+annotate S.E with {
+    description @(
+        Common.Text : modifiedBy,
+        Common.Text.@UI.TextArrangement : #TextFirst,
+)};`;
+                await testWriter(
+                    fixture,
+                    [
+                        {
+                            type: 'delete-annotation',
+                            pointer: '/targets/0/assignments/1'
+                        }
+                    ],
+                    `Service S { entity E { description: String; }; };
+annotate S.E with {
+    description @(
+        Common.Text : modifiedBy,
+)};`
+                );
+            });
+            test('when there are three annotations in compound annotation', async () => {
+                const fixture = `Service S { entity E { description: String; }; };
+annotate S.E with {
+    description @(
+        Common.Text : modifiedBy,
+        UI.Hidden : true,
+        Common.Text.@UI.TextArrangement : #TextFirst,
+)};`;
+                await testWriter(
+                    fixture,
+                    [
+                        {
+                            type: 'delete-annotation',
+                            pointer: '/targets/0/assignments/2'
+                        }
+                    ],
+                    `Service S { entity E { description: String; }; };
+annotate S.E with {
+    description @(
+        Common.Text : modifiedBy,
+        UI.Hidden : true,
+)};`
                 );
             });
         });


### PR DESCRIPTION
Write CDS annotations using new annotation syntax (without `![]` escaping).

Also fixed issues with indentation and added trailing comma for inserts.