### PR TITLE
tbi(ui5-info): Update default opt `useCache` to true.

### DIFF
--- a/packages/ui5-info/src/types.ts
+++ b/packages/ui5-info/src/types.ts
@@ -24,7 +24,10 @@ export interface UI5VersionFilterOptions {
      */
     minSupportedUI5Version?: string;
     /**
-     * Will use the cached versions from previous network calls if available otherwise will make network calls and populate cache
+     * Will use the cached versions from previous network calls if available otherwise will make network calls and populate cache.
+     * If false, always make a network call to return the very latest UI5 versions, also populating the cache.
+     *
+     * @default true
      */
     useCache?: boolean;
     /**

--- a/packages/ui5-info/src/ui5-version-info.ts
+++ b/packages/ui5-info/src/ui5-version-info.ts
@@ -140,35 +140,21 @@ async function parseUI5VersionsAndSupport(
  * Returns ui5 versions from cache object.
  *
  * @param type 'officialVersions', 'snapshotsVersions or 'support'
- * @param useCache - will not make a network call but use pre-cached versions
+ * @param useCache - true, use the cache if available, false, always make a network call to retrieve the latest UI5 versions
  * @param snapshotUrl - the url from which snapshot UI5 versions may be requested
  * @returns Array of UI5 versions or UI5VersionSupport objects
  */
 const retrieveUI5VersionsCache = async (
     type: ui5VersionsType.official | ui5VersionsType.snapshot | ui5VersionsType.support,
-    useCache = false,
+    useCache = true,
     snapshotUrl?: string
 ): Promise<string[] | UI5VersionSupport[]> => {
     let versions: string[] = [];
     let support: UI5VersionSupport[] = [];
 
-    if (!useCache) {
-        switch (type) {
-            case ui5VersionsType.official:
-            case ui5VersionsType.support:
-                ({ versions, support } = await parseUI5VersionsAndSupport());
-                return type === ui5VersionsType.official ? versions : support;
-            case ui5VersionsType.snapshot:
-                if (snapshotUrl) {
-                    ({ versions } = await parseUI5VersionsAndSupport(snapshotUrl));
-                    return versions;
-                }
-                break;
-            default:
-        }
-    }
-
-    if (ui5VersionsCache[type].length === 0) {
+    // If the cache is empty populate it with the latest UI5 versions
+    // Or, if `useCache` is false, then always make a network call to retrieve the latest UI5 versions
+    if (ui5VersionsCache[type].length === 0 || !useCache) {
         switch (type) {
             case ui5VersionsType.official:
             case ui5VersionsType.support:
@@ -185,7 +171,11 @@ const retrieveUI5VersionsCache = async (
             default:
         }
     }
-    return ui5VersionsCache[type];
+
+    if (useCache) {
+        return ui5VersionsCache[type];
+    }
+    return versions;
 };
 
 /**

--- a/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
+++ b/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
@@ -1490,7 +1490,7 @@ exports[`getUI5Versions filterOptions: all available versions -  minSupportedVer
 ]
 `;
 
-exports[`getUI5Versions filterOptions: loads and use cached versions - useCache: true 1`] = `
+exports[`getUI5Versions filterOptions: loads and use cached versions by default - useCache: true (default) 1`] = `
 [
   {
     "version": "1.109.3",
@@ -1930,7 +1930,7 @@ exports[`getUI5Versions filterOptions: loads and use cached versions - useCache:
 ]
 `;
 
-exports[`getUI5Versions filterOptions: loads and use cached versions - useCache: true 2`] = `
+exports[`getUI5Versions filterOptions: loads and use cached versions by default - useCache: true (default) 2`] = `
 [
   {
     "version": "snapshot",
@@ -2433,7 +2433,7 @@ exports[`getUI5Versions filterOptions: loads and use cached versions - useCache:
 ]
 `;
 
-exports[`getUI5Versions filterOptions: loads and use cached versions - useCache: true 3`] = `
+exports[`getUI5Versions filterOptions: loads and use cached versions by default - useCache: true (default) 3`] = `
 [
   {
     "maintained": true,
@@ -4099,6 +4099,446 @@ exports[`getUI5Versions filterOptions: snapshots included - snapshotVersionsHost
   },
   {
     "version": "snapshot-1.65",
+  },
+  {
+    "version": "1.65.1",
+  },
+]
+`;
+
+exports[`getUI5Versions filterOptions: useCache: false, retrieves latest versions (and populates the cache) 1`] = `
+[
+  {
+    "version": "1.109.3",
+  },
+  {
+    "version": "1.109.2",
+  },
+  {
+    "version": "1.109.1",
+  },
+  {
+    "version": "1.109.0",
+  },
+  {
+    "version": "1.108.4",
+  },
+  {
+    "version": "1.108.3",
+  },
+  {
+    "version": "1.108.2",
+  },
+  {
+    "version": "1.108.1",
+  },
+  {
+    "version": "1.108.0",
+  },
+  {
+    "version": "1.107.1",
+  },
+  {
+    "version": "1.107.0",
+  },
+  {
+    "version": "1.106.1",
+  },
+  {
+    "version": "1.106.0",
+  },
+  {
+    "version": "1.105.4",
+  },
+  {
+    "version": "1.105.3",
+  },
+  {
+    "version": "1.105.2",
+  },
+  {
+    "version": "1.105.1",
+  },
+  {
+    "version": "1.105.0",
+  },
+  {
+    "version": "1.104.2",
+  },
+  {
+    "version": "1.104.1",
+  },
+  {
+    "version": "1.104.0",
+  },
+  {
+    "version": "1.103.1",
+  },
+  {
+    "version": "1.103.0",
+  },
+  {
+    "version": "1.102.13",
+  },
+  {
+    "version": "1.102.12",
+  },
+  {
+    "version": "1.102.11",
+  },
+  {
+    "version": "1.102.10",
+  },
+  {
+    "version": "1.102.9",
+  },
+  {
+    "version": "1.102.8",
+  },
+  {
+    "version": "1.102.7",
+  },
+  {
+    "version": "1.102.6",
+  },
+  {
+    "version": "1.102.5",
+  },
+  {
+    "version": "1.102.4",
+  },
+  {
+    "version": "1.102.3",
+  },
+  {
+    "version": "1.102.2",
+  },
+  {
+    "version": "1.102.1",
+  },
+  {
+    "version": "1.102.0",
+  },
+  {
+    "version": "1.101.1",
+  },
+  {
+    "version": "1.101.0",
+  },
+  {
+    "version": "1.100.2",
+  },
+  {
+    "version": "1.100.1",
+  },
+  {
+    "version": "1.100.0",
+  },
+  {
+    "version": "1.99.4",
+  },
+  {
+    "version": "1.99.3",
+  },
+  {
+    "version": "1.99.2",
+  },
+  {
+    "version": "1.99.1",
+  },
+  {
+    "version": "1.99.0",
+  },
+  {
+    "version": "1.98.0",
+  },
+  {
+    "version": "1.97.2",
+  },
+  {
+    "version": "1.97.1",
+  },
+  {
+    "version": "1.97.0",
+  },
+  {
+    "version": "1.96.16",
+  },
+  {
+    "version": "1.96.15",
+  },
+  {
+    "version": "1.96.14",
+  },
+  {
+    "version": "1.96.13",
+  },
+  {
+    "version": "1.96.12",
+  },
+  {
+    "version": "1.96.11",
+  },
+  {
+    "version": "1.96.10",
+  },
+  {
+    "version": "1.96.9",
+  },
+  {
+    "version": "1.96.8",
+  },
+  {
+    "version": "1.96.7",
+  },
+  {
+    "version": "1.96.6",
+  },
+  {
+    "version": "1.96.5",
+  },
+  {
+    "version": "1.96.4",
+  },
+  {
+    "version": "1.96.3",
+  },
+  {
+    "version": "1.96.2",
+  },
+  {
+    "version": "1.96.1",
+  },
+  {
+    "version": "1.96.0",
+  },
+  {
+    "version": "1.95.0",
+  },
+  {
+    "version": "1.94.1",
+  },
+  {
+    "version": "1.93.7",
+  },
+  {
+    "version": "1.93.6",
+  },
+  {
+    "version": "1.93.5",
+  },
+  {
+    "version": "1.93.4",
+  },
+  {
+    "version": "1.93.3",
+  },
+  {
+    "version": "1.93.2",
+  },
+  {
+    "version": "1.93.0",
+  },
+  {
+    "version": "1.92.2",
+  },
+  {
+    "version": "1.92.1",
+  },
+  {
+    "version": "1.92.0",
+  },
+  {
+    "version": "1.91.1",
+  },
+  {
+    "version": "1.90.14",
+  },
+  {
+    "version": "1.90.13",
+  },
+  {
+    "version": "1.90.12",
+  },
+  {
+    "version": "1.90.11",
+  },
+  {
+    "version": "1.90.10",
+  },
+  {
+    "version": "1.90.9",
+  },
+  {
+    "version": "1.90.8",
+  },
+  {
+    "version": "1.90.7",
+  },
+  {
+    "version": "1.90.6",
+  },
+  {
+    "version": "1.90.0",
+  },
+  {
+    "version": "1.87.7",
+  },
+  {
+    "version": "1.84.31",
+  },
+  {
+    "version": "1.84.30",
+  },
+  {
+    "version": "1.84.29",
+  },
+  {
+    "version": "1.84.28",
+  },
+  {
+    "version": "1.84.27",
+  },
+  {
+    "version": "1.84.26",
+  },
+  {
+    "version": "1.84.25",
+  },
+  {
+    "version": "1.84.24",
+  },
+  {
+    "version": "1.84.23",
+  },
+  {
+    "version": "1.84.22",
+  },
+  {
+    "version": "1.84.21",
+  },
+  {
+    "version": "1.84.20",
+  },
+  {
+    "version": "1.84.19",
+  },
+  {
+    "version": "1.84.16",
+  },
+  {
+    "version": "1.84.13",
+  },
+  {
+    "version": "1.84.8",
+  },
+  {
+    "version": "1.84.3",
+  },
+  {
+    "version": "1.84.1",
+  },
+  {
+    "version": "1.84.0",
+  },
+  {
+    "version": "1.82.0",
+  },
+  {
+    "version": "1.80.0",
+  },
+  {
+    "version": "1.78.9",
+  },
+  {
+    "version": "1.75.0",
+  },
+  {
+    "version": "1.74.0",
+  },
+  {
+    "version": "1.73.1",
+  },
+  {
+    "version": "1.71.53",
+  },
+  {
+    "version": "1.71.52",
+  },
+  {
+    "version": "1.71.51",
+  },
+  {
+    "version": "1.71.50",
+  },
+  {
+    "version": "1.71.49",
+  },
+  {
+    "version": "1.71.48",
+  },
+  {
+    "version": "1.71.47",
+  },
+  {
+    "version": "1.71.46",
+  },
+  {
+    "version": "1.71.45",
+  },
+  {
+    "version": "1.71.44",
+  },
+  {
+    "version": "1.71.43",
+  },
+  {
+    "version": "1.71.42",
+  },
+  {
+    "version": "1.71.41",
+  },
+  {
+    "version": "1.71.40",
+  },
+  {
+    "version": "1.71.39",
+  },
+  {
+    "version": "1.71.36",
+  },
+  {
+    "version": "1.71.35",
+  },
+  {
+    "version": "1.71.33",
+  },
+  {
+    "version": "1.71.30",
+  },
+  {
+    "version": "1.71.29",
+  },
+  {
+    "version": "1.71.24",
+  },
+  {
+    "version": "1.71.23",
+  },
+  {
+    "version": "1.71.22",
+  },
+  {
+    "version": "1.71.17",
+  },
+  {
+    "version": "1.71.9",
+  },
+  {
+    "version": "1.71.5",
+  },
+  {
+    "version": "1.71.2",
   },
   {
     "version": "1.65.1",

--- a/packages/ui5-info/test/ui5-version-info.test.ts
+++ b/packages/ui5-info/test/ui5-version-info.test.ts
@@ -1,16 +1,26 @@
-import nock from 'nock';
 import axios from 'axios';
-import snapshotResponse from './testdata/snapshot-response.json';
-import officialResponse from './testdata/official-response.json';
-import officialOutOfMaintenanceResponse from './testdata/official-response-latest-out-of-maintenance.json';
+import nock from 'nock';
 import officialBlockOutOfMaintenanceResponse from './testdata/official-latest-block-out-of-maintenance.json';
+import officialOutOfMaintenanceResponse from './testdata/official-response-latest-out-of-maintenance.json';
+import officialResponse from './testdata/official-response.json';
+import snapshotResponse from './testdata/snapshot-response.json';
 
-import { getLatestUI5Version, getUI5Versions } from '../src/ui5-version-info';
-import * as commands from '../src/commands';
 import { ToolsLogger } from '@sap-ux/logger';
+import * as commands from '../src/commands';
+import * as ui5VersionConstants from '../src/constants';
 import { ui5VersionRequestInfo } from '../src/constants';
+import { getLatestUI5Version, getUI5Versions } from '../src/ui5-version-info';
 
 const snapshotVersionsHost = 'http://ui5.versions.snapshots';
+
+const resetUI5VersionsCache = () => {
+    // reset the UI5 versions cache so each test is isolated
+    (ui5VersionConstants as any).ui5VersionsCache = {
+        officialVersions: [],
+        snapshotsVersions: [],
+        support: []
+    };
+};
 
 describe('getUI5Versions', () => {
     beforeEach(() => {
@@ -19,6 +29,7 @@ describe('getUI5Versions', () => {
             .get(`/${ui5VersionRequestInfo.VersionsFile}`)
             .reply(200, officialResponse);
         nock(snapshotVersionsHost).persist().get(`/${ui5VersionRequestInfo.NeoAppFile}`).reply(200, snapshotResponse);
+        resetUI5VersionsCache();
     });
 
     afterEach(() => {
@@ -65,24 +76,26 @@ describe('getUI5Versions', () => {
         expect(hasDups).toEqual(false);
     });
 
-    test('filterOptions: loads and use cached versions - useCache: true', async () => {
+    test('filterOptions: loads and use cached versions by default - useCache: true (default)', async () => {
         const axiosGetSpy = jest.spyOn(axios, 'get');
-        const versions1 = await getUI5Versions({
-            useCache: true
-        });
+        const versions1 = await getUI5Versions();
         expect(axiosGetSpy).toHaveBeenCalled();
         expect(versions1).toMatchSnapshot();
 
+        // Ensure default (no option) and `useCache:true` have the same behaviour
+        resetUI5VersionsCache();
+        const versions1WithUseCache = await getUI5Versions({ useCache: true });
+        expect(axiosGetSpy).toHaveBeenCalled();
+        expect(versions1WithUseCache).toEqual(versions1);
+
         axiosGetSpy.mockClear();
-        const versions2 = await getUI5Versions({
-            useCache: true
-        });
+        // Should not make a network call, but return cached versions
+        const versions2 = await getUI5Versions();
         expect(axiosGetSpy).not.toHaveBeenCalled();
         expect(versions1).toEqual(versions2);
 
         axiosGetSpy.mockClear();
         const versions3 = await getUI5Versions({
-            useCache: true,
             snapshotVersionsHost
         });
         expect(axiosGetSpy).toHaveBeenCalled();
@@ -90,7 +103,6 @@ describe('getUI5Versions', () => {
 
         axiosGetSpy.mockClear();
         const versions4 = await getUI5Versions({
-            useCache: true,
             snapshotVersionsHost
         });
         expect(axiosGetSpy).not.toHaveBeenCalled();
@@ -98,7 +110,6 @@ describe('getUI5Versions', () => {
 
         axiosGetSpy.mockClear();
         const versions5 = await getUI5Versions({
-            useCache: true,
             includeMaintained: true
         });
         // ui5VersionsType.support is already cached when ui5VersionsType.offical is called(1st test case)
@@ -106,11 +117,23 @@ describe('getUI5Versions', () => {
 
         axiosGetSpy.mockClear();
         const versions6 = await getUI5Versions({
-            useCache: true,
             includeMaintained: true
         });
         expect(axiosGetSpy).not.toHaveBeenCalled();
         expect(versions5).toEqual(versions6);
+    });
+
+    test('filterOptions: useCache: false, retrieves latest versions (and populates the cache)', async () => {
+        const axiosGetSpy = jest.spyOn(axios, 'get');
+        const versions1 = await getUI5Versions({ useCache: false });
+        expect(axiosGetSpy).toHaveBeenCalled();
+        expect(versions1).toMatchSnapshot();
+
+        axiosGetSpy.mockClear();
+        // Should not make a network call, but return cached versions
+        const versions2 = await getUI5Versions({ useCache: false });
+        expect(axiosGetSpy).toHaveBeenCalled();
+        expect(versions1).toEqual(versions2);
     });
 
     test('filterOptions: mark default versions - `includeDefault`', async () => {
@@ -168,6 +191,7 @@ describe('getUI5Versions: Handle error cases while getting UI5 versions: ', () =
 
     beforeEach(() => {
         nock(ui5VersionRequestInfo.OfficialUrl).get(`/${ui5VersionRequestInfo.VersionsFile}`).reply(500, '');
+        resetUI5VersionsCache();
     });
 
     afterEach(() => {
@@ -209,6 +233,7 @@ describe('getUI5Versions: Handle fatal cases while getting UI5 versions: ', () =
         nock(ui5VersionRequestInfo.OfficialUrl)
             .get(`/${ui5VersionRequestInfo.VersionsFile}`)
             .replyWithError('Fatal error');
+        resetUI5VersionsCache();
     });
 
     afterEach(() => {
@@ -236,6 +261,7 @@ describe('getUI5Versions: npm listed versions', () => {
 
     beforeEach(() => {
         jest.resetModules();
+        resetUI5VersionsCache();
     });
 
     afterEach(() => {


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3355

- Updates default option `useCache` to true
- Always populates cache if not populated
- `useCache: false` will always request latest versions
- Fixes test isolation, adds test to cover new default