### PR TITLE
Update Validation Logic when No App Is Selected

### DIFF
--- a/.changeset/two-lions-heal.md
+++ b/.changeset/two-lions-heal.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': patch
+---
+
+update validation logic to return ValidationLink or string in repo-app-import-sub-generator when no app is selected

--- a/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
+++ b/packages/repo-app-import-sub-generator/src/prompts/prompts.ts
@@ -8,6 +8,7 @@ import { PromptState } from './prompt-state';
 import { fetchAppListForSelectedSystem, formatAppChoices } from './prompt-helpers';
 import type { FileBrowserQuestion } from '@sap-ux/inquirer-common';
 import { validateAppSelection } from '../utils/validators';
+import type { ValidationLink } from '@sap-ux/inquirer-common';
 import type { AppWizard } from '@sap-devx/yeoman-ui-types';
 import RepoAppDownloadLogger from '../utils/logger';
 import { type Question } from 'inquirer';
@@ -130,9 +131,8 @@ export async function getPrompts(
                 },
                 message: t('prompts.appSelection.message'),
                 choices: (): { name: string; value: AppInfo }[] => (appList.length ? formatAppChoices(appList) : []),
-                validate: async (answers: AppInfo): Promise<boolean> => {
-                    const result = await validateAppSelection(answers, appList, quickDeployedAppConfig, appWizard);
-                    return !!result;
+                validate: async (answers: AppInfo): Promise<boolean | ValidationLink | string> => {
+                    return await validateAppSelection(answers, appList, quickDeployedAppConfig, appWizard);
                 }
             }
         ];


### PR DESCRIPTION
- update to validation logic of `@sap-ux/repo-app-import-sub-generator` package when no app is selected & app list is empty - function now returns either a `ValidationLink` object or a string message or a boolean value
- Added tests