### PR TITLE
feat(generator-adp): Various bug fixes and improvements for ADP generator

### DIFF
--- a/packages/generator-adp/src/app/layer.ts
+++ b/packages/generator-adp/src/app/layer.ts
@@ -1,18 +1,5 @@
-import { isAppStudio } from '@sap-ux/btp-utils';
 import { FlexLayer } from '@sap-ux/adp-tooling';
-import { isFeatureEnabled } from '@sap-devx/feature-toggle-node';
-
-/**
- * Determines whether the generator is being run in an internal context.
- *
- * @returns {Promise<boolean>} True if internal usage; otherwise, false.
- */
-export async function isInternalUsage(): Promise<boolean> {
-    if (isAppStudio()) {
-        return isFeatureEnabled('adaptation-project', 'internal');
-    }
-    return false;
-}
+import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
 
 /**
  * Determines and returns the appropriate FlexLayer based on internal usage.
@@ -20,6 +7,6 @@ export async function isInternalUsage(): Promise<boolean> {
  * @returns {Promise<FlexLayer>} True if internal usage; otherwise, false.
  */
 export async function getFlexLayer(): Promise<FlexLayer> {
-    const internal = await isInternalUsage();
+    const internal = isInternalFeaturesSettingEnabled();
     return internal ? FlexLayer.VENDOR : FlexLayer.CUSTOMER_BASE;
 }

--- a/packages/generator-adp/test/app.test.ts
+++ b/packages/generator-adp/test/app.test.ts
@@ -19,9 +19,9 @@ import { isAppStudio } from '@sap-ux/btp-utils';
 import type { ToolsLogger } from '@sap-ux/logger';
 import type { Manifest } from '@sap-ux/project-access';
 import { getCredentialsFromStore } from '@sap-ux/system-access';
-import type { AttributesAnswers, ConfigAnswers, Language, SourceApplication, VersionDetail } from '@sap-ux/adp-tooling';
 import { type AbapServiceProvider, AdaptationProjectType } from '@sap-ux/axios-extension';
 import { getHostEnvironment, hostEnvironment, sendTelemetry } from '@sap-ux/fiori-generator-shared';
+import type { AttributesAnswers, ConfigAnswers, Language, SourceApplication, VersionDetail } from '@sap-ux/adp-tooling';
 
 import adpGenerator from '../src/app';
 import { initI18n, t } from '../src/utils/i18n';
@@ -32,9 +32,8 @@ import * as subgenHelpers from '../src/utils/subgenHelpers';
 import { ConfigPrompter } from '../src/app/questions/configuration';
 import { getDefaultProjectName } from '../src/app/questions/helper/default-values';
 
