### PR TITLE
test(preview-middleware): add adaptation editor integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,98 @@
+name: Integration Tests
+
+on:
+    workflow_dispatch:
+    # workflow_run:
+    #     workflows: ["CI/CD Pipeline"]
+    # workflow_call:
+    #     # workflows: ["CI/CD Pipeline"]
+    #     secrets:
+    #         personal_access_token:
+    #             required: true
+        
+jobs:
+    ui5-versions:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        outputs:
+            ui5_versions: ${{ steps.output-ui5-versions.outputs.ui5_versions }}
+        steps:
+            - name: Read UI5 versions from cache
+              uses: actions/cache/restore@v4
+              with:
+                path: |
+                  tests/integration/adaptation-editor/versions.json
+                key: ui5-versions
+                restore-keys: ui5-versions-
+            - name: Output UI5 versions
+              id: output-ui5-versions
+              run: |
+                  cat tests/integration/adaptation-editor/versions.json
+                  echo "ui5_versions=$(cat tests/integration/adaptation-editor/versions.json)" >> $GITHUB_OUTPUT
+                  
+    playwright-tests:
+        # if: github.repository == 'SAP/open-ux-tools' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        strategy:
+            fail-fast: false
+            matrix:
+                ui5-version: ${{ fromJson(needs.ui5-versions.outputs.ui5_versions) }}
+        runs-on: ubuntu-latest
+        needs: ui5-versions
+        timeout-minutes: 30
+        steps:
+            - name: Checkout code repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: true
+            - name: Cache pnpm modules
+              uses: actions/cache@v4
+              env:
+                  cache-name: cache-pnpm-modules
+              with:
+                  path: ~/.pnpm-store
+                  key: ubuntu-latest-build-${{ env.cache-name }}-20.x-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ubuntu-latest-build-build-${{ env.cache-name }}-20.x-
+            - name: Use Node.js 20.x
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - name: Install pnpm modules
+              run: pnpm install
+            - name: Run build
+              run: pnpm run build
+              env:
+                NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+            - name: Cache playwright browsers
+              id: cache-playwright-browsers
+              uses: actions/cache@v4
+              with:
+                path: |
+                    ~/.cache/ms-playwright
+                key: playwright-browsers-os-ubuntu-latest-node-version-20.x
+            - name: Install playwright chrome browsers
+              if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+              run: npx playwright install chrome
+            - name: Read UI5 versions from cache
+              uses: actions/cache/restore@v4
+              with:
+                path: |
+                  tests/integration/adaptation-editor/versions.json
+                key: ui5-versions-
+                restore-keys: ui5-versions
+            - name: Run playwright tests
+              run: cd tests/integration/adaptation-editor && pnpm exec playwright test --project=${{ matrix.ui5-version }} --reporter=blob
+              env:
+                NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+            - name: Upload blob report to GitHub Actions Artifacts
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                
+                name: blob-report-${{ matrix.ui5-version }}
+                path: tests/integration/adaptation-editor/blob-report
+                retention-days: 1

--- a/.github/workflows/ui5-maintenance-versions.yml
+++ b/.github/workflows/ui5-maintenance-versions.yml
@@ -1,0 +1,58 @@
+name: Update UI5 Maintenance Versions
+
+on:
+    workflow_dispatch:
+jobs:
+    ui5-versions:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        outputs:
+            ui5_versions: ${{ steps.output-ui5-versions.outputs.ui5_versions }}
+        steps:
+            - name: Checkout code repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  run_install: true
+            - name: Cache pnpm modules
+              uses: actions/cache@v4
+              env:
+                  cache-name: cache-pnpm-modules
+              with:
+                  path: ~/.pnpm-store
+                  key: ubuntu-latest-build-cache-pnpm-modules-20.x-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ubuntu-latest-build-$cache-pnpm-modules-20.x-
+            - name: Use Node.js 20.x
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - name: Install pnpm modules
+              run: pnpm install
+            - name: Run build
+              run: pnpm --filter @sap-ux/ui5-info... build 
+            - name: Cache UI5 maintenance versions 
+              id: cache-ui5-versions
+              uses: actions/cache/restore@v4
+              with:
+                  path: tests/integration/adaptation-editor/versions.json
+                  key: ui5-versions
+            - name: List previously cached UI5 maintenance versions
+              id: previous-ui5-versions
+              run: |
+                cat tests/integration/adaptation-editor/versions.json
+                echo "versions=$(cat tests/integration/adaptation-editor/versions.json)" >> $GITHUB_OUTPUT
+            - name: Load UI5 maintenance versions
+              id: current-ui5-versions
+              run: |
+                  cd tests/integration/adaptation-editor && pnpm exec node version.js
+                  cat versions.json
+                  echo "versions=$(cat versions.json)" >> $GITHUB_OUTPUT
+            - name: Cache ui5-versions modules
+              uses: actions/cache/save@v4
+              with:
+                  path: tests/integration/adaptation-editor/versions.json
+                  key: ui5-versions-${{fromJson(steps.current-ui5-versions.outputs.versions)[0]}}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "lint:fix": "nx run-many --target=lint:fix --all",
         "lint:dependency-versions": "check-dependency-version-consistency .",
         "test": "nx run-many --target=test --all",
-        "test:integration": "nx run-many --target=test:integration --all",
+        "test:integration": "nx run-many --target=test:integration --all --exclude @sap-ux-private/adaptation-editor-tests",
         "link": "pnpm recursive run link",
         "unlink": "pnpm recursive run unlink",
         "prepare": "husky install",
@@ -68,6 +68,7 @@
     "pnpm": {
         "overrides": {
             "router>path-to-regexp": "0.1.12",
+            "router@2.0.0>path-to-regexp": "8.2.0",
             "@storybook/manager-api>store2": "2.14.4"
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   router>path-to-regexp: 0.1.12
+  router@2.0.0>path-to-regexp: 8.2.0
   '@storybook/manager-api>store2': 2.14.4
 
 importers:
@@ -4508,6 +4509,76 @@ importers:
         specifier: 4.14.202
         version: 4.14.202
 
+  tests/fixtures/projects/mock:
+    devDependencies:
+      '@sap-ux/backend-proxy-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/backend-proxy-middleware
+      '@sap-ux/fe-mockserver-plugin-cds':
+        specifier: 1.2.6
+        version: 1.2.6(@sap/cds-compiler@4.8.0)
+      '@sap-ux/preview-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/preview-middleware
+      '@sap-ux/reload-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/reload-middleware
+      '@sap-ux/ui5-middleware-fe-mockserver':
+        specifier: 2.2.97
+        version: 2.2.97
+      '@sap-ux/ui5-proxy-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/ui5-proxy-middleware
+      '@ui5/cli':
+        specifier: '3'
+        version: 3.8.0
+
+  tests/integration/adaptation-editor:
+    dependencies:
+      '@sap-ux-private/playwright':
+        specifier: workspace:*
+        version: link:../../../packages/playwright
+      '@sap-ux/project-access':
+        specifier: workspace:*
+        version: link:../../../packages/project-access
+      '@sap-ux/ui5-info':
+        specifier: workspace:*
+        version: link:../../../packages/ui5-info
+      '@sap-ux/yaml':
+        specifier: workspace:*
+        version: link:../../../packages/yaml
+      adm-zip:
+        specifier: 0.5.10
+        version: 0.5.10
+      dotenv:
+        specifier: 16.3.1
+        version: 16.3.1
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      jest-dev-server:
+        specifier: 10.0.0
+        version: 10.0.0
+      npm-run-all2:
+        specifier: 6.2.0
+        version: 6.2.0
+      portfinder:
+        specifier: 1.0.32
+        version: 1.0.32
+      semver:
+        specifier: 7.7.1
+        version: 7.7.1
+    devDependencies:
+      '@types/adm-zip':
+        specifier: 0.5.5
+        version: 0.5.5
+      '@types/express':
+        specifier: 4.17.21
+        version: 4.17.21
+      '@types/semver':
+        specifier: 7.7.0
+        version: 7.7.0
+
   types:
     devDependencies:
       '@types/mem-fs-editor':
@@ -4850,7 +4921,7 @@ packages:
       '@babel/core': 7.22.20
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -4865,7 +4936,7 @@ packages:
       '@babel/core': 7.22.20
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -4880,7 +4951,7 @@ packages:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -7032,7 +7103,7 @@ packages:
       '@babel/parser': 7.25.3
       '@babel/template': 7.25.0
       '@babel/types': 7.25.2
-      debug: 4.3.7
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7075,7 +7146,7 @@ packages:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /@changesets/assemble-release-plan@6.0.5:
@@ -7086,7 +7157,7 @@ packages:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /@changesets/changelog-git@0.2.0:
@@ -7123,7 +7194,7 @@ packages:
       package-manager-detector: 0.2.2
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       spawndamnit: 3.0.1
       term-size: 2.2.1
     dev: true
@@ -7152,7 +7223,7 @@ packages:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /@changesets/get-release-plan@4.0.5:
@@ -7236,6 +7307,14 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+    dev: true
+
+  /@chevrotain/types@9.1.0:
+    resolution: {integrity: sha512-3hbCD1CThkv9gnaSIPq0GUXwKni68e0ph6jIHwCvcWiQ4JB2xi8bFxBain0RF04qHUWuDjgnZLj4rLgimuGO+g==}
+    dev: true
+
+  /@chevrotain/utils@9.1.0:
+    resolution: {integrity: sha512-llLJZ8OAlZrjGlBvamm6Zdo/HmGAcCLq5gx7cSwUX8No+n/8ip+oaC4x33IdZIif8+Rh5dQUIZXmfbSghiOmNQ==}
     dev: true
 
   /@colors/colors@1.5.0:
@@ -8370,7 +8449,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       ssri: 8.0.1
       treeverse: 1.0.4
       walk-up-path: 1.0.0
@@ -8388,7 +8467,7 @@ packages:
       nopt: 7.2.0
       proc-log: 3.0.0
       read-package-json-fast: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       walk-up-path: 3.0.1
     dev: true
 
@@ -8396,20 +8475,20 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   /@npmcli/fs@2.1.2:
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   /@npmcli/fs@3.1.0:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   /@npmcli/git@2.1.0:
     resolution: {integrity: sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==}
@@ -8420,7 +8499,7 @@ packages:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -8435,7 +8514,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -8450,7 +8529,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -8498,7 +8577,7 @@ packages:
       cacache: 15.3.0
       json-parse-even-better-errors: 2.3.1
       pacote: 12.0.3
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -8793,7 +8872,7 @@ packages:
       '@types/shimmer': 1.0.5
       import-in-the-middle: 1.4.2
       require-in-the-middle: 7.2.0
-      semver: 7.6.3
+      semver: 7.7.1
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -9011,13 +9090,47 @@ packages:
     resolution: {integrity: sha512-mLQTJv4SXyxbizE2guXi/m9BuFi+jcn7Vk8pGzkbdjWhBgI2OK0F30GXEsy7lprYFGycCLzXbBj/X7Unz+pIeg==}
     dependencies:
       '@sap-ux/vocabularies-types': 0.13.0
-    dev: false
 
   /@sap-ux/edmx-parser@0.9.1:
     resolution: {integrity: sha512-qgDXrJP+WtBbYJdedtCEVyIyKTs2eVcfplE2Mk4AbW8oxU85rqq8h8gNRoQlIUCcXXBJwXeoVlWTvSCF5mF7Rw==}
     dependencies:
       xml-js: 1.6.11
-    dev: false
+
+  /@sap-ux/fe-mockserver-core@1.4.25:
+    resolution: {integrity: sha512-NoYqHT5cwR5rmOY5phQNHk9jIfZNL1rwTr4RSnEvz6gBQAXCmjOUhSK3N9RFRdCy749MJRKuftH65f9zS6lanQ==}
+    dependencies:
+      '@sap-ux/annotation-converter': 0.10.3
+      '@sap-ux/edmx-parser': 0.9.1
+      balanced-match: 1.0.2
+      body-parser: 1.20.3
+      braces: 3.0.3
+      chevrotain: 9.1.0
+      chokidar: 3.6.0
+      etag: 1.8.1
+      graceful-fs: 4.2.11
+      lodash.clonedeep: 4.5.0
+      lodash.merge: 4.6.2
+      query-string: 7.1.3
+      router: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@sap-ux/fe-mockserver-plugin-cds@1.2.6(@sap/cds-compiler@4.8.0):
+    resolution: {integrity: sha512-CXyNgZ8Nuee638Afe74Y7afPhnk/bWAYDzmw/esh+5cdTLvSQfWGqwp5e/Qd72dA7mgiTZq4BV/SE0Rvp3G5AQ==}
+    peerDependencies:
+      '@sap/cds-compiler': ^4.8 || ^5.4
+    dependencies:
+      '@sap/cds-compiler': 4.8.0
+    dev: true
+
+  /@sap-ux/ui5-middleware-fe-mockserver@2.2.97:
+    resolution: {integrity: sha512-QQBvLo0EkmVJd+VfF99xvrgiIanSiwS8SrsqMgMzu7ZL1I2iKIC719QQcXCW2trEntRKmvgCKghbBxceuTa9JA==}
+    dependencies:
+      '@sap-ux/fe-mockserver-core': 1.4.25
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@sap-ux/vocabularies-types@0.13.0:
     resolution: {integrity: sha512-srR9ffXpgvVxsrD/3ZvX6PnxXyY6yeth6LuKfCDgcyDoPeRj1jQknpgVF+k9hHDv7LkGkDiHYvjWY+JP8OlDLw==}
@@ -9292,7 +9405,7 @@ packages:
     dependencies:
       '@storybook/core-webpack': 8.4.2(storybook@8.4.2)
       '@types/node': 22.9.0
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
@@ -9304,7 +9417,7 @@ packages:
       magic-string: 0.30.11
       path-browserify: 1.0.1
       process: 0.11.10
-      semver: 7.6.3
+      semver: 7.7.1
       storybook: 8.4.2(prettier@2.8.8)
       style-loader: 3.3.3(webpack@5.96.1)
       terser-webpack-plugin: 5.3.10(esbuild@0.19.2)(webpack@5.96.1)
@@ -9335,7 +9448,7 @@ packages:
     dependencies:
       '@storybook/core-webpack': 8.4.2(storybook@8.4.2)
       '@types/node': 22.9.0
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
@@ -9347,7 +9460,7 @@ packages:
       magic-string: 0.30.11
       path-browserify: 1.0.1
       process: 0.11.10
-      semver: 7.6.3
+      semver: 7.7.1
       storybook: 8.4.2(prettier@2.8.8)
       style-loader: 3.3.3(webpack@5.96.1)
       terser-webpack-plugin: 5.3.10(esbuild@0.19.2)(webpack@5.96.1)
@@ -9425,7 +9538,7 @@ packages:
       prettier: 2.8.8
       process: 0.11.10
       recast: 0.23.9
-      semver: 7.6.3
+      semver: 7.7.1
       util: 0.12.5
       ws: 8.18.0
     transitivePeerDependencies:
@@ -9496,14 +9609,14 @@ packages:
       '@storybook/react': 8.4.2(react-dom@16.14.0)(react@16.14.0)(storybook@8.4.2)(typescript@5.6.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.96.1)
       '@types/node': 22.9.0
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       find-up: 5.0.0
       magic-string: 0.30.11
       react: 16.14.0
       react-docgen: 7.0.3
       react-dom: 16.14.0(react@16.14.0)
       resolve: 1.22.8
-      semver: 7.6.3
+      semver: 7.7.1
       storybook: 8.4.2(prettier@2.8.8)
       tsconfig-paths: 4.2.0
       typescript: 5.6.2
@@ -9533,14 +9646,14 @@ packages:
       '@storybook/react': 8.4.2(react-dom@16.14.0)(react@16.14.0)(storybook@8.4.2)(typescript@5.8.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.3)(webpack@5.96.1)
       '@types/node': 22.9.0
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       find-up: 5.0.0
       magic-string: 0.30.11
       react: 16.14.0
       react-docgen: 7.0.3
       react-dom: 16.14.0(react@16.14.0)
       resolve: 1.22.8
-      semver: 7.6.3
+      semver: 7.7.1
       storybook: 8.4.2(prettier@2.8.8)
       tsconfig-paths: 4.2.0
       typescript: 5.8.3
@@ -9587,7 +9700,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -9606,7 +9719,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -10470,6 +10583,10 @@ packages:
 
   /@types/semver@7.5.8:
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+    dev: true
+
+  /@types/semver@7.7.0:
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   /@types/send@0.17.1:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
@@ -10908,10 +11025,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@5.6.2)
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -10929,10 +11046,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       tsutils: 3.21.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10954,7 +11071,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 1.3.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10976,7 +11093,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 1.2.1(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -10991,13 +11108,13 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.2)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11011,13 +11128,13 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
       eslint: 8.57.0
       eslint-scope: 5.1.1
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11047,12 +11164,12 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.8.3)
       eslint: 8.57.0
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11098,7 +11215,7 @@ packages:
       less-openui5: 0.11.6
       pretty-data: 0.40.0
       rimraf: 5.0.5
