### PR TITLE
fix: We now ignore `module` type dependencies

### DIFF
--- a/.changeset/ten-poems-wonder.md
+++ b/.changeset/ten-poems-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/jest-environment-ui5': patch
+---
+
+We now ignore `module` type dependency during the jest environment processing


### PR DESCRIPTION
Fix for #3449
Ui5 detect dependencies of the project that are non ui5 and expose them as `module` but that also doesn't work when trying to build the dependency path.