### PR TITLE
fix: abap-deploy-config-inquirer - Use more specific GA link texts for cert errors.

### DIFF
--- a/.changeset/spicy-icons-type.md
+++ b/.changeset/spicy-icons-type.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+'@sap-ux/inquirer-common': patch
+'@sap-ux/deploy-tooling': patch
+---
+
+Adds more specific cert error messages with GA links.

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -1,44 +1,44 @@
-import { PromptState } from './prompt-state';
-import { type Destinations, isS4HC, isAbapEnvironmentOnBtp } from '@sap-ux/btp-utils';
-import {
-    createTransportNumber,
-    getTransportList,
-    isEmptyString,
-    isValidClient,
-    isValidUrl,
-    isAppNameValid
-} from '../validator-utils';
-import { DEFAULT_PACKAGE_ABAP } from '../constants';
-import { getTransportListFromService, getSystemInfo, isAbapCloud } from '../service-provider-utils';
-import { t } from '../i18n';
-import {
-    findBackendSystemByUrl,
-    initTransportConfig,
-    getPackageAnswer,
-    queryPackages,
-    getSystemConfig
-} from '../utils';
-import { handleTransportConfigError } from '../error-handler';
-import { AuthenticationType } from '@sap-ux/store';
+import type { IValidationLink } from '@sap-devx/yeoman-ui-types';
+import { AdaptationProjectType } from '@sap-ux/axios-extension';
+import { isAbapEnvironmentOnBtp, isS4HC, type Destinations } from '@sap-ux/btp-utils';
 import { getHelpUrl, HELP_TREE } from '@sap-ux/guided-answers-helper';
+import { ErrorHandler } from '@sap-ux/inquirer-common';
+import { AuthenticationType } from '@sap-ux/store';
+import { DEFAULT_PACKAGE_ABAP } from '../constants';
+import { handleTransportConfigError } from '../error-handler';
+import { t } from '../i18n';
 import LoggerHelper from '../logger-helper';
+import { getSystemInfo, getTransportListFromService, isAbapCloud } from '../service-provider-utils';
+import { AbapServiceProviderManager } from '../service-provider-utils/abap-service-provider';
 import {
     ClientChoiceValue,
     PackageInputChoices,
     TargetSystemType,
     TransportChoices,
-    type SystemConfig,
     type AbapDeployConfigAnswersInternal,
     type AbapSystemChoice,
     type BackendTarget,
     type PackagePromptOptions,
+    type SystemConfig,
     type TargetSystemPromptOptions,
     type UI5AbapRepoPromptOptions
 } from '../types';
-import { AdaptationProjectType } from '@sap-ux/axios-extension';
-import { AbapServiceProviderManager } from '../service-provider-utils/abap-service-provider';
-import type { IValidationLink } from '@sap-devx/yeoman-ui-types';
-import { ERROR_TYPE, ErrorHandler } from '@sap-ux/inquirer-common';
+import {
+    findBackendSystemByUrl,
+    getPackageAnswer,
+    getSystemConfig,
+    initTransportConfig,
+    queryPackages
+} from '../utils';
+import {
+    createTransportNumber,
+    getTransportList,
+    isAppNameValid,
+    isEmptyString,
+    isValidClient,
+    isValidUrl
+} from '../validator-utils';
+import { PromptState } from './prompt-state';
 
 const allowedPackagePrefixes = ['$', 'Z', 'Y', 'SAP'];
 
@@ -386,7 +386,7 @@ export async function validatePackageChoiceInput(
             }
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
-                helpLink = ErrorHandler.getHelpForError(ERROR_TYPE.CERT);
+                helpLink = new ErrorHandler().getValidationErrorHelp(error);
                 return helpLink ?? true;
             }
             throw error;
