### PR TITLE
fix(app-config):fix ui5.yaml file path error

### DIFF
--- a/.changeset/chatty-moles-switch.md
+++ b/.changeset/chatty-moles-switch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': patch
+---
+
+fix ui5.yaml file path error

--- a/packages/app-config-writer/src/cards-config/index.ts
+++ b/packages/app-config-writer/src/cards-config/index.ts
@@ -79,12 +79,12 @@ async function updatePackageJson(basePath: string, fs: Editor, yamlPath?: string
     const packageJson = (fs.readJSON(packageJsonPath) ?? {}) as Package;
     const ui5YamlFile = yamlPath ? basename(yamlPath) : FileName.Ui5Yaml;
     const ui5YamlConfig = await readUi5Yaml(basePath, ui5YamlFile, fs);
-    const previewMiddleware = await getPreviewMiddleware(ui5YamlConfig, basePath, yamlPath, fs);
+    const previewMiddleware = await getPreviewMiddleware(ui5YamlConfig, basePath, ui5YamlFile, fs);
     const intent = getIntentFromPreviewConfig(previewMiddleware?.configuration) ?? '#app-preview';
     const cardGeneratorPath =
         (previewMiddleware?.configuration as PreviewConfig)?.editors?.cardGenerator?.path ??
         '/test/flpCardGeneratorSandbox.html';
-    const cliForPreview = await getCLIForPreview(basePath, yamlPath ?? '', fs);
+    const cliForPreview = await getCLIForPreview(basePath, ui5YamlFile, fs);
 
     packageJson.scripts ??= {};
     packageJson.scripts['start-cards-generator'] = `${cliForPreview} --open "${cardGeneratorPath}${intent}"`;

--- a/packages/app-config-writer/test/unit/cards-config/index.test.ts
+++ b/packages/app-config-writer/test/unit/cards-config/index.test.ts
@@ -20,7 +20,7 @@ describe('enableCardGenerator', () => {
     test('Valid LROP', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = createTestFs(basePath);
-        await enableCardGeneratorConfig(basePath, 'ui5.yaml', undefined, fs);
+        await enableCardGeneratorConfig(basePath, join(basePath, 'ui5.yaml'), undefined, fs);
 
         expect(fs.read(join(basePath, 'package.json'))).toMatchSnapshot();
         expect(fs.read(join(basePath, 'ui5.yaml'))).toMatchSnapshot();
@@ -29,7 +29,7 @@ describe('enableCardGenerator', () => {
     test('V4 LROP with CLI 3.0', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = create(createStorage());
-        await enableCardGeneratorConfig(basePath, 'ui5.yaml', undefined, fs);
+        await enableCardGeneratorConfig(basePath, join(basePath, 'ui5.yaml'), undefined, fs);
 
         if (process.env.UX_DEBUG) {
             fs.commit(() => {});
@@ -42,7 +42,7 @@ describe('enableCardGenerator', () => {
     test('Valid LROP without cardGenerator config', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = create(createStorage());
-        await enableCardGeneratorConfig(basePath, 'ui5-without-generator.yaml', undefined, fs);
+        await enableCardGeneratorConfig(basePath, join(basePath, 'ui5-without-generator.yaml'), undefined, fs);
 
         if (process.env.UX_DEBUG) {
             fs.commit(() => {});
@@ -55,7 +55,7 @@ describe('enableCardGenerator', () => {
     test('Valid LROP with deprecated preview config', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = create(createStorage());
-        await enableCardGeneratorConfig(basePath, 'ui5-with-deprecated-config.yaml', undefined, fs);
+        await enableCardGeneratorConfig(basePath, join(basePath, 'ui5-with-deprecated-config.yaml'), undefined, fs);
 
         if (process.env.UX_DEBUG) {
             fs.commit(() => {});
@@ -68,7 +68,7 @@ describe('enableCardGenerator', () => {
     test('Valid LROP with deprecated rta config', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = create(createStorage());
-        await enableCardGeneratorConfig(basePath, 'ui5-with-deprecated-rta-config.yaml', undefined, fs);
+        await enableCardGeneratorConfig(basePath, join(basePath, 'ui5-with-deprecated-rta-config.yaml'), undefined, fs);
 
         if (process.env.UX_DEBUG) {
             fs.commit(() => {});
@@ -81,7 +81,12 @@ describe('enableCardGenerator', () => {
     test('Valid LROP with deprecated config with cards generator', async () => {
         const basePath = join(__dirname, '../../fixtures/cards-config/lrop-v4');
         const fs = create(createStorage());
-        await enableCardGeneratorConfig(basePath, 'ui5-with-deprecated-config-and-cards-generator.yaml', undefined, fs);
+        await enableCardGeneratorConfig(
+            basePath,
+            join(basePath, 'ui5-with-deprecated-config-and-cards-generator.yaml'),
+            undefined,
+            fs
+        );
 
         if (process.env.UX_DEBUG) {
             fs.commit(() => {});


### PR DESCRIPTION
#3407

Calls to `getPreviewMiddleware` expects the ui5.yaml fule name - not the path