### PR TITLE
Fix/preview middleware/no default for rta layer

### DIFF
--- a/.changeset/five-dingos-buy.md
+++ b/.changeset/five-dingos-buy.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/preview-middleware': patch
+---
+
+fix: default layer for rta

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -292,7 +292,7 @@ export class FlpSandbox {
             config.ui5.libs = libs.join(',');
         }
         config.flex = {
-            layer: rta.layer,
+            layer: rta.layer ?? 'CUSTOMER_BASE',
             ...rta.options,
             generator: editor.generator ?? defaultGenerator,
             developerMode: editor.developerMode === true,


### PR DESCRIPTION
According to the documentation `CUSTOMER_BASE` is the default rta layer, but currently it's not. This is fixed in this PR.