### PR TITLE
fix(ui-components): UIDialog: Override FluentUI overlay background with VSCode theme variable

### DIFF
--- a/.changeset/early-boxes-vanish.md
+++ b/.changeset/early-boxes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UIDialog: Override FluentUI overlay background with VSCode theme variable

--- a/packages/ui-components/src/components/UIDialog/UIDialog.tsx
+++ b/packages/ui-components/src/components/UIDialog/UIDialog.tsx
@@ -48,6 +48,10 @@ export const DIALOG_STYLES = {
     contentText: {
         fontSize: 13,
         color: 'var(--vscode-foreground)'
+    },
+    modalOverlay: {
+        background: 'var(--vscode-editor-background)',
+        opacity: 0.8
     }
 };
 
@@ -263,6 +267,14 @@ export class UIDialog extends React.Component<DialogProps, DialogState> {
                 layerProps: {
                     onLayerDidMount: this.onModalLayerMount,
                     onLayerWillUnmount: this.onModalLayerUnmount
+                },
+                overlay: {
+                    styles: {
+                        root: {
+                            background: DIALOG_STYLES.modalOverlay.background,
+                            opacity: DIALOG_STYLES.modalOverlay.opacity
+                        }
+                    }
                 }
             },
             styles: {

--- a/packages/ui-components/test/unit/components/UIDialog.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDialog.test.tsx
@@ -209,8 +209,10 @@ describe('<UIDialog />', () => {
             const dialog = wrapper.find(Dialog);
             const props = dialog.props();
             expect(props.modalProps?.overlay?.styles).toEqual({
-                background: 'var(--vscode-editor-background)',
-                opacity: 0.8
+                root: {
+                    background: 'var(--vscode-editor-background)',
+                    opacity: 0.8
+                }
             });
         });
         it('Title - single line', () => {

--- a/packages/ui-components/test/unit/components/UIDialog.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDialog.test.tsx
@@ -205,6 +205,14 @@ describe('<UIDialog />', () => {
     });
 
     describe('Styles', () => {
+        it('Basic style', () => {
+            const dialog = wrapper.find(Dialog);
+            const props = dialog.props();
+            expect(props.modalProps?.overlay?.styles).toEqual({
+                background: 'var(--vscode-editor-background)',
+                opacity: 0.8
+            });
+        });
         it('Title - single line', () => {
             const dialog = wrapper.find(Dialog);
             const props = dialog.props();


### PR DESCRIPTION
Problem - overlay background for dialogs used buildin color from fluentui instead of vscode theme variable.
Appllied corrected version proposed by Goran:
```
  background: 'var(--vscode-editor-background)',
  opacity: 0.8
```

Light theme:
![image](https://github.com/user-attachments/assets/04609d04-4818-4471-be44-26944b44bf93)

Dark theme:
![image](https://github.com/user-attachments/assets/c908282f-7985-4f98-bd97-53c514b0fb19)
