### PR TITLE
chore - renovate add ignore '**/expected-output/**'

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -32,7 +32,7 @@
 
     assigneesFromCodeOwners: true,
 
-    ignorePaths: ['**/templates/**', '**/test-input/**', '**/test-output/**', '**/test/fixtures/**', '**/test/fixture/**', '**/test/test-data/**'],
+    ignorePaths: ['**/templates/**', '**/test-input/**', '**/test-output/**', '**/test/fixtures/**', '**/test/fixture/**', '**/test/test-data/**', '**/expected-output/**' ],
 
     packageRules: [
         {


### PR DESCRIPTION
Renovate should update `**/expected-output/**` package.json files
E.g. https://github.com/SAP/open-ux-tools/pull/3143/ 
<img width="1430" alt="Screenshot 2025-06-19 at 15 13 18" src="https://github.com/user-attachments/assets/b3dd9a81-207b-4ef4-8459-7bcb59412e38" />
