### PR TITLE
fix(fiori-gen): updates FioriAppGeneratorPromptSettings type

### DIFF
--- a/.changeset/lemon-pigs-guess.md
+++ b/.changeset/lemon-pigs-guess.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-app-sub-generator': patch
+---
+
+updates FioriAppGeneratorPromptSettings

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -171,7 +171,7 @@ export class FioriAppGenerator extends Generator {
                     capService: cachedService?.capService ?? this.state.service?.capService,
                     requiredOdataVersion: getRequiredOdataVersion(this.state.floorplan),
                     allowNoDatasource: isFioriFreestyleTemplate,
-                    promptOptions: generatorOptions.promptSettings,
+                    promptOptions: generatorOptions.promptSettings?.['@sap/generator-fiori'],
                     showCollabDraftWarning: generatorOptions.showCollabDraftWarning,
                     workspaceFolders: generatorOptions.workspaceFolders
                 };
@@ -259,7 +259,7 @@ export class FioriAppGenerator extends Generator {
                             targetFolder: this.state.project?.targetFolder,
                             service: this.state.service,
                             floorplan: this.state.floorplan,
-                            promptSettings: generatorOptions.promptSettings,
+                            promptSettings: generatorOptions.promptSettings?.['@sap/generator-fiori'],
                             promptExtension: generatorOptions.extensions
                         },
                         [this.yeomanUiStepConfig],

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/prompting.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/prompting.ts
@@ -24,7 +24,7 @@ import type { Question } from 'inquirer';
 import merge from 'lodash/merge';
 import { join } from 'path';
 import type { Adapter } from 'yeoman-environment';
-import type { FioriAppGeneratorPromptSettings, Floorplan, Project, Service, YeomanUiStepConfig } from '../types';
+import type { Floorplan, Project, Service, YeomanUiStepConfig } from '../types';
 import { Features, defaultPromptValues } from '../types';
 import { getMinSupportedUI5Version, t, validateNextStep } from '../utils';
 
@@ -80,7 +80,7 @@ type PromptUI5AppAnswersOptions = {
     projectName?: Project['name'];
     targetFolder?: Project['targetFolder'];
     service: Partial<Service>;
-    promptSettings?: FioriAppGeneratorPromptSettings;
+    promptSettings?: UI5ApplicationPromptOptions;
     floorplan: Floorplan;
     promptExtension?: UI5ApplicationPromptOptions;
 };
@@ -101,15 +101,7 @@ type PromptUI5AppAnswersOptions = {
  * @returns
  */
 export async function promptUI5ApplicationAnswers(
-    {
-        service,
-        projectName,
-        targetFolder,
-        promptSettings,
-
-        floorplan,
-        promptExtension
-    }: PromptUI5AppAnswersOptions,
+    { service, projectName, targetFolder, promptSettings, floorplan, promptExtension }: PromptUI5AppAnswersOptions,
     yeomanUiStepConfig: YeomanUiStepConfig[],
     adapter: Adapter
 ): Promise<{ ui5AppAnswers: UI5ApplicationAnswers; localUI5Version: string | undefined }> {
@@ -223,7 +215,7 @@ export async function createUI5ApplicationPromptOptions(
     floorplan: Floorplan,
     projectName?: Project['name'],
     targetFolder?: Project['targetFolder'],
-    promptSettings?: FioriAppGeneratorPromptSettings,
+    promptSettings?: UI5ApplicationPromptOptions,
     extensions?: UI5ApplicationPromptOptions
 ): Promise<UI5ApplicationPromptOptions> {
     // prompt settings may be additionally provided e.g. set by adaptors
@@ -352,7 +344,7 @@ export interface OdataServiceInquirerOptions {
      * Note: only some of the allowed prompt options are currently supported.
      * Eventually all should be supported by merging the options with the prompt specific options.
      */
-    promptOptions?: FioriAppGeneratorPromptSettings;
+    promptOptions?: OdataServicePromptOptions;
     showCollabDraftWarning?: boolean;
     workspaceFolders?: string[];
 }

--- a/packages/fiori-app-sub-generator/src/types/common.ts
+++ b/packages/fiori-app-sub-generator/src/types/common.ts
@@ -25,11 +25,10 @@ export interface SubGeneratorPromptSettings {
 }
 
 export interface FioriGeneratorPromptSettings {
-    '@sap/generator-fiori': OdataServicePromptOptions & UI5ApplicationPromptOptions;
+    '@sap/generator-fiori'?: OdataServicePromptOptions & UI5ApplicationPromptOptions;
 }
 
-export type FioriAppGeneratorPromptSettings = FioriGeneratorPromptSettings['@sap/generator-fiori'] &
-    SubGeneratorPromptSettings;
+export type FioriAppGeneratorPromptSettings = FioriGeneratorPromptSettings & SubGeneratorPromptSettings;
 
 /**
  * Custom environment type until yeoman-environment provides one

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle1.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle1.test.ts
@@ -269,8 +269,10 @@ describe('Test FioriAppGenerator', () => {
         options.showCollabDraftWarning = true;
         options.workspaceFolders = ['folder1', 'folder2'];
         options.promptSettings = {
-            systemSelection: {
-                defaultChoice: 'system1'
+            '@sap/generator-fiori': {
+                systemSelection: {
+                    defaultChoice: 'system1'
+                }
             }
         };
 
@@ -472,14 +474,16 @@ describe('Test FioriAppGenerator', () => {
             floorplan: FloorplanFE.FE_WORKLIST
         };
         options.promptSettings = {
-            name: {
-                hide: true
-            },
-            targetFolder: {
-                hide: true
-            },
-            ui5Version: {
-                hide: true
+            '@sap/generator-fiori': {
+                name: {
+                    hide: true
+                },
+                targetFolder: {
+                    hide: true
+                },
+                ui5Version: {
+                    hide: true
+                }
             }
         };
         options.extensions = {
@@ -497,14 +501,14 @@ describe('Test FioriAppGenerator', () => {
         // Should call to prompt for UI5 application answers with the expected parameters
         expect(promptUI5ApplicationAnswers).toHaveBeenCalledWith(
             {
-                projectName: undefined,
+                name: undefined,
                 targetFolder: undefined,
                 service: {
                     edmx: '<edmx></edmx>',
                     source: DatasourceType.sapSystem
                 },
                 floorplan: FloorplanFF.FF_SIMPLE,
-                promptSettings: options.promptSettings,
+                promptSettings: options.promptSettings['@sap/generator-fiori'],
                 promptExtension: options.extensions
             },
             expect.arrayContaining([


### PR DESCRIPTION
Removes specific key reference from FioriAppGeneratorPromptSettings type and makes necessary updates in Fiori sub gen

This is so the `FioriAppGeneratorPromptSettings` has the prompt options at the appropriate level, and not with UI5 app prompt options and odata service inquirer at the root level