@@ -596,7 +596,7 @@ export async function validateTransportChoiceInput({
             );
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
-                return ErrorHandler.getHelpForError(ERROR_TYPE.CERT) ?? true;
+                return new ErrorHandler().getValidationErrorHelp(error) ?? true;
             }
         }
     } else if (input === TransportChoices.CreateNewChoice) {

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -601,9 +601,11 @@ export async function validateTransportChoiceInput({
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
                 return (
-                    new ErrorHandler(undefined, undefined, '@sap-ux/abap-deploy-config-inquirer').getValidationErrorHelp(
-                        error
-                    ) ?? true
+                    new ErrorHandler(
+                        undefined,
+                        undefined,
+                        '@sap-ux/abap-deploy-config-inquirer'
+                    ).getValidationErrorHelp(error) ?? true
                 );
             }
         }

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -601,7 +601,7 @@ export async function validateTransportChoiceInput({
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
                 return (
-                    new ErrorHandler(undefined, undefined, '@sap-ux/abap-deplu-config-inquirer').getValidationErrorHelp(
+                    new ErrorHandler(undefined, undefined, '@sap-ux/abap-deploy-config-inquirer').getValidationErrorHelp(
                         error
                     ) ?? true
                 );

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -386,7 +386,11 @@ export async function validatePackageChoiceInput(
             }
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
-                helpLink = new ErrorHandler().getValidationErrorHelp(error);
+                helpLink = new ErrorHandler(
+                    undefined,
+                    undefined,
+                    '@sap-ux/abap-deploy-config-inquirer'
+                ).getValidationErrorHelp(error);
                 return helpLink ?? true;
             }
             throw error;
@@ -596,7 +600,11 @@ export async function validateTransportChoiceInput({
             );
         } catch (error) {
             if (ErrorHandler.isCertError(error)) {
-                return new ErrorHandler().getValidationErrorHelp(error) ?? true;
+                return (
+                    new ErrorHandler(undefined, undefined, '@sap-ux/abap-deplu-config-inquirer').getValidationErrorHelp(
+                        error
+                    ) ?? true
+                );
             }
         }
     } else if (input === TransportChoices.CreateNewChoice) {

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
@@ -1,6 +1,6 @@
 import type { AtoSettings } from '@sap-ux/axios-extension';
 import { AtoService } from '@sap-ux/axios-extension';
-import { ERROR_TYPE, ErrorHandler } from '@sap-ux/inquirer-common';
+import { ErrorHandler } from '@sap-ux/inquirer-common';
 import { t } from '../i18n';
 import LoggerHelper from '../logger-helper';
 import type { BackendTarget, Credentials, InitTransportConfigResult, TransportConfig } from '../types';
@@ -139,7 +139,7 @@ class DefaultTransportConfig implements TransportConfig {
                     t('warnings.certificateError', { url: backendTarget?.abapTarget?.url, error: err.message })
                 );
                 // Stringified version of the GA link will be reported in the logs
-                result.warning = ErrorHandler.getHelpForError(ERROR_TYPE.CERT)?.toString();
+                result.warning = new ErrorHandler().getValidationErrorHelp(err)?.toString();
             } else if (err.response?.status === 401) {
                 const auth: string = err.response.headers?.['www-authenticate'];
                 result.transportConfigNeedsCreds = !!auth?.toLowerCase()?.startsWith('basic');

--- a/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
+++ b/packages/abap-deploy-config-inquirer/src/service-provider-utils/transport-config.ts
@@ -139,7 +139,9 @@ class DefaultTransportConfig implements TransportConfig {
                     t('warnings.certificateError', { url: backendTarget?.abapTarget?.url, error: err.message })
                 );
                 // Stringified version of the GA link will be reported in the logs
-                result.warning = new ErrorHandler().getValidationErrorHelp(err)?.toString();
+                result.warning = new ErrorHandler(undefined, undefined, '@sap-ux/abap-deploy-config-inquirer')
+                    .getValidationErrorHelp(err)
+                    ?.toString();
             } else if (err.response?.status === 401) {
                 const auth: string = err.response.headers?.['www-authenticate'];
                 result.transportConfigNeedsCreds = !!auth?.toLowerCase()?.startsWith('basic');

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -344,7 +344,7 @@ describe('Test validators', () => {
                     text: 'Need help with this error?',
                     url: `https://ga.support.sap.com/dtp/viewer/index.html#/tree/${HELP_TREE.FIORI_TOOLS}/actions/${HELP_NODES.CERTIFICATE_ERROR}`
                 },
-                message: 'A certificate error has occurred'
+                message: 'The system URL is using an expired security certificate.'
             });
         });
     });
@@ -699,7 +699,7 @@ describe('Test validators', () => {
                     text: 'Need help with this error?',
                     url: `https://ga.support.sap.com/dtp/viewer/index.html#/tree/${HELP_TREE.FIORI_TOOLS}/actions/${HELP_NODES.CERTIFICATE_ERROR}`
                 },
-                message: 'A certificate error has occurred'
+                message: 'The system URL is using an unknown or invalid security certificate.'
             });
         });
     });

