### PR TITLE
Adds GA link when cert errors during deployment

### DIFF
--- a/packages/abap-deploy-config-inquirer/package.json
+++ b/packages/abap-deploy-config-inquirer/package.json
@@ -34,6 +34,7 @@
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/guided-answers-helper": "workspace:*",
         "@sap-ux/inquirer-common": "workspace:*",
+        "@sap-ux/nodejs-utils": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/store": "workspace:*",
         "@sap-ux/system-access": "workspace:*",

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/abap-service-provider.ts
@@ -1,5 +1,5 @@
 import { isAppStudio } from '@sap-ux/btp-utils';
-import { isSameSystem, setGlobalRejectUnauthorized } from '../utils';
+import { isSameSystem } from '../utils';
 import { createAbapServiceProvider } from '@sap-ux/system-access';
 import { AuthenticationType } from '@sap-ux/store';
 import { PromptState } from '../prompts/prompt-state';
@@ -8,6 +8,7 @@ import type { AbapServiceProvider, AxiosRequestConfig, ProviderConfiguration } f
 import type { DestinationAbapTarget, UrlAbapTarget } from '@sap-ux/system-access';
 import type { BackendTarget, Credentials, SystemConfig } from '../types';
 import type { AbapTarget } from '@sap-ux/ui5-config';
+import { setGlobalRejectUnauthorized } from '@sap-ux/nodejs-utils';
 import { t } from '../i18n';
 
 /**

--- a/packages/abap-deploy-config-inquirer/src/utils.ts
+++ b/packages/abap-deploy-config-inquirer/src/utils.ts
@@ -1,10 +1,11 @@
+import type { Destination, Destinations } from '@sap-ux/btp-utils';
 import { isAppStudio, listDestinations } from '@sap-ux/btp-utils';
+import type { BackendSystem, BackendSystemKey } from '@sap-ux/store';
 import { getService } from '@sap-ux/store';
-import { PackageInputChoices, TargetSystemType, TransportChoices } from './types';
-import { getTransportConfigInstance } from './service-provider-utils';
+import { CREATE_TR_DURING_DEPLOY } from './constants';
 import { t } from './i18n';
 import LoggerHelper from './logger-helper';
-import { listPackages } from './validator-utils';
+import { getTransportConfigInstance } from './service-provider-utils';
 import type {
     AbapDeployConfigAnswers,
     AbapDeployConfigAnswersInternal,
@@ -13,10 +14,8 @@ import type {
     InitTransportConfigResult,
     SystemConfig
 } from './types';
-import type { BackendSystem, BackendSystemKey } from '@sap-ux/store';
-import type { Destinations, Destination } from '@sap-ux/btp-utils';
-import { CREATE_TR_DURING_DEPLOY } from './constants';
-import https from 'https';
+import { PackageInputChoices, TargetSystemType, TransportChoices } from './types';
+import { listPackages } from './validator-utils';
 
 let cachedDestinations: Destinations = {};
 let cachedBackendSystems: BackendSystem[] = [];
@@ -293,20 +292,4 @@ export function getSystemConfig(
         client: configSource?.client,
         destination: configSource?.destination
     };
-}
-
-/**
- * Set the rejectUnauthorized option of the global https agent.
- *
- * @param rejectUnauthorized - true to reject unauthorized certificates, false to accept them
- */
-export function setGlobalRejectUnauthorized(rejectUnauthorized: boolean): void {
-    if (https.globalAgent.options) {
-        https.globalAgent.options.rejectUnauthorized = rejectUnauthorized;
-    }
-    //@ts-expect-error - fallbackAgent is only present in BoundHttpsProxyAgent implementation and is not part of the Node.js API
-    if (https.globalAgent.fallbackAgent) {
-        //@ts-expect-error - fallbackAgent is not typed in Node.js API
-        https.globalAgent.fallbackAgent.options.rejectUnauthorized = rejectUnauthorized;
-    }
 }

