### PR TITLE
Reuse existing sap.cloud.service when adding config

### DIFF
--- a/.changeset/ninety-ties-accept.md
+++ b/.changeset/ninety-ties-accept.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/cf-deploy-config-sub-generator': patch
+'@sap-ux/deploy-config-sub-generator': patch
+'@sap-ux/cf-deploy-config-writer': patch
+---
+
+Aligned `sap.cloud.service` property with CAP generator

--- a/packages/cf-deploy-config-sub-generator/test/fixtures/sap-ux-test/mta.managed.yaml
+++ b/packages/cf-deploy-config-sub-generator/test/fixtures/sap-ux-test/mta.managed.yaml
@@ -27,12 +27,12 @@ modules:
                       - Name: sap-ux-test_html_repo_host
                         ServiceInstanceName: sap-ux-test-html5-service
                         ServiceKeyName: sap-ux-test-repo-host-key
-                        sap.cloud.service: sap-ux-test
+                        sap.cloud.service: sapuxtest
                       - Authentication: OAuth2UserTokenExchange
                         Name: sap-ux-test_uaa
                         ServiceInstanceName: sap-ux-test-xsuaa-service
                         ServiceKeyName: sap-ux-test-uaa-key
-                        sap.cloud.service: sap-ux-test
+                        sap.cloud.service: sapuxtest
                   existing_destinations_policy: update
       build-parameters:
           no-source: true

--- a/packages/cf-deploy-config-writer/src/mta-config/mta.ts
+++ b/packages/cf-deploy-config-writer/src/mta-config/mta.ts
@@ -1126,14 +1126,14 @@ export class MtaConfig {
                                         Name: `${this.prefix.slice(0, 100)}_html_repo_host`,
                                         ServiceInstanceName: appHostServiceName,
                                         ServiceKeyName: `${appHostName}-key`,
-                                        'sap.cloud.service': `${this.prefix.slice(0, 100)}`
+                                        'sap.cloud.service': `${this.cloudServiceName ?? `${this.prefix.replace(/-/g, '').slice(0, 100)}`}`
                                     },
                                     {
                                         Authentication: 'OAuth2UserTokenExchange',
                                         Name: `${this.prefix.slice(0, 100)}_uaa`,
                                         ServiceInstanceName: managedXSUAAServiceName,
                                         ServiceKeyName: `${managedXSUAAName}-key`,
-                                        'sap.cloud.service': `${this.prefix.slice(0, 100)}`
+                                        'sap.cloud.service': `${this.cloudServiceName ?? `${this.prefix.replace(/-/g, '').slice(0, 100)}`}`
                                     }
                                 ],
                                 'existing_destinations_policy': 'update'

--- a/packages/cf-deploy-config-writer/test/unit/fixtures/mta-ext/app/mta.yaml
+++ b/packages/cf-deploy-config-writer/test/unit/fixtures/mta-ext/app/mta.yaml
@@ -24,12 +24,12 @@ modules:
         - Name: test-mta_html_repo_host
           ServiceInstanceName: test-mta-html5-srv
           ServiceKeyName: test-mta-repo-host-key
-          sap.cloud.service: test-mta
+          sap.cloud.service: testmta
         - Authentication: OAuth2UserTokenExchange
           Name: test-mta_uaa
           ServiceInstanceName: test-mta-xsuaa-srv
           ServiceKeyName: test-mta-uaa-key
-          sap.cloud.service: test-mta
+          sap.cloud.service: testmta
         existing_destinations_policy: update
   build-parameters:
     no-source: true

--- a/packages/deploy-config-sub-generator/test/headless/__snapshots__/app-headless.test.ts.snap
+++ b/packages/deploy-config-sub-generator/test/headless/__snapshots__/app-headless.test.ts.snap
@@ -594,12 +594,12 @@ modules:
             - Name: existing-id-deploy_html_repo_host
               ServiceInstanceName: existing-id-deploy-html5-service
               ServiceKeyName: existing-id-deploy-repo-host-key
-              sap.cloud.service: existing-id-deploy
+              sap.cloud.service: existingiddeploy
             - Authentication: OAuth2UserTokenExchange
               Name: existing-id-deploy_uaa
               ServiceInstanceName: existing-id-deploy-xsuaa-service
               ServiceKeyName: existing-id-deploy-uaa-key
-              sap.cloud.service: existing-id-deploy
+              sap.cloud.service: existingiddeploy
           existing_destinations_policy: update
     build-parameters:
       no-source: true
@@ -1444,7 +1444,7 @@ exports[`Test headless generator Test: Headless deploy-config - localAppChanges 
   },
   "sap.cloud": {
     "public": true,
-    "service": "existing-id-deploy"
+    "service": "existingiddeploy"
   }
 }
 "


### PR DESCRIPTION
Hi colleagues,

currently when adding a Fiori app and the managed approuter config is not yet present, Fiori tools adds the config. However when there is already an existing destination with 'sap.cloud.service' this is not reused but instead the name for the new destinations is generated.

This PR fixes this gap, that first an existing `sap.cloud.service` name will be used before generating a new one. 

In addition the generation now strips away dashes ('-') from the name as those are apparently not allowed.

BR,
Marten