-jest.mock('@sap-devx/feature-toggle-node', () => ({
-    // Is BAS this will mean that the layer is CUSTOMER_BASE
-    isFeatureEnabled: jest.fn().mockResolvedValue(false)
+jest.mock('@sap-ux/feature-toggle', () => ({
+    isInternalFeaturesSettingEnabled: jest.fn().mockReturnValue(false)
 }));
 
 jest.mock('../src/app/questions/helper/default-values.ts', () => ({

--- a/packages/generator-adp/test/unit/layer.test.ts
+++ b/packages/generator-adp/test/unit/layer.test.ts
@@ -1,52 +1,13 @@
-import { isFeatureEnabled } from '@sap-devx/feature-toggle-node';
-
-import { isAppStudio } from '@sap-ux/btp-utils';
 import { FlexLayer } from '@sap-ux/adp-tooling';
+import { isInternalFeaturesSettingEnabled } from '@sap-ux/feature-toggle';
 
-import { getFlexLayer, isInternalUsage } from '../../src/app/layer';
+import { getFlexLayer } from '../../src/app/layer';
 
-jest.mock('@sap-ux/btp-utils', () => ({
-    isAppStudio: jest.fn()
+jest.mock('@sap-ux/feature-toggle', () => ({
+    isInternalFeaturesSettingEnabled: jest.fn()
 }));
 
-jest.mock('@sap-devx/feature-toggle-node', () => ({
-    isFeatureEnabled: jest.fn()
-}));
-
-const mockIsAppStudio = isAppStudio as jest.Mock;
-const isFeatureEnabledMock = isFeatureEnabled as jest.Mock;
-
-describe('isInternalUsage', () => {
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    it('should return true if running in AppStudio and feature is enabled', async () => {
-        mockIsAppStudio.mockReturnValue(true);
-        isFeatureEnabledMock.mockReturnValue(true);
-
-        const result = await isInternalUsage();
-        expect(result).toBe(true);
-        expect(isFeatureEnabled).toHaveBeenCalledWith('adaptation-project', 'internal');
-    });
-
-    it('should return false if running in AppStudio but feature is disabled', async () => {
-        mockIsAppStudio.mockReturnValue(true);
-        isFeatureEnabledMock.mockReturnValue(false);
-
-        const result = await isInternalUsage();
-        expect(result).toBe(false);
-    });
-
-    it('should return false if not running in AppStudio', async () => {
-        mockIsAppStudio.mockReturnValue(false);
-        const result = await isInternalUsage();
-
-        expect(result).toBe(false);
-
-        expect(isFeatureEnabled).not.toHaveBeenCalled();
-    });
-});
+const isFeatureEnabledMock = isInternalFeaturesSettingEnabled as jest.Mock;
 
 describe('getFlexLayer', () => {
     afterEach(() => {
@@ -54,7 +15,6 @@ describe('getFlexLayer', () => {
     });
 
     it('should return FlexLayer.VENDOR if internal usage is true', async () => {
-        mockIsAppStudio.mockReturnValue(true);
         isFeatureEnabledMock.mockReturnValue(true);
 
         const layer = await getFlexLayer();
@@ -63,7 +23,7 @@ describe('getFlexLayer', () => {
     });
 
     it('should return FlexLayer.CUSTOMER_BASE if internal usage is false', async () => {
-        mockIsAppStudio.mockReturnValue(false);
+        isFeatureEnabledMock.mockReturnValue(false);
 
         const layer = await getFlexLayer();
 

--- a/packages/project-input-validator/src/adp/validators.ts
+++ b/packages/project-input-validator/src/adp/validators.ts
@@ -64,9 +64,9 @@ export function validateProjectName(value: string, destinationPath: string, isCu
     }
 
     if (!isCustomerBase) {
-        return validateProjectNameInternal(value, destinationPath);
+        return validateProjectNameInternal(value);
     } else {
-        return validateProjectNameExternal(value, destinationPath);
+        return validateProjectNameExternal(value);
     }
 }
 
@@ -74,10 +74,9 @@ export function validateProjectName(value: string, destinationPath: string, isCu
  * Validates that project name is valid for CUSTOMER_BASE layer.
  *
  * @param {string} value - The project name.
- * @param {string} destinationPath - The project directory.
  * @returns {string | boolean} If value is valid returns true otherwise error message.
  */
-export function validateProjectNameExternal(value: string, destinationPath: string): boolean | string {
+export function validateProjectNameExternal(value: string): boolean | string {
     if (value.length > 61 || value.toLocaleLowerCase().endsWith('component')) {
         return t('adp.projectNameLengthErrorExt');
     }
@@ -86,17 +85,16 @@ export function validateProjectNameExternal(value: string, destinationPath: stri
         return t('adp.projectNameValidationErrorExt');
     }
 
-    return validateDuplicateProjectName(value, destinationPath);
+    return true;
 }
 
 /**
  * Validates that project name is valid for VENDOR layer.
  *
  * @param {string} value - The project name.
- * @param {string} destinationPath - The project directory.
  * @returns {string | boolean} If value is valid returns true otherwise error message.
  */
-export function validateProjectNameInternal(value: string, destinationPath: string): boolean | string {
+export function validateProjectNameInternal(value: string): boolean | string {
     if (
         value.toLowerCase().startsWith('customer') ||
         value.length > 61 ||
@@ -109,7 +107,7 @@ export function validateProjectNameInternal(value: string, destinationPath: stri
         return t('adp.projectNameValidationErrorInt');
     }
 
-    return validateDuplicateProjectName(value, destinationPath);
+    return true;
 }
 
 /**

--- a/packages/project-input-validator/test/adp-validators.test.ts
+++ b/packages/project-input-validator/test/adp-validators.test.ts
@@ -117,21 +117,16 @@ describe('project input validators', () => {
         });
 
         it('returns length error if name > 61 chars or ends with component', () => {
-            expect(validateProjectNameExternal('a'.repeat(62), path)).toBe(t('adp.projectNameLengthErrorExt'));
-            expect(validateProjectNameExternal('appcomponent', path)).toBe(t('adp.projectNameLengthErrorExt'));
+            expect(validateProjectNameExternal('a'.repeat(62))).toBe(t('adp.projectNameLengthErrorExt'));
+            expect(validateProjectNameExternal('appcomponent')).toBe(t('adp.projectNameLengthErrorExt'));
         });
 
         it('returns validation error if name does not match pattern', () => {
-            expect(validateProjectNameExternal('invalid name!', path)).toBe(t('adp.projectNameValidationErrorExt'));
-        });
-
-        it('returns duplication error if name already exists', () => {
-            existsSyncMock.mockReturnValue(true);
-            expect(validateProjectNameExternal('validname', path)).toBe(t('adp.duplicatedProjectName'));
+            expect(validateProjectNameExternal('invalid name!')).toBe(t('adp.projectNameValidationErrorExt'));
         });
 
         it('returns true for valid name', () => {
-            expect(validateProjectNameExternal('validname', path)).toBe(true);
+            expect(validateProjectNameExternal('validname')).toBe(true);
         });
     });
 
@@ -139,18 +134,18 @@ describe('project input validators', () => {
         const path = '/mock/path';
 
         it('returns error if name starts with "customer", is too long, or ends with component', () => {
-            expect(validateProjectNameInternal('customerapp', path)).toBe(t('adp.projectNameLengthErrorInt'));
-            expect(validateProjectNameInternal('a'.repeat(62), path)).toBe(t('adp.projectNameLengthErrorInt'));
-            expect(validateProjectNameInternal('mycomponent', path)).toBe(t('adp.projectNameLengthErrorInt'));
+            expect(validateProjectNameInternal('customerapp')).toBe(t('adp.projectNameLengthErrorInt'));
+            expect(validateProjectNameInternal('a'.repeat(62))).toBe(t('adp.projectNameLengthErrorInt'));
+            expect(validateProjectNameInternal('mycomponent')).toBe(t('adp.projectNameLengthErrorInt'));
         });
 
         it('returns validation error if name does not match pattern', () => {
-            expect(validateProjectNameInternal('invalid name!', path)).toBe(t('adp.projectNameValidationErrorInt'));
+            expect(validateProjectNameInternal('invalid name!')).toBe(t('adp.projectNameValidationErrorInt'));
         });
 
         it('returns true for valid internal project name', () => {
             existsSyncMock.mockReturnValue(false);
-            expect(validateProjectNameInternal('vendorapp', path)).toBe(true);
+            expect(validateProjectNameInternal('vendorapp')).toBe(true);
         });
     });
 


### PR DESCRIPTION
Fix for #3015.
- Adds a check whether we are in an internal scenario by interacting with the internal enablement extension.
- Duplicate project name validation now only executes for the target folder prompt, as this is causing issues.