### PR TITLE
fix(preview-middleware): enhancedhomepage loading issues from UI5 v1.137

### DIFF
--- a/.changeset/funny-owls-protect.md
+++ b/.changeset/funny-owls-protect.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+fix: enhanced homepage loading issues in  ui5 v1.137.0

--- a/packages/preview-middleware-client/src/flp/init.ts
+++ b/packages/preview-middleware-client/src/flp/init.ts
@@ -305,9 +305,12 @@ export async function init({
     enhancedHomePage?: boolean | null;
     enableCardGenerator?: boolean
 }): Promise<void> {
+    // Set CDM configuration before importing ushell container
+    // to ensure proper configuration pickup during bootstrap
     if (enhancedHomePage) {
-        await initCdm();
+        initCdm();
     }
+
     const urlParams = new URLSearchParams(window.location.search);
     const container = sap?.ushell?.Container ??
         (await import('sap/ushell/Container')).default as unknown as typeof sap.ushell.Container;

--- a/packages/preview-middleware-client/src/flp/init.ts
+++ b/packages/preview-middleware-client/src/flp/init.ts
@@ -305,6 +305,9 @@ export async function init({
     enhancedHomePage?: boolean | null;
     enableCardGenerator?: boolean
 }): Promise<void> {
+    if (enhancedHomePage) {
+        await initCdm();
+    }
     const urlParams = new URLSearchParams(window.location.search);
     const container = sap?.ushell?.Container ??
         (await import('sap/ushell/Container')).default as unknown as typeof sap.ushell.Container;
@@ -389,7 +392,7 @@ export async function init({
     registerSAPFonts();
 
     if (enhancedHomePage) {
-        await initCdm(container);
+        await container.init('cdm');
     }
 
     const renderer =

--- a/packages/preview-middleware-client/src/flp/initCdm.ts
+++ b/packages/preview-middleware-client/src/flp/initCdm.ts
@@ -3,10 +3,9 @@ import { Window } from 'types/global';
 /**
  * Initializes the CDM (Common Data Model) configuration for the SAP Fiori Launchpad.
  *
- * @param {sap.ushell.Container} container - The SAP Fiori Launchpad container.
  * @returns {Promise<void>} A promise that resolves when the initialization is complete.
  */
-export default async function initCdm(container: typeof sap.ushell.Container): Promise<void> {
+export default async function initCdm(): Promise<void> {
     (window as unknown as Window)['sap-ushell-config'] = {
         defaultRenderer: 'fiori2',
         renderers: {
@@ -113,6 +112,4 @@ export default async function initCdm(container: typeof sap.ushell.Container): P
             }
         }
     };
-
-    await container.init('cdm');
 }

--- a/packages/preview-middleware-client/src/flp/initCdm.ts
+++ b/packages/preview-middleware-client/src/flp/initCdm.ts
@@ -3,9 +3,9 @@ import { Window } from 'types/global';
 /**
  * Initializes the CDM (Common Data Model) configuration for the SAP Fiori Launchpad.
  *
- * @returns {Promise<void>} A promise that resolves when the initialization is complete.
+ * @returns {void}
  */
-export default async function initCdm(): Promise<void> {
+export default function initCdm(): void {
     (window as unknown as Window)['sap-ushell-config'] = {
         defaultRenderer: 'fiori2',
         renderers: {

--- a/packages/preview-middleware-client/test/unit/flp/__snapshots__/init.test.ts.snap
+++ b/packages/preview-middleware-client/test/unit/flp/__snapshots__/init.test.ts.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flp/init init enhancedHomePage mode is enabled 1`] = `
+Object {
+  "defaultRenderer": "fiori2",
+  "renderers": Object {
+    "fiori2": Object {
+      "componentData": Object {
+        "config": Object {
+          "enableRecentActivity": true,
+          "enableSearch": false,
+          "rootIntent": "Shell-home",
+        },
+      },
+    },
+  },
+  "services": Object {
+    "AppState": Object {
+      "adapter": Object {
+        "module": "sap.ushell.adapters.local.AppStateAdapter",
+      },
+      "config": Object {
+        "transient": true,
+      },
+    },
+    "CommonDataModel": Object {
+      "adapter": Object {
+        "config": Object {
+          "ignoreSiteDataPersonalization": true,
+          "siteDataUrl": "/cdm.json",
+        },
+      },
+    },
+    "Container": Object {
+      "adapter": Object {
+        "config": Object {
+          "userProfile": Object {
+            "defaults": Object {
+              "email": "john.doe@sap.com",
+              "firstName": "John",
+              "fullName": "John Doe",
+              "id": "DOEJ",
+              "lastName": "Doe",
+            },
+            "metadata": Object {
+              "editablePropterties": Array [
+                "accessibility",
+                "contentDensity",
+                "theme",
+              ],
+            },
+          },
+        },
+      },
+    },
+    "FlpLaunchPage": Object {
+      "adapter": Object {
+        "module": "sap.ushell.adapters.cdm.v3.FlpLaunchPageAdapter",
+      },
+    },
+    "NavTargetResolutionInternal": Object {
+      "adapter": Object {
+        "module": "sap.ushell.adapters.local.NavTargetResolutionInternalAdapter",
+      },
+      "config": Object {
+        "allowTestUrlComponentConfig": false,
+        "enableClientSideTargetResolution": true,
+      },
+    },
+    "Personalization": Object {
+      "adapter": Object {
+        "config": Object {
+          "storageType": "MEMORY",
+        },
+        "module": "sap.ushell.adapters.local.PersonalizationAdapter",
+      },
+    },
+    "PersonalizationV2": Object {
+      "adapter": Object {
+        "config": Object {
+          "storageType": "MEMORY",
+        },
+        "module": "sap.ushell.adapters.local.PersonalizationAdapter",
+      },
+    },
+    "UserInfo": Object {
+      "adapter": Object {
+        "module": "sap.ushell.adapters.local.UserInfoAdapter",
+      },
+    },
+  },
+  "ushell": Object {
+    "customPreload": Object {
+      "enabled": false,
+    },
+    "homeApp": Object {
+      "component": Object {
+        "name": "open.ux.preview.client.flp.homepage",
+        "url": "/preview/client/flp/homepage",
+      },
+    },
+    "spaces": Object {
+      "enabled": true,
+      "myHome": Object {
+        "enabled": true,
+      },
+    },
+  },
+}
+`;

--- a/packages/preview-middleware-client/test/unit/flp/init.test.ts
+++ b/packages/preview-middleware-client/test/unit/flp/init.test.ts
@@ -15,6 +15,7 @@ import type { Scenario } from '@sap-ux-private/control-property-editor-common';
 import VersionInfo from 'mock/sap/ui/VersionInfo';
 import { CommunicationService } from '../../../src/cpe/communication-service';
 import type Component from 'sap/ui/core/Component';
+import { Window } from 'types/global';
 
 jest.mock('../../../src/i18n', () => {
     return {
@@ -411,6 +412,14 @@ describe('flp/init', () => {
             expect(mockService.attachAppLoaded.mock.calls[0][0]).toBeInstanceOf(Function);
             expect(sapMock.ushell.Container.attachRendererCreatedEvent).toBeCalled();
             expect(sapMock.ushell.Container.createRenderer).toBeCalledWith(undefined, true);
+        });
+
+        test('enhancedHomePage mode is enabled', async () => {
+            VersionInfo.load.mockResolvedValue({ name: 'sap.ui.core', version: '1.130.0' });
+            await init({ enhancedHomePage: true });
+
+            expect((window as unknown as Window)['sap-ushell-config']).toMatchSnapshot();
+            expect(sapMock.ushell.Container.init).toBeCalledWith('cdm');
         });
     });
 });

--- a/packages/preview-middleware-client/test/unit/flp/initCdm.test.ts
+++ b/packages/preview-middleware-client/test/unit/flp/initCdm.test.ts
@@ -9,11 +9,9 @@ describe('flp/initCdm', () => {
     });
 
     test('ensure that ushell config is set properly', async () => {
-        const container = sapMock.ushell.Container;
-        await initCdm(container as unknown as typeof sap.ushell.Container);
+        await initCdm();
 
         expect((window as unknown as Window)['sap-ushell-config']).toMatchSnapshot();
-        expect(sapMock.ushell.Container.init).toHaveBeenCalledWith('cdm');
     });
 
     test('ensure that homepage component is defined', async () => {


### PR DESCRIPTION
The latest ushell changes break enhanced homepage loading when using UI5 version 1.137 and above. This fix ensures custom CDN-related ushell configuration is provided before the container is required, following ushell team recommendations.

- Addresses breaking changes introduced in recent ushell updates
- Maintains compatibility with UI5 1.137+ versions
- Implements ushell-recommended configuration order