--- a/packages/abap-deploy-config-inquirer/tsconfig.json
+++ b/packages/abap-deploy-config-inquirer/tsconfig.json
@@ -1,37 +1,43 @@
 {
-    "extends": "../../tsconfig.json",
-    "include": ["src", "src/**/*.json"],
-    "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist"
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src",
+    "src/**/*.json"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {
+      "path": "../axios-extension"
     },
-    "references": [
-        {
-            "path": "../axios-extension"
-        },
-        {
-            "path": "../btp-utils"
-        },
-        {
-            "path": "../fiori-generator-shared"
-        },
-        {
-            "path": "../guided-answers-helper"
-        },
-        {
-            "path": "../inquirer-common"
-        },
-        {
-            "path": "../logger"
-        },
-        {
-            "path": "../store"
-        },
-        {
-            "path": "../system-access"
-        },
-        {
-            "path": "../ui5-config"
-        }
-    ]
+    {
+      "path": "../btp-utils"
+    },
+    {
+      "path": "../fiori-generator-shared"
+    },
+    {
+      "path": "../guided-answers-helper"
+    },
+    {
+      "path": "../inquirer-common"
+    },
+    {
+      "path": "../logger"
+    },
+    {
+      "path": "../nodejs-utils"
+    },
+    {
+      "path": "../store"
+    },
+    {
+      "path": "../system-access"
+    },
+    {
+      "path": "../ui5-config"
+    }
+  ]
 }

