### PR TITLE
fix(deploy-gens): re-add conflicter.force prop for yui standalone

### DIFF
--- a/.changeset/thirty-balloons-pay.md
+++ b/.changeset/thirty-balloons-pay.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/abap-deploy-config-sub-generator': patch
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+add conflicter force prop for yui usage

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -10,7 +10,8 @@ import {
     YUI_EXTENSION_ID,
     YUI_MIN_VER_FILES_GENERATED_MSG,
     sendTelemetry,
-    TelemetryHelper
+    TelemetryHelper,
+    YeomanEnvironment
 } from '@sap-ux/fiori-generator-shared';
 import { getPackageAnswer, getTransportAnswer, reconcileAnswers } from '@sap-ux/abap-deploy-config-inquirer';
 import { generate as generateAbapDeployConfig } from '@sap-ux/abap-deploy-config-writer';
@@ -85,6 +86,9 @@ export default class extends DeploymentGenerator {
             watchTelemetrySettingStore: false
         });
 
+        if ((this.env as unknown as YeomanEnvironment).conflicter) {
+            (this.env as unknown as YeomanEnvironment).conflicter.force = this.options.force ?? true;
+        }
         if (!this.launchDeployConfigAsSubGenerator) {
             await this._initializing();
         }

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -5,13 +5,13 @@ import {
     ErrorHandler,
     showOverwriteQuestion
 } from '@sap-ux/deploy-config-generator-shared';
+import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import {
     isExtensionInstalled,
     YUI_EXTENSION_ID,
     YUI_MIN_VER_FILES_GENERATED_MSG,
     sendTelemetry,
-    TelemetryHelper,
-    YeomanEnvironment
+    TelemetryHelper
 } from '@sap-ux/fiori-generator-shared';
 import { getPackageAnswer, getTransportAnswer, reconcileAnswers } from '@sap-ux/abap-deploy-config-inquirer';
 import { generate as generateAbapDeployConfig } from '@sap-ux/abap-deploy-config-writer';

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -86,6 +86,8 @@ export default class extends DeploymentGenerator {
             watchTelemetrySettingStore: false
         });
 
+        // hack to suppress yeoman's overwrite prompt when files already exist
+        // required when running the deploy config generator in standalone mode
         if ((this.env as unknown as YeomanEnvironment).conflicter) {
             (this.env as unknown as YeomanEnvironment).conflicter.force = this.options.force ?? true;
         }

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -5,7 +5,6 @@ import {
     ErrorHandler,
     showOverwriteQuestion
 } from '@sap-ux/deploy-config-generator-shared';
-import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import {
     isExtensionInstalled,
     YUI_EXTENSION_ID,
@@ -33,6 +32,7 @@ import { initI18n } from '../utils/i18n';
 import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
 import { isAppStudio } from '@sap-ux/btp-utils';
 import { DEFAULT_PACKAGE_ABAP } from '@sap-ux/abap-deploy-config-inquirer/dist/constants';
+import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import type { AbapDeployConfig, FioriToolsProxyConfigBackend } from '@sap-ux/ui5-config';
 import type { AbapDeployConfigOptions } from './types';
 import type {

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -2,13 +2,13 @@ import { join, dirname } from 'path';
 import { platform } from 'os';
 import hasbin = require('hasbin');
 import { AppWizard, MessageType } from '@sap-devx/yeoman-ui-types';
+import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import {
     sendTelemetry,
     TelemetryHelper,
     isExtensionInstalled,
     YUI_EXTENSION_ID,
-    YUI_MIN_VER_FILES_GENERATED_MSG,
-    YeomanEnvironment
+    YUI_MIN_VER_FILES_GENERATED_MSG
 } from '@sap-ux/fiori-generator-shared';
 import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
 import { isFullUrlDestination } from '@sap-ux/btp-utils';

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -2,7 +2,6 @@ import { join, dirname } from 'path';
 import { platform } from 'os';
 import hasbin = require('hasbin');
 import { AppWizard, MessageType } from '@sap-devx/yeoman-ui-types';
-import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import {
     sendTelemetry,
     TelemetryHelper,
@@ -36,6 +35,7 @@ import { loadManifest } from './utils';
 import { getMtaPath, findCapProjectRoot, FileName, type Package } from '@sap-ux/project-access';
 import { EventName } from '../telemetryEvents';
 import { getCFQuestions, getCAPMTAQuestions } from './questions';
+import type { YeomanEnvironment } from '@sap-ux/fiori-generator-shared';
 import type { ApiHubConfig, CFAppConfig, CAPConfig } from '@sap-ux/cf-deploy-config-writer';
 import type { Logger } from '@sap-ux/logger';
 import { CfDeployConfigOptions } from './types';

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -7,7 +7,8 @@ import {
     TelemetryHelper,
     isExtensionInstalled,
     YUI_EXTENSION_ID,
-    YUI_MIN_VER_FILES_GENERATED_MSG
+    YUI_MIN_VER_FILES_GENERATED_MSG,
+    YeomanEnvironment
 } from '@sap-ux/fiori-generator-shared';
 import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
 import { isFullUrlDestination } from '@sap-ux/btp-utils';
@@ -104,6 +105,10 @@ export default class extends DeploymentGenerator {
         await initI18n();
 
         DeploymentGenerator.logger?.debug(t('cfGen.debug.initTelemetry'));
+
+        if ((this.env as unknown as YeomanEnvironment).conflicter) {
+            (this.env as unknown as YeomanEnvironment).conflicter.force = this.options.force ?? true;
+        }
 
         await TelemetryHelper.initTelemetrySettings({
             consumerModule: {

--- a/packages/cf-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/index.ts
@@ -106,6 +106,8 @@ export default class extends DeploymentGenerator {
 
         DeploymentGenerator.logger?.debug(t('cfGen.debug.initTelemetry'));
 
+        // hack to suppress yeoman's overwrite prompt when files already exist
+        // required when running the deploy config generator in standalone mode
         if ((this.env as unknown as YeomanEnvironment).conflicter) {
             (this.env as unknown as YeomanEnvironment).conflicter.force = this.options.force ?? true;
         }


### PR DESCRIPTION
Yeoman environment property `conflicter.force` is still required when running deploy config standalone