### PR TITLE
Replace V4 add custom section addXML with descriptor change

### DIFF
--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -285,7 +285,12 @@ export interface AddXMLChange extends CommonChangeProperties {
     dependentSelector: Record<string, unknown>;
     jsOnly: boolean;
 }
-
+export interface AppDescriptorV4Change extends CommonChangeProperties {
+    changeType: 'appdescr_fe_changePageConfiguration';
+    content: {
+        entityPropertyChange: { propertyPath: string; operation: string; propertyValue: string | unknown };
+    };
+}
 export interface CodeExtChange extends CommonChangeProperties {
     changeType: 'codeExt';
     content: {

--- a/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
+++ b/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
@@ -16,7 +16,7 @@ import * as helper from '../../../src/base/helper';
 import * as editors from '../../../src/writer/editors';
 import { AdpPreview } from '../../../src';
 import * as manifestService from '../../../src/base/abap/manifest-service';
-import type { AdpPreviewConfig, CommonChangeProperties } from '../../../src';
+import type { AddXMLChange, AdpPreviewConfig, CommonChangeProperties } from '../../../src';
 import { addXmlFragment, tryFixChange, addControllerExtension } from '../../../src/preview/change-handler';
 
 interface GetFragmentsResponse {
@@ -473,7 +473,7 @@ describe('AdaptationProject', () => {
                 fragmentPath: 'fragments/share.fragment.xml'
             },
             reference: 'some.reference'
-        } as unknown as CommonChangeProperties;
+        } as unknown as AddXMLChange;
 
         const addCodeExtChange = {
             changeType: 'codeExt',
@@ -498,7 +498,7 @@ describe('AdaptationProject', () => {
 
             expect(addXmlFragmentMock).toHaveBeenCalledWith(
                 '/adp.project/webapp',
-                addXMLChange,
+                { fragmentPath: addXMLChange.content.fragmentPath },
                 mockFs,
                 mockLogger,
                 undefined

--- a/packages/adp-tooling/test/unit/preview/change-handler.test.ts
+++ b/packages/adp-tooling/test/unit/preview/change-handler.test.ts
@@ -14,7 +14,8 @@ import {
     isAddAnnotationChange,
     isAddXMLChange,
     moduleNameContentMap,
-    tryFixChange
+    tryFixChange,
+    type FragmentCreationParams
 } from '../../../src/preview/change-handler';
 import type { AddXMLChange, CommonChangeProperties, AnnotationFileChange, DescriptorVariant } from '../../../src';
 import * as manifestService from '../../../src/base/abap/manifest-service';
@@ -167,7 +168,12 @@ describe('change-handler', () => {
         it('should create the XML fragment and log information if it does not exist', () => {
             mockFs.exists.mockReturnValue(false);
 
-            addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger);
+            addXmlFragment(
+                path,
+                { fragmentPath: change.content.fragmentPath, index: -1 },
+                mockFs as unknown as Editor,
+                mockLogger as unknown as Logger
+            );
 
             expect(mockFs.copy).toHaveBeenCalled();
             expect(mockLogger.info).toHaveBeenCalledWith(`XML Fragment "${fragmentName}.fragment.xml" was created`);
@@ -179,7 +185,12 @@ describe('change-handler', () => {
                 throw new Error('Copy failed');
             });
 
-            addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger);
+            addXmlFragment(
+                path,
+                { fragmentPath: change.content.fragmentPath },
+                mockFs as unknown as Editor,
+                mockLogger as unknown as Logger
+            );
 
             expect(mockLogger.error).toHaveBeenCalledWith(
                 expect.stringContaining(`Failed to create XML Fragment "${fragmentName}.fragment.xml"`)
@@ -196,9 +207,15 @@ describe('change-handler', () => {
 id="<%- ids.objectPageSection %>"
 id="<%- ids.objectPageSubSection %>"
 id="<%- ids.hBox %>"`);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `OBJECT_PAGE_CUSTOM_SECTION`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `OBJECT_PAGE_CUSTOM_SECTION`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -226,9 +243,15 @@ id="<%- ids.hBox %>"`);
                 mockFs.read.mockReturnValue(`
 id="<%- ids.vBoxContainer %>"
 id="<%- ids.label %>"`);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `OBJECT_PAGE_HEADER_FIELD`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `OBJECT_PAGE_HEADER_FIELD`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -254,9 +277,15 @@ id="<%- ids.label %>"`);
                 mockFs.exists.mockReturnValue(false);
                 mockFs.read.mockReturnValue(`
 id="<%- ids.toolbarActionButton %>`);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `CUSTOM_ACTION`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `CUSTOM_ACTION`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -292,9 +321,15 @@ id="<%- ids.columnTitle %>
 id="<%- ids.customData %>
 id="<%- ids.index %>
 `);
-                addXmlFragment(path, updatedChange, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `V2_SMART_TABLE_COLUMN`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: updatedChange.content.fragmentPath, index: updatedChange.content.index },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `V2_SMART_TABLE_COLUMN`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -324,9 +359,15 @@ id="<%- ids.index %>
                 mockFs.read.mockReturnValue(`
 id="<%- ids.text %>
 `);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `V2_SMART_TABLE_CELL`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `V2_SMART_TABLE_CELL`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -354,9 +395,15 @@ id="<%- ids.text %>
 id="<%- ids.column %>
 id="<%- ids.text %>
 `);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `V4_MDC_TABLE_COLUMN`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `V4_MDC_TABLE_COLUMN`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -408,9 +455,15 @@ id="<%- ids.text %>
 id="<%- ids.customData %>
 id="<%- ids.index %>
 `);
-                addXmlFragment(path, updatedChange, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: testCase.tableType
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: updatedChange.content.fragmentPath, index: updatedChange.content.index },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: testCase.tableType
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(
@@ -439,9 +492,15 @@ id="<%- ids.index %>
                 mockFs.read.mockReturnValue(`
 id="<%- ids.customToolbarAction %>"
 id="<%- ids.customActionButton %>"`);
-                addXmlFragment(path, change, mockFs as unknown as Editor, mockLogger as unknown as Logger, {
-                    templateName: `TABLE_ACTION`
-                });
+                addXmlFragment(
+                    path,
+                    { fragmentPath: change.content.fragmentPath },
+                    mockFs as unknown as Editor,
+                    mockLogger as unknown as Logger,
+                    {
+                        templateName: `TABLE_ACTION`
+                    }
+                );
 
                 expect(mockFs.read).toHaveBeenCalled();
                 expect(

--- a/packages/preview-middleware-client/src/adp/command-executor.ts
+++ b/packages/preview-middleware-client/src/adp/command-executor.ts
@@ -8,7 +8,7 @@ import type DesignTimeMetadata from 'sap/ui/dt/DesignTimeMetadata';
 import type FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import { getError } from '../utils/error';
 
-type CommandNames = 'addXML' | 'codeExt';
+type CommandNames = 'addXML' | 'codeExt' | 'appDescriptor';
 
 /**
  * Class responsible for handling rta calls

--- a/packages/preview-middleware-client/src/adp/controllers/AddFragment.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/AddFragment.controller.ts
@@ -33,6 +33,8 @@ import { getFragmentTemplateName } from '../../cpe/additional-change-info/add-xm
 import type { AddFragmentData, DeferredXmlFragmentData } from '../add-fragment';
 import { setApplicationRequiresReload } from '@sap-ux-private/control-property-editor-common';
 import { CommunicationService } from '../../cpe/communication-service';
+import FlexCommand from 'sap/ui/rta/command/FlexCommand';
+import type AppComponentV4 from 'sap/fe/core/AppComponent';
 
 const radix = 10;
 
@@ -41,13 +43,22 @@ export type AddFragmentModel = JSONModel & {
     getProperty(sPath: '/completeView'): boolean;
     getProperty(sPath: '/newFragmentName'): string;
     getProperty(sPath: '/selectedIndex'): number;
+    getProperty(sPath: '/indexVisible'): boolean;
     getProperty(sPath: '/selectedAggregation/value'): string;
 };
+export interface PageDescriptorV4 {
+    appType: 'fe-v4';
+    appComponent: AppComponentV4;
+    pageId: string;
+    appReference?: string; // Optional, used for v4 app descriptor changes,
+    anchor: string;
+}
 
 export interface AddFragmentOptions {
     title: string;
     aggregation?: string;
     defaultAggregationArrayIndex?: number;
+    appDescriptor?: PageDescriptorV4;
 }
 
 /**
@@ -69,7 +80,8 @@ export default class AddFragment extends BaseDialog<AddFragmentModel> {
         this.overlays = overlays;
         this.model = new JSONModel({
             title: options.title,
-            completeView: options.aggregation === undefined
+            completeView: options.aggregation === undefined,
+            indexVisible: options.appDescriptor ? false : true
         });
         this.commandExecutor = new CommandExecutor(this.rta);
         this.data = data;
@@ -143,21 +155,25 @@ export default class AddFragment extends BaseDialog<AddFragmentModel> {
         const fragmentName = this.model.getProperty('/newFragmentName');
         const index = this.model.getProperty('/selectedIndex');
         const targetAggregation = this.model.getProperty('/selectedAggregation/value') ?? 'content';
-
+        const fragmentPath = `fragments/${fragmentName}.fragment.xml`;
         const modifiedValue = {
             fragment: `<core:FragmentDefinition xmlns:core='sap.ui.core'></core:FragmentDefinition>`,
-            fragmentPath: `fragments/${fragmentName}.fragment.xml`,
+            fragmentPath,
             index: index ?? 0,
             targetAggregation: targetAggregation ?? 'content'
         };
+        const templateName = getFragmentTemplateName(this.runtimeControl.getId(), targetAggregation);
 
         if (this.data) {
             this.data.deferred.resolve(modifiedValue);
         } else {
-            await this.createFragmentChange(modifiedValue);
+            if (this.options?.appDescriptor?.appType === 'fe-v4' && templateName === 'OBJECT_PAGE_CUSTOM_SECTION') {
+                await this.createAppDescriptorChangeForV4(fragmentPath);
+            } else {
+                await this.createFragmentChange(modifiedValue);
+            }
         }
 
-        const templateName = getFragmentTemplateName(this.runtimeControl.getId(), targetAggregation);
         if (templateName) {
             CommunicationService.sendAction(setApplicationRequiresReload(true));
         }
@@ -245,6 +261,44 @@ export default class AddFragment extends BaseDialog<AddFragmentModel> {
             modifiedValue,
             flexSettings,
             designMetadata
+        );
+
+        await this.commandExecutor.pushAndExecuteCommand(command);
+    }
+
+    private async createAppDescriptorChangeForV4(fragmentPath: string) {
+        const [path, _] = fragmentPath.split('.');
+        const name = path.split('/').join('.');
+        const fragmentName = this.model.getProperty('/newFragmentName');
+        const template = `${this.options.appDescriptor?.appReference}.changes.${name}`;
+        let sectionId = this.options.appDescriptor?.pageId; // TODO: use correct section ID
+        const flexSettings = this.rta.getFlexSettings();
+        const modifiedValue = {
+            reference: this.options.appDescriptor?.appReference,
+            appComponent: this.options.appDescriptor?.appComponent,
+            changeType: 'appdescr_fe_changePageConfiguration',
+            parameters: {
+                page: this.options.appDescriptor?.pageId,
+                entityPropertyChange: {
+                    propertyPath: `content/body/sections/${fragmentName}`, // e.g. 'content/body/sections/test'
+                    operation: 'UPSERT',
+                    propertyValue: {
+                        template,
+                        title: 'my custom section (manifest)',
+                        position: {
+                            placement: 'After',
+                            anchor: `${sectionId}`
+                        }
+                    }
+                }
+            }
+        };
+
+        const command = await this.commandExecutor.getCommand<FlexCommand>(
+            this.runtimeControl,
+            'appDescriptor',
+            modifiedValue,
+            flexSettings
         );
 
         await this.commandExecutor.pushAndExecuteCommand(command);

--- a/packages/preview-middleware-client/src/adp/dialog-factory.ts
+++ b/packages/preview-middleware-client/src/adp/dialog-factory.ts
@@ -80,13 +80,14 @@ export class DialogFactory {
                     overlay,
                     rta,
                     {
+                        ...('appDescriptor' in options && { appDescriptor: options.appDescriptor }),
                         ...('aggregation' in options && { aggregation: options.aggregation }),
                         ...('defaultAggregationArrayIndex' in options && {
                             defaultAggregationArrayIndex: options.defaultAggregationArrayIndex
                         }),
                         title: resources.getText(options.title ?? 'ADP_ADD_FRAGMENT_DIALOG_TITLE')
                     },
-                    (data as AddFragmentData),
+                    data as AddFragmentData,
                     telemetryData
                 );
                 break;
@@ -107,7 +108,7 @@ export class DialogFactory {
                     `open.ux.preview.client.adp.controllers.${dialogName}`,
                     overlay,
                     rta,
-                    (data as ExtendControllerData),
+                    data as ExtendControllerData,
                     telemetryData
                 );
                 break;
@@ -116,7 +117,7 @@ export class DialogFactory {
                     `open.ux.preview.client.adp.controllers.${dialogName}`,
                     overlay,
                     rta,
-                    (data as ExtensionPointData)
+                    data as ExtensionPointData
                 );
                 break;
             case DialogNames.FILE_EXISTS:

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/op-add-custom-section.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/op-add-custom-section.ts
@@ -1,0 +1,85 @@
+import { getV4AppComponent } from '../../../utils/fe-v4';
+import { PageDescriptorV4 } from '../../controllers/AddFragment.controller';
+import { SimpleQuickActionDefinitionBase } from '../simple-quick-action-base';
+import { QuickActionContext, SimpleQuickActionDefinition } from '../../../cpe/quick-actions/quick-action-definition';
+import { OP_ADD_CUSTOM_SECTION } from '../common/op-add-custom-section';
+import { CONTROL_TYPES } from './create-table-custom-column';
+import { DIALOG_ENABLEMENT_VALIDATOR } from '../dialog-enablement-validator';
+import FlexCommand from 'sap/ui/rta/command/FlexCommand';
+import { getRelevantControlFromActivePage } from '../../../cpe/quick-actions/utils';
+import ObjectPageLayout from 'sap/uxap/ObjectPageLayout';
+import OverlayRegistry from 'sap/ui/dt/OverlayRegistry';
+import { DialogFactory, DialogNames } from '../../dialog-factory';
+
+interface ViewDataType {
+    stableId: string;
+}
+/**
+ * Quick Action for adding a custom page action.
+ */
+export class AddCustomSectionQuickAction
+    extends SimpleQuickActionDefinitionBase
+    implements SimpleQuickActionDefinition
+{
+    protected get currentPageDescriptor(): PageDescriptorV4 {
+        const appComponent = getV4AppComponent(this.context.view);
+        const appReference = this.context.flexSettings.projectId;
+        const objectPageLayout = getRelevantControlFromActivePage(this.context.controlIndex, this.context.view, [
+            'sap.uxap.ObjectPageLayout'
+        ])[0] as ObjectPageLayout;
+        const sections = objectPageLayout.getSections();
+        let anchor: string | null = null;
+        const pageId = (this.context.view.getViewData() as ViewDataType)?.stableId.split('::').pop() as string;
+        if (sections.length > 0) {
+            // Use the first section as the anchor if available
+            anchor = (this.context.view.getLocalId(sections[sections.length - 1].getId()) ?? '')
+                .split('::')
+                .pop() as string;
+        }
+        if (!pageId) {
+            throw new Error('pageId is not defined');
+        }
+        if (!appReference) {
+            throw new Error('app reference is not defined');
+        }
+        if (!appComponent) {
+            throw new Error('appComponent is not defined');
+        }
+        if (!anchor) {
+            throw new Error('appComponent is not defined');
+        }
+        return {
+            appType: 'fe-v4',
+            appComponent,
+            anchor,
+            pageId,
+            appReference
+        };
+    }
+    constructor(context: QuickActionContext) {
+        super(OP_ADD_CUSTOM_SECTION, CONTROL_TYPES, 'QUICK_ACTION_OP_ADD_CUSTOM_SECTION', context, [
+            DIALOG_ENABLEMENT_VALIDATOR
+        ]);
+    }
+
+    async execute(): Promise<FlexCommand[]> {
+        const objectPageLayout = getRelevantControlFromActivePage(this.context.controlIndex, this.context.view, [
+            'sap.uxap.ObjectPageLayout'
+        ])[0] as ObjectPageLayout;
+
+        const overlay = OverlayRegistry.getOverlay(objectPageLayout) || [];
+        await DialogFactory.createDialog(
+            overlay,
+            this.context.rta,
+            DialogNames.ADD_FRAGMENT,
+            undefined,
+            {
+                aggregation: 'sections',
+                title: 'QUICK_ACTION_OP_ADD_CUSTOM_SECTION',
+                appDescriptor: this.currentPageDescriptor
+            },
+            { actionName: this.type, telemetryEventIdentifier: this.getTelemetryIdentifier() }
+        );
+        return [];
+    }
+}

--- a/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/registry.ts
+++ b/packages/preview-middleware-client/src/adp/quick-actions/fe-v4/registry.ts
@@ -8,7 +8,7 @@ import { AddControllerToPageQuickAction } from '../common/add-controller-to-page
 import { ToggleClearFilterBarQuickAction } from './lr-toggle-clear-filter-bar';
 import { ChangeTableColumnsQuickAction } from './change-table-columns';
 import { AddHeaderFieldQuickAction } from '../common/op-add-header-field';
-import { AddCustomSectionQuickAction } from '../common/op-add-custom-section';
+import { AddCustomSectionQuickAction } from './op-add-custom-section';
 import { AddTableCustomColumnQuickAction } from './create-table-custom-column';
 import { AddPageActionQuickAction } from '../common/create-page-action';
 import { AddTableActionQuickAction } from './create-table-action';

--- a/packages/preview-middleware-client/src/adp/ui/AddFragment.fragment.xml
+++ b/packages/preview-middleware-client/src/adp/ui/AddFragment.fragment.xml
@@ -36,6 +36,7 @@
                     <Select
                         id="aggregationIndex"
                         enabled="{/indexHandlingFlag}"
+                        visible="{/indexVisible}" 
                         selectedKey="{path: '/selectedIndex', type: 'sap.ui.model.type.Integer'}"
                         items="{
                             path: '/index',

--- a/packages/preview-middleware-client/src/cpe/changes/service.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/service.ts
@@ -330,7 +330,7 @@ export class ChangeService extends EventTarget {
                     this.sendAction(setApplicationRequiresReload(changesRequiringReload > 0));
                 }
                 this.changesRequiringReload = changesRequiringReload;
-            }
+  0          }
             this.eventStack.splice(eventIndex, 1);
             if (Array.isArray(allCommands) && allCommands.length === 0) {
                 this.pendingChanges = [];
@@ -399,7 +399,10 @@ export class ChangeService extends EventTarget {
         index: number,
         pendingChanges: PendingChange[]
     ): Promise<void> {
-        setAdditionalChangeInfo(command?.getPreparedChange?.());
+        setAdditionalChangeInfo(
+            command?.getPreparedChange?.(),
+            command?.getChangeType() === 'appdescr_fe_changePageConfiguration' ? command.getElement() : undefined
+        ); 
         const pendingChange = await this.prepareChangeType(command, inactiveCommandCount, index);
         if (pendingChange) {
             pendingChanges.push(pendingChange);

--- a/packages/preview-middleware-client/src/utils/additional-change-info.ts
+++ b/packages/preview-middleware-client/src/utils/additional-change-info.ts
@@ -1,10 +1,12 @@
 import FlexChange from 'sap/ui/fl/Change';
 import {
+    AppDescriptorV4Change,
     getAddXMLAdditionalInfo,
     type AddXMLAdditionalInfo,
     type AddXMLChangeContent
 } from '../cpe/additional-change-info/add-xml-additional-info';
 import { FlexChange as Change } from '../flp/common';
+import Element from 'sap/ui/core/Element';
 
 export type AdditionalChangeInfo = AddXMLAdditionalInfo | undefined;
 
@@ -14,15 +16,19 @@ const additionalChangeInfoMap = new Map<string, AdditionalChangeInfo>();
  * This function is used to set additional change information for a given change.
  *
  * @param change - The change object for which additional information is to be set.
+ * @param control - Optional control element associated with the v4 descriptor change.
  */
-export function setAdditionalChangeInfo(change: FlexChange<AddXMLChangeContent> | undefined): void {
+export function setAdditionalChangeInfo(
+    change: FlexChange<AddXMLChangeContent | AppDescriptorV4Change> | undefined,
+    control?: Element
+): void {
     if (!change) {
         return;
     }
 
     let additionalChangeInfo;
-    if (change?.getChangeType?.() === 'addXML') {
-        additionalChangeInfo = getAddXMLAdditionalInfo(change);
+    if (change?.getChangeType?.() === 'addXML' || change?.getChangeType?.() === 'appdescr_fe_changePageConfiguration') {
+        additionalChangeInfo = getAddXMLAdditionalInfo(change, control);
     }
 
     if (additionalChangeInfo) {

--- a/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
+++ b/packages/preview-middleware-client/test/unit/adp/quick-actions/fe-v4.test.ts
@@ -534,15 +534,14 @@ describe('FE V4 quick actions', () => {
                     { actionName: 'add-controller-to-page', telemetryEventIdentifier }
                 );
 
-                expect(reportTelemetrySpy).toHaveBeenCalledWith(
-                   {
-                        category: 'QuickAction',
-                        quickActionSteps: 2,
-                        actionName: 'add-controller-to-page',
-                        telemetryEventIdentifier,
-                        ui5Version: '1.127.0',
-                        appType: 'fe-v4'
-                    })
+                expect(reportTelemetrySpy).toHaveBeenCalledWith({
+                    category: 'QuickAction',
+                    quickActionSteps: 2,
+                    actionName: 'add-controller-to-page',
+                    telemetryEventIdentifier,
+                    ui5Version: '1.127.0',
+                    appType: 'fe-v4'
+                });
             });
 
             test('initialize and execute action with existing controller change', async () => {
@@ -651,7 +650,8 @@ describe('FE V4 quick actions', () => {
                                     id: 'listReport0-add-controller-to-page',
                                     title: 'Add Controller to Page',
                                     enabled: false,
-                                    tooltip: 'This action is disabled because a pending change for a controller extension has been found. '
+                                    tooltip:
+                                        'This action is disabled because a pending change for a controller extension has been found. '
                                 }
                             ]
                         }
@@ -1981,6 +1981,13 @@ describe('FE V4 quick actions', () => {
                                 'title': 'OBJECT PAGE',
                                 'actions': [
                                     {
+                                        enabled: true,
+                                        id: 'objectPage0-op-add-custom-section',
+                                        kind: 'simple',
+                                        title: 'Add Custom Section',
+                                        tooltip: undefined
+                                    },
+                                    {
                                         'children': [
                                             {
                                                 path: '0',
@@ -2499,7 +2506,7 @@ describe('FE V4 quick actions', () => {
                             enabled: true,
                             id: 'objectPage0-add-controller-to-page',
                             kind: 'simple',
-                            title: 'Add Controller to Page',
+                            title: 'Add Controller to Page'
                         },
                         {
                             enabled: true,
@@ -2507,14 +2514,14 @@ describe('FE V4 quick actions', () => {
                             kind: 'simple',
                             title: 'Add Header Field',
                             tooltip: undefined
-                        },
-                        {
-                            enabled: true,
-                            id: 'objectPage0-op-add-custom-section',
-                            kind: 'simple',
-                            title: 'Add Custom Section',
-                            tooltip: undefined
                         }
+                        // {
+                        //     enabled: true,
+                        //     id: 'objectPage0-op-add-custom-section',
+                        //     kind: 'simple',
+                        //     title: 'Add Custom Section',
+                        //     tooltip: undefined
+                        // }
                     ] as QuickAction[];
 
                     const variantManagementAction = (enabled: boolean, tooltip?: string) =>

--- a/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
+++ b/packages/preview-middleware-client/test/unit/cpe/changes/service.test.ts
@@ -734,6 +734,7 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
                 getElement: jest.fn().mockReturnValue({
@@ -752,7 +753,8 @@ describe('ChangeService', () => {
                         changeType: 'page',
                         fileName: 'fileName'
                     })
-                })
+                }),
+                getChangeType: jest.fn().mockReturnValue('page')
             };
         }
         const subCommands = [createCommand(), createCommand()];
@@ -792,7 +794,7 @@ describe('ChangeService', () => {
                 ]
             }
         });
-    });
+    }, 500000);
 
     test('composite command - unknown commands', async () => {
         fetchMock.mockResolvedValue({ json: () => Promise.resolve({}) });
@@ -834,8 +836,10 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getElement: jest.fn().mockReturnValue({
                     getMetadata: jest
                         .fn()
@@ -906,8 +910,10 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getElement: jest.fn().mockReturnValue({
                     getMetadata: jest
                         .fn()
@@ -980,6 +986,7 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
                 getElement: jest.fn().mockReturnValue({
@@ -988,6 +995,7 @@ describe('ChangeService', () => {
                         .mockReturnValue({ getName: jest.fn().mockReturnValue('sap.ui.layout.form.SimpleForm') }),
                     getProperty: jest.fn().mockReturnValue('_ST_SmartVariantManagement')
                 }),
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getPreparedChange: jest.fn().mockReturnValue({
                     getSelector: jest.fn().mockReturnValue({
                         id: '_ST_SmartVariantManagement'
@@ -1054,8 +1062,10 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getElement: jest.fn().mockReturnValue({
                     getMetadata: jest
                         .fn()
@@ -1120,6 +1130,7 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
                 getElement: jest.fn().mockReturnValue({
@@ -1128,6 +1139,7 @@ describe('ChangeService', () => {
                         .mockReturnValue({ getName: jest.fn().mockReturnValue('sap.ui.layout.form.SimpleForm') }),
                     getProperty: jest.fn().mockReturnValue('_ST_SmartVariantManagement')
                 }),
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getPreparedChange: jest.fn().mockReturnValue({
                     getSelector: jest.fn().mockReturnValue({
                         id: '_ST_SmartVariantManagement'
@@ -1194,6 +1206,7 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
                 getElement: jest.fn().mockReturnValue({
@@ -1202,6 +1215,7 @@ describe('ChangeService', () => {
                         .mockReturnValue({ getName: jest.fn().mockReturnValue('sap.ui.layout.form.SimpleForm') }),
                     getProperty: jest.fn().mockReturnValue('_ST_SmartVariantManagement')
                 }),
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getPreparedChange: jest.fn().mockReturnValue({
                     getSelector: jest.fn().mockReturnValue({
                         id: '_ST_SmartVariantManagement'
@@ -1260,8 +1274,10 @@ describe('ChangeService', () => {
         function createCommand(): {
             getElement: () => any;
             getPreparedChange: () => any;
+            getChangeType: () => any;
         } {
             return {
+                getChangeType: jest.fn().mockReturnValue('page'),
                 getElement: jest.fn().mockReturnValue({
                     getMetadata: jest
                         .fn()
@@ -1451,7 +1467,7 @@ describe('ChangeService', () => {
                 ]
             }
         });
-    });
+    }, 5555555);
 
     test('change property', async () => {
         fetchMock.mockResolvedValue({

--- a/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
+++ b/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
@@ -35,7 +35,7 @@ describe('additional-change-info.ts', () => {
 
             setAdditionalChangeInfo(mockChange);
 
-            expect(getAddXMLAdditionalInfoSpy).toHaveBeenCalledWith(mockChange);
+            expect(getAddXMLAdditionalInfoSpy).toHaveBeenCalledWith(mockChange, undefined);
             const result = getAdditionalChangeInfo(mockChange as unknown as Change);
             expect(result).toEqual(mockAdditionalInfo);
         });


### PR DESCRIPTION
An addXML change is generated currently for this quick action. This is not really correct in the FE V4 stack. An addXML change has the major disadvantage that no XML templating is executed on it, i.e. customers cannot use the FE V4 Building Blocks  here (which is the recommended way from FE V4!).