--- a/packages/deploy-tooling/package.json
+++ b/packages/deploy-tooling/package.json
@@ -40,6 +40,7 @@
     "dependencies": {
         "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/btp-utils": "workspace:*",
+        "@sap-ux/inquirer-common": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/system-access": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -13,6 +13,7 @@ import { promptConfirmation } from './prompt';
 import { createAbapServiceProvider, getCredentialsWithPrompts } from '@sap-ux/system-access';
 import { getAppDescriptorVariant } from './archive';
 import { validateBeforeDeploy, formatSummary, showAdditionalInfoForOnPrem, checkForCredentials } from './validate';
+import { ERROR_TYPE, ErrorHandler } from '@sap-ux/inquirer-common';
 
 /**
  * Internal deployment commands
@@ -42,6 +43,13 @@ async function handleError(
     logger: Logger,
     archive: Buffer
 ): Promise<void> {
+    if (ErrorHandler.isCertError(error)) {
+        const gaLink = ErrorHandler.getHelpForError(ERROR_TYPE.CERT)?.toString();
+        if (gaLink) {
+            logger.info(gaLink);
+        }
+    }
+
     const retry = config.retry === undefined ? true : config.retry;
     if (retry && isAxiosError(error)) {
         const success = await axiosErrorRetryHandler(command, error.response, provider, config, logger, archive);

--- a/packages/deploy-tooling/tsconfig.json
+++ b/packages/deploy-tooling/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../btp-utils"
     },
     {
+      "path": "../inquirer-common"
+    },
+    {
       "path": "../logger"
     },
     {

--- a/packages/inquirer-common/src/error-handler/error-handler.ts
+++ b/packages/inquirer-common/src/error-handler/error-handler.ts
@@ -381,7 +381,7 @@ export class ErrorHandler {
      * @param status the error type
      * @returns true if the error is a general certificate error
      */
-    public static isCertError(status: string | number): boolean {
+    public static isCertError(status: string | number | Error): boolean {
         return [
             ERROR_TYPE.CERT,
             ERROR_TYPE.CERT_EXPIRED,

--- a/packages/nodejs-utils/src/httpsUtils.ts
+++ b/packages/nodejs-utils/src/httpsUtils.ts
@@ -1,0 +1,17 @@
+import https from 'https';
+
+/**
+ * Set the rejectUnauthorized option of the global https agent.
+ *
+ * @param rejectUnauthorized - true to reject unauthorized certificates, false to accept them
+ */
+export function setGlobalRejectUnauthorized(rejectUnauthorized: boolean): void {
+    if (https.globalAgent.options) {
+        https.globalAgent.options.rejectUnauthorized = rejectUnauthorized;
+    }
+    //@ts-expect-error - fallbackAgent is only present in BoundHttpsProxyAgent implementation and is not part of the Node.js API
+    if (https.globalAgent.fallbackAgent?.options) {
+        //@ts-expect-error - fallbackAgent is not typed in Node.js API
+        https.globalAgent.fallbackAgent.options.rejectUnauthorized = rejectUnauthorized;
+    }
+}

--- a/packages/nodejs-utils/src/index.ts
+++ b/packages/nodejs-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './commandRunner';
 export * from './installedCheck';
+export * from './httpsUtils';

--- a/packages/nodejs-utils/test/unit/httpsUtils.test.ts
+++ b/packages/nodejs-utils/test/unit/httpsUtils.test.ts
@@ -1,0 +1,19 @@
+import { setGlobalRejectUnauthorized } from '../../src/httpsUtils';
+import https from 'https';
+
+describe('httpsUtils tests', () => {
+    it('should set global https reject unauthorized', () => {
+        // Mocking the fallbackAgent for testing purposes
+        (https.globalAgent as any).fallbackAgent = {
+            options: {
+                rejectUnauthorized: true
+            }
+        };
+        setGlobalRejectUnauthorized(false);
+        expect(https.globalAgent.options.rejectUnauthorized).toBe(false);
+        expect((https.globalAgent as any).fallbackAgent.options.rejectUnauthorized).toBe(false);
+        setGlobalRejectUnauthorized(true);
+        expect(https.globalAgent.options.rejectUnauthorized).toBe(true);
+        expect((https.globalAgent as any).fallbackAgent.options.rejectUnauthorized).toBe(true);
+    });
+});

--- a/packages/odata-service-inquirer/package.json
+++ b/packages/odata-service-inquirer/package.json
@@ -40,6 +40,7 @@
         "@sap-ux/telemetry": "workspace:*",
         "@sap-ux/inquirer-common": "workspace:*",
         "@sap-ux/logger": "workspace:*",
+        "@sap-ux/nodejs-utils": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/project-input-validator": "workspace:*",
         "@sap-ux/store": "workspace:*",

--- a/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/service-url/validators.ts
@@ -1,14 +1,14 @@
 import { createForAbap, type AxiosRequestConfig, type ODataService, type ODataVersion } from '@sap-ux/axios-extension';
 import { ERROR_TYPE, ErrorHandler } from '@sap-ux/inquirer-common';
+import { setGlobalRejectUnauthorized } from '@sap-ux/nodejs-utils';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 import { t } from '../../../i18n';
 import { SAP_CLIENT_KEY } from '../../../types';
 import { PromptState, originToRelative } from '../../../utils';
-import { ConnectionValidator } from '../../connectionValidator';
 import LoggerHelper from '../../logger-helper';
 import { errorHandler } from '../../prompt-helpers';
 import { validateODataVersion } from '../../validators';
-import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 
 type ValidateServiceUrlResult = {
     validationResult: boolean | string;
@@ -35,7 +35,7 @@ export async function validateService(
 ): Promise<ValidateServiceUrlResult> {
     try {
         if (ignoreCertError === true) {
-            ConnectionValidator.setGlobalRejectUnauthorized(!ignoreCertError);
+            setGlobalRejectUnauthorized(!ignoreCertError);
         }
         const metadata = await odataService.metadata();
         const odataVersionValResult = validateODataVersion(metadata, requiredVersion);
@@ -101,6 +101,6 @@ export async function validateService(
             validationResult: errorHandler.logErrorMsgs(error)
         };
     } finally {
-        ConnectionValidator.setGlobalRejectUnauthorized(true);
+        setGlobalRejectUnauthorized(true);
     }
 }

--- a/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/connectionValidator.test.ts
@@ -14,11 +14,17 @@ import { initI18nOdataServiceInquirer, t } from '../../../src/i18n';
 import { ConnectionValidator } from '../../../src/prompts/connectionValidator';
 import LoggerHelper from '../../../src/prompts/logger-helper';
 import type { ConnectedSystem } from '../../../src/types';
+import * as nodejsUtils from '@sap-ux/nodejs-utils';
 
 const odataServicesMock: ODataServiceInfo[] = [];
 const catalogServiceMock = jest.fn().mockImplementation(() => ({
     interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
     listServices: jest.fn().mockImplementation(() => odataServicesMock)
+}));
+
+jest.mock('@sap-ux/nodejs-utils', () => ({
+    __esModule: true,
+    ...jest.requireActual('@sap-ux/nodejs-utils')
 }));
 
 jest.mock('@sap-ux/axios-extension', () => ({
@@ -235,7 +241,7 @@ describe('ConnectionValidator', () => {
         jest.spyOn(ODataService.prototype, 'get').mockResolvedValueOnce({ status: 200 });
         const warnLogSpy = jest.spyOn(LoggerHelper.logger, 'warn');
 
-        const setGlobalRejectUnauthSpy = jest.spyOn(ConnectionValidator, 'setGlobalRejectUnauthorized');
+        const setGlobalRejectUnauthSpy = jest.spyOn(nodejsUtils, 'setGlobalRejectUnauthorized');
 
         const validator = new ConnectionValidator();
         expect(await validator.validateUrl(serviceUrl)).toBe(true);
@@ -270,7 +276,7 @@ describe('ConnectionValidator', () => {
 
         const createForAbapProviderSpy = jest.spyOn(axiosExtension, 'createForAbap');
         const warnLogSpy = jest.spyOn(LoggerHelper.logger, 'warn');
-        const setGlobalRejectUnauthSpy = jest.spyOn(ConnectionValidator, 'setGlobalRejectUnauthorized');
+        const setGlobalRejectUnauthSpy = jest.spyOn(nodejsUtils, 'setGlobalRejectUnauthorized');
 
         const validator = new ConnectionValidator();
         expect(await validator.validateUrl(systemUrl, { isSystem: true })).toBe(true);
@@ -603,7 +609,7 @@ describe('ConnectionValidator', () => {
 
         const createForAbapProviderSpy = jest.spyOn(axiosExtension, 'createForAbap');
         const warnLogSpy = jest.spyOn(LoggerHelper.logger, 'warn');
-        const setGlobalRejectUnauthSpy = jest.spyOn(ConnectionValidator, 'setGlobalRejectUnauthorized');
+        const setGlobalRejectUnauthSpy = jest.spyOn(nodejsUtils, 'setGlobalRejectUnauthorized');
 
         const connectValidator = new ConnectionValidator();
         await connectValidator.validateUrl('https://example.com:1234', { isSystem: true });

--- a/packages/odata-service-inquirer/tsconfig.json
+++ b/packages/odata-service-inquirer/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../logger"
     },
     {
+      "path": "../nodejs-utils"
+    },
+    {
       "path": "../odata-service-writer"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
+      '@sap-ux/nodejs-utils':
+        specifier: workspace:*
+        version: link:../nodejs-utils
       '@sap-ux/store':
         specifier: workspace:*
         version: link:../store
@@ -1635,6 +1638,9 @@ importers:
       '@sap-ux/btp-utils':
         specifier: workspace:*
         version: link:../btp-utils
+      '@sap-ux/inquirer-common':
+        specifier: workspace:*
+        version: link:../inquirer-common
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
@@ -2841,6 +2847,9 @@ importers:
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
+      '@sap-ux/nodejs-utils':
+        specifier: workspace:*
+        version: link:../nodejs-utils
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access


### PR DESCRIPTION
TBI: https://github.com/SAP/open-ux-tools/issues/3315

- Adds GA link to deploy for cert errors
- Adds tests to cover
- Moves `setGlobalRejectUnauthorized` to `nodejs-utils` to promote re-use