-      semver: 7.6.3
+      semver: 7.7.1
       terser: 5.32.0
       workerpool: 6.5.1
       xml2js: 0.6.2
@@ -11594,7 +11711,6 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: true
 
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
@@ -11963,7 +12079,6 @@ packages:
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-    dev: true
 
   /array-flatten@3.0.0:
     resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==}
@@ -12585,7 +12700,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -12761,7 +12875,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   /bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -12778,7 +12892,6 @@ packages:
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
@@ -13084,7 +13197,7 @@ packages:
       edit-json-file: 1.8.1
       globby: 14.1.0
       js-yaml: 4.1.0
-      semver: 7.6.3
+      semver: 7.7.1
       table: 6.9.0
       type-fest: 4.38.0
     dev: true
@@ -13117,6 +13230,14 @@ packages:
     resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
     dependencies:
       regexp-to-ast: 0.5.0
+
+  /chevrotain@9.1.0:
+    resolution: {integrity: sha512-A86/55so63HCfu0dgGg3j9u8uuuBOrSqly1OhBZxRu2x6sAKILLzfVjbGMw45kgier6lz45EzcjjWtTRgoT84Q==}
+    dependencies:
+      '@chevrotain/types': 9.1.0
+      '@chevrotain/utils': 9.1.0
+      regexp-to-ast: 0.5.0
+    dev: true
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -13581,12 +13702,10 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /continuation-local-storage@3.2.1:
     resolution: {integrity: sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==}
@@ -13606,12 +13725,10 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: true
 
   /cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -13918,7 +14035,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
-    dev: true
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -14163,7 +14279,6 @@ packages:
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
@@ -14176,7 +14291,6 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dev: true
 
   /detect-content-type@1.2.0:
     resolution: {integrity: sha512-YCBxuqJLY9rMxV44Ict2kNgjYFN3v1dnsn6sJvd6sUwwU1TWP3D+K2dr/S9AF/fio2/RsAKYdRiEOtNoRbmiag==}
