### PR TITLE
Bugfix/preview-config-ui5-cli-4

### DIFF
--- a/.changeset/fuzzy-tomatoes-give.md
+++ b/.changeset/fuzzy-tomatoes-give.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': minor
+---
+
+fix the error related to the @ui5/cli dependency with the ^4 version range

--- a/packages/app-config-writer/src/preview-config/prerequisites.ts
+++ b/packages/app-config-writer/src/preview-config/prerequisites.ts
@@ -8,7 +8,7 @@ import {
     hasDependency
 } from '@sap-ux/project-access';
 import type { ToolsLogger } from '@sap-ux/logger';
-import { satisfies, valid } from 'semver';
+import { satisfies, valid, validRange, outside } from 'semver';
 
 const packageName = {
     WDIO_QUNIT_SERVICE: 'wdio-qunit-service',
@@ -42,6 +42,10 @@ function isLowerThanMinimalVersion(
     if (versionInfo === 'latest') {
         // In case of 'latest' we know the minimal version is met
         return false;
+    }
+    if (validRange(versionInfo)) {
+        // In case of a valid range the minimal version must not be outside the range in high direction
+        return outside(minVersionInfo, versionInfo, '>');
     }
     if (valid(versionInfo)) {
         // In case of a valid version we add a prefix to make it a range

--- a/packages/app-config-writer/test/unit/preview-config/prerequisites.test.ts
+++ b/packages/app-config-writer/test/unit/preview-config/prerequisites.test.ts
@@ -44,6 +44,18 @@ describe('prerequisites', () => {
         );
     });
 
+    test('check prerequisites with UI5 cli 3.0 dependency', async () => {
+        fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '3.0.0' } }));
+
+        expect(await checkPrerequisites(basePath, fs, false, logger)).toBeTruthy();
+    });
+
+    test('check prerequisites with UI5 cli 4.0 dependency', async () => {
+        fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '4.0.0' } }));
+
+        expect(await checkPrerequisites(basePath, fs, false, logger)).toBeTruthy();
+    });
+
     test('check prerequisites with UI5 cli ^3 dependency', async () => {
         fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '^3' } }));
 
@@ -57,6 +69,12 @@ describe('prerequisites', () => {
         expect(errorLogMock).toHaveBeenCalledWith(
             'UI5 CLI version 3.0.0 or higher is required to convert the preview to virtual files. For more information, see https://sap.github.io/ui5-tooling/v3/updates/migrate-v3.'
         );
+    });
+
+    test('check prerequisites with UI5 cli ^4 dependency', async () => {
+        fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '^4' } }));
+
+        expect(await checkPrerequisites(basePath, fs, false, logger)).toBeTruthy();
     });
 
     test('check prerequisites with UI5 ux-ui5-tooling 1.16.0 dependency', async () => {


### PR DESCRIPTION
## Issue
When a Fiori Elements project is set with  @ui5/cli dependency with the ^4 version range the following error occurs when trying to setup preview config from Application Information page: "UI5 CLI version 3.0.0 or higher is required to convert the preview to virtual files."

## Expected behavior
^4 version range is higher than the minimal required version 3.0.0 so no error should be raised.

## Fix
Logic to take higher version ranges into account has been added.

## Test
Missing unit tests for ^4 version range have been added.