### PR TITLE
fix(fiori-gen): adds preview settings to external service state object

### DIFF
--- a/.changeset/lazy-rice-brake.md
+++ b/.changeset/lazy-rice-brake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-app-sub-generator': patch
+---
+
+adds preview settings to external service state

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/transforms.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/transforms.ts
@@ -208,7 +208,7 @@ export async function transformState<T>(
             name: MAIN_DATASOURCE_NAME,
             client: service.client,
             model: appConfig.template?.type === TemplateTypeFE.OverviewPage ? MAIN_MODEL_NAME : '', // OVP requires a named default model
-            previewSettings: {},
+            previewSettings: service.previewSettings ?? {},
             annotations:
                 project.skipAnnotations !== true
                     ? await getAnnotations(project.name, service.annotations?.[0], service?.capService)
@@ -240,7 +240,7 @@ export async function transformState<T>(
         } else if (
             service.connectedSystem?.backendSystem?.serviceKeys ||
             // If 'cloud' write `scp` property to yamls to enable preview on VSCode (using oAuth)
-            (getHostEnvironment() === hostEnvironment.vscode &&
+            (getHostEnvironment() === hostEnvironment.bas &&
                 service.connectedSystem?.destination &&
                 isAbapEnvironmentOnBtp(service.connectedSystem?.destination))
         ) {

--- a/packages/fiori-app-sub-generator/src/types/state.ts
+++ b/packages/fiori-app-sub-generator/src/types/state.ts
@@ -1,3 +1,4 @@
+import type { AuthenticationType } from '@sap-ux/store';
 import type { Annotations } from '@sap-ux/axios-extension';
 import type { CapServiceCdsInfo } from '@sap-ux/cap-config-writer';
 import type { CdsUi5PluginInfo, UI5FlexLayer } from '@sap-ux/project-access';
@@ -74,6 +75,13 @@ export interface Service {
     destinationAuthType?: string;
     apiHubConfig?: ApiHubConfig;
     ignoreCertError?: boolean;
+    /**
+     * Can be set by adaptors if preview settings have been determined
+     */
+    previewSettings?: {
+        scp?: boolean;
+        authenticationType?: AuthenticationType;
+    };
 }
 
 /**

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5-local.yaml
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5-local.yaml
@@ -39,9 +39,9 @@ server:
       configuration:
         ignoreCertError: true # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
         backend:
-          - path: /sap
+          - scp: true
+            path: /sap
             url: https://sap-ux-mock-services-v2-lrop.cfapps.us10.hana.ondemand.com
-            client: '012'
     - name: sap-fe-mockserver
       beforeMiddleware: csp
       configuration:

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5-mock.yaml
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5-mock.yaml
@@ -16,9 +16,9 @@ server:
             - /test-resources
           url: https://ui5.sap.com
         backend:
-          - path: /sap
+          - scp: true
+            path: /sap
             url: https://sap-ux-mock-services-v2-lrop.cfapps.us10.hana.ondemand.com
-            client: '012'
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5.yaml
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/worklist_v2/ui5.yaml
@@ -16,9 +16,9 @@ server:
             - /test-resources
           url: https://ui5.sap.com
         backend:
-          - path: /sap
+          - scp: true
+            path: /sap
             url: https://sap-ux-mock-services-v2-lrop.cfapps.us10.hana.ondemand.com
-            client: '012'
     - name: fiori-tools-appreload
       afterMiddleware: compression
       configuration:

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/writing-v2.test.ts
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/writing-v2.test.ts
@@ -327,7 +327,11 @@ describe('Generate v2 apps', () => {
             floorplan: FloorplanFE.FE_WORKLIST,
             service: {
                 ...v2Service,
-                ignoreCertError: true
+                client: undefined,
+                ignoreCertError: true,
+                previewSettings: {
+                    scp: true
+                }
             },
             entityRelatedConfig: v2EntityConfig
         });

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
@@ -101,7 +101,7 @@ describe('Test transform state', () => {
                 } as Service['connectedSystem']
             }
         };
-        (getHostEnvironment as jest.Mock).mockReturnValue(hostEnvironment.vscode);
+        (getHostEnvironment as jest.Mock).mockReturnValue(hostEnvironment.bas);
 
         let ffApp = await transformState<FreestyleApp<BasicAppSettings>>(state);
         expect(ffApp.service?.previewSettings?.scp).toBe(true);


### PR DESCRIPTION
Internal bug #31013

- Updates the external `Service` state object to allow configuration of the `previewSettings` i.e `scp` and `authenticationType`