### PR TITLE
fix(fiori-gen): ensure service runtimeName is upper case to match service id

### DIFF
--- a/.changeset/old-rats-poke.md
+++ b/.changeset/old-rats-poke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-generator-shared': patch
+---
+
+ensure service runtimeName is upper case to match service id

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/writing-v2.test.ts
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/writing-v2.test.ts
@@ -74,7 +74,7 @@ describe('Generate v2 apps', () => {
 
         const destService: Service = {
             localEdmxFilePath: '',
-            serviceId: 'ABCD_MockService_O2',
+            serviceId: 'ABCD_MOCKSERVICE_O2',
             servicePath: v2Service.servicePath,
             version: v2Service.version,
             host: v2Service.host!,

--- a/packages/fiori-generator-shared/src/app-gen-info.ts
+++ b/packages/fiori-generator-shared/src/app-gen-info.ts
@@ -26,7 +26,7 @@ export function transformAbapCSNForAppGenInfo(
     const serviceUri = serviceUrlObj?.pathname?.endsWith('/')
         ? serviceUrlObj.pathname
         : (serviceUrlObj?.pathname ?? '') + '/';
-    const serviceNameCsn = abapCSN.services.find((s) => s.runtimeName === serviceId)?.csnServiceName;
+    const serviceNameCsn = abapCSN.services.find((s) => s.runtimeName.toUpperCase() === serviceId)?.csnServiceName;
 
     return [
         {

--- a/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
+++ b/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
@@ -27,7 +27,7 @@ describe('Readme file generation tests', () => {
             generatorVersion: '2.0.1',
             generationDate: 'Jan 01 1975',
             generatorPlatform: 'CLI',
-            serviceId: 'ABCD_MockService_O2',
+            serviceId: 'ABCD_MOCKSERVICE_O2',
             serviceUrl: 'http://mock.url/with/path/to/odata',
             appName: 'appName',
             appTitle: 'appTitle',


### PR DESCRIPTION
`serviceId` from the chosen service is upper case and the `runtimeName` passed in the abapCSN object must be converted in order to succesfully match 