### PR TITLE
feat(fe-fpm-writer): use sap.fe.ariba template for new OP, LR pages when dependency is listed in manifest.json dependencies 

### DIFF
--- a/.changeset/smart-sloths-protect.md
+++ b/.changeset/smart-sloths-protect.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': minor
+---
+
+Support 'sap.fe.ariba' dependency for new pages'. If the dependency is listed in the manifest, it will be used as the template(property "name") for new LR and OP pages.

--- a/packages/fe-fpm-writer/src/page/common.ts
+++ b/packages/fe-fpm-writer/src/page/common.ts
@@ -3,7 +3,7 @@ import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
 import { render } from 'ejs';
 import type { ManifestNamespace } from '@sap-ux/project-access';
-import { validateBasePath } from '../common/validate';
+import { validateBasePath, validateDependenciesLibs } from '../common/validate';
 import type {
     CustomPage,
     FCL,
@@ -33,6 +33,11 @@ type EnhancePageConfigFunction = (
  * Suffix for patterns to support arbitrary paramters
  */
 export const PATTERN_SUFFIX = ':?query:';
+
+/**
+ * List of special page templates that differs from the standard 'sap.fe.templates'.
+ */
+export const SPECIAL_PAGE_TEMPLATES = ['sap.fe.ariba'];
 
 /**
  * Generates the pattern for a new route based on the input.
@@ -283,4 +288,21 @@ export async function extendPageJSON(
     });
 
     return fs;
+}
+
+/**
+ * Returns the template name prefix based on the provided manifest.
+ * If the dependencies in manifest matches any of the special page templates, that template is returned.
+ * Otherwise, it defaults to 'sap.fe.templates'.
+ *
+ * @param manifest The application manifest to check against special templates.
+ * @returns The matched template prefix or the default 'sap.fe.templates'.
+ */
+export function getTemplateNamePrefix(manifest: Manifest): string {
+    for (const template of SPECIAL_PAGE_TEMPLATES) {
+        if (validateDependenciesLibs(manifest, [template])) {
+            return template;
+        }
+    }
+    return 'sap.fe.templates';
 }

--- a/packages/fe-fpm-writer/src/page/custom.ts
+++ b/packages/fe-fpm-writer/src/page/custom.ts
@@ -33,6 +33,8 @@ export function enhanceData(data: CustomPage, manifestPath: string, fs: Editor):
 
     // set common defaults
     const config = setCommonDefaults(data, manifestPath, manifest) as InternalCustomPage;
+    // currently the custom page template is always the same
+    config.template = 'sap.fe.core.fpm';
     config.settings = initializeTargetSettings(data);
 
     // set library dependencies

--- a/packages/fe-fpm-writer/src/page/list.ts
+++ b/packages/fe-fpm-writer/src/page/list.ts
@@ -1,5 +1,11 @@
 import type { Editor } from 'mem-fs-editor';
-import { getFclConfig, extendPageJSON, initializeTargetSettings, getLibraryDependencies } from './common';
+import {
+    getFclConfig,
+    extendPageJSON,
+    initializeTargetSettings,
+    getLibraryDependencies,
+    getTemplateNamePrefix
+} from './common';
 import type { Manifest } from '../common/types';
 import type { ListReport, InternalListReport } from './types';
 import { PageType } from './types';
@@ -16,6 +22,7 @@ function enhanceData(data: ListReport, manifest: Manifest): InternalListReport {
         ...data,
         settings: initializeTargetSettings(data, data.settings),
         name: PageType.ListReport,
+        template: `${getTemplateNamePrefix(manifest)}.ListReport`,
         ...getFclConfig(manifest)
     };
 

--- a/packages/fe-fpm-writer/src/page/object.ts
+++ b/packages/fe-fpm-writer/src/page/object.ts
@@ -1,5 +1,11 @@
 import type { Editor } from 'mem-fs-editor';
-import { getFclConfig, extendPageJSON, initializeTargetSettings, getLibraryDependencies } from './common';
+import {
+    getFclConfig,
+    extendPageJSON,
+    initializeTargetSettings,
+    getLibraryDependencies,
+    getTemplateNamePrefix
+} from './common';
 import type { Manifest } from '../common/types';
 import type { ObjectPage, InternalObjectPage } from './types';
 import { PageType } from './types';
@@ -15,7 +21,8 @@ function enhanceData(data: ObjectPage, manifest: Manifest): InternalObjectPage {
     const config: InternalObjectPage = {
         ...data,
         settings: initializeTargetSettings(data, data.settings),
-        name: PageType.ObjectPage
+        name: PageType.ObjectPage,
+        template: `${getTemplateNamePrefix(manifest)}.ObjectPage`
     };
 
     // set FCL configuration

--- a/packages/fe-fpm-writer/src/page/types.ts
+++ b/packages/fe-fpm-writer/src/page/types.ts
@@ -142,6 +142,10 @@ export interface FCL {
  */
 export type InternalFpmPage = FCL & {
     settings: Record<string, unknown | undefined>;
+    /**
+     * Allows setting a non-standard template (sets the "name" property in manifest.json for the page).
+     */
+    template: string;
 };
 
 export enum PageType {

--- a/packages/fe-fpm-writer/templates/page/custom/1.94/manifest.json
+++ b/packages/fe-fpm-writer/templates/page/custom/1.94/manifest.json
@@ -8,7 +8,7 @@
                 "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %><%- name %><% } %>": {
                     "type": "Component",
                     "id": "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %><%- name %><% } %>",
-                    "name": "sap.fe.core.fpm",<%if (locals.controlAggregation) {%>
+                    "name": "<%- template %>",<%if (locals.controlAggregation) {%>
                     "controlAggregation": "<%- locals.controlAggregation %>",<% } %>
                     "options": {
                         "settings": <%- JSON.stringify({ ...settings, viewName: `${ns}.${name}`}) %>

--- a/packages/fe-fpm-writer/templates/page/list/manifest.json
+++ b/packages/fe-fpm-writer/templates/page/list/manifest.json
@@ -8,7 +8,7 @@
                 "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %>ListReport<% } %>": {
                     "type": "Component",
                     "id": "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %>ListReport<% } %>",
-                    "name": "sap.fe.templates.ListReport",<%if (locals.controlAggregation) {%>
+                    "name": "<%- template %>",<%if (locals.controlAggregation) {%>
                     "controlAggregation": "<%- locals.controlAggregation %>",<% } %>
                     "options": {
                         "settings": <%- JSON.stringify(settings) %>

--- a/packages/fe-fpm-writer/templates/page/object/manifest.json
+++ b/packages/fe-fpm-writer/templates/page/object/manifest.json
@@ -8,7 +8,7 @@
                 "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %>ObjectPage<% } %>": {
                     "type": "Component",
                     "id": "<% if (typeof id !== 'undefined') { %><%- id %><% } else { %><%- entity %>ObjectPage<% } %>",
-                    "name": "sap.fe.templates.ObjectPage",<%if (locals.controlAggregation) {%>
+                    "name": "<%- template %>",<%if (locals.controlAggregation) {%>
                     "controlAggregation": "<%- locals.controlAggregation %>",<% } %>
                     "options": {
                         "settings": <%- JSON.stringify(settings) %>

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/custom.test.ts.snap
@@ -9,6 +9,51 @@ Object {
 }
 `;
 
+exports[`CustomPage Add when "sap.fe.ariba" dependency is listed 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.ariba": Object {},
+        "sap.fe.core": Object {},
+      },
+    },
+    "routing": Object {
+      "routes": Array [
+        Object {
+          "name": "TestObjectPage",
+          "pattern": ":?query:",
+          "target": "TestObjectPage",
+        },
+        Object {
+          "name": "RootEntityCustomPage",
+          "pattern": "RootEntity:?query:",
+          "target": "RootEntityCustomPage",
+        },
+      ],
+      "targets": Object {
+        "RootEntityCustomPage": Object {
+          "id": "RootEntityCustomPage",
+          "name": "sap.fe.core.fpm",
+          "options": Object {
+            "settings": Object {
+              "contextPath": "/RootEntity",
+              "navigation": Object {},
+              "viewName": "my.test.App.ext.customPage.CustomPage",
+            },
+          },
+          "type": "Component",
+        },
+        "TestObjectPage": Object {},
+      },
+    },
+  },
+}
+`;
+
 exports[`CustomPage Test property custom "tabSizing" 1 tab 1`] = `
 "#XTIT: Custom view title
 CustomPageTitle=CustomPage"

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/list.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/list.test.ts.snap
@@ -8,6 +8,44 @@ Object {
 }
 `;
 
+exports[`ListReport generate Add when "sap.fe.ariba" dependency is listed 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.ariba": Object {},
+        "sap.fe.templates": Object {},
+      },
+    },
+    "routing": Object {
+      "routes": Array [
+        Object {
+          "name": "RootEntityListReport",
+          "pattern": ":?query:",
+          "target": "RootEntityListReport",
+        },
+      ],
+      "targets": Object {
+        "RootEntityListReport": Object {
+          "id": "RootEntityListReport",
+          "name": "sap.fe.ariba.ListReport",
+          "options": Object {
+            "settings": Object {
+              "contextPath": "/RootEntity",
+              "navigation": Object {},
+            },
+          },
+          "type": "Component",
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`ListReport generate all optional settings used 1`] = `
 Object {
   "sap.app": Object {

--- a/packages/fe-fpm-writer/test/unit/page/__snapshots__/object.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/page/__snapshots__/object.test.ts.snap
@@ -123,6 +123,56 @@ Object {
 }
 `;
 
+exports[`ObjectPage generate Add when "sap.fe.ariba" dependency is listed 1`] = `
+Object {
+  "sap.app": Object {
+    "id": "my.test.App",
+  },
+  "sap.ui5": Object {
+    "dependencies": Object {
+      "libs": Object {
+        "sap.fe.ariba": Object {},
+        "sap.fe.templates": Object {},
+      },
+    },
+    "routing": Object {
+      "routes": Array [
+        Object {
+          "name": "RootEntityListReport",
+          "pattern": ":?query:",
+          "target": "TestListReport",
+        },
+        Object {
+          "name": "RootEntityObjectPage",
+          "pattern": "RootEntity({RootEntityKey}):?query:",
+          "target": "RootEntityObjectPage",
+        },
+        Object {
+          "name": "OtherEntityObjectPage",
+          "pattern": "OtherEntity:?query:",
+          "target": "OtherEntityObjectPage",
+        },
+      ],
+      "targets": Object {
+        "OtherEntityObjectPage": Object {
+          "id": "OtherEntityObjectPage",
+          "name": "sap.fe.ariba.ObjectPage",
+          "options": Object {
+            "settings": Object {
+              "contextPath": "/OtherEntity",
+              "navigation": Object {},
+            },
+          },
+          "type": "Component",
+        },
+        "RootEntityListReport": Object {},
+        "RootEntityObjectPage": Object {},
+      },
+    },
+  },
+}
+`;
+
 exports[`ObjectPage generate all optional settings 1`] = `
 Object {
   "sap.app": Object {

--- a/packages/fe-fpm-writer/test/unit/page/custom.test.ts
+++ b/packages/fe-fpm-writer/test/unit/page/custom.test.ts
@@ -369,4 +369,19 @@ describe('CustomPage', () => {
         //check
         expect((fs.readJSON(join(target, 'webapp/manifest.json')) as any)?.['sap.ui5'].dependencies).toMatchSnapshot();
     });
+
+    test('Add when "sap.fe.ariba" dependency is listed', async () => {
+        const testManifest = JSON.parse(testAppManifest);
+        testManifest['sap.ui5'].dependencies.libs['sap.fe.ariba'] = {};
+        const minimalInput: CustomPage = {
+            name: 'CustomPage',
+            entity: 'RootEntity'
+        };
+        const target = join(testDir, 'ariba');
+        fs.write(join(target, 'webapp/manifest.json'), JSON.stringify(testManifest));
+        //act
+        await generateCustomPage(target, minimalInput, fs);
+        //check
+        expect(fs.readJSON(join(target, 'webapp/manifest.json'))).toMatchSnapshot();
+    });
 });

--- a/packages/fe-fpm-writer/test/unit/page/list.test.ts
+++ b/packages/fe-fpm-writer/test/unit/page/list.test.ts
@@ -128,5 +128,16 @@ describe('ListReport', () => {
                 (fs.readJSON(join(target, 'webapp/manifest.json')) as any)?.['sap.ui5'].dependencies
             ).toMatchSnapshot();
         });
+
+        test('Add when "sap.fe.ariba" dependency is listed', async () => {
+            const testManifest = JSON.parse(testAppManifest);
+            testManifest['sap.ui5'].dependencies.libs['sap.fe.ariba'] = {};
+            const target = join(testDir, 'ariba');
+            fs.write(join(target, 'webapp/manifest.json'), JSON.stringify(testManifest));
+            //act
+            await generate(target, minimalInput, fs);
+            //check
+            expect(fs.readJSON(join(target, 'webapp/manifest.json'))).toMatchSnapshot();
+        });
     });
 });

--- a/packages/fe-fpm-writer/test/unit/page/object.test.ts
+++ b/packages/fe-fpm-writer/test/unit/page/object.test.ts
@@ -191,6 +191,17 @@ describe('ObjectPage', () => {
                 (fs.readJSON(join(target, 'webapp/manifest.json')) as any)?.['sap.ui5'].dependencies
             ).toMatchSnapshot();
         });
+
+        test('Add when "sap.fe.ariba" dependency is listed', async () => {
+            const testManifest = JSON.parse(testAppManifest);
+            testManifest['sap.ui5'].dependencies.libs['sap.fe.ariba'] = {};
+            const target = join(testDir, 'ariba');
+            fs.write(join(target, 'webapp/manifest.json'), JSON.stringify(testManifest));
+            //act
+            await generate(target, minimalInput, fs);
+            //check
+            expect(fs.readJSON(join(target, 'webapp/manifest.json'))).toMatchSnapshot();
+        });
     });
 
     describe('FCL is enabled', () => {


### PR DESCRIPTION
Issue #3306

Use `sap.fe.ariba` template prefix for new Object Page and List Report pages if `sap.fe.ariba` is listed in `"sap.ui5"/"dependencies"` in `manifest.json`. Otherwise old approach with `sap.fe.templates` will be used.

Changes does not affect Custom Page, it stays as before - always uses `sap.fe.core.fpm`