### PR TITLE
fix(preview-middleware): missing variant changes

### DIFF
--- a/.changeset/beige-dogs-rush.md
+++ b/.changeset/beige-dogs-rush.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix: variant changes are not shown in Adaptation Editor

--- a/packages/preview-middleware/src/base/flex.ts
+++ b/packages/preview-middleware/src/base/flex.ts
@@ -18,7 +18,7 @@ export async function readChanges(
 ): Promise<Record<string, CommonChangeProperties>> {
     const changes: Record<string, CommonChangeProperties> = {};
     const files = await project.byGlob(
-        '/**/changes/**/*.{change,ctrl_variant,ctrl_variant_change,ctrl_variant_management_change}'
+        '/**/changes/**/*.{change,variant,ctrl_variant,ctrl_variant_change,ctrl_variant_management_change}'
     );
     for (const file of files) {
         try {


### PR DESCRIPTION
After restricting what files are processed as changes in #3301 variant changes were excluded and were no longer shown in Adaptation Editor.