### PR TITLE
fix(app-config-writer): preview middleware dependency

### DIFF
--- a/.changeset/hot-cows-provide.md
+++ b/.changeset/hot-cows-provide.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': patch
+---
+
+fix preview middleware dependency

--- a/packages/app-config-writer/test/unit/preview-config/ui5-yaml.test.ts
+++ b/packages/app-config-writer/test/unit/preview-config/ui5-yaml.test.ts
@@ -478,7 +478,7 @@ describe('update preview middleware config', () => {
         fs.write(join(variousConfigsPath, 'package.json'), JSON.stringify(packageJson));
 
         await updatePreviewMiddlewareConfigs(fs, variousConfigsPath, false, logger);
-        expect(warnLogMock).toHaveBeenCalledTimes(5);
+        expect(warnLogMock).toHaveBeenCalledTimes(6);
     });
 
     test('same yaml config different endpoints', async () => {


### PR DESCRIPTION
Currently there's a devDependency to preview-middleware in app-config-writer but actually it is needed at runtime. This PR fixes the dependency.