### PR TITLE
fix(preview-middleware): wrong property path

### DIFF
--- a/.changeset/hungry-timers-attend.md
+++ b/.changeset/hungry-timers-attend.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: wrong property path used for Show Counts configuration change

--- a/packages/preview-middleware-client/src/cpe/changes/generic-change.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/generic-change.ts
@@ -129,7 +129,7 @@ export type GenericChange =
     | ConfigChange
     | V2ConfigChange;
 
-export type changeType = GenericChange['changeType'];
+export type ChangeType = GenericChange['changeType'];
 
 /**
  * Returns a shortened version of the given configuration path segments by removing excess segments,

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -36,7 +36,7 @@ import UI5Element from 'sap/ui/core/Element';
 import { setAdditionalChangeInfo } from '../../utils/additional-change-info';
 import {
     ChangeHandler,
-    changeType,
+    ChangeType,
     ConfigChange,
     GENERIC_CHANGE_HANDLER,
     getControlIdByChange,
@@ -444,7 +444,7 @@ export class ChangeService extends EventTarget {
 
         const changeDefinition = change.getDefinition ? change.getDefinition() : (change.getJson() as ChangeDefinition);
         const { fileName } = changeDefinition;
-        const handler = GENERIC_CHANGE_HANDLER[changeType as changeType] as unknown as ChangeHandler<GenericChange>;
+        const handler = GENERIC_CHANGE_HANDLER[changeType as ChangeType] as unknown as ChangeHandler<GenericChange>;
         if (handler) {
             const {
                 properties,

--- a/packages/preview-middleware-client/src/cpe/utils.ts
+++ b/packages/preview-middleware-client/src/cpe/utils.ts
@@ -124,7 +124,7 @@ export function getManifestProperties(
             },
             item: DesigntimeSetting
         ) => {
-            const propertyId = item.id;
+            const propertyId = item.path ?? item.id;
             const value = changeService.getConfigurationPropertyValue(control.getId(), propertyId);
             let propertyValue = value === 0 || value === false || value ? value : manifestPropertiesValue[propertyId];
             if (item?.type && ['boolean', 'number', 'string'].includes(item?.type)) {

--- a/packages/preview-middleware-client/src/utils/fe-v4.ts
+++ b/packages/preview-middleware-client/src/utils/fe-v4.ts
@@ -103,13 +103,24 @@ export async function createManifestPropertyChange(
     if (!overlay) {
         return undefined;
     }
-    const overlayData = overlay?.getDesignTimeMetadata().getData();
+    const overlayData = overlay.getDesignTimeMetadata().getData();
+    const settings = overlayData.manifestSettings(modifiedControl);
     let manifestPropertyPath = overlayData.manifestPropertyPath(modifiedControl);
     if (propertyPathExtraSegments) {
         manifestPropertyPath += '/' + propertyPathExtraSegments.join('/');
     }
+    const adjustedChanges: Record<string, string | string[] | boolean | number | object | undefined> = {};
+    for (const [key, value] of Object.entries(propertyChanges)) {
+        const setting = settings.find((s) => s.id === key);
+        if (setting) {
+            adjustedChanges[setting.path ?? setting.id] = value;
+        } else {
+            adjustedChanges[key] = value;
+        }
+        
+    }
     const [manifestPropertyChange] = overlayData.manifestPropertyChange(
-        propertyChanges,
+        adjustedChanges,
         manifestPropertyPath,
         modifiedControl
     );

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -534,15 +534,14 @@ describe('FE V4 quick actions', () => {
                     { actionName: 'add-controller-to-page', telemetryEventIdentifier }
                 );
 
-                expect(reportTelemetrySpy).toHaveBeenCalledWith(
-                   {
-                        category: 'QuickAction',
-                        quickActionSteps: 2,
-                        actionName: 'add-controller-to-page',
-                        telemetryEventIdentifier,
-                        ui5Version: '1.127.0',
-                        appType: 'fe-v4'
-                    })
+                expect(reportTelemetrySpy).toHaveBeenCalledWith({
+                    category: 'QuickAction',
+                    quickActionSteps: 2,
+                    actionName: 'add-controller-to-page',
+                    telemetryEventIdentifier,
+                    ui5Version: '1.127.0',
+                    appType: 'fe-v4'
+                });
             });
 
             test('initialize and execute action with existing controller change', async () => {
@@ -651,7 +650,8 @@ describe('FE V4 quick actions', () => {
                                     id: 'listReport0-add-controller-to-page',
                                     title: 'Add Controller to Page',
                                     enabled: false,
-                                    tooltip: 'This action is disabled because a pending change for a controller extension has been found. '
+                                    tooltip:
+                                        'This action is disabled because a pending change for a controller extension has been found. '
                                 }
                             ]
                         }
@@ -1201,6 +1201,7 @@ describe('FE V4 quick actions', () => {
 
                 mockOverlay.getDesignTimeMetadata.mockReturnValue({
                     getData: jest.fn().mockReturnValue({
+                        manifestSettings: jest.fn().mockReturnValue([]),
                         manifestPropertyPath: jest.fn().mockReturnValue('dummyManifestPath'),
                         manifestPropertyChange: jest.fn().mockImplementation((propertyValue, propertyPath) => [
                             {
@@ -1519,6 +1520,7 @@ describe('FE V4 quick actions', () => {
 
                         mockOverlay.getDesignTimeMetadata.mockReturnValue({
                             getData: jest.fn().mockReturnValue({
+                                manifestSettings: jest.fn().mockReturnValue([]),
                                 manifestPropertyPath: jest.fn().mockReturnValue('dummyManifestPath'),
                                 manifestPropertyChange: jest.fn().mockImplementation((propertyValue, propertyPath) => [
                                     {
@@ -2154,6 +2156,7 @@ describe('FE V4 quick actions', () => {
 
                         mockOverlay.getDesignTimeMetadata.mockReturnValue({
                             getData: jest.fn().mockReturnValue({
+                                manifestSettings: jest.fn().mockReturnValue([]),
                                 manifestPropertyPath: jest.fn().mockReturnValue('dummyManifestPath'),
                                 manifestPropertyChange: jest.fn().mockImplementation((propertyValue, propertyPath) => [
                                     {
@@ -2427,6 +2430,7 @@ describe('FE V4 quick actions', () => {
 
                             mockOverlay.getDesignTimeMetadata.mockReturnValue({
                                 getData: jest.fn().mockReturnValue({
+                                    manifestSettings: jest.fn().mockReturnValue([]),
                                     manifestPropertyPath: jest.fn().mockReturnValue('dummyManifestPath'),
                                     manifestPropertyChange: jest
                                         .fn()
@@ -2499,7 +2503,7 @@ describe('FE V4 quick actions', () => {
                             enabled: true,
                             id: 'objectPage0-add-controller-to-page',
                             kind: 'simple',
-                            title: 'Add Controller to Page',
+                            title: 'Add Controller to Page'
                         },
                         {
                             enabled: true,

--- a/packages/preview-middleware-client/test/unit/cpe/__snapshots__/control-data.test.ts.snap
+++ b/packages/preview-middleware-client/test/unit/cpe/__snapshots__/control-data.test.ts.snap
@@ -164,6 +164,22 @@ Object {
     },
     Object {
       "documentation": Object {
+        "defaultValue": "false",
+        "description": "Show Counts",
+        "propertyName": "showCounts",
+        "type": "boolean",
+      },
+      "editor": "checkbox",
+      "isEnabled": true,
+      "name": "showCounts",
+      "propertyType": "configuration",
+      "readableName": "Show Counts",
+      "type": "boolean",
+      "ui5Type": undefined,
+      "value": true,
+    },
+    Object {
+      "documentation": Object {
         "defaultValue": "gridTable",
         "description": "table type",
         "propertyName": "type",

--- a/packages/preview-middleware-client/test/unit/cpe/changes/flex-change.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/changes/flex-change.test.ts
@@ -176,7 +176,12 @@ describe('flexChange', () => {
                             },
                             selector: {} as any
                         }
-                    ] as ManifestPropertyChange[])
+                    ] as ManifestPropertyChange[]),
+                    manifestSettings: jest.fn().mockReturnValue([
+                        {
+                            id: 'someConfiguration/test/component/settings'
+                        }
+                    ])
                 })
             })
         });
@@ -213,6 +218,84 @@ describe('flexChange', () => {
             },
             null,
             flexSettings
+        );
+        expect(pushAndExecuteMock).toBeCalledWith(mockCommand);
+    });
+
+    test('applyChange - manifest change with path', async () => {
+        const manifestPropertyChange = jest.fn().mockReturnValue([
+            {
+                appComponent: {} as any,
+                changeSpecificData: {
+                    appDescriptorChangeType: 'appdescr_fe_changePageConfiguration',
+                    content: {
+                        parameters: {
+                            entityPropertyChange: {
+                                operation: 'upsert',
+                                propertyPath: 'someConfiguration/test/component/settings/longer/path',
+                                propertyValue: 'apply'
+                            },
+                            page: 'ListReport'
+                        }
+                    }
+                },
+                selector: {} as any
+            }
+        ] as ManifestPropertyChange[]);
+        OverlayUtil.getClosestOverlayFor = jest.fn().mockReturnValue({
+            getDesignTimeMetadata: jest.fn().mockReturnValue({
+                getData: jest.fn().mockReturnValue({
+                    manifestPropertyPath: jest.fn().mockReturnValue('someConfiguration/test/component/settings'),
+                    manifestPropertyChange,
+                    manifestSettings: jest.fn().mockReturnValue([
+                        {
+                            id: 'someConfiguration/test/component/settings',
+                            path: 'someConfiguration/test/component/settings/longer/path'
+                        }
+                    ])
+                })
+            })
+        });
+        sapCoreMock.byId.mockReturnValueOnce(control);
+        const change: PropertyChange = {
+            controlId: 'testId',
+            propertyName: 'someConfiguration/test/component/settings',
+            propertyType: PropertyType.Configuration,
+            value: 'apply',
+            controlName: 'controlName',
+            changeType: 'propertyChange'
+        };
+
+        // act
+        await applyChange(testOptions, change);
+
+        // assert
+        expect(CommandFactory.getCommandFor).toBeCalledWith(
+            control,
+            'appDescriptor',
+            {
+                appComponent: {},
+                changeType: 'appdescr_fe_changePageConfiguration',
+                parameters: {
+                    entityPropertyChange: {
+                        operation: 'upsert',
+                        propertyPath: 'someConfiguration/test/component/settings/longer/path',
+                        propertyValue: 'apply'
+                    },
+                    page: 'ListReport'
+                },
+                reference: '',
+                selector: {}
+            },
+            null,
+            flexSettings
+        );
+        expect(manifestPropertyChange).toHaveBeenCalledWith(
+            {
+                'someConfiguration/test/component/settings/longer/path': 'apply'
+            },
+            'someConfiguration/test/component/settings',
+            { 'getMetadata': expect.any(Function), 'name': 'sap.m.Button' }
         );
         expect(pushAndExecuteMock).toBeCalledWith(mockCommand);
     });

--- a/packages/preview-middleware-client/test/unit/cpe/control-data.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/control-data.test.ts
@@ -222,7 +222,8 @@ describe('controlData', () => {
                     type: 'responsiveTable',
                     header: 'USA table',
                     frozenColumnCount: 12,
-                    enableExportExcel: false
+                    enableExportExcel: false,
+                    'view/showCounts': true
                 } as ManifestSettingsValue),
                 manifestSettings: jest.fn().mockReturnValue([
                     {
@@ -272,6 +273,14 @@ describe('controlData', () => {
                         id: 'enableExportExcel',
                         description: 'Enable Export Excel',
                         name: 'Enable Export Excel',
+                        value: false,
+                        type: 'boolean'
+                    },
+                    {
+                        id: 'showCounts',
+                        description: 'Show Counts',
+                        name: 'Show Counts',
+                        path: 'view/showCounts',
                         value: false,
                         type: 'boolean'
                     }


### PR DESCRIPTION
Fixed an issue where incomplete property path was used for configuration changes created from property panel e.g "Show Counts" for table. 