### PR TITLE
fix(preview-middleware): only parse changes

### DIFF
--- a/.changeset/chilled-hounds-travel.md
+++ b/.changeset/chilled-hounds-travel.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix: only parse change files from `changes` folder.

--- a/packages/preview-middleware/src/base/flex.ts
+++ b/packages/preview-middleware/src/base/flex.ts
@@ -17,7 +17,9 @@ export async function readChanges(
     logger: Logger
 ): Promise<Record<string, CommonChangeProperties>> {
     const changes: Record<string, CommonChangeProperties> = {};
-    const files = await project.byGlob('/**/changes/**/*.*');
+    const files = await project.byGlob(
+        '/**/changes/**/*.{change,ctrl_variant,ctrl_variant_change,ctrl_variant_management_change}'
+    );
     for (const file of files) {
         try {
             changes[`sap.ui.fl.${parse(file.getName()).name}`] = JSON.parse(


### PR DESCRIPTION
Preview middleware was logging the following warnings when trying to parse non change files as JSON.
```
warn fiori-tools-preview Unexpected token '<', "<edmx:Edmx"... is not valid JSON
warn fiori-tools-preview Unexpected token '<', "<!-- Use s"... is not valid JSON
```
