### PR TITLE
feat: Add optional  isActive parameter to  isExtensionInstalled function

### DIFF
--- a/.changeset/loud-ants-visit.md
+++ b/.changeset/loud-ants-visit.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-generator-shared': minor
+---
+
+Add optional isActive parameter to isExtensionInstalled function

--- a/packages/fiori-generator-shared/test/installedCheck.test.ts
+++ b/packages/fiori-generator-shared/test/installedCheck.test.ts
@@ -19,4 +19,36 @@ describe('Installed module checker', () => {
         expect(isExtensionInstalled(mockVSCodeRef, 'version.equal.extension', '1.2.3')).toBe(true);
         expect(isExtensionInstalled(mockVSCodeRef, 'version.lower.extension', '0.0.1')).toBe(true);
     });
+
+    test('isExtensionInstalled with isActive parameter', () => {
+        const mockVSCodeRefActive = {
+            extensions: {
+                getExtension: () => ({
+                    packageJSON: {
+                        version: '1.2.3'
+                    },
+                    isActive: true
+                })
+            }
+        };
+
+        const mockVSCodeRefInactive = {
+            extensions: {
+                getExtension: () => ({
+                    packageJSON: {
+                        version: '1.2.3'
+                    },
+                    isActive: false
+                })
+            }
+        };
+
+        // active extension checks
+        expect(isExtensionInstalled(mockVSCodeRefActive, 'active.extension', undefined, true)).toBe(true);
+        expect(isExtensionInstalled(mockVSCodeRefActive, 'active.extension', '1.2.3', true)).toBe(true);
+
+        // inactive extension checks
+        expect(isExtensionInstalled(mockVSCodeRefInactive, 'inactive.extension', undefined, true)).toBe(false);
+        expect(isExtensionInstalled(mockVSCodeRefInactive, 'inactive.extension', '1.2.3', true)).toBe(false);
+    });
 });


### PR DESCRIPTION

- Enhanced the `isExtensionInstalled` function to include an optional `isActive` parameter.
- The `isActive` parameter defaults to `false` and allows checking if the extension is active.