### PR TITLE
fix(@sap-ux-private/ui-prompting-examples): sonar issue for prompting examples

### DIFF
--- a/examples/ui-prompting-examples/src/addons/preview/component.tsx
+++ b/examples/ui-prompting-examples/src/addons/preview/component.tsx
@@ -8,7 +8,7 @@ getWebSocket(false);
 
 type SupportedLanguages = 'html' | 'json';
 
-export const render = (props: { active?: boolean }): React.ReactElement => {
+export const CodePreview = (props: { active?: boolean }): React.ReactElement => {
     const { active = false } = props;
     const [preview, setPreview] = useState<{
         codeSnippets: { content: string; fileName: string; language: SupportedLanguages }[];

--- a/examples/ui-prompting-examples/src/addons/project/component.tsx
+++ b/examples/ui-prompting-examples/src/addons/project/component.tsx
@@ -173,7 +173,7 @@ export const ProjectPathForm = memo(() => {
 
 ProjectPathForm.displayName = 'ProjectPathForm';
 
-export const render = (props: { active?: boolean }): React.ReactElement => {
+export const ProjectSelector = (props: { active?: boolean }): React.ReactElement => {
     const { active = false } = props;
     return (
         <AddonPanel key="panel" active={active}>

--- a/examples/ui-prompting-examples/src/addons/register.ts
+++ b/examples/ui-prompting-examples/src/addons/register.ts
@@ -1,28 +1,28 @@
 import { addons, types } from '@storybook/addons';
-import { render as renderPreview } from './preview/component';
-import { render as renderProject } from './project/component';
+import { CodePreview } from './preview/component';
+import { ProjectSelector } from './project/component';
 
 const ADDONS = [
     {
         id: 'code-preview',
         title: 'Code preview',
-        render: renderPreview
+        component: CodePreview
     },
     {
         id: 'project-selector',
         title: 'Project path',
-        render: renderProject
+        component: ProjectSelector
     }
 ];
 
 for (const addon of ADDONS) {
-    const { id, render, title } = addon;
+    const { id, component, title } = addon;
     addons.register(id, () => {
         addons.add(id, {
             title: title,
             type: types.PANEL,
             match: ({ viewMode }) => !!viewMode?.match(/^(story|docs)$/),
-            render: render
+            render: component
         });
     });
 }


### PR DESCRIPTION
Issue to fix sonar issue:
<img width="1908" height="912" alt="image" src="https://github.com/user-attachments/assets/eb4c007b-d719-493b-90e5-3e62597c864a" />

Solution - use component name approach:
<img width="654" height="383" alt="image" src="https://github.com/user-attachments/assets/2dd0736c-8ff8-4d76-9c44-eafb5eba22a5" />

No changelog, because package is private and used as sandbox