--- a/packages/abap-deploy-config-inquirer/test/service-provider-utils/transport-config.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/service-provider-utils/transport-config.test.ts
@@ -193,7 +193,7 @@ describe('getTransportConfigInstance', () => {
             credentials: {}
         });
         expect(transportConfigResult3.transportConfigNeedsCreds).toBe(undefined);
-        expect(transportConfigResult3.warning).toContain('A certificate error has occurred Need help with this error?');
+        expect(transportConfigResult3.warning).toContain('The system URL is using a self-signed security certificate. Need help with this error?');
         // Expect GA link to be logged
         expect(loggerSpy).toHaveBeenCalledWith(
             t('warnings.certificateError', { url: 'https://example.com', error: 'self signed certificate' })

--- a/packages/adp-flp-config-sub-generator/src/app/index.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/index.ts
@@ -360,7 +360,7 @@ export default class extends Generator {
      * @returns {ValidationLink | string | undefined} The validation link or error message.
      */
     private _getErrorHandlerMessage(error: Error | AxiosError): ValidationLink | string | undefined {
-        const errorHandler = new ErrorHandler();
+        const errorHandler = new ErrorHandler(undefined, undefined, '@sap-ux/adp-flp-config');
         return errorHandler.getValidationErrorHelp(error);
     }
 

--- a/packages/cf-deploy-config-inquirer/src/prompts/app-router-prompts.ts
+++ b/packages/cf-deploy-config-inquirer/src/prompts/app-router-prompts.ts
@@ -159,7 +159,7 @@ function getDestinationService(): CfAppRouterDeployConfigQuestions {
  * @returns {CfAppRouterDeployConfigQuestions} - The prompt configuration object for selecting for selecting an ABAP environment service.
  */
 function getServiceProvider(): CfAppRouterDeployConfigQuestions {
-    const errorHandler = new ErrorHandler();
+    const errorHandler = new ErrorHandler(undefined, undefined, '@sap-ux/cf-deploy-config-inquirer');
     return {
         when: (previousAnswers: CfAppRouterDeployConfigAnswers): boolean => {
             return !!previousAnswers.addABAPServiceBinding && previousAnswers.routerType === RouterModuleType.Standard;

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -13,7 +13,7 @@ import { promptConfirmation } from './prompt';
 import { createAbapServiceProvider, getCredentialsWithPrompts } from '@sap-ux/system-access';
 import { getAppDescriptorVariant } from './archive';
 import { validateBeforeDeploy, formatSummary, showAdditionalInfoForOnPrem, checkForCredentials } from './validate';
-import { ERROR_TYPE, ErrorHandler } from '@sap-ux/inquirer-common';
+import { ErrorHandler } from '@sap-ux/inquirer-common';
 
 /**
  * Internal deployment commands
@@ -44,7 +44,7 @@ async function handleError(
     archive: Buffer
 ): Promise<void> {
     if (ErrorHandler.isCertError(error)) {
-        const gaLink = ErrorHandler.getHelpForError(ERROR_TYPE.CERT)?.toString();
+        const gaLink = new ErrorHandler().getValidationErrorHelp(error)?.toString();
         if (gaLink) {
             logger.info(gaLink);
         }

--- a/packages/deploy-tooling/src/base/deploy.ts
+++ b/packages/deploy-tooling/src/base/deploy.ts
@@ -44,7 +44,9 @@ async function handleError(
     archive: Buffer
 ): Promise<void> {
     if (ErrorHandler.isCertError(error)) {
-        const gaLink = new ErrorHandler().getValidationErrorHelp(error)?.toString();
+        const gaLink = new ErrorHandler(undefined, undefined, '@sap-ux/deploy-tooling')
+            .getValidationErrorHelp(error)
+            ?.toString();
         if (gaLink) {
             logger.info(gaLink);
         }

--- a/packages/inquirer-common/src/error-handler/error-handler.ts
+++ b/packages/inquirer-common/src/error-handler/error-handler.ts
@@ -281,6 +281,7 @@ export class ErrorHandler {
         const errorToHelp: Record<ERROR_TYPE, number | undefined> = {
             [ERROR_TYPE.SERVICES_UNAVAILABLE]: isBAS ? HELP_NODES.BAS_CATALOG_SERVICES_REQUEST_FAILED : undefined,
             [ERROR_TYPE.CERT]: HELP_NODES.CERTIFICATE_ERROR,
+            [ERROR_TYPE.CERT_EXPIRED]: HELP_NODES.CERTIFICATE_ERROR,
             [ERROR_TYPE.CERT_SELF_SIGNED]: HELP_NODES.CERTIFICATE_ERROR,
             [ERROR_TYPE.CERT_UKNOWN_OR_INVALID]: HELP_NODES.CERTIFICATE_ERROR,
             [ERROR_TYPE.INVALID_SSL_CERTIFICATE]: HELP_NODES.CERTIFICATE_ERROR,
@@ -295,7 +296,6 @@ export class ErrorHandler {
             [ERROR_TYPE.AUTH]: undefined,
             [ERROR_TYPE.AUTH_TIMEOUT]: undefined,
             [ERROR_TYPE.REDIRECT]: undefined,
-            [ERROR_TYPE.CERT_EXPIRED]: undefined,
             [ERROR_TYPE.UNKNOWN]: undefined,
             [ERROR_TYPE.INVALID_URL]: undefined,
             [ERROR_TYPE.CONNECTION]: undefined,

--- a/packages/inquirer-common/src/error-handler/error-handler.ts
+++ b/packages/inquirer-common/src/error-handler/error-handler.ts
@@ -334,8 +334,9 @@ export class ErrorHandler {
      * Create an instance of the ErrorHandler.
      *
      * @param logger the logger instance to use
-     * @param enableGuidedAnswers if true, the end user validation errors will include guided answers to provide help
-     * @param logPrefix optional, a prefix to be used for the logger to distinguish the source of the log messages
+     * @param enableGuidedAnswers if true, Guided Answers help links will include a command to launch the Guided Answers UI.
+     *     Should be set to true if the Guided Answers UI extension is available.
+     * @param logPrefix optional, a prefix to be used for the logger to distinguish the source of the log messages, if a logger is not provided
      */
     constructor(logger?: Logger, enableGuidedAnswers = false, logPrefix?: string) {
         ErrorHandler._logger = logger ?? new ToolsLogger({ logPrefix: logPrefix ?? '@sap-ux/inquirer-common' });

--- a/packages/inquirer-common/src/error-handler/error-handler.ts
+++ b/packages/inquirer-common/src/error-handler/error-handler.ts
@@ -335,9 +335,10 @@ export class ErrorHandler {
      *
      * @param logger the logger instance to use
      * @param enableGuidedAnswers if true, the end user validation errors will include guided answers to provide help
+     * @param logPrefix optional, a prefix to be used for the logger to distinguish the source of the log messages
      */
-    constructor(logger?: Logger, enableGuidedAnswers = false) {
-        ErrorHandler._logger = logger ?? new ToolsLogger({ logPrefix: '@sap-ux/odata-service-inquirer' });
+    constructor(logger?: Logger, enableGuidedAnswers = false, logPrefix?: string) {
+        ErrorHandler._logger = logger ?? new ToolsLogger({ logPrefix: logPrefix ?? '@sap-ux/inquirer-common' });
         ErrorHandler.guidedAnswersEnabled = enableGuidedAnswers;
     }
 

--- a/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import { DatasourceType, type DatasourceTypePromptOptions } from '../types';
 
 // Error handling is a cross-cutting concern, a single instance is required
-export const errorHandler = new ErrorHandler();
+export const errorHandler = new ErrorHandler(undefined, undefined, '@sap-ux/pdata-service-inquirer');
 
 /**
  * Get the datasource type choices.

--- a/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/prompt-helpers.ts
@@ -4,7 +4,7 @@ import { t } from '../i18n';
 import { DatasourceType, type DatasourceTypePromptOptions } from '../types';
 
 // Error handling is a cross-cutting concern, a single instance is required
-export const errorHandler = new ErrorHandler(undefined, undefined, '@sap-ux/pdata-service-inquirer');
+export const errorHandler = new ErrorHandler(undefined, undefined, '@sap-ux/odata-service-inquirer');
 
 /**
  * Get the datasource type choices.


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3264

- Replace the generic cert error types with the actual error so the specific texts can be generated
- Updates tests
- Update `inquirer-common` `ErrorHandler` log prefix to be configurable
- Updates all instances of `new ErrorHandler` where a logger is not provided, to use the consumer module name as prefix