### PR TITLE
fix(odata-inquirer): ensure user display name is assigned to backend system

### DIFF
--- a/.changeset/three-ladybugs-boil.md
+++ b/.changeset/three-ladybugs-boil.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+ensure userdisplayname is assigned to backend system

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -1054,6 +1054,7 @@ export class ConnectionValidator {
 
             if (valResult === true) {
                 if (this.validity.authenticated === true) {
+                    this._connectedUserName = username;
                     return { valResult: true };
                 } else if (this.validity.authenticated === false) {
                     return { valResult: t('errors.authenticationFailed'), errorType: ERROR_TYPE.AUTH };

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/credentials/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/credentials/questions.ts
@@ -155,7 +155,7 @@ function updatePromptStateWithConnectedSystem(
             PromptState.odataService.connectedSystem.backendSystem = Object.assign(backendSystem, {
                 username: username,
                 password,
-                userDisplayName: username, // userDisplayName needs also to be updated
+                userDisplayName: username,
                 newOrUpdated: true
             } as Partial<BackendSystem>);
         }

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/credentials/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/credentials/questions.ts
@@ -155,6 +155,7 @@ function updatePromptStateWithConnectedSystem(
             PromptState.odataService.connectedSystem.backendSystem = Object.assign(backendSystem, {
                 username: username,
                 password,
+                userDisplayName: username, // userDisplayName needs also to be updated
                 newOrUpdated: true
             } as Partial<BackendSystem>);
         }

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/new-system/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/new-system/questions.test.ts
@@ -82,7 +82,7 @@ describe('Test new system prompt', () => {
             refreshToken: undefined,
             serviceKeys: undefined,
             url: 'http://abap.on.prem:1234',
-            userDisplayName: undefined,
+            userDisplayName: 'user01',
             username: 'user01',
             newOrUpdated: true,
             systemType: 'OnPrem'
@@ -130,7 +130,7 @@ describe('Test new system prompt', () => {
             refreshToken: undefined,
             serviceKeys: undefined,
             url: 'http://mock.abap.on.prem:4300',
-            userDisplayName: undefined,
+            userDisplayName: 'testUser',
             username: 'testUser',
             newOrUpdated: true,
             systemType: 'OnPrem'


### PR DESCRIPTION
- When a validate connection is made for on prem (basic auth) - we need to assign the userdisplay name. Same is done for BTP systems https://github.com/SAP/open-ux-tools/blob/3c63deb8df253bfc9b607727e4361daa53cfe75a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts#L673
- Also updates the `userDisplayName` this when system credentials are updated for an existing system