### PR TITLE
fix(project-access): method getSpecificationPath returns corrupted path when local specification is linked

### DIFF
--- a/.changeset/eleven-rabbits-hammer.md
+++ b/.changeset/eleven-rabbits-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+fix: correct `getSpecificationPath` to return the right path when local specification is linked as a dependency

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -457,7 +457,7 @@
             "request": "launch",
             "name": "project-access: Debug Current Jest File",
             "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
-            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
+            "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js", "--coverage=false"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "windows": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -457,7 +457,7 @@
             "request": "launch",
             "name": "project-access: Debug Current Jest File",
             "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
-            "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js", "--coverage=false"],
+            "args": ["${file}", "--config", "jest.config.js", "--coverage=false"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "windows": {

--- a/packages/project-access/src/project/specification.ts
+++ b/packages/project-access/src/project/specification.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { readdir } from 'fs/promises';
-import { join } from 'path';
+import { join, dirname, sep } from 'path';
 import { valid } from 'semver';
 import type { Logger } from '@sap-ux/logger';
 import { deleteModule, getModule, getModulePath, loadModuleFromProject } from './module-loader';
@@ -191,10 +191,10 @@ function extractSpecificationBasePath(modulePath: string): string {
             modulePath.lastIndexOf(specificationNodeModuleFolder) + specificationNodeModuleFolder.length
         );
     } else {
-        const specificationFolder = join('packages', 'specification');
-        const specificationDistFolder = join(specificationFolder, 'dist');
-        if (modulePath.includes(specificationDistFolder)) {
-            return modulePath.slice(0, modulePath.lastIndexOf(specificationDistFolder) + specificationFolder.length);
+        let moduleFolderPath = dirname(modulePath);
+        if (moduleFolderPath.endsWith(`${sep}dist`)) {
+            // remove 'dist' folder
+            return dirname(moduleFolderPath);
         }
     }
     throw new Error(`Unsupported specification module path: ${modulePath}`);

--- a/packages/project-access/src/project/specification.ts
+++ b/packages/project-access/src/project/specification.ts
@@ -191,7 +191,7 @@ function extractSpecificationBasePath(modulePath: string): string {
             modulePath.lastIndexOf(specificationNodeModuleFolder) + specificationNodeModuleFolder.length
         );
     } else {
-        let moduleFolderPath = dirname(modulePath);
+        const moduleFolderPath = dirname(modulePath);
         if (moduleFolderPath.endsWith(`${sep}dist`)) {
             // remove 'dist' folder
             return dirname(moduleFolderPath);

--- a/packages/project-access/test/project/specification.test.ts
+++ b/packages/project-access/test/project/specification.test.ts
@@ -113,7 +113,7 @@ describe('Test getSpecification', () => {
 
     test('Get specification path from project - unsupported path', async () => {
         const specificationLocalFolder = join('SAPDevelop', 'dummy');
-        const dummyModuleJsFile = join(specificationLocalFolder, 'dist', 'index-min.js');
+        const dummyModuleJsFile = join(specificationLocalFolder, 'index-min.js');
         getModulePathSpy.mockResolvedValue(dummyModuleJsFile);
         const logger = getMockLogger();
         const root = join(__dirname, '../test-data/module-loader/@sap/ux-specification/0.1.2');


### PR DESCRIPTION
Issue #3436

### Steps to Reproduce
Steps to reproduce the behavior:
1. Setup fiori application to point to local `@sap/ux-specification'` source - use `nom link' or ` "@sap/ux-specification": "file:./....",` approach
2. Call function `getSpecificationPath`

Problem, following wrong path is returned:

<img width="1384" height="476" alt="Image" src="https://github.com/user-attachments/assets/b127bd56-d57f-4f39-aef4-71629cd88080" />

Changes:
1. As fix - if original approach with `node_modules/@sap/ux-specification` path fails, then resolve path using `packages/specification/dist` path as target.
2. Throw error if path is failed to resolve;