### PR TITLE
fix(launch-config): fix start mock args for launch config

### DIFF
--- a/.changeset/mighty-bottles-clap.md
+++ b/.changeset/mighty-bottles-clap.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/launch-config': patch
+---
+
+fix start mock args in launch config

--- a/packages/launch-config/src/debug-config/config.ts
+++ b/packages/launch-config/src/debug-config/config.ts
@@ -15,7 +15,7 @@ const testFlpSandboxMockServerHtml = 'test/flpSandboxMockServer.html';
  * @param {string} [migratorMockIntent] - The optional mock intent string to be used in the migrator.
  * @returns {string | undefined} - The migrator mock intent prefixed with `#` or undefined.
  */
-export function getMigratorMockIntentWithHash(migratorMockIntent?: string): string | undefined {
+function getMigratorMockIntentWithHash(migratorMockIntent?: string): string | undefined {
     if (!migratorMockIntent) {
         return undefined;
     }
@@ -29,20 +29,22 @@ export function getMigratorMockIntentWithHash(migratorMockIntent?: string): stri
  *
  * @param {boolean} isMigrator - Indicates whether the application is being migrated.
  * @param {string} odataVersion - The version of OData being used (`2.0` or `4.0`).
- * @param {string | undefined} targetMockHtmlFile - The target mock HTML file, can be `undefined`.
+ * @param {string} targetMockHtmlFile - The target mock HTML file, can be `undefined`.
+ * @param {string} startHtmlFile - The starting HTML file to be used.
  * @param {string} params - The parameters to append to the mock HTML file.
  * @returns {string[]} - The command arguments used for starting flp sandbox html.
  */
-export function getMockCmdArgs(
+function getMockCmdArgs(
     isMigrator: boolean,
     odataVersion: string,
-    targetMockHtmlFile: string | undefined,
-    params: string
+    targetMockHtmlFile?: string,
+    startHtmlFile?: string,
+    params?: string
 ): string[] {
     if (isMigrator && odataVersion === '2.0') {
-        return ['--open', `${targetMockHtmlFile ?? testFlpSandboxHtml}${params}`];
+        return ['--open', `${targetMockHtmlFile ?? startHtmlFile}${params}`];
     }
-    return ['--config', './ui5-mock.yaml', '--open', `${testFlpSandboxHtml}${params}`];
+    return ['--config', './ui5-mock.yaml', '--open', `${startHtmlFile}${params}`];
 }
 
 /**
@@ -147,7 +149,7 @@ export function configureLaunchJsonFile(
     if (odataVersion && ['2.0', '4.0'].includes(odataVersion)) {
         const migratorMockIntentWithHash = getMigratorMockIntentWithHash(migratorMockIntent);
         const params = migratorMockIntentWithHash ?? flpAppIdWithHash;
-        const mockCmdArgs = getMockCmdArgs(isMigrator, odataVersion, targetMockHtmlFile, params);
+        const mockCmdArgs = getMockCmdArgs(isMigrator, odataVersion, targetMockHtmlFile, startHtmlFile, params);
         const mockConfig = configureLaunchConfig(
             `Start ${projectName} Mock`,
             cwd,

--- a/packages/launch-config/test/debug-config/config.test.ts
+++ b/packages/launch-config/test/debug-config/config.test.ts
@@ -165,11 +165,30 @@ describe('debug config tests', () => {
         configOptions.flpSandboxAvailable = false;
         configOptions.flpAppId = 'app-preview';
         const launchFile = configureLaunchJsonFile(projectPath, cwd, configOptions, 'test/flp.html');
+
+        // live config
+        const liveConfig = {
+            ...liveConfigurationObj,
+            args: ['--config', './ui5-local.yaml', '--open', 'test/flp.html#app-preview']
+        };
+        expect(findConfiguration(launchFile, `Start ${projectName}`)).toEqual({
+            ...liveConfig,
+            args: ['--open', 'test/flp.html#app-preview']
+        });
+
+        // local config
         const localConfig = {
             ...localConfigurationObj,
             args: ['--config', './ui5-local.yaml', '--open', 'test/flp.html#app-preview']
         };
         expect(findConfiguration(launchFile, `Start ${projectName} Local`)).toEqual(localConfig);
+
+        // mock config
+        const mockConfig = {
+            ...mockConfigurationObj,
+            args: ['--config', './ui5-mock.yaml', '--open', 'test/flp.html#app-preview']
+        };
+        expect(findConfiguration(launchFile, `Start ${projectName} Mock`)).toEqual(mockConfig);
     });
 
     it('Should return correct configuration when migrator mock intent is provided', () => {


### PR DESCRIPTION
Ensure `Start xxx Mock` launch config has the correct args (html file) in a virtual endpoint scenario