### PR TITLE
move headless AppConfig type and associated types to fiori gen shared module

### DIFF
--- a/.changeset/cyan-timers-jog.md
+++ b/.changeset/cyan-timers-jog.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux/deploy-config-sub-generator': patch
+'@sap-ux/fiori-app-sub-generator': patch
+'@sap-ux/fiori-generator-shared': patch
+'@sap-ux/cap-config-writer': patch
+---
+
+move headless AppConfig type and associated types to fiori gen shared module

--- a/packages/cap-config-writer/src/cap-config/types.ts
+++ b/packages/cap-config-writer/src/cap-config/types.ts
@@ -1,6 +1,5 @@
+import type { CapRuntime } from '@sap-ux/fiori-generator-shared';
 import type { CdsVersionInfo, CdsUi5PluginInfo } from '@sap-ux/project-access';
-
-export type CapRuntime = 'Node.js' | 'Java';
 
 export interface CapService {
     /**

--- a/packages/cap-config-writer/src/cap-writer/utils.ts
+++ b/packages/cap-config-writer/src/cap-writer/utils.ts
@@ -1,5 +1,5 @@
 import { initI18n, t } from '../i18n';
-import type { CapRuntime } from '../cap-config/types';
+import type { CapRuntime } from '@sap-ux/fiori-generator-shared';
 
 /**
  * Returns the url to the specified cap app as served by `cds serve` or `cds watch`.

--- a/packages/cap-config-writer/src/index.ts
+++ b/packages/cap-config-writer/src/index.ts
@@ -1,6 +1,7 @@
 import { checkCdsUi5PluginEnabled } from '@sap-ux/project-access';
 export { checkCdsUi5PluginEnabled };
 export { enableCdsUi5Plugin } from './cap-config';
-export type { CapService, CapRuntime } from './cap-config/types';
+export type { CapService } from './cap-config/types';
+export type { CapRuntime } from '@sap-ux/fiori-generator-shared';
 export type { CapServiceCdsInfo, CapProjectSettings } from './cap-config/types';
 export * from './cap-writer';

--- a/packages/deploy-config-sub-generator/package.json
+++ b/packages/deploy-config-sub-generator/package.json
@@ -57,7 +57,6 @@
         "@sap-ux/abap-deploy-config-inquirer": "workspace:*",
         "@sap-ux/cf-deploy-config-inquirer": "workspace:*",
         "@sap-ux/cf-deploy-config-writer": "workspace:*",
-        "@sap-ux/fiori-app-sub-generator": "workspace:*",
         "@sap-ux/jest-file-matchers": "workspace:*",
         "@sap/mta-lib": "1.7.4",
         "fs-extra": "10.0.0",

--- a/packages/deploy-config-sub-generator/src/headless/index.ts
+++ b/packages/deploy-config-sub-generator/src/headless/index.ts
@@ -1,11 +1,10 @@
 import { join, resolve } from 'path';
 import { unlinkSync } from 'fs';
 import { DeploymentGenerator } from '@sap-ux/deploy-config-generator-shared';
-import { DeployTarget } from '@sap-ux/fiori-generator-shared';
 import { t, generatorNamespace, abapChoice, cfChoice } from '../utils';
+import { DeployTarget, type AppConfig } from '@sap-ux/fiori-generator-shared';
 import type { CfDeployConfigOptions } from '@sap-ux/cf-deploy-config-sub-generator';
 import type { AbapDeployConfigOptions } from '@sap-ux/abap-deploy-config-sub-generator';
-import type { AppConfig } from '@sap-ux/fiori-app-sub-generator';
 import type {
     CFDeployConfig as CfHeadlessDeployConfig,
     AbapDeployConfigOptions as AbapHeadlessDeployConfigOptions

--- a/packages/deploy-config-sub-generator/tsconfig.json
+++ b/packages/deploy-config-sub-generator/tsconfig.json
@@ -31,9 +31,6 @@
       "path": "../deploy-config-generator-shared"
     },
     {
-      "path": "../fiori-app-sub-generator"
-    },
-    {
       "path": "../fiori-generator-shared"
     },
     {

--- a/packages/fiori-app-sub-generator/src/app-headless/transforms.ts
+++ b/packages/fiori-app-sub-generator/src/app-headless/transforms.ts
@@ -1,11 +1,11 @@
 import type { CapService } from '@sap-ux/cap-config-writer';
 import { OdataVersion } from '@sap-ux/fiori-elements-writer';
-import { getCapFolderPathsSync } from '@sap-ux/fiori-generator-shared';
+import { getCapFolderPathsSync, type AppConfig } from '@sap-ux/fiori-generator-shared';
 import { DatasourceType, type EntityRelatedAnswers } from '@sap-ux/odata-service-inquirer';
 import { promptNames } from '@sap-ux/ui5-application-inquirer';
 import { getDefaultUI5Theme, supportedUi5VersionFallbacks } from '@sap-ux/ui5-info';
 import { join } from 'path';
-import type { AppConfig, FEAppConfig, FFAppConfig, Project, Service, State } from '../types';
+import type { FEAppConfig, FFAppConfig, Project, Service, State } from '../types';
 import { ApiHubType, FloorplanFE, FloorplanFF, capTypeConversion, defaultPromptValues } from '../types';
 import { getODataVersion, t } from '../utils';
 

--- a/packages/fiori-app-sub-generator/src/types/external.ts
+++ b/packages/fiori-app-sub-generator/src/types/external.ts
@@ -1,8 +1,7 @@
 import type { IPrompt as Step } from '@sap-devx/yeoman-ui-types';
-import type { Annotations } from '@sap-ux/axios-extension';
 import { TemplateType as FETemplateType } from '@sap-ux/fiori-elements-writer';
 import { TemplateType as FFTemplateType } from '@sap-ux/fiori-freestyle-writer';
-import type { DeployConfig, FLPConfig } from '@sap-ux/fiori-generator-shared';
+import { AppConfig, type Floorplan, FloorplanFE, FloorplanFF } from '@sap-ux/fiori-generator-shared';
 import type { CapRuntime, EntityRelatedAnswers } from '@sap-ux/odata-service-inquirer';
 import { OdataVersion } from '@sap-ux/odata-service-inquirer';
 import {
@@ -11,12 +10,9 @@ import {
 } from '@sap-ux/ui5-application-inquirer';
 import type { Answers } from 'inquirer';
 import { LEGACY_CAP_TYPE_JAVA, LEGACY_CAP_TYPE_NODE } from './constants';
-import { type ALPOptions, type Project, type Service, type Floorplan, FloorplanFE, FloorplanFF } from './state';
+import { type ALPOptions, type Project, type Service } from './state';
 
 export { Floorplan, FloorplanFE, FloorplanFF };
-
-// Used in external interfaces to define floorplans using a simple meaningful string key
-export type FloorplanKey = keyof typeof FloorplanFE | keyof typeof FloorplanFF;
 
 type FloorplanAttributesType = {
     [K in Floorplan]: {
@@ -56,59 +52,6 @@ export const FloorplanAttributes: FloorplanAttributesType = {
         templateType: FFTemplateType.Basic
     }
 };
-
-/**
- * Defines the external interface used to generate in headless mode (no prompts)
- * This is a deliberate re-definition of internal interfaces to avoid consumers having
- * to update when internal interfaces are changed
- * NOTE: Any breaking changes to this interface require a version bump
- */
-export interface AppConfig {
-    readonly version: string; // The interface version
-    readonly floorplan: FloorplanKey;
-    project: {
-        readonly name: string;
-        targetFolder?: string; // Current working directory will be used if not provided
-        readonly namespace?: string;
-        readonly title?: string;
-        readonly description?: string;
-        readonly ui5Theme?: string;
-        readonly ui5Version?: string;
-        readonly localUI5Version?: string;
-        readonly sapux?: boolean;
-        readonly skipAnnotations?: boolean;
-        readonly enableCodeAssist?: boolean;
-        readonly enableEslint?: boolean;
-        readonly enableTypeScript?: boolean;
-    };
-    service?: {
-        readonly host?: string;
-        readonly servicePath?: string;
-        readonly client?: string;
-        readonly scp?: boolean; // If available key store entry must be available or provided at app runtime
-        readonly destination?: string;
-        readonly destinationInstance?: string;
-        readonly edmx?: string;
-        readonly annotations?: Annotations | Annotations[];
-        readonly capService?: {
-            readonly projectPath: string;
-            readonly serviceName: string;
-            readonly serviceCdsPath: string;
-            readonly capType?: CapRuntime;
-            readonly appPath?: string; // Alternative app path
-        };
-        readonly apiHubApiKey?: string; // Non-enterprise support only currently
-    };
-    deployConfig?: DeployConfig;
-    flpConfig?: FLPConfig;
-    /**
-     * Adds telemetry data when passed to generator `@sap/generator-fiori:headless`
-     */
-    telemetryData?: {
-        generationSourceName?: string;
-        generationSourceVersion?: string;
-    };
-}
 
 /**
  * Defines the entity config property of the external app config interface used to generate in headless mode (no prompts)

--- a/packages/fiori-app-sub-generator/src/types/state.ts
+++ b/packages/fiori-app-sub-generator/src/types/state.ts
@@ -12,7 +12,7 @@ import type {
 } from '@sap-ux/odata-service-inquirer';
 import type { ApiHubType, SapSystemSourceType } from '../types/constants';
 import type { Script } from './common';
-import type { AppGenInfo } from '@sap-ux/fiori-generator-shared';
+import type { AppGenInfo, Floorplan } from '@sap-ux/fiori-generator-shared';
 
 export interface Project {
     targetFolder: string;
@@ -149,36 +149,3 @@ export interface ALPOptions {
     smartVariantManagement: boolean;
     selectionMode: TableSelectionMode;
 }
-
-// Union types to expose a single interface property for Floorplan
-// This provides a layer of abstraction to isolate internal changes from external headless API consumers
-// Since these keys are used as an external API definiton they need to be meaningful
-// Note that ordering here determines rendering order
-/**
- * Due to ts(18033) we cannot use the type values directly here:
- * FF_SIMPLE = FFTemplateType.Basic // Once https://github.com/microsoft/TypeScript/pull/59475 is merged we can remove the hardcoded values and directly use the template values
- */
-export enum FloorplanFF {
-    FF_SIMPLE = 'basic'
-}
-/**
- * Due to ts(18033) we cannot use the type values directly here:
- * Once https://github.com/microsoft/TypeScript/pull/59475 is merged we can remove hardcoded values and directly use the template values
- * FE_FPM = FETemplateType.FlexibleProgrammingModel,
- * FE_LROP = FETemplateType.ListReportObjectPage,
- * FE_OVP = FETemplateType.OverviewPage,
- * FE_ALP = FETemplateType.AnalyticalListPage,
- * FE_FEOP = FETemplateType.FormEntryObjectPage,
- * FE_WORKLIST = FETemplateType.Worklist
- */
-export enum FloorplanFE {
-    FE_FPM = 'fpm',
-    FE_LROP = 'lrop',
-    FE_OVP = 'ovp',
-    FE_ALP = 'alp',
-    FE_FEOP = 'feop',
-    FE_WORKLIST = 'worklist'
-}
-
-// Used internally to join Floorplan types from multiple generators (until we have a merged type)
-export type Floorplan = FloorplanFE | FloorplanFF;

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -45,6 +45,7 @@
         "@types/semver": "7.5.2",
         "@types/vscode": "1.73.1",
         "@types/yeoman-environment": "2.10.11",
+        "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/logger": "workspace:*"
     },
     "engines": {

--- a/packages/fiori-generator-shared/src/types/app-gen.ts
+++ b/packages/fiori-generator-shared/src/types/app-gen.ts
@@ -82,3 +82,39 @@ export interface AppGenInfo {
      */
     externalParameters?: ExternalParameters;
 }
+
+// Union types to expose a single interface property for Floorplan
+// This provides a layer of abstraction to isolate internal changes from external headless API consumers
+// Since these keys are used as an external API definiton they need to be meaningful
+// Note that ordering here determines rendering order
+/**
+ * Due to ts(18033) we cannot use the type values directly here:
+ * FF_SIMPLE = FFTemplateType.Basic // Once https://github.com/microsoft/TypeScript/pull/59475 is merged we can remove the hardcoded values and directly use the template values
+ */
+export enum FloorplanFF {
+    FF_SIMPLE = 'basic'
+}
+/**
+ * Due to ts(18033) we cannot use the type values directly here:
+ * Once https://github.com/microsoft/TypeScript/pull/59475 is merged we can remove hardcoded values and directly use the template values
+ * FE_FPM = FETemplateType.FlexibleProgrammingModel,
+ * FE_LROP = FETemplateType.ListReportObjectPage,
+ * FE_OVP = FETemplateType.OverviewPage,
+ * FE_ALP = FETemplateType.AnalyticalListPage,
+ * FE_FEOP = FETemplateType.FormEntryObjectPage,
+ * FE_WORKLIST = FETemplateType.Worklist
+ */
+export enum FloorplanFE {
+    FE_FPM = 'fpm',
+    FE_LROP = 'lrop',
+    FE_OVP = 'ovp',
+    FE_ALP = 'alp',
+    FE_FEOP = 'feop',
+    FE_WORKLIST = 'worklist'
+}
+
+// Used internally to join Floorplan types from multiple generators (until we have a merged type)
+export type Floorplan = FloorplanFE | FloorplanFF;
+
+// Used in external interfaces to define floorplans using a simple meaningful string key
+export type FloorplanKey = keyof typeof FloorplanFE | keyof typeof FloorplanFF;

--- a/packages/fiori-generator-shared/src/types/cap.ts
+++ b/packages/fiori-generator-shared/src/types/cap.ts
@@ -1,0 +1,1 @@
+export type CapRuntime = 'Node.js' | 'Java';

--- a/packages/fiori-generator-shared/src/types/headless.ts
+++ b/packages/fiori-generator-shared/src/types/headless.ts
@@ -1,4 +1,8 @@
 import { Authentication } from '@sap-ux/btp-utils';
+import type { Annotations } from '@sap-ux/axios-extension';
+import type { FloorplanKey } from './app-gen';
+import type { CapRuntime } from './cap';
+
 /**
  * Shared types used by headless generation from multiple modules
  */
@@ -70,4 +74,57 @@ export interface FLPConfig {
     readonly action?: string;
     readonly title?: string;
     readonly semanticObject?: string;
+}
+
+/**
+ * Defines the external interface used to generate in headless mode (no prompts)
+ * This is a deliberate re-definition of internal interfaces to avoid consumers having
+ * to update when internal interfaces are changed
+ * NOTE: Any breaking changes to this interface require a version bump
+ */
+export interface AppConfig {
+    readonly version: string; // The interface version
+    readonly floorplan: FloorplanKey;
+    project: {
+        readonly name: string;
+        targetFolder?: string; // Current working directory will be used if not provided
+        readonly namespace?: string;
+        readonly title?: string;
+        readonly description?: string;
+        readonly ui5Theme?: string;
+        readonly ui5Version?: string;
+        readonly localUI5Version?: string;
+        readonly sapux?: boolean;
+        readonly skipAnnotations?: boolean;
+        readonly enableCodeAssist?: boolean;
+        readonly enableEslint?: boolean;
+        readonly enableTypeScript?: boolean;
+    };
+    service?: {
+        readonly host?: string;
+        readonly servicePath?: string;
+        readonly client?: string;
+        readonly scp?: boolean; // If available key store entry must be available or provided at app runtime
+        readonly destination?: string;
+        readonly destinationInstance?: string;
+        readonly edmx?: string;
+        readonly annotations?: Annotations | Annotations[];
+        readonly capService?: {
+            readonly projectPath: string;
+            readonly serviceName: string;
+            readonly serviceCdsPath: string;
+            readonly capType?: CapRuntime;
+            readonly appPath?: string; // Alternative app path
+        };
+        readonly apiHubApiKey?: string; // Non-enterprise support only currently
+    };
+    deployConfig?: DeployConfig;
+    flpConfig?: FLPConfig;
+    /**
+     * Adds telemetry data when passed to generator `@sap/generator-fiori:headless`
+     */
+    telemetryData?: {
+        generationSourceName?: string;
+        generationSourceVersion?: string;
+    };
 }

--- a/packages/fiori-generator-shared/src/types/index.ts
+++ b/packages/fiori-generator-shared/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './app-gen';
+export * from './cap';
 export * from './environment';
 export * from './headless';

--- a/packages/fiori-generator-shared/tsconfig.json
+++ b/packages/fiori-generator-shared/tsconfig.json
@@ -10,6 +10,9 @@
   },
   "references": [
     {
+      "path": "../axios-extension"
+    },
+    {
       "path": "../btp-utils"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 3.1.3(prettier@2.8.8)
       react-select:
         specifier: 5.8.0
-        version: 5.8.0(react-dom@16.14.0)(react@16.14.0)
+        version: 5.8.0(@types/react@16.14.55)(react-dom@16.14.0)(react@16.14.0)
       react-virtualized:
         specifier: 9.22.5
         version: 9.22.5(react-dom@16.14.0)(react@16.14.0)
@@ -987,56 +987,6 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
 
-  packages/cards-editor-config-writer:
-    dependencies:
-      '@sap-ux/ui5-config':
-        specifier: workspace:*
-        version: link:../ui5-config
-      mem-fs:
-        specifier: 2.1.0
-        version: 2.1.0
-      mem-fs-editor:
-        specifier: 9.4.0
-        version: 9.4.0(mem-fs@2.1.0)
-    devDependencies:
-      '@sap-ux/project-access':
-        specifier: workspace:*
-        version: link:../project-access
-      '@types/mem-fs':
-        specifier: 1.1.2
-        version: 1.1.2
-      '@types/mem-fs-editor':
-        specifier: 7.0.1
-        version: 7.0.1
-
-  packages/cards-editor-middleware:
-    dependencies:
-      '@sap-ux/logger':
-        specifier: workspace:*
-        version: link:../logger
-      '@sap-ux/project-access':
-        specifier: workspace:*
-        version: link:../project-access
-      ejs:
-        specifier: 3.1.10
-        version: 3.1.10
-    devDependencies:
-      '@types/ejs':
-        specifier: 3.1.2
-        version: 3.1.2
-      '@types/express':
-        specifier: 4.17.21
-        version: 4.17.21
-      '@types/supertest':
-        specifier: 2.0.12
-        version: 2.0.12
-      express:
-        specifier: 4.21.2
-        version: 4.21.2
-      supertest:
-        specifier: 6.3.3
-        version: 6.3.3
-
   packages/cds-annotation-parser:
     dependencies:
       '@sap-ux/odata-annotation-core':
@@ -1593,9 +1543,6 @@ importers:
       '@sap-ux/cf-deploy-config-writer':
         specifier: workspace:*
         version: link:../cf-deploy-config-writer
-      '@sap-ux/fiori-app-sub-generator':
-        specifier: workspace:*
-        version: link:../fiori-app-sub-generator
       '@sap-ux/jest-file-matchers':
         specifier: workspace:*
         version: link:../jest-file-matchers
@@ -2244,6 +2191,9 @@ importers:
         specifier: 7.5.4
         version: 7.5.4
     devDependencies:
+      '@sap-ux/axios-extension':
+        specifier: workspace:*
+        version: link:../axios-extension
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
@@ -22229,28 +22179,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.23.2
-      '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.1(@types/react@16.14.55)(react@16.14.0)
-      '@floating-ui/dom': 1.5.1
-      '@types/react-transition-group': 4.4.6
-      memoize-one: 6.0.0
-      prop-types: 15.8.1
-      react: 16.14.0
-      react-dom: 16.14.0(react@16.14.0)
-      react-transition-group: 4.4.5(react-dom@16.14.0)(react@16.14.0)
-      use-isomorphic-layout-effect: 1.1.2(@types/react@16.14.55)(react@16.14.0)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
-    dev: false
-
-  /react-select@5.8.0(react-dom@16.14.0)(react@16.14.0):
-    resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
       '@babel/runtime': 7.27.6
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@16.14.55)(react@16.14.0)
@@ -22265,7 +22193,6 @@ packages:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
-    dev: true
 
   /react-test-renderer@16.14.0(react@16.14.0):
     resolution: {integrity: sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==}


### PR DESCRIPTION
Moves `AppConfig` type used by headless generators into `@sap-ux/fiori-generator-shared`

This allows the removal of the `@sap-ux/fiori-app-sub-generator` dep from the deploy config sub gen