### PR TITLE
Fix(app config writer): prerequisites check for convert preview config

### DIFF
--- a/.changeset/two-dolphins-help.md
+++ b/.changeset/two-dolphins-help.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': patch
+---
+
+fix: prerequisites check for convert preview config

--- a/packages/app-config-writer/test/unit/preview-config/prerequisites.test.ts
+++ b/packages/app-config-writer/test/unit/preview-config/prerequisites.test.ts
@@ -50,6 +50,18 @@ describe('prerequisites', () => {
         expect(await checkPrerequisites(basePath, fs, false, logger)).toBeTruthy();
     });
 
+    test('check prerequisites with UI5 cli ^4 dependency', async () => {
+        fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '^4' } }));
+
+        expect(await checkPrerequisites(basePath, fs, false, logger)).toBeTruthy();
+    });
+
+    test('check prerequisites with invalid UI5 cli dependency', async () => {
+        fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': 'foo' } }));
+
+        expect(await checkPrerequisites(basePath, fs, false, logger)).toBeFalsy();
+    });
+
     test('check prerequisites with UI5 cli ^2 dependency', async () => {
         fs.write(join(basePath, 'package.json'), JSON.stringify({ devDependencies: { '@ui5/cli': '^2' } }));
 


### PR DESCRIPTION
The `isLowerThanMinimalVersion` check was erroneous for e.g. `minVersionInfo` `'3.0.0'` and `versionInfo` `'^4'`. The check did not consider higher ranges and somebody forgot to write unit test for that 🙈 