@@ -14232,7 +14346,7 @@ packages:
   /diagnostic-channel@1.1.1:
     resolution: {integrity: sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: false
 
   /diff-sequences@29.6.3:
@@ -14415,7 +14529,6 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-    dev: true
 
   /ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -14466,12 +14579,10 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -15015,7 +15126,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.19.2
     transitivePeerDependencies:
       - supports-color
@@ -15142,7 +15253,6 @@ packages:
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-    dev: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -15320,7 +15430,7 @@ packages:
       eslint: 8.56.0
       esquery: 1.6.0
       is-builtin-module: 3.2.1
-      semver: 7.6.3
+      semver: 7.7.1
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15586,7 +15696,6 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -15735,7 +15844,6 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -15764,7 +15872,7 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -15912,6 +16020,11 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /filter-obj@2.0.2:
     resolution: {integrity: sha512-lO3ttPjHZRfjMcxWKb1j1eDhTFsu4meeR3lnMcnBFhk6RuLhvEiuALu2TlfL310ph4lCYYwgF/ElIjdP739tdg==}
     engines: {node: '>=8'}
@@ -15945,7 +16058,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
@@ -15984,7 +16096,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -16122,7 +16234,7 @@ packages:
       minimatch: 3.0.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.6.3
+      semver: 7.7.1
       tapable: 2.2.1
       typescript: 5.6.2
       webpack: 5.96.1(esbuild@0.19.2)
@@ -16145,7 +16257,7 @@ packages:
       minimatch: 3.0.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.6.3
+      semver: 7.7.1
       tapable: 2.2.1
       typescript: 5.8.3
       webpack: 5.96.1(esbuild@0.19.2)
@@ -16176,7 +16288,6 @@ packages:
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /fraction.js@4.3.6:
     resolution: {integrity: sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==}
@@ -16185,7 +16296,6 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -16496,7 +16606,7 @@ packages:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16593,7 +16703,7 @@ packages:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.6.3
+      semver: 7.7.1
       serialize-error: 7.0.1
     dev: true
 
@@ -16605,7 +16715,7 @@ packages:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.6.3
+      semver: 7.7.1
       serialize-error: 7.0.1
     dev: true
 
@@ -17075,7 +17185,6 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-    dev: true
 
   /http-proxy-agent@4.0.1:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
@@ -17093,7 +17202,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17319,6 +17428,7 @@ packages:
   /import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
+    hasBin: true
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
@@ -17462,7 +17572,6 @@ packages:
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-    dev: true
 
   /is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -17767,6 +17876,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: true
+
   /is-redirect@1.0.0:
     resolution: {integrity: sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==}
     engines: {node: '>=0.10.0'}
@@ -17998,7 +18111,7 @@ packages:
       '@babel/parser': 7.25.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18016,7 +18129,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -18476,7 +18589,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -18989,6 +19102,10 @@ packages:
   /lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  /lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+    dev: true
+
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
@@ -19188,7 +19305,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /make-error@1.3.6:
@@ -19372,7 +19489,6 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mem-fs-editor@9.4.0(mem-fs@2.1.0):
     resolution: {integrity: sha512-HSSOLSVRrsDdui9I6i96dDtG+oAez/4EB2g4cjSrNhgNQ3M+L57/+22NuPdORSoxvOHjIg/xeOE+C0wwF91D2g==}
@@ -19438,7 +19554,6 @@ packages:
   /memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
-    dev: true
 
   /meow@5.0.0:
     resolution: {integrity: sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==}
@@ -19457,7 +19572,6 @@ packages:
 
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-    dev: true
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -19474,12 +19588,11 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -19511,7 +19624,6 @@ packages:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -19733,7 +19845,6 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -19811,7 +19922,6 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -19873,7 +19983,7 @@ packages:
     resolution: {integrity: sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /node-abort-controller@3.1.1:
@@ -19910,7 +20020,7 @@ packages:
       make-fetch-happen: 13.0.0
       nopt: 7.2.0
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -19929,7 +20039,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -19949,7 +20059,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -20026,7 +20136,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.15.0
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
 
   /normalize-package-data@6.0.0:
@@ -20035,7 +20145,7 @@ packages:
     dependencies:
       hosted-git-info: 7.0.0
       is-core-module: 2.15.0
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -20095,13 +20205,13 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   /npm-install-checks@6.1.1:
     resolution: {integrity: sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   /npm-keyword@6.1.0:
     resolution: {integrity: sha512-ghcShMAA28IPhJAP4d3T+tndUPzHmvqEfaYwLG1whi4WJ06pdhA3vqL8gXF+Jn8wiqbaRuGVfjE5VXjOgVpW4Q==}
@@ -20133,7 +20243,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-name: 5.0.0
 
   /npm-package-arg@11.0.1:
@@ -20142,7 +20252,7 @@ packages:
     dependencies:
       hosted-git-info: 7.0.0
       proc-log: 3.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -20151,7 +20261,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-name: 3.0.0
 
   /npm-packlist@3.0.0:
@@ -20183,7 +20293,7 @@ packages:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.6.3
+      semver: 7.7.1
 
   /npm-pick-manifest@8.0.1:
     resolution: {integrity: sha512-mRtvlBjTsJvfCCdmPtiu2bdlx8d/KXtF7yNXNWe7G0Z36qWA9Ny5zXsI2PfBZEv7SXgoxTmNaTzGSbbzDZChoA==}
@@ -20192,7 +20302,7 @@ packages:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.6.3
+      semver: 7.7.1
 
   /npm-pick-manifest@9.0.0:
     resolution: {integrity: sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==}
@@ -20201,7 +20311,7 @@ packages:
       npm-install-checks: 6.1.1
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.1
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /npm-registry-fetch@12.0.2:
@@ -20258,7 +20368,6 @@ packages:
       pidtree: 0.6.0
       read-package-json-fast: 3.0.2
       shell-quote: 1.7.3
-    dev: true
 
   /npm-run-all2@7.0.2:
     resolution: {integrity: sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==}
@@ -20400,7 +20509,7 @@ packages:
       open: 8.4.2
       ora: 5.3.0
       resolve.exports: 2.0.3
-      semver: 7.6.3
+      semver: 7.7.1
       string-width: 4.2.3
       tar-stream: 2.2.0
       tmp: 0.2.3
@@ -20576,7 +20685,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
-    dev: true
 
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
@@ -20900,7 +21008,7 @@ packages:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.4.0
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -20948,7 +21056,7 @@ packages:
       got: 11.8.6
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /package-json@8.1.1:
@@ -20958,7 +21066,7 @@ packages:
       got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /package-manager-detector@0.2.2:
@@ -21141,7 +21249,6 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
@@ -21205,10 +21312,14 @@ packages:
 
   /path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-    dev: true
 
   /path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+    dev: true
+
+  /path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
     dev: true
 
   /path-type@3.0.0:
@@ -21261,7 +21372,6 @@ packages:
   /pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
-    dev: true
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -21694,14 +21804,13 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-    dev: true
 
   /proxy-agent@6.4.0:
     resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       lru-cache: 7.18.3
@@ -21798,6 +21907,16 @@ packages:
       strict-uri-encode: 1.1.0
     dev: true
 
+  /query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+    dev: true
+
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -21859,7 +21978,6 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -21869,7 +21987,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -22513,7 +22630,7 @@ packages:
     resolution: {integrity: sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==}
     engines: {node: '>=8.6.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -22731,6 +22848,19 @@ packages:
       - supports-color
     dev: true
 
+  /router@2.0.0:
+    resolution: {integrity: sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      array-flatten: 3.0.0
+      is-promise: 4.0.0
+      methods: 1.1.2
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+      setprototypeof: 1.2.0
+      utils-merge: 1.0.1
+    dev: true
+
   /rst-selector-parser@2.2.3:
     resolution: {integrity: sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==}
     dependencies:
@@ -22937,7 +23067,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /semver-regex@2.0.0:
@@ -22977,6 +23107,11 @@ packages:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
 
+  /semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   /send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -22996,7 +23131,6 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
@@ -23021,7 +23155,6 @@ packages:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -23057,7 +23190,6 @@ packages:
 
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-    dev: true
 
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -23083,7 +23215,6 @@ packages:
 
   /shell-quote@1.7.3:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
-    dev: true
 
   /shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
@@ -23219,7 +23350,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -23229,7 +23360,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -23377,7 +23508,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -23391,13 +23522,18 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
       spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
     dev: true
 
   /sprintf-js@1.0.3:
@@ -23466,7 +23602,6 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /store2@2.14.4:
     resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
@@ -23536,6 +23671,11 @@ packages:
   /strict-uri-encode@1.1.0:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
     dev: true
 
   /string-hash@1.1.3:
@@ -23831,7 +23971,7 @@ packages:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.11.0
-      semver: 7.6.3
+      semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -24157,7 +24297,6 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-    dev: true
 
   /tough-cookie@4.1.3:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
@@ -24422,7 +24561,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.3.7
+      debug: 4.4.0
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -24432,7 +24571,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.7
+      debug: 4.4.0
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -24534,7 +24673,6 @@ packages:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-    dev: true
 
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
@@ -24857,7 +24995,6 @@ packages:
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -24944,7 +25081,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.6.3
+      semver: 7.7.1
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: true
@@ -24964,7 +25101,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.6.3
+      semver: 7.7.1
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
@@ -25077,7 +25214,6 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-    dev: true
 
   /uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -25130,7 +25266,6 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
@@ -25670,7 +25805,6 @@ packages:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     dependencies:
       sax: 1.2.4
-    dev: false
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -25861,7 +25995,7 @@ packages:
       preferred-pm: 3.1.4
       pretty-bytes: 5.6.0
       readable-stream: 4.7.0
-      semver: 7.6.3
+      semver: 7.7.1
       slash: 3.0.0
       strip-ansi: 6.0.1
       text-table: 0.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
     - 'packages/*'
     - 'examples/*'
+    - 'tests/integration/*'
+    - 'tests/fixtures/projects/mock'
     - 'types'
     - '!**/test/**'

--- a/tests/fixtures/projects/mock/package.json
+++ b/tests/fixtures/projects/mock/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "test-project",
+    "version": "0.0.1",
+    "private": true,
+    "devDependencies": {
+        "@sap-ux/ui5-middleware-fe-mockserver": "2.2.97",
+        "@sap-ux/fe-mockserver-plugin-cds": "1.2.6",
+        "@sap-ux/preview-middleware": "workspace:*",
+        "@sap-ux/reload-middleware": "workspace:*",
+        "@sap-ux/backend-proxy-middleware": "workspace:*",
+        "@sap-ux/ui5-proxy-middleware": "workspace:*",
+        "@ui5/cli": "3"
+    }
+}

--- a/tests/integration/adaptation-editor/.eslintignore
+++ b/tests/integration/adaptation-editor/.eslintignore
@@ -1,0 +1,2 @@
+test/fixtures
+dist

--- a/tests/integration/adaptation-editor/.eslintrc.js
+++ b/tests/integration/adaptation-editor/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    extends: ['../../../.eslintrc'],
+    parserOptions: {
+        project: './tsconfig.eslint.json',
+        tsconfigRootDir: __dirname
+    }
+};

--- a/tests/integration/adaptation-editor/.gitignore
+++ b/tests/integration/adaptation-editor/.gitignore
@@ -1,0 +1,4 @@
+package-lock.json
+node_modules
+dist
+blob-report

--- a/tests/integration/adaptation-editor/LICENSE
+++ b/tests/integration/adaptation-editor/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/integration/adaptation-editor/README.md
+++ b/tests/integration/adaptation-editor/README.md
@@ -1,0 +1,4 @@
+# Integration tests for Adaptation Editor
+
+## Preview
+Folder for all integration tests of the Adaptation Editor

--- a/tests/integration/adaptation-editor/package.json
+++ b/tests/integration/adaptation-editor/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@sap-ux-private/adaptation-editor-tests",
+    "description": "Adaptation Editor UI tests",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "author": "@SAP/ux-tools-team",
+    "main": "dist/index.js",
+    "private": true,
+    "scripts": {
+        "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
+        "lint": "eslint . --ext .ts",
+        "lint:fix": "eslint . --ext .ts --fix",
+        "test:clean": "rimraf --glob playwright-report",
+        "test:run": "playwright test",
+        "test:integration": "npm-run-all -l -s test:clean test:run",
+        "link": "pnpm link --global",
+        "unlink": "pnpm unlink --global"
+    },
+    "dependencies": {
+        "@sap-ux/ui5-info": "workspace:*",
+        "@sap-ux-private/playwright": "workspace:*",
+        "@sap-ux/project-access": "workspace:*",
+        "@sap-ux/yaml": "workspace:*",
+        "adm-zip": "0.5.10",
+        "dotenv": "16.3.1",
+        "express": "4.21.2",
+        "jest-dev-server": "10.0.0",
+        "npm-run-all2": "6.2.0",
+        "portfinder": "1.0.32",
+        "semver": "7.7.1"
+    },
+    "devDependencies": {
+        "@types/adm-zip": "0.5.5",
+        "@types/express": "4.17.21",
+        "@types/semver": "7.7.0"
+    },
+    "engines": {
+        "node": ">=20.x"
+    }
+}

--- a/tests/integration/adaptation-editor/playwright.config.ts
+++ b/tests/integration/adaptation-editor/playwright.config.ts
@@ -1,0 +1,56 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import { defineConfig, devices } from '@sap-ux-private/playwright';
+import type { PlaywrightTestConfig, Project } from '@sap-ux-private/playwright';
+
+/**
+ * Read environment variables from `.env` file.
+ */
+import 'dotenv/config';
+
+import type { TestOptions } from './src/fixture';
+
+const versions = JSON.parse(readFileSync(join(__dirname, 'versions.json').toString()) as unknown as string) as string[];
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig<TestOptions> = {
+    testDir: './src',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 1 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: 4,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: [['html', { open: 'never' }]],
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure'
+    },
+    /* Configure projects for major browsers */
+    projects: versions.map((version: string) => ({
+        name: `${version}`,
+        use: {
+            ...devices['Desktop Chrome'],
+            channel: 'chrome',
+            viewport: { width: 1720, height: 900 },
+            ui5Version: version
+        }
+    })) as Project<{}, TestOptions>[],
+    // timeout: 9999 * 1000,
+    globalSetup: require.resolve('./src/global-setup')
+    // webServer: {
+    //     command: 'node server',
+    //     url: 'http://localhost:3050/status',
+    //     reuseExistingServer: !process.env.CI,
+    //     stderr: 'pipe',
+    //     stdout: 'ignore'
+    // }
+};
+export default defineConfig(config);

--- a/tests/integration/adaptation-editor/playwright.config.ts
+++ b/tests/integration/adaptation-editor/playwright.config.ts
@@ -1,3 +1,4 @@
+import { exit } from 'process';
 import { join } from 'path';
 import { readFileSync } from 'fs';
 import { defineConfig, devices } from '@sap-ux-private/playwright';
@@ -10,8 +11,18 @@ import 'dotenv/config';
 
 import type { TestOptions } from './src/fixture';
 
-const versions = JSON.parse(readFileSync(join(__dirname, 'versions.json').toString()) as unknown as string) as string[];
-
+let versions;
+try {
+    versions = JSON.parse(readFileSync(join(__dirname, 'versions.json').toString()) as unknown as string) as string[];
+} catch (error) {
+    if (error.code === 'ENOENT') {
+        console.error(
+            'The versions.json file is missing. Please run "node version.js" in the tests/integration/adaptation-editor directory to generate it.'
+        );
+        exit(1);
+    }
+    throw error;
+}
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/tests/integration/adaptation-editor/server.js
+++ b/tests/integration/adaptation-editor/server.js
@@ -1,0 +1,203 @@
+'use strict';
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { 'default': mod };
+    };
+Object.defineProperty(exports, '__esModule', { value: true });
+const promises_1 = require('fs/promises');
+const path_1 = require('path');
+const path_2 = __importDefault(require('path'));
+const fs_1 = __importDefault(require('fs'));
+const express_1 = __importDefault(require('express'));
+const adm_zip_1 = __importDefault(require('adm-zip'));
+const playwright_1 = require('@sap-ux-private/playwright');
+/**
+ * Global setup.
+ *
+ * It fetches maintained UI5 versions and add them to `process.env` variable.
+ */
+async function globalSetup() {
+    // await (0, playwright_1.install)((0, path_1.join)(__dirname, 'test', 'fixtures', 'mock'));
+    const app = (0, express_1.default)();
+    const port = 3050;
+    const mapping = {};
+    // Define the path to the static content
+    const staticPath = path_2.default.join(__dirname, 'fixtures-copy');
+    app.use((req, res, next) => {
+        console.log('Request URL:', req.url);
+        next();
+    });
+
+    app.get('/status', (req, res) => {
+        res.sendStatus(200);
+    });
+    // Serve static files
+    app.use('/sap/bc/ui5_ui5/ui5/', express_1.default.static(staticPath));
+    app.get('/sap/bc/lrep/actions/getcsrftoken', (req, res) => {
+        res.sendStatus(200);
+    });
+    app.get('/sap/bc/adt/discovery', (req, res) => {
+        const filePath = path_2.default.join(__dirname, 'src', 'responses', 'discovery.xml');
+        const readStream = fs_1.default.createReadStream(filePath);
+        readStream.on('open', () => {
+            res.setHeader('Content-Type', 'application/xml');
+            readStream.pipe(res);
+        });
+        readStream.on('error', (err) => {
+            console.error('Error reading file:', err);
+            res.status(500).send('Internal Server Error');
+        });
+    });
+    app.put('/sap/bc/lrep/appdescr_variant_preview', (req, res) => {
+        const bufferChunks = [];
+        req.on('data', (chunk) => {
+            bufferChunks.push(chunk);
+        });
+        req.on('end', async () => {
+            var _a;
+            var _b;
+            const buffer = Buffer.concat(bufferChunks);
+            try {
+                const directory = new adm_zip_1.default(buffer);
+                const variant = JSON.parse(directory.readFile('manifest.appdescr_variant').toString('utf-8'));
+                const baseAppDirectory = `${variant.reference}`;
+                const manifestText = await (0, promises_1.readFile)(
+                    (0, path_1.join)(
+                        __dirname,
+
+                        'fixtures-copy',
+                        `${variant.reference}`,
+                        'webapp',
+                        'manifest.json'
+                    ),
+                    'utf-8'
+                );
+                const manifest = JSON.parse(manifestText);
+                manifest['sap.app'].id = variant.id;
+                (_a = mapping[(_b = variant.reference)]) !== null && _a !== void 0 ? _a : (mapping[_b] = new Set());
+                mapping[variant.reference].add(variant.id);
+                res.json({
+                    [variant.id]: {
+                        name: variant.reference,
+                        manifest,
+                        asyncHints: {
+                            libs: [
+                                // {
+                                //     name: 'sap.ui.core'
+                                // },
+                                // {
+                                //     name: 'sap.m'
+                                // },
+                                // {
+                                //     name: 'sap.suite.ui.generic.template'
+                                // },
+                                // {
+                                //     name: 'sap.uxap',
+                                //     lazy: true
+                                // },
+                                // {
+                                //     name: 'sap.ui.table',
+                                //     lazy: true
+                                // },
+                                // {
+                                //     name: 'sap.ui.commons',
+                                //     lazy: true
+                                // },
+                                // {
+                                //     name: 'sap.ui.comp'
+                                // },
+                                // {
+                                //     name: 'sap.ui.rta'
+                                // },
+                                // {
+                                //     name: 'sap.ui.generic.app'
+                                // }
+                            ]
+                        },
+                        url: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp`,
+                        components: [
+                            {
+                                name: variant.id,
+                                url: {
+                                    url: '/',
+                                    final: true
+                                },
+                                lazy: true
+                            }
+                        ],
+                        minUi5Versions: ['1.71.0'],
+                        requests: [
+                            {
+                                name: 'sap.ui.fl.changes',
+                                reference: variant.id,
+                                preview: {
+                                    maxLayer: 'PARTNER',
+                                    reference: variant.reference
+                                }
+                            }
+                        ]
+                    }
+                });
+            } catch (err) {
+                console.error('Error processing zip buffer:', err);
+                res.status(500).send('Error processing zip buffer');
+            }
+        });
+    });
+    app.get('/sap/bc/ui2/app_index/ui5_app_info_json', (req, res) => {
+        const baseAppDirectory = `${req.query.id}`;
+        const variants = mapping[req.query.id];
+        if (!variants) {
+            res.status(404).send('No variants found');
+            return;
+        }
+        res.json(
+            [...variants.values()].reduce((acc, key) => {
+                acc[key] = {
+                    name: req.query.id,
+                    manifest: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp/manifest.json`,
+                    url: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp`,
+                    components: [
+                        {
+                            name: key,
+                            url: {
+                                url: '/',
+                                final: true
+                            },
+                            lazy: true
+                        }
+                    ],
+                    minUi5Versions: ['1.71.0'],
+                    requests: [
+                        {
+                            name: 'sap.ui.fl.changes',
+                            reference: key,
+                            preview: {
+                                maxLayer: 'PARTNER',
+                                reference: req.query.id
+                            }
+                        }
+                    ]
+                };
+                return acc;
+            }, {})
+        );
+    });
+    // Start the server
+    const server = app.listen(port, () => {
+        console.log(`Mock ABAP backend is running on http://localhost:${port}`);
+    });
+    // await use(`http://localhost:${port}`);
+    // server.close(() => {
+    //     console.log(`Mock ABAP backend server closed: http://localhost:${port}`);
+    // });
+}
+
+globalSetup()
+    .then(() => {
+        console.log('Global setup completed successfully.');
+    })
+    .catch((error) => {
+        console.error('Error during global setup:', error);
+    });

--- a/tests/integration/adaptation-editor/src/constant.ts
+++ b/tests/integration/adaptation-editor/src/constant.ts
@@ -1,0 +1,2 @@
+export const TIMEOUT = 5 * 60000; // 5 min for npm install
+export const SERVER_TIMEOUT = 50 * 1000;

--- a/tests/integration/adaptation-editor/src/fixture.ts
+++ b/tests/integration/adaptation-editor/src/fixture.ts
@@ -1,0 +1,165 @@
+import { rm, stat, symlink } from 'fs/promises';
+import { join } from 'path';
+
+import { getPortPromise } from 'portfinder';
+import { setup, teardown } from 'jest-dev-server';
+
+import type { FrameLocator } from '@sap-ux-private/playwright';
+import { test as base, expect } from '@sap-ux-private/playwright';
+
+import { SERVER_TIMEOUT, TIMEOUT } from './constant';
+import {
+    ADAPTATION_EDITOR_PATH,
+    generateUi5Project,
+    generateAdpProject,
+    SIMPLE_APP,
+    type ProjectConfig
+} from './project';
+import { satisfies } from 'semver';
+
+export type TestOptions = {
+    previewFrame: FrameLocator;
+    testSkipper: boolean;
+};
+
+// Avoid installing npm packages every time, but use symlink instead
+const PACKAGE_ROOT = join(__dirname, '..', '..', '..', 'fixtures', 'projects', 'mock');
+export type WorkerFixtures = {
+    projectCopy: string;
+    projectServer: number;
+    ui5Version: string;
+    projectConfig: ProjectConfig;
+
+    log: (message: string) => void;
+};
+
+let i = 0;
+let j = 0;
+
+const RESET = '\x1b[0m';
+
+function colorize(color: number) {
+    return (text: string) => `\x1b[3${color + 1}m${text}${RESET}`;
+}
+
+function createLogger(index: number) {
+    const timestamp = new Date().toISOString();
+    return (message: string) => console.log('[' + colorize(index)(timestamp) + ']', colorize(index)(message));
+}
+
+export const test = base.extend<TestOptions, WorkerFixtures>({
+    ui5Version: ['1.71.75', { option: true, scope: 'worker' }],
+    testSkipper: [
+        async ({ ui5Version, log }, use, testInfo) => {
+            // test setup takes time, so we should check and skip the test before that
+            const annotation = testInfo.annotations.find((annotation) => annotation.type === 'skipUI5Version');
+            if (annotation?.description) {
+                const skip = satisfies(ui5Version, annotation.description, { loose: true });
+                if (skip) {
+                    log(`skipping ${testInfo.title}`);
+                }
+                testInfo.skip(skip, `Test is not supported in this UI5 version`);
+            }
+
+            await use(true);
+        },
+        {
+            scope: 'test',
+            auto: true
+        }
+    ],
+    projectConfig: [SIMPLE_APP, { option: true, scope: 'worker' }],
+    log: [
+        async ({}, use, testInfo) => {
+            const logger = createLogger(testInfo.parallelIndex);
+            await use(logger);
+        },
+        { scope: 'worker' }
+    ],
+    projectCopy: [
+        async ({ ui5Version, projectConfig, log }, use, workerInfo) => {
+            log(
+                `Using UI5 version: ${ui5Version} workerIndex: ${workerInfo.workerIndex} parallel: ${workerInfo.parallelIndex}`
+            );
+
+            if (projectConfig.type === 'generated') {
+                if (projectConfig.kind === 'adp') {
+                    await generateUi5Project(projectConfig.baseApp, workerInfo.parallelIndex.toString(), ui5Version);
+                    const root = await generateAdpProject(
+                        projectConfig,
+                        workerInfo.parallelIndex.toString(),
+                        ui5Version,
+                        'http://localhost:3050',
+                        35750 + workerInfo.parallelIndex
+                    );
+                    const targetPath = join(root, 'node_modules');
+                    log(`Linking ${PACKAGE_ROOT} -> ${targetPath}`);
+                    try {
+                        await stat(targetPath);
+                        await rm(targetPath, { recursive: true });
+                    } catch (error) {
+                        if (error?.code !== 'ENOENT') {
+                            console.log(error);
+                        }
+                    } finally {
+                        // type required for windows
+                        await symlink(join(PACKAGE_ROOT, 'node_modules'), targetPath, 'junction');
+                    }
+
+                    log(`Copying project to ${root} time = ${++i}`);
+
+                    await use(root);
+                    return;
+                }
+            }
+            throw new Error(`Unsupported project kind: ${projectConfig.kind}`);
+        },
+        { timeout: TIMEOUT, scope: 'worker' }
+    ],
+    projectServer: [
+        async ({ projectCopy, log }, use, workerInfo) => {
+            log(`Starting ui5 tooling to ${projectCopy} time = ${++j}`);
+
+            const start = 3000 + workerInfo.parallelIndex * 100;
+            const port = await getPortPromise({ port: start });
+
+            process.env.FIORI_TOOLS_USER = 'test';
+            process.env.FIORI_TOOLS_PASSWORD = 'test';
+            const server = await setup({
+                command: `cd ${projectCopy} && npx ui5 serve --port=${port}`,
+                launchTimeout: SERVER_TIMEOUT,
+                port: port,
+                host: 'localhost',
+                protocol: 'http',
+                usedPortAction: 'error',
+                debug: false
+            });
+
+            await use(port);
+            log(`Stopping server for ${projectCopy}`);
+            await teardown(server);
+        },
+        { timeout: TIMEOUT, scope: 'worker' }
+    ],
+    // Override default "page" fixture.
+    page: async ({ page, projectServer, ui5Version }, use) => {
+        await page.goto(
+            `http://localhost:${projectServer}${ADAPTATION_EDITOR_PATH}?fiori-tools-rta-mode=true#app-preview`
+        );
+        if (satisfies(ui5Version, '1.84.0 - 1.130.0')) {
+            // Sync clones are created which trigger sync views warning
+            await expect.soft(page.getByText('Synchronous views are')).toBeVisible({ timeout: 15_000 });
+            await page.getByRole('button', { name: 'OK' }).click();
+            await expect.soft(page.locator('.ms-Overlay')).toBeHidden();
+        }
+        await expect(page.getByRole('button', { name: 'UI Adaptation' })).toBeEnabled({ timeout: 15_000 });
+        // Each test will get a "page" that already has the person name.
+        await use(page);
+    },
+    previewFrame: [
+        async ({ page }, use) => {
+            await use(page.locator('iframe[title="Application Preview"]').contentFrame());
+        },
+        { scope: 'test' }
+    ]
+});

--- a/tests/integration/adaptation-editor/src/global-setup.ts
+++ b/tests/integration/adaptation-editor/src/global-setup.ts
@@ -1,0 +1,238 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import path from 'path';
+import fs from 'fs';
+
+import express from 'express';
+import ZipFile from 'adm-zip';
+
+/**
+ * Global setup.
+ *
+ * It fetches maintained UI5 versions and add them to `process.env` variable.
+ */
+async function globalSetup(): Promise<void> {
+    const app = express();
+    const port = 3050;
+    const mapping: Record<string, Set<string>> = {};
+
+    // Define the path to the static content
+    const staticPath = path.join(__dirname, '..', 'fixtures-copy');
+
+    const mergedManifestCache = new Map<string, object>();
+
+    // Serve static files
+
+    app.use('/sap/bc/ui5_ui5/ui5/', (req, res, next) => {
+        const manifest = mergedManifestCache.get(req.path);
+        if (manifest) {
+            return res.json(manifest);
+        }
+        next();
+    });
+    app.use('/sap/bc/ui5_ui5/ui5/', express.static(staticPath));
+    app.get('/sap/bc/lrep/actions/getcsrftoken', (req, res) => {
+        res.sendStatus(200);
+    });
+    app.get('/sap/bc/adt/discovery', (req, res) => {
+        const filePath = path.join(__dirname, 'responses', 'discovery.xml');
+        const readStream = fs.createReadStream(filePath);
+
+        readStream.on('open', () => {
+            res.setHeader('Content-Type', 'application/xml');
+            readStream.pipe(res);
+        });
+
+        readStream.on('error', (err) => {
+            console.error('Error reading file:', err);
+            res.status(500).send('Internal Server Error');
+        });
+    });
+
+    app.put('/sap/bc/lrep/appdescr_variant_preview', (req, res) => {
+        const bufferChunks: any[] = [];
+        req.on('data', (chunk) => {
+            bufferChunks.push(chunk);
+        });
+
+        req.on('end', async () => {
+            const buffer = Buffer.concat(bufferChunks);
+            try {
+                const directory = new ZipFile(buffer);
+
+                const variant = JSON.parse(
+                    directory.readFile('manifest.appdescr_variant')!.toString('utf-8')
+                ) as unknown as {
+                    id: string;
+                    reference: string;
+                    appId: string;
+                    appType: string;
+                };
+
+                const changes = directory
+                    .getEntries()
+                    .filter(
+                        (entry) =>
+                            // match changes from https://github.com/SAP/open-ux-tools/blob/674da278697811d72d09f64938bfd2292bfee9cf/packages/reload-middleware/src/base/livereload.ts#L77-L82
+                            entry.name.endsWith('appdescr_fe_changePageConfiguration.change') ||
+                            entry.name.endsWith('appdescr_ui_generic_app_changePageConfiguration.change') ||
+                            entry.name.endsWith('appdescr_ui_gen_app_changePageConfig.change') ||
+                            entry.name.endsWith('appdescr_app_addAnnotationsToOData.change') ||
+                            entry.name.endsWith('appdescr_ui_generic_app_addNewObjectPage.change') ||
+                            entry.name.endsWith('appdescr_fe_addNewPage.change')
+                    )
+                    .map((entry) => {
+                        const change = JSON.parse(directory.readAsText(entry)) as unknown as {
+                            changeType: string;
+                            content: unknown;
+                            layer: string;
+                        };
+                        return {
+                            changeType: change.changeType,
+                            content: change.content,
+                            layer: change.layer
+                        };
+                    });
+
+                const baseAppDirectory = `${variant.reference}`;
+                const manifestText = await readFile(
+                    join(__dirname, '..', 'fixtures-copy', `${variant.reference}`, 'webapp', 'manifest.json'),
+                    'utf-8'
+                );
+
+                const manifest = JSON.parse(manifestText);
+                manifest['sap.app'].id = variant.id;
+                manifest['sap.ui5'].appVariantId = variant.id; // component name in version 1.84 and 1.96
+                if (changes.length > 0) {
+                    manifest['$sap.ui.fl.changes'] = {
+                        descriptor: changes
+                    };
+                }
+                // This does not seem to be needed, but keep ABAP backend also includes fl changes in the manifest requests
+                const manifestPath = `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/manifest.json`;
+                mergedManifestCache.set(manifestPath, manifest);
+                mapping[variant.reference] ??= new Set();
+                mapping[variant.reference].add(variant.id);
+
+                res.json({
+                    [variant.id]: {
+                        name: variant.reference,
+                        manifest,
+                        asyncHints: {
+                            libs: [
+                                {
+                                    name: 'sap.ui.core'
+                                },
+                                {
+                                    name: 'sap.m'
+                                },
+                                {
+                                    name: 'sap.suite.ui.generic.template'
+                                },
+                                {
+                                    name: 'sap.uxap',
+                                    lazy: true
+                                },
+                                {
+                                    name: 'sap.ui.table',
+                                    lazy: true
+                                },
+                                {
+                                    name: 'sap.ui.commons',
+                                    lazy: true
+                                },
+                                {
+                                    name: 'sap.ui.comp'
+                                },
+                                {
+                                    name: 'sap.ui.rta'
+                                },
+                                {
+                                    name: 'sap.ui.generic.app'
+                                }
+                            ]
+                        },
+                        url: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp`,
+                        components: [
+                            {
+                                name: variant.id,
+                                url: {
+                                    url: '/',
+                                    final: true
+                                },
+                                lazy: true
+                            }
+                        ],
+                        minUi5Versions: ['1.71.0'],
+                        requests: [
+                            {
+                                name: 'sap.ui.fl.changes',
+                                reference: variant.id,
+                                preview: {
+                                    maxLayer: 'PARTNER',
+                                    reference: variant.reference
+                                }
+                            }
+                        ]
+                    }
+                });
+            } catch (err) {
+                console.error('Error processing zip buffer:', err);
+                res.status(500).send('Error processing zip buffer');
+            }
+        });
+    });
+
+    app.get('/sap/bc/ui2/app_index/ui5_app_info_json', (req, res) => {
+        const baseAppDirectory = `${req.query.id}`;
+        const variants = mapping[req.query.id];
+        if (!variants) {
+            res.status(404).send('No variants found');
+            return;
+        }
+        res.json(
+            [...variants.values()].reduce((acc, key) => {
+                acc[key] = {
+                    name: req.query.id,
+                    manifest: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp/manifest.json`,
+                    url: `/sap/bc/ui5_ui5/ui5/${baseAppDirectory}/webapp`,
+                    components: [
+                        {
+                            name: key,
+                            url: {
+                                url: '/',
+                                final: true
+                            },
+                            lazy: true
+                        }
+                    ],
+                    minUi5Versions: ['1.71.0'],
+                    requests: [
+                        {
+                            name: 'sap.ui.fl.changes',
+                            reference: key,
+                            preview: {
+                                maxLayer: 'PARTNER',
+                                reference: req.query.id
+                            }
+                        }
+                    ]
+                };
+                return acc;
+            }, {} as Record<string, any>)
+        );
+    });
+
+    // Start the server
+    app.listen(port, () => {
+        console.log(`Mock ABAP backend is running on http://localhost:${port}`);
+    });
+
+    // await use(`http://localhost:${port}`);
+
+    // server.close(() => {
+    //     console.log(`Mock ABAP backend server closed: http://localhost:${port}`);
+    // });
+}
+
+export default globalSetup;

--- a/tests/integration/adaptation-editor/src/project/builder.ts
+++ b/tests/integration/adaptation-editor/src/project/builder.ts
@@ -1,0 +1,279 @@
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import type { Manifest } from '@sap-ux/project-access';
+import { YamlDocument } from '@sap-ux/yaml';
+import template from './templates/manifest-fe-v2.json';
+import type { FIORI_ELEMENTS_V2, ADP_FIORI_ELEMENTS_V2 } from './projects';
+import { existsSync } from 'fs';
+
+export interface ProjectParameters {
+    id: string;
+    mainServiceUri: string;
+    entitySet: string;
+}
+
+export const ADAPTATION_EDITOR_PATH = '/adaptation-editor.html';
+
+function getProjectParametersWithDefaults(parameters: ProjectParameters): ProjectParameters {
+    return {
+        id: parameters.id,
+        mainServiceUri: parameters.mainServiceUri ?? `/sap/opu/odata/sap/SERVICE/`,
+        entitySet: parameters.entitySet ?? 'RootEntity'
+    };
+}
+
+export function createV2Manifest(userParameters: ProjectParameters, workerId: string): Manifest {
+    const { id, mainServiceUri, entitySet } = getProjectParametersWithDefaults(userParameters);
+    const result = structuredClone(template) as Manifest;
+    result['sap.app'].id = id + '.' + workerId;
+    result['sap.app'].dataSources!.mainService.uri = mainServiceUri;
+    result['sap.app'].sourceTemplate!.id = 'preview-middleware-tests';
+    result['sap.app'].sourceTemplate!.version = '1.0.0';
+    result['sap.app'].sourceTemplate!.toolsId = id;
+
+    result['sap.ui.generic.app']!.pages = {
+        [`ListReport|${entitySet}`]: {
+            'entitySet': entitySet,
+            'component': {
+                'name': 'sap.suite.ui.generic.template.ListReport',
+                'list': true,
+                'settings': {
+                    'condensedTableLayout': true,
+                    'smartVariantManagement': true,
+                    'enableTableFilterInPageVariant': true,
+                    'filterSettings': {
+                        'dateSettings': {
+                            'useDateRange': true
+                        }
+                    },
+                    'tableSettings': {
+                        'type': 'ResponsiveTable'
+                    }
+                }
+            },
+            'pages': {
+                [`ObjectPage|${entitySet}`]: {
+                    'entitySet': entitySet,
+                    'defaultLayoutTypeIfExternalNavigation': 'MidColumnFullScreen',
+                    'component': {
+                        'name': 'sap.suite.ui.generic.template.ObjectPage'
+                    }
+                }
+            }
+        }
+    };
+
+    return result;
+}
+
+export async function createYamlFile(
+    userParameters: ProjectParameters,
+    ui5Version: string,
+    workerId: string
+): Promise<string> {
+    const { id, mainServiceUri } = getProjectParametersWithDefaults(userParameters);
+    const template = await readFile(join(__dirname, 'templates', 'ui5.yaml'), 'utf-8');
+    const document = await YamlDocument.newInstance(template);
+
+    document.setIn({ path: 'metadata.name', value: id + '.' + workerId });
+    document.setIn({ path: 'server.customMiddleware.0.configuration.services.urlPath', value: mainServiceUri });
+    document.setIn({ path: 'server.customMiddleware.3.configuration.version', value: ui5Version });
+
+    return document.toString();
+}
+
+export function createComponent(userParameters: ProjectParameters, workerId: string): string {
+    const { id } = getProjectParametersWithDefaults(userParameters);
+    return `sap.ui.define(
+    ["sap/suite/ui/generic/template/lib/AppComponent"],
+    function (Component) {
+        "use strict";
+
+        return Component.extend("${id}.${workerId}.Component", {
+            metadata: {
+                manifest: "json"
+            }
+        });
+    }
+);`;
+}
+
+export function createPackageJson(id: string): string {
+    return `{
+    "name": "${id}",
+    "version": "0.0.1",
+    "private": true,
+    "devDependencies": {
+        "@sap-ux/ui5-middleware-fe-mockserver": "2.1.112",
+        "@ui5/cli": "3"
+    }
+}
+`;
+}
+
+export async function generateUi5Project(
+    projectConfig: typeof FIORI_ELEMENTS_V2,
+    workerId: string,
+    ui5Version: string
+): Promise<string> {
+    const { id } = getProjectParametersWithDefaults(projectConfig);
+    const root = join(__dirname, '..', '..', 'fixtures-copy', `${projectConfig.id}.${workerId}`);
+    const yamlContent = await createYamlFile(projectConfig, ui5Version, workerId);
+    const manifestContent = JSON.stringify(createV2Manifest(projectConfig, workerId), undefined, 2);
+
+    if (!existsSync(root)) {
+        await mkdir(root, { recursive: true });
+    }
+
+    if (!existsSync(join(root, 'webapp'))) {
+        await mkdir(join(root, 'webapp'), { recursive: true });
+    }
+
+    if (!existsSync(join(root, 'data'))) {
+        await mkdir(join(root, 'data'), { recursive: true });
+    }
+
+    await Promise.all([
+        writeFile(join(root, 'ui5.yaml'), yamlContent),
+        writeFile(join(root, 'package.json'), createPackageJson(id + workerId)),
+        writeFile(join(root, 'webapp', 'manifest.json'), manifestContent),
+        writeFile(join(root, 'webapp', 'Component.js'), createComponent(projectConfig, workerId)),
+        writeFile(join(root, 'service.cds'), await readFile(join(__dirname, 'templates', 'service.cds'), 'utf-8')),
+        writeFile(
+            join(root, 'data', 'RootEntity.json'),
+            JSON.stringify(
+                [
+                    {
+                        'ID': 1,
+                        'StringProperty': 'Hello',
+                        'NumberProperty': 78.777,
+                        'IntegerProperty': 89,
+                        'BooleanProperty': true,
+                        'Currency': 'JPY',
+                        'TextProperty': 'Description'
+                    }
+                ],
+                undefined,
+                2
+            )
+        )
+    ]);
+    return root;
+}
+
+export interface AdpProjectParameters {
+    id: string;
+}
+
+function getAdpProjectParametersWithDefaults(parameters: AdpProjectParameters): AdpProjectParameters {
+    return {
+        id: parameters.id
+        // mainServiceUri: parameters.mainServiceUri ?? `/sap/opu/odata/sap/SERVICE/`,
+        // entitySet: parameters.entitySet ?? 'RootEntity'
+    };
+}
+
+async function createAdpYamlFile(
+    userParameters: AdpProjectParameters,
+    ui5Version: string,
+    backendUrl: string,
+    mainServiceUri: string,
+    livereloadPort: number
+): Promise<string> {
+    const { id } = getAdpProjectParametersWithDefaults(userParameters);
+    const template = await readFile(join(__dirname, 'templates', 'adp.yaml'), 'utf-8');
+    const document = await YamlDocument.newInstance(template);
+
+    document.setIn({ path: 'metadata.name', value: id });
+    document.setIn({ path: 'server.customMiddleware.0.configuration.services.urlPath', value: mainServiceUri });
+    document.setIn({
+        path: 'server.customMiddleware.1.configuration.port',
+        value: livereloadPort,
+        createIntermediateKeys: true
+    });
+    document.setIn({ path: 'server.customMiddleware.2.configuration.adp.target.url', value: backendUrl });
+    // document.setIn({ path: 'server.customMiddleware.2.configuration.adp.target.url', value: backendUrl });
+    document.setIn({ path: 'server.customMiddleware.3.configuration.version', value: ui5Version });
+
+    return document.toString();
+}
+
+export async function createAppDescriptorVariant(
+    userParameters: AdpProjectParameters,
+    reference: string
+): Promise<object> {
+    const { id } = getAdpProjectParametersWithDefaults(userParameters);
+    const text = await readFile(join(__dirname, 'templates', 'manifest.appdescr_variant'), 'utf-8');
+    const result = JSON.parse(text) as Record<string, any>;
+    result.reference = reference;
+    result.id = id;
+    result.namespace = `${reference}/${id}/`;
+
+    return result;
+}
+
+export async function generateAdpProject(
+    projectConfig: typeof ADP_FIORI_ELEMENTS_V2,
+    workerId: string,
+    ui5Version: string,
+    backendUrl: string,
+    livereloadPort: number
+): Promise<string> {
+    const { id } = getAdpProjectParametersWithDefaults(projectConfig);
+    const root = join(__dirname, '..', '..', 'fixtures-copy', `${projectConfig.id}.${workerId}`);
+    const yamlContent = await createAdpYamlFile(
+        projectConfig,
+        ui5Version,
+        backendUrl,
+        projectConfig.baseApp.mainServiceUri,
+        livereloadPort
+    );
+    const appDescriptorVariant = JSON.stringify(
+        await createAppDescriptorVariant(projectConfig, projectConfig.baseApp.id + '.' + workerId),
+        undefined,
+        2
+    );
+
+    if (!existsSync(root)) {
+        await mkdir(root, { recursive: true });
+    }
+
+    if (!existsSync(join(root, 'webapp'))) {
+        await mkdir(join(root, 'webapp'), { recursive: true });
+    }
+
+    if (!existsSync(join(root, 'data'))) {
+        await mkdir(join(root, 'data'), { recursive: true });
+    }
+    if (existsSync(join(root, 'webapp', 'changes'))) {
+        await rm(join(root, 'webapp', 'changes'), { recursive: true });
+    }
+
+    await Promise.all([
+        writeFile(join(root, 'ui5.yaml'), yamlContent),
+        writeFile(join(root, 'package.json'), createPackageJson(id + '.' + workerId)),
+        writeFile(join(root, 'webapp', 'manifest.appdescr_variant'), appDescriptorVariant),
+        writeFile(join(root, 'service.cds'), await readFile(join(__dirname, 'templates', 'service.cds'), 'utf-8')),
+        writeFile(
+            join(root, 'data', 'RootEntity.json'),
+            JSON.stringify(
+                [
+                    {
+                        'ID': 1,
+                        'StringProperty': 'Hello',
+                        'NumberProperty': 78.777,
+                        'IntegerProperty': 89,
+                        'BooleanProperty': true,
+                        'Currency': 'JPY',
+                        'TextProperty': 'Description',
+                        'DateProperty': '/Date(1746057600000)/'
+                    }
+                ],
+                undefined,
+                2
+            )
+        )
+    ]);
+    return root;
+}

--- a/tests/integration/adaptation-editor/src/project/index.ts
+++ b/tests/integration/adaptation-editor/src/project/index.ts
@@ -1,0 +1,2 @@
+export * from './projects';
+export { generateAdpProject, generateUi5Project, ADAPTATION_EDITOR_PATH } from './builder';

--- a/tests/integration/adaptation-editor/src/project/projects.ts
+++ b/tests/integration/adaptation-editor/src/project/projects.ts
@@ -1,0 +1,48 @@
+export interface ProjectConfigBase {
+    type: 'template';
+    kind: 'ui5';
+    id: string;
+    root: string;
+}
+
+export interface GeneratedBaseProjectConfig {
+    type: 'generated';
+    kind: 'ui5';
+    id: string;
+    mainServiceUri: string;
+    entitySet: string;
+}
+
+export interface GeneratedAdpProjectConfig {
+    type: 'generated';
+    kind: 'adp';
+    baseApp: GeneratedBaseProjectConfig;
+    id: string;
+}
+
+export const SIMPLE_APP: ProjectConfigBase = {
+    type: 'template',
+    kind: 'ui5',
+    id: 'test.fe.v2.app',
+    root: 'simple-app'
+};
+
+export const FIORI_ELEMENTS_V2: GeneratedBaseProjectConfig = {
+    type: 'generated',
+    kind: 'ui5',
+    id: 'fiori.elements.v2',
+    mainServiceUri: '/sap/opu/odata/sap/SERVICE/',
+    entitySet: 'RootEntity'
+};
+
+export const ADP_FIORI_ELEMENTS_V2: GeneratedAdpProjectConfig = {
+    type: 'generated',
+    kind: 'adp',
+    baseApp: FIORI_ELEMENTS_V2,
+    id: 'adp.fiori.elements.v2'
+};
+
+export type UI5ProjectConfig = typeof SIMPLE_APP | typeof FIORI_ELEMENTS_V2;
+export type AdpProjectConfig = typeof ADP_FIORI_ELEMENTS_V2;
+
+export type ProjectConfig = UI5ProjectConfig | AdpProjectConfig;

--- a/tests/integration/adaptation-editor/src/project/templates/adp.yaml
+++ b/tests/integration/adaptation-editor/src/project/templates/adp.yaml
@@ -1,0 +1,85 @@
+specVersion: "2.4"
+metadata:
+  name: project1
+type: application
+server:
+  customMiddleware:
+    - name: sap-fe-mockserver
+      mountPath: /
+      afterMiddleware: compression
+      configuration:
+        metadataProcessor: 
+          name: "@sap-ux/fe-mockserver-plugin-cds"
+          options: 
+            odataVersion: v2
+        services:
+          urlPath: /sap/opu/odata/sap/SERVICE/
+          metadataPath: ./service.cds
+          mockdataPath: ./data
+    - name: reload-middleware
+      afterMiddleware: sap-fe-mockserver
+    - name: preview-middleware
+      afterMiddleware: reload-middleware
+      configuration:
+        adp:
+          ignoreCertErrors: true
+          target:
+            url: http://localhost:3050
+            client: "000"
+        rta:
+          layer: CUSTOMER_BASE
+          editors:
+            - path: /adaptation-editor.html
+              developerMode: true
+        debug: true
+    - name: ui5-proxy-middleware
+      afterMiddleware: preview-middleware
+      configuration:
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+    - name: backend-proxy-middleware
+      afterMiddleware: preview-middleware
+      configuration:
+        backend:
+          path: /sap
+          url: http://localhost:3050
+          client: "000"
+          autoRewrite: true
+        options:
+          secure: false
+          xfwd: true
+---
+specVersion: "3.0"
+metadata:
+  name: preview-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/preview-middleware/dist/ui5/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: ui5-proxy-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/ui5-proxy-middleware/dist/ui5/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: backend-proxy-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/backend-proxy-middleware/dist/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: reload-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/reload-middleware/dist/ui5/middleware.js

--- a/tests/integration/adaptation-editor/src/project/templates/manifest-fe-v2.json
+++ b/tests/integration/adaptation-editor/src/project/templates/manifest-fe-v2.json
@@ -1,0 +1,110 @@
+{
+  "_version": "1.18.0",
+  "sap.app": {
+    "id": "fev2",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "0.0.1"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "resources": "resources.json",
+    "sourceTemplate": {
+      "id": "@sap/generator-fiori:lrop",
+      "version": "1.17.1",
+      "toolsId": "bcacbec8-9d9e-4123-acbb-85b16cec1ea7"
+    },
+    "dataSources": {
+      "mainService": {
+        "uri": "/sap/opu/odata/sap/SERVICE/",
+        "type": "OData",
+        "settings": {
+          "annotations": [],
+          "localUri": "localService/mainService/metadata.xml",
+          "odataVersion": "2.0"
+        }
+      }
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "icons": {
+      "icon": "",
+      "favIcon": "",
+      "phone": "",
+      "phone@2": "",
+      "tablet": "",
+      "tablet@2": ""
+    },
+    "deviceTypes": {
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
+  },
+  "sap.ui5": {
+    "flexEnabled": true,
+    "dependencies": {
+      "minUI5Version": "1.71.0",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {},
+        "sap.ushell": {},
+        "sap.f": {},
+        "sap.ui.comp": {},
+        "sap.ui.generic.app": {},
+        "sap.suite.ui.generic.template": {}
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "fev2.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "defaultBindingMode": "TwoWay",
+          "defaultCountMode": "Inline",
+          "refreshAfterChange": false,
+          "metadataUrlParams": {
+            "sap-value-list": "none"
+          }
+        }
+      },
+      "@i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "uri": "i18n/i18n.properties"
+      }
+    },
+    "resources": {
+      "css": []
+    },
+    "routing": {
+      "config": {},
+      "routes": [],
+      "targets": {}
+    }
+  },
+  "sap.ui.generic.app": {
+    "_version": "1.3.0",
+    "settings": {
+      "forceGlobalRefresh": false,
+      "objectPageHeaderType": "Dynamic",
+      "considerAnalyticalParameters": true,
+      "showDraftToggle": false
+    }
+  },
+  "sap.fiori": {
+    "registrationIds": [],
+    "archeType": "transactional"
+  }
+}

--- a/tests/integration/adaptation-editor/src/project/templates/manifest.appdescr_variant
+++ b/tests/integration/adaptation-editor/src/project/templates/manifest.appdescr_variant
@@ -1,0 +1,24 @@
+{
+  "fileName": "manifest",
+  "layer": "CUSTOMER_BASE",
+  "fileType": "appdescr_variant",
+  "reference": "project1",
+  "id": "adp.moock",
+  "namespace": "project1/adp.mock/",
+  "version": "${project.version}",
+  "content": [
+    {
+      "changeType": "appdescr_app_setTitle",
+      "content": {},
+      "texts": {
+        "i18n": "i18n/i18n.properties"
+      }
+    },
+    {
+      "changeType": "appdescr_ui5_setMinUI5Version",
+      "content": {
+        "minUI5Version": "1.71.0"
+      }
+    }
+  ]
+}

--- a/tests/integration/adaptation-editor/src/project/templates/service.cds
+++ b/tests/integration/adaptation-editor/src/project/templates/service.cds
@@ -1,0 +1,43 @@
+service Service {
+    @UI: {
+        HeaderInfo: {
+            TypeName: 'Root Entity',
+            TypeNamePlural: 'Root Entities',
+            Title: { Value: StringProperty }
+        },
+        Facets: [
+            {
+                $Type: 'UI.ReferenceFacet',
+                Label: 'General Information',
+                Target: '@UI.FieldGroup#GeneralInfo'
+            }
+        ],
+        FieldGroup#GeneralInfo: {
+            Data: [
+                { $Type: 'UI.DataField', Value: StringProperty },
+                { $Type: 'UI.DataField', Value: IntegerProperty }
+            ]
+        },
+        SelectionFields: [StringProperty, DateProperty]
+    }
+    @UI.LineItem : [ { Value: StringProperty }, { Value: DateProperty}]
+    @Capabilities.FilterRestrictions : {
+        FilterExpressionRestrictions : [
+            {
+                Property : 'DateProperty',
+                AllowedExpressions : 'SingleValue'
+            },
+        ],
+    }
+  entity RootEntity {
+    key ID              : Integer       @Common.Label: 'Identifier';
+        StringProperty  : String        @Common.Label: 'String Property';
+        IntegerProperty : Integer       @Common.Label: 'Integer Property';
+        NumberProperty  : Decimal(4, 2) @Common.Label: 'Number Property';
+        BooleanProperty : Boolean       @Common.Label: 'Boolean Property';
+        Currency        : String        @Common.Label: 'Currency';
+        TextProperty    : String        @Common.Label: 'Text Property';
+        @Common.ValueListWithFixedValues: true
+        DateProperty    : Date          @Common.Label: 'Date Property';
+  }
+}

--- a/tests/integration/adaptation-editor/src/project/templates/ui5.yaml
+++ b/tests/integration/adaptation-editor/src/project/templates/ui5.yaml
@@ -1,0 +1,80 @@
+specVersion: "2.4"
+metadata:
+  name: project1
+type: application
+server:
+  customMiddleware:
+    - name: sap-fe-mockserver
+      mountPath: /
+      afterMiddleware: compression
+      configuration:
+        metadataProcessor: 
+          name: "@sap-ux/fe-mockserver-plugin-cds"
+          options: 
+            odataVersion: v2
+        services:
+          urlPath: /sap/opu/odata/sap/SERVICE/
+          metadataPath: ./service.cds
+          mockdataPath: ./data
+    - name: reload-middleware
+      afterMiddleware: sap-fe-mockserver
+    - name: preview-middleware
+      afterMiddleware: reload-middleware
+      configuration:
+        rta:
+          layer: CUSTOMER_BASE
+          editors:
+            - path: /adaptation-editor.html
+              developerMode: true
+        debug: true
+    - name: ui5-proxy-middleware
+      afterMiddleware: preview-middleware
+      configuration:
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://ui5.sap.com
+    - name: backend-proxy-middleware
+      afterMiddleware: preview-middleware
+      configuration:
+        backend:
+          path: /sap
+          url: http://localhost:3050
+          client: "000"
+          autoRewrite: true
+        options:
+          secure: false
+          xfwd: true
+---
+specVersion: "3.0"
+metadata:
+  name: preview-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/preview-middleware/dist/ui5/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: ui5-proxy-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/ui5-proxy-middleware/dist/ui5/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: backend-proxy-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/backend-proxy-middleware/dist/middleware.js
+---
+specVersion: "3.0"
+metadata:
+  name: reload-middleware
+kind: extension
+type: server-middleware
+middleware:
+  path: node_modules/@sap-ux/reload-middleware/dist/ui5/middleware.js

--- a/tests/integration/adaptation-editor/src/responses/discovery.xml
+++ b/tests/integration/adaptation-editor/src/responses/discovery.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom">
+  <app:workspace>
+    <atom:title>Adaptation Transport Organizer (ATO)</atom:title>
+    <app:collection href="/sap/bc/adt/ato/settings">
+      <atom:title>Settings</atom:title>
+      <atom:category term="settings" scheme="http://www.sap.com/adt/categories/ato" />
+      <adtcomp:templateLinks xmlns:adtcomp="http://www.sap.com/adt/compatibility" />
+    </app:collection>
+    <app:collection href="/sap/bc/adt/ato/notifications">
+      <atom:title>Notifications</atom:title>
+      <app:accept>application/vnd.sap.adt.ato.notification.v1+xml</app:accept>
+      <app:accept>application/vnd.sap.adt.ato.notification.v1+json</app:accept>
+      <atom:category term="notifications" scheme="http://www.sap.com/adt/categories/ato" />
+      <adtcomp:templateLinks xmlns:adtcomp="http://www.sap.com/adt/compatibility" />
+    </app:collection>
+  </app:workspace>
+  </app:service>

--- a/tests/integration/adaptation-editor/src/scenarios/quick-actions/list-report-v2.spec.ts
+++ b/tests/integration/adaptation-editor/src/scenarios/quick-actions/list-report-v2.spec.ts
@@ -1,0 +1,631 @@
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+
+import { expect, type FrameLocator, type Page } from '@sap-ux-private/playwright';
+import { gte, lt, satisfies } from 'semver';
+
+import { test } from '../../fixture';
+import { ADP_FIORI_ELEMENTS_V2 } from '../../project';
+
+test.use({ projectConfig: ADP_FIORI_ELEMENTS_V2 });
+
+class QuickActionPanel {
+    private readonly page: Page;
+    get addControllerToPage() {
+        return this.page.getByRole('button', { name: 'Add Controller to Page' });
+    }
+    get showPageController() {
+        return this.page.getByRole('button', { name: 'Show Page Controller' });
+    }
+    get enableClearButton() {
+        return this.page.getByRole('button', { name: 'Enable "Clear" Button in Filter Bar' });
+    }
+    get disableClearButton() {
+        return this.page.getByRole('button', { name: 'Disable "Clear" Button in Filter Bar' });
+    }
+    get enableSemanticDateRange() {
+        return this.page.getByRole('button', { name: 'Enable Semantic Date Range in Filter Bar' });
+    }
+    get disableSemanticDateRange() {
+        return this.page.getByRole('button', { name: 'Disable Semantic Date Range in Filter Bar' });
+    }
+    get changeTableColumns() {
+        return this.page.getByRole('button', { name: 'Change Table Columns' });
+    }
+    get addCustomTableAction() {
+        return this.page.getByRole('button', { name: 'Add Custom Table Action' });
+    }
+    get addCustomTableColumn() {
+        return this.page.getByRole('button', { name: 'Add Custom Table Column' });
+    }
+    get enableVariantManagementInTablesAndCharts() {
+        return this.page.getByRole('button', { name: 'Enable Variant Management in Tables and Charts' });
+    }
+    constructor(page: Page) {
+        this.page = page;
+    }
+}
+
+class Toolbar {
+    private readonly page: Page;
+    get saveButton() {
+        return this.page.getByRole('button', { name: 'Save' });
+    }
+    get saveAndReloadButton() {
+        return this.page.getByRole('button', { name: 'Save and Reload' });
+    }
+    get uiAdaptationModeButton() {
+        return this.page.getByRole('button', { name: 'UI Adaptation' });
+    }
+    get navigationModeButton() {
+        return this.page.getByRole('button', { name: 'Navigation' });
+    }
+    constructor(page: Page) {
+        this.page = page;
+    }
+}
+class ChangesPanel {
+    private readonly page: Page;
+    get reloadButton() {
+        return this.page.getByRole('link', { name: 'Reload' });
+    }
+    constructor(page: Page) {
+        this.page = page;
+    }
+}
+
+class AdaptationEditorShell {
+    private readonly page: Page;
+    private readonly ui5Version: string;
+    readonly quickActions: QuickActionPanel;
+    readonly toolbar: Toolbar;
+    readonly changesPanel: ChangesPanel;
+
+    async reloadCompleted(): Promise<void> {
+        await expect(this.toolbar.uiAdaptationModeButton).toBeEnabled({ timeout: 15_000 });
+    }
+    constructor(page: Page, ui5Version: string) {
+        this.ui5Version = ui5Version;
+        this.page = page;
+        this.quickActions = new QuickActionPanel(page);
+        this.toolbar = new Toolbar(page);
+        this.changesPanel = new ChangesPanel(page);
+    }
+}
+
+class ListReport {
+    private readonly frame: FrameLocator;
+    get goButton() {
+        return this.frame.getByRole('button', { name: 'Go' });
+    }
+
+    get clearButton() {
+        return this.frame.getByRole('button', { name: 'Clear' });
+    }
+    constructor(frame: FrameLocator) {
+        this.frame = frame;
+    }
+}
+
+class AdpDialog {
+    private readonly frame: FrameLocator;
+    private readonly ui5Version: string;
+    get createButton() {
+        if (gte(this.ui5Version, '1.120.0')) {
+            return this.frame.getByLabel('Footer actions').getByRole('button', { name: 'Create' });
+        } else {
+            return this.frame.locator('#createDialogBtn');
+        }
+    }
+
+    constructor(frame: FrameLocator, ui5Version: string) {
+        this.frame = frame;
+        this.ui5Version = ui5Version;
+    }
+}
+
+class TableSettings {
+    private readonly frame: FrameLocator;
+    get dialog() {
+        return this.frame.getByLabel('View Settings');
+    }
+    get tableSettingsDialog() {
+        return this.dialog;
+    }
+    constructor(frame: FrameLocator) {
+        this.frame = frame;
+    }
+}
+
+interface Changes {
+    annotations: Record<string, string>;
+    coding: Record<string, string>;
+    fragments: Record<string, string>;
+    changes: object[];
+}
+
+async function readChanges(root: string): Promise<Changes> {
+    const changesDirectory = join(root, 'webapp', 'changes');
+    const result: Changes = {
+        annotations: {},
+        coding: {},
+        fragments: {},
+        changes: []
+    };
+    try {
+        const files = await readdir(changesDirectory, { withFileTypes: true });
+        for (const file of files) {
+            try {
+                if (file.isFile()) {
+                    const text = await readFile(join(changesDirectory, file.name), { encoding: 'utf-8' });
+                    result.changes.push(JSON.parse(text) as object);
+                } else if (file.name === 'annotations' || file.name === 'coding' || file.name === 'fragments') {
+                    const children = await readdir(join(changesDirectory, file.name), { withFileTypes: true });
+                    for (const child of children) {
+                        if (child.isFile()) {
+                            result[file.name][child.name] = await readFile(
+                                join(changesDirectory, file.name, child.name),
+                                {
+                                    encoding: 'utf-8'
+                                }
+                            );
+                        }
+                    }
+                }
+            } catch (e) {
+                // ignore error
+            }
+        }
+    } catch (e) {
+        // ignore error
+    }
+    return result;
+}
+
+test.describe(`@quick-actions @fe-v2`, () => {
+    test.describe(`@list-report`, () => {
+        test('Enable/Disable clear filter bar button', {}, async ({ page, previewFrame, ui5Version, projectCopy }) => {
+            const lr = new ListReport(previewFrame);
+            const editor = new AdaptationEditorShell(page, ui5Version);
+
+            await editor.reloadCompleted();
+            await expect(lr.clearButton).toBeHidden();
+
+            await editor.quickActions.enableClearButton.click();
+
+            await expect(lr.clearButton).toBeVisible();
+
+            await editor.toolbar.saveButton.click();
+
+            await expect(editor.toolbar.saveButton).toBeDisabled();
+
+            await expect
+                .poll(async () => readChanges(projectCopy), {
+                    message: 'make sure change file is created'
+                })
+                .toEqual(
+                    expect.objectContaining({
+                        changes: expect.arrayContaining([
+                            expect.objectContaining({
+                                fileType: 'change',
+                                changeType: 'propertyChange',
+                                content: expect.objectContaining({ property: 'showClearOnFB', newValue: true })
+                            })
+                        ])
+                    })
+                );
+            await editor.quickActions.disableClearButton.click();
+
+            await expect(lr.clearButton).toBeHidden();
+
+            await editor.toolbar.saveButton.click();
+
+            await expect(editor.toolbar.saveButton).toBeDisabled();
+            await expect
+                .poll(async () => readChanges(projectCopy), {
+                    message: 'make sure change file is created'
+                })
+                .toEqual(
+                    expect.objectContaining({
+                        changes: expect.arrayContaining([
+                            expect.objectContaining({
+                                fileType: 'change',
+                                changeType: 'propertyChange',
+                                content: expect.objectContaining({ property: 'showClearOnFB', newValue: false })
+                            })
+                        ])
+                    })
+                );
+        });
+
+        test(
+            'Add controller to page',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    // TODO: 1.84 and 1.96 there is an error when saving changes
+                    description: '~1.134.0 || ~1.135.0'
+                }
+            },
+            async ({ page, previewFrame, projectCopy, ui5Version }) => {
+                const lr = new ListReport(previewFrame);
+                const dialog = new AdpDialog(previewFrame, ui5Version);
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                await editor.quickActions.addControllerToPage.click();
+
+                await previewFrame.getByRole('textbox', { name: 'Controller Name' }).fill('TestController');
+                await dialog.createButton.click();
+
+                if (lt(ui5Version, '1.136.0')) {
+                    await expect(page.getByText('Changes detected!')).toBeVisible();
+                }
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            coding: expect.objectContaining({
+                                ['TestController.js']: expect.stringMatching(
+                                    /ControllerExtension\.extend\("adp\.fiori\.elements\.v2\.TestController"/
+                                )
+                            }),
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'codeExt',
+                                    content: expect.objectContaining({ codeRef: 'coding/TestController.js' })
+                                })
+                            ])
+                        })
+                    );
+
+                await expect
+                    .poll(
+                        async () => {
+                            const changesDirectory = join(projectCopy, 'webapp', 'changes', 'coding');
+                            const codingChanges = await readdir(changesDirectory);
+                            return codingChanges.length;
+                        },
+                        {
+                            message: 'make sure controller file is created',
+                            timeout: 4_000
+                        }
+                    )
+                    .toEqual(1);
+
+                await editor.changesPanel.reloadButton.click();
+
+                await expect(editor.changesPanel.reloadButton).toBeHidden();
+
+                await expect(lr.goButton).toBeVisible();
+
+                await editor.reloadCompleted();
+
+                await editor.quickActions.showPageController.click();
+
+                await expect(
+                    previewFrame.getByText('adp.fiori.elements.v2/changes/coding/TestController.js')
+                ).toBeVisible();
+
+                await expect(previewFrame.getByRole('button', { name: 'Open in VS Code' })).toBeVisible();
+            }
+        );
+
+        test(
+            'Change table columns',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    description: '<1.96.0'
+                }
+            },
+            async ({ page, previewFrame, ui5Version }) => {
+                const tableSettings = new TableSettings(previewFrame);
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                await editor.quickActions.changeTableColumns.click();
+
+                await expect(tableSettings.tableSettingsDialog.getByText('String Property')).toBeVisible();
+                await expect(tableSettings.tableSettingsDialog.getByText('Boolean Property')).toBeVisible();
+                await expect(tableSettings.tableSettingsDialog.getByText('Currency')).toBeVisible();
+            }
+        );
+
+        test(
+            'Add Custom Table Action',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    description: '<1.96.0'
+                }
+            },
+            async ({ page, previewFrame, projectCopy, ui5Version }) => {
+                const dialog = new AdpDialog(previewFrame, ui5Version);
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                await editor.quickActions.addCustomTableAction.click();
+
+                await previewFrame.getByRole('textbox', { name: 'Fragment Name' }).fill('table-action');
+                await dialog.createButton.click();
+
+                await editor.toolbar.saveAndReloadButton.click();
+
+                await expect(editor.toolbar.saveButton).toBeDisabled();
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            fragments: expect.objectContaining({
+                                'table-action.fragment.xml': expect.stringMatching(
+                                    new RegExp(`<!-- Use stable and unique IDs!-->
+<core:FragmentDefinition xmlns:core='sap.ui.core' xmlns='sap.m'>
+    <!--  add your xml here -->
+    <Button text="New Button"  id="btn-[a-z0-9]+"></Button>
+</core:FragmentDefinition>
+`)
+                                )
+                            }),
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'addXML',
+                                    content: expect.objectContaining({
+                                        targetAggregation: 'content',
+                                        fragmentPath: 'fragments/table-action.fragment.xml'
+                                    })
+                                })
+                            ])
+                        })
+                    );
+            }
+        );
+
+        test(
+            'Add Custom Table Column',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    description: '<1.96.0'
+                }
+            },
+            async ({ page, previewFrame, projectCopy, ui5Version }) => {
+                const dialog = new AdpDialog(previewFrame, ui5Version);
+                const lr = new ListReport(previewFrame);
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                if (await editor.quickActions.addCustomTableColumn.isDisabled()) {
+                    await editor.toolbar.navigationModeButton.click();
+                    await lr.goButton.click();
+                    await editor.toolbar.uiAdaptationModeButton.click();
+                }
+
+                await editor.quickActions.addCustomTableColumn.click();
+
+                await previewFrame.getByRole('textbox', { name: 'Column Fragment Name' }).fill('table-column');
+                await previewFrame.getByRole('textbox', { name: 'Cell Fragment Name' }).fill('table-cell');
+                await dialog.createButton.click();
+
+                await editor.toolbar.saveAndReloadButton.click();
+
+                await expect(editor.toolbar.saveButton).toBeDisabled();
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            fragments: expect.objectContaining({
+                                'table-cell.fragment.xml': expect.stringMatching(
+                                    new RegExp(`<core:FragmentDefinition xmlns:core='sap.ui.core' xmlns='sap.m'>
+    <!--  add your xml here -->
+    <Text id="cell-text-[a-z0-9]+" text="Sample data" />
+</core:FragmentDefinition>`)
+                                ),
+                                'table-column.fragment.xml': expect.stringMatching(
+                                    new RegExp(`<!-- Use stable and unique IDs!-->
+<core:FragmentDefinition xmlns:core='sap.ui.core' xmlns='sap.m'>
+    <!--  add your xml here -->
+     <Column id="column-[a-z0-9]+"
+        width="12em"
+        hAlign="Left"
+        vAlign="Middle">
+        <Text id="column-title-[a-z0-9]+" text="New column" />
+
+        <customData>
+            <core:CustomData key="p13nData" id="custom-data-[a-z0-9]+"
+                value='\\\\{"columnKey": "column-[a-z0-9]+", "columnIndex": "3"}' />
+        </customData>
+    </Column>
+</core:FragmentDefinition>`)
+                                )
+                            }),
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'addXML',
+                                    content: expect.objectContaining({
+                                        targetAggregation: 'columns',
+                                        fragmentPath: 'fragments/table-column.fragment.xml'
+                                    })
+                                }),
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'addXML',
+                                    content: expect.objectContaining({
+                                        boundAggregation: 'items',
+                                        targetAggregation: 'cells',
+                                        fragmentPath: 'fragments/table-cell.fragment.xml'
+                                    })
+                                })
+                            ])
+                        })
+                    );
+
+                await expect(lr.goButton).toBeVisible();
+
+                await editor.reloadCompleted();
+
+                await editor.toolbar.navigationModeButton.click();
+                await lr.goButton.click();
+                await expect(
+                    previewFrame.getByRole('columnheader', { name: 'New column' }).locator('div')
+                ).toBeVisible();
+                if (satisfies(ui5Version, '<1.120.0')) {
+                    await expect(previewFrame.getByRole('cell', { name: 'Sample data' })).toBeVisible();
+                } else {
+                    await expect(previewFrame.getByRole('gridcell', { name: 'Sample data' })).toBeVisible();
+                }
+            }
+        );
+
+        test(
+            'Enable/Disable Semantic Date Range in Filter Bar',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    // TODO: it is supposed to work in 1.96 as well, but by default semantic date is disabled unlike other versions
+                    // and quick action does not work correctly
+                    description: '<1.108.0'
+                }
+            },
+            async ({ page, previewFrame, projectCopy, ui5Version }) => {
+                const lr = new ListReport(previewFrame);
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                await editor.toolbar.navigationModeButton.click();
+                if (satisfies(ui5Version, '~1.96.0')) {
+                    await previewFrame.getByTitle('Open Picker').click();
+                } else {
+                    // click on second filter value help
+                    await previewFrame
+                        .locator(
+                            '[id="fiori\\.elements\\.v2\\.0\\:\\:sap\\.suite\\.ui\\.generic\\.template\\.ListReport\\.view\\.ListReport\\:\\:RootEntity--listReportFilter-filterItemControl_BASIC-DateProperty-input-vhi"]'
+                        )
+                        .click();
+                }
+                await expect(previewFrame.getByText('Yesterday')).toBeVisible();
+                await editor.toolbar.uiAdaptationModeButton.click();
+
+                await editor.quickActions.disableSemanticDateRange.click();
+
+                await editor.toolbar.saveAndReloadButton.click();
+                await expect(editor.toolbar.saveButton).toBeDisabled();
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'appdescr_ui_generic_app_changePageConfiguration',
+                                    content: expect.objectContaining({
+                                        entityPropertyChange: expect.objectContaining({
+                                            propertyPath: 'component/settings/filterSettings/dateSettings',
+                                            propertyValue: expect.objectContaining({
+                                                useDateRange: false
+                                            })
+                                        })
+                                    })
+                                })
+                            ])
+                        })
+                    );
+
+                await expect(lr.goButton).toBeVisible();
+                await editor.reloadCompleted();
+
+                await editor.toolbar.navigationModeButton.click();
+
+                await previewFrame.getByLabel('Open Picker').click();
+                await expect(
+                    previewFrame.getByRole('button', { name: new Date().getFullYear().toString() })
+                ).toBeVisible();
+                await editor.toolbar.uiAdaptationModeButton.click();
+
+                await editor.quickActions.enableSemanticDateRange.click();
+
+                await editor.toolbar.saveAndReloadButton.click();
+                await expect(editor.toolbar.saveButton).toBeDisabled();
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'appdescr_ui_generic_app_changePageConfiguration',
+                                    content: expect.objectContaining({
+                                        entityPropertyChange: expect.objectContaining({
+                                            propertyPath: 'component/settings/filterSettings/dateSettings',
+                                            propertyValue: expect.objectContaining({
+                                                useDateRange: true
+                                            })
+                                        })
+                                    })
+                                })
+                            ])
+                        })
+                    );
+            }
+        );
+
+        test(
+            'Enable Variant Management in Tables and Charts',
+            {
+                annotation: {
+                    type: 'skipUI5Version',
+                    description: '<1.96.0'
+                }
+            },
+            async ({ page, projectCopy, ui5Version }) => {
+                const editor = new AdaptationEditorShell(page, ui5Version);
+
+                await editor.quickActions.enableVariantManagementInTablesAndCharts.click();
+
+                await editor.toolbar.saveAndReloadButton.click();
+                await expect(editor.toolbar.saveButton).toBeDisabled();
+
+                await expect
+                    .poll(async () => readChanges(projectCopy), {
+                        message: 'make sure change file is created'
+                    })
+                    .toEqual(
+                        expect.objectContaining({
+                            changes: expect.arrayContaining([
+                                expect.objectContaining({
+                                    fileType: 'change',
+                                    changeType: 'appdescr_ui_generic_app_changePageConfiguration',
+                                    content: expect.objectContaining({
+                                        parentPage: expect.objectContaining({
+                                            component: 'sap.suite.ui.generic.template.ListReport'
+                                        }),
+                                        entityPropertyChange: expect.objectContaining({
+                                            propertyPath: 'component/settings',
+                                            propertyValue: expect.objectContaining({
+                                                smartVariantManagement: false
+                                            })
+                                        })
+                                    })
+                                })
+                            ])
+                        })
+                    );
+
+                // await expect(editor.quickActions.enableVariantManagementInTablesAndCharts).
+            }
+        );
+    });
+});

--- a/tests/integration/adaptation-editor/tsconfig.eslint.json
+++ b/tests/integration/adaptation-editor/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src", "test", ".eslintrc.js", "playwright.config.ts"]
+}

--- a/tests/integration/adaptation-editor/tsconfig.json
+++ b/tests/integration/adaptation-editor/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "src",
+    "src/**/*.json"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "erasableSyntaxOnly": true
+  },
+  "references": [
+    {
+      "path": "../../../packages/playwright"
+    },
+    {
+      "path": "../../../packages/project-access"
+    },
+    {
+      "path": "../../../packages/ui5-info"
+    },
+    {
+      "path": "../../../packages/yaml"
+    }
+  ]
+}

--- a/tests/integration/adaptation-editor/version.js
+++ b/tests/integration/adaptation-editor/version.js
@@ -1,0 +1,18 @@
+const { writeFile } = require('fs/promises');
+const { join } = require('path');
+const { getUI5Versions } = require('@sap-ux/ui5-info');
+
+getUI5Versions({
+    minSupportedUI5Version: '1.71',
+    includeMaintained: true,
+    onlyLatestPatchVersion: true
+})
+    .then((versions) => {
+        'use strict';
+        const maintenanceVersions = versions.filter((version) => version.maintained).map((version) => version.version);
+        return writeFile(join(__dirname, 'versions.json'), JSON.stringify(maintenanceVersions));
+    })
+    .catch((error) => {
+        'use strict';
+        console.error('Error fetching UI5 versions:', error);
+    });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -284,6 +284,9 @@
     },
     {
       "path": "examples/ui-prompting-examples"
+    },
+    {
+      "path": "tests/integration/adaptation-editor"
     }
   ]
 }


### PR DESCRIPTION
Add a new workflow for running Adaptation Editor integration tests. In these tests ABAP backend is mocked and applications are generated on the fly for each test case. Currently only one SAP Fiori Elements for OData V2 project is supported, but more can be added and customized if that is required in test cases. 

UI5 versions used in tests are dynamically loaded from cache and can be updated using `Update UI5 Maintenance Versions` workflow. For each version a different job is triggered and runs in parallel, later all the results are merged back together and the combined Playwright report can be downloaded and viewed.