### PR TITLE
fix(deploy-config): fix conflict of overwrite prompt name

### DIFF
--- a/.changeset/slow-wasps-hope.md
+++ b/.changeset/slow-wasps-hope.md
@@ -1,0 +1,8 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': minor
+'@sap-ux/cf-deploy-config-inquirer': minor
+'@sap-ux/abap-deploy-config-sub-generator': patch
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+fix overwrite prompt conflict

--- a/.changeset/tiny-cougars-return.md
+++ b/.changeset/tiny-cougars-return.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/cf-deploy-config-inquirer': minor
+'@sap-ux/cf-deploy-config-sub-generator': patch
+---
+
+fix conflict of overwrite prompt name

--- a/.changeset/tiny-cougars-return.md
+++ b/.changeset/tiny-cougars-return.md
@@ -1,6 +1,0 @@
----
-'@sap-ux/cf-deploy-config-inquirer': minor
-'@sap-ux/cf-deploy-config-sub-generator': patch
----
-
-fix conflict of overwrite prompt name

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/confirm.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/confirm.ts
@@ -30,7 +30,7 @@ function getIndexPrompt(options: AbapDeployConfigPromptOptions): Question<AbapDe
  */
 function getOverwritePrompt(): Question<AbapDeployConfigAnswersInternal> {
     return {
-        name: promptNames.overwrite,
+        name: promptNames.overwriteAbapConfig,
         type: 'confirm',
         message: t('prompts.confirm.overwrite.message'),
         guiOptions: {
@@ -49,7 +49,7 @@ function getOverwritePrompt(): Question<AbapDeployConfigAnswersInternal> {
  */
 export function getConfirmPrompts(options: AbapDeployConfigPromptOptions): Question<AbapDeployConfigAnswersInternal>[] {
     const questions = [getIndexPrompt(options)];
-    if (options.overwrite?.hide !== true) {
+    if (options.overwriteAbapConfig?.hide !== true) {
         questions.push(getOverwritePrompt());
     }
     return questions;

--- a/packages/abap-deploy-config-inquirer/src/types.ts
+++ b/packages/abap-deploy-config-inquirer/src/types.ts
@@ -51,6 +51,9 @@ export interface AbapSystemChoice {
 
 /**
  * Enumeration of prompt names used by
+ *
+ * N.B. as these prompts are merged with CF prompts (see `promptNames` in packages/cf-deploy-config-inquirer/src/types.ts),
+ * ensure that the names are unique across both files.
  */
 export enum promptNames {
     destination = 'destination',

--- a/packages/abap-deploy-config-inquirer/src/types.ts
+++ b/packages/abap-deploy-config-inquirer/src/types.ts
@@ -80,7 +80,7 @@ export enum promptNames {
     transportFromList = 'transportFromList',
     transportManual = 'transportManual',
     index = 'index',
-    overwrite = 'overwrite'
+    overwriteAbapConfig = 'overwriteAbapConfig'
 }
 
 /**
@@ -211,7 +211,7 @@ type abapPromptOptions = {
     [promptNames.packageManual]: PackageManualPromptOptions & CommonPromptOptions;
     [promptNames.transportManual]: TransportManualPromptOptions & CommonPromptOptions;
     [promptNames.transportCreated]: TransportCreatedPromptOptions & CommonPromptOptions;
-    [promptNames.overwrite]: OverwritePromptOptions & CommonPromptOptions;
+    [promptNames.overwriteAbapConfig]: OverwritePromptOptions & CommonPromptOptions;
     [promptNames.index]: IndexPromptOptions & CommonPromptOptions;
     [promptNames.packageAutocomplete]: PackageAutocompletePromptOptions & CommonPromptOptions;
     [promptNames.transportInputChoice]: TransportInputChoicePromptOptions & CommonPromptOptions;

--- a/packages/abap-deploy-config-inquirer/test/prompts/questions/confirm.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/questions/confirm.test.ts
@@ -28,7 +28,7 @@ describe('getConfirmPrompts', () => {
                   "hint": "Deployment config will abort if you choose no. Click 'Finish' to abort.",
                 },
                 "message": "Editing the deployment configuration will overwrite the existing configuration. Are you sure you want to continue?",
-                "name": "overwrite",
+                "name": "overwriteAbapConfig",
                 "type": "confirm",
                 "validate": [Function],
               },
@@ -53,7 +53,7 @@ describe('getConfirmPrompts', () => {
         jest.spyOn(validators, 'validateConfirmQuestion').mockReturnValue(true);
 
         const confirmPrompts = getConfirmPrompts({});
-        const overwritePrompt = confirmPrompts.find((prompt) => prompt.name === promptNames.overwrite);
+        const overwritePrompt = confirmPrompts.find((prompt) => prompt.name === promptNames.overwriteAbapConfig);
 
         if (overwritePrompt) {
             expect(overwritePrompt.message).toBe(t('prompts.confirm.overwrite.message'));

--- a/packages/abap-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/questions.ts
@@ -143,7 +143,7 @@ export async function getAbapQuestions({
                 useAutocomplete: true,
                 ...promptOptions?.packageAutocomplete
             },
-            overwrite: { hide: !showOverwriteQuestion },
+            overwriteAbapConfig: { hide: !showOverwriteQuestion },
             transportInputChoice: { hideIfOnPremise: promptOptions?.transportInputChoice?.hideIfOnPremise ?? false },
             targetSystem: promptOptions?.targetSystem
         },

--- a/packages/abap-deploy-config-sub-generator/test/app.test.ts
+++ b/packages/abap-deploy-config-sub-generator/test/app.test.ts
@@ -378,7 +378,7 @@ describe('Test abap deploy configuration generator', () => {
                         shouldValidateFormatAndSpecialCharacters: false
                     }
                 },
-                overwrite: { hide: true },
+                overwriteAbapConfig: { hide: true },
                 transportInputChoice: {
                     hideIfOnPremise: false
                 },
@@ -486,7 +486,7 @@ describe('Test abap deploy configuration generator', () => {
                         shouldValidateFormatAndSpecialCharacters: true
                     }
                 },
-                overwrite: { hide: true },
+                overwriteAbapConfig: { hide: true },
                 transportInputChoice: {
                     hideIfOnPremise: true
                 },

--- a/packages/abap-deploy-config-sub-generator/test/unit/app/questions.test.ts
+++ b/packages/abap-deploy-config-sub-generator/test/unit/app/questions.test.ts
@@ -110,7 +110,7 @@ describe('Test getAbapQuestions', () => {
                         shouldValidateFormatAndSpecialCharacters: false
                     }
                 },
-                overwrite: { hide: true },
+                overwriteAbapConfig: { hide: true },
                 transportInputChoice: { hideIfOnPremise: false },
                 targetSystem: { additionalValidation: { shouldRestrictDifferentSystemType: false } }
             },
@@ -193,7 +193,7 @@ describe('Test getAbapQuestions', () => {
                         shouldValidateFormatAndSpecialCharacters: false
                     }
                 },
-                overwrite: { hide: true },
+                overwriteAbapConfig: { hide: true },
                 transportInputChoice: { hideIfOnPremise: false },
                 targetSystem: { additionalValidation: { shouldRestrictDifferentSystemType: false } }
             },

--- a/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
+++ b/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
@@ -106,7 +106,7 @@ function getAddManagedAppRouterPrompt(): CfDeployConfigQuestions {
 function getOverwritePrompt(): CfDeployConfigQuestions {
     return {
         type: 'confirm',
-        name: promptNames.overwrite,
+        name: promptNames.overwriteDestinationName,
         guiOptions: {
             hint: t('prompts.overwriteHintMessage')
         },
@@ -162,7 +162,7 @@ export async function getQuestions(
     log?: Logger
 ): Promise<CfDeployConfigQuestions[]> {
     const destinationOptions = promptOptions[promptNames.destinationName] as DestinationNamePromptOptions;
-    const addOverwriteQuestion = !promptOptions.overwrite?.hide;
+    const addOverwriteQuestion = !promptOptions.overwriteDestinationName?.hide;
     const addManagedAppRouterQuestions = !promptOptions.addManagedAppRouter?.hide;
     const addRouterTypeQuestion = !promptOptions.routerType?.hide;
 

--- a/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
+++ b/packages/cf-deploy-config-inquirer/src/prompts/prompts.ts
@@ -106,7 +106,7 @@ function getAddManagedAppRouterPrompt(): CfDeployConfigQuestions {
 function getOverwritePrompt(): CfDeployConfigQuestions {
     return {
         type: 'confirm',
-        name: promptNames.overwriteDestinationName,
+        name: promptNames.overwriteCfConfig,
         guiOptions: {
             hint: t('prompts.overwriteHintMessage')
         },
@@ -162,7 +162,7 @@ export async function getQuestions(
     log?: Logger
 ): Promise<CfDeployConfigQuestions[]> {
     const destinationOptions = promptOptions[promptNames.destinationName] as DestinationNamePromptOptions;
-    const addOverwriteQuestion = !promptOptions.overwriteDestinationName?.hide;
+    const addOverwriteQuestion = !promptOptions.overwriteCfConfig?.hide;
     const addManagedAppRouterQuestions = !promptOptions.addManagedAppRouter?.hide;
     const addRouterTypeQuestion = !promptOptions.routerType?.hide;
 

--- a/packages/cf-deploy-config-inquirer/src/types.ts
+++ b/packages/cf-deploy-config-inquirer/src/types.ts
@@ -3,6 +3,9 @@ import type { AutocompleteQuestionOptions } from 'inquirer-autocomplete-prompt';
 
 /**
  * Enum defining prompt names for Cloud Foundry (CF) deployment configuration.
+ *
+ * N.B. as these prompts are merged with ABAP prompts (see `promptNames` in packages/abap-deploy-config-inquirer/src/types.ts),
+ * ensure that the names are unique across both files.
  */
 export enum promptNames {
     /** The prompt to specify the destination name for CF deployment. */
@@ -10,7 +13,7 @@ export enum promptNames {
     /** The prompt to specify if a managed app router should be added to the deployment. */
     addManagedAppRouter = 'addManagedAppRouter',
     /** The prompt for confirming destination overwrite. */
-    overwrite = 'overwrite',
+    overwriteDestinationName = 'overwriteDestinationName',
     /** The prompt for confirming the router type. */
     routerType = 'routerType'
 }
@@ -78,7 +81,7 @@ export type DestinationRouterPromptOptions = {
 type cfDeployConfigPromptOptions = {
     [promptNames.destinationName]: DestinationNamePromptOptions & CommonPromptOptions;
     [promptNames.addManagedAppRouter]: CommonPromptOptions;
-    [promptNames.overwrite]: CommonPromptOptions;
+    [promptNames.overwriteDestinationName]: CommonPromptOptions;
     [promptNames.routerType]: CommonPromptOptions;
 };
 

--- a/packages/cf-deploy-config-inquirer/src/types.ts
+++ b/packages/cf-deploy-config-inquirer/src/types.ts
@@ -12,8 +12,8 @@ export enum promptNames {
     destinationName = 'destinationName',
     /** The prompt to specify if a managed app router should be added to the deployment. */
     addManagedAppRouter = 'addManagedAppRouter',
-    /** The prompt for confirming destination overwrite. */
-    overwriteDestinationName = 'overwriteDestinationName',
+    /** The prompt for confirming cf config overwrite. */
+    overwriteCfConfig = 'overwriteCfConfig',
     /** The prompt for confirming the router type. */
     routerType = 'routerType'
 }
@@ -81,7 +81,7 @@ export type DestinationRouterPromptOptions = {
 type cfDeployConfigPromptOptions = {
     [promptNames.destinationName]: DestinationNamePromptOptions & CommonPromptOptions;
     [promptNames.addManagedAppRouter]: CommonPromptOptions;
-    [promptNames.overwriteDestinationName]: CommonPromptOptions;
+    [promptNames.overwriteCfConfig]: CommonPromptOptions;
     [promptNames.routerType]: CommonPromptOptions;
 };
 

--- a/packages/cf-deploy-config-inquirer/test/index.test.ts
+++ b/packages/cf-deploy-config-inquirer/test/index.test.ts
@@ -25,7 +25,7 @@ describe('index', () => {
         [promptNames.addManagedAppRouter]: {
             hide: true
         },
-        [promptNames.overwriteDestinationName]: {
+        [promptNames.overwriteCfConfig]: {
             hide: false
         }
     };

--- a/packages/cf-deploy-config-inquirer/test/index.test.ts
+++ b/packages/cf-deploy-config-inquirer/test/index.test.ts
@@ -25,7 +25,7 @@ describe('index', () => {
         [promptNames.addManagedAppRouter]: {
             hide: true
         },
-        [promptNames.overwrite]: {
+        [promptNames.overwriteDestinationName]: {
             hide: false
         }
     };

--- a/packages/cf-deploy-config-inquirer/test/prompts.test.ts
+++ b/packages/cf-deploy-config-inquirer/test/prompts.test.ts
@@ -232,7 +232,7 @@ describe('Prompt Generation Tests', () => {
         beforeEach(() => {
             promptOptions = {
                 ...promptOptions,
-                [promptNames.overwriteDestinationName]: {
+                [promptNames.overwriteCfConfig]: {
                     hide: false
                 }
             };
@@ -240,9 +240,7 @@ describe('Prompt Generation Tests', () => {
 
         it('Displays get overwrite prompt when enabled', async () => {
             const questions: CfDeployConfigQuestions[] = await getQuestions(promptOptions, mockLog);
-            const overwritePrompt = questions.find(
-                (question) => question.name === promptNames.overwriteDestinationName
-            );
+            const overwritePrompt = questions.find((question) => question.name === promptNames.overwriteCfConfig);
             expect(overwritePrompt?.type).toBe('confirm');
             expect((overwritePrompt?.default as Function)()).toBe(true);
             expect((overwritePrompt?.message as Function)()).toBe(t('prompts.overwriteMessage'));
@@ -250,15 +248,13 @@ describe('Prompt Generation Tests', () => {
         });
 
         it('Displays get overwrite prompt when disabled', async () => {
-            if (promptOptions[promptNames.overwriteDestinationName]) {
-                promptOptions[promptNames.overwriteDestinationName] = {
+            if (promptOptions[promptNames.overwriteCfConfig]) {
+                promptOptions[promptNames.overwriteCfConfig] = {
                     hide: true
                 };
             }
             const questions: CfDeployConfigQuestions[] = await getQuestions(promptOptions, mockLog);
-            const overwritePrompt = questions.find(
-                (question) => question.name === promptNames.overwriteDestinationName
-            );
+            const overwritePrompt = questions.find((question) => question.name === promptNames.overwriteCfConfig);
             expect(overwritePrompt?.type).toBeUndefined();
         });
     });

--- a/packages/cf-deploy-config-inquirer/test/prompts.test.ts
+++ b/packages/cf-deploy-config-inquirer/test/prompts.test.ts
@@ -232,7 +232,7 @@ describe('Prompt Generation Tests', () => {
         beforeEach(() => {
             promptOptions = {
                 ...promptOptions,
-                [promptNames.overwrite]: {
+                [promptNames.overwriteDestinationName]: {
                     hide: false
                 }
             };
@@ -240,7 +240,9 @@ describe('Prompt Generation Tests', () => {
 
         it('Displays get overwrite prompt when enabled', async () => {
             const questions: CfDeployConfigQuestions[] = await getQuestions(promptOptions, mockLog);
-            const overwritePrompt = questions.find((question) => question.name === promptNames.overwrite);
+            const overwritePrompt = questions.find(
+                (question) => question.name === promptNames.overwriteDestinationName
+            );
             expect(overwritePrompt?.type).toBe('confirm');
             expect((overwritePrompt?.default as Function)()).toBe(true);
             expect((overwritePrompt?.message as Function)()).toBe(t('prompts.overwriteMessage'));
@@ -248,13 +250,15 @@ describe('Prompt Generation Tests', () => {
         });
 
         it('Displays get overwrite prompt when disabled', async () => {
-            if (promptOptions[promptNames.overwrite]) {
-                promptOptions[promptNames.overwrite] = {
+            if (promptOptions[promptNames.overwriteDestinationName]) {
+                promptOptions[promptNames.overwriteDestinationName] = {
                     hide: true
                 };
             }
             const questions: CfDeployConfigQuestions[] = await getQuestions(promptOptions, mockLog);
-            const overwritePrompt = questions.find((question) => question.name === promptNames.overwrite);
+            const overwritePrompt = questions.find(
+                (question) => question.name === promptNames.overwriteDestinationName
+            );
             expect(overwritePrompt?.type).toBeUndefined();
         });
     });

--- a/packages/cf-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/questions.ts
@@ -70,7 +70,7 @@ export async function getCFQuestions({
         },
         [promptNames.addManagedAppRouter]: { hide: true, ...promptOptions?.addManagedAppRouter },
         [promptNames.routerType]: { hide: mtaYamlExists || isCap, ...promptOptions?.routerType },
-        [promptNames.overwrite]: { hide: !addOverwrite, ...promptOptions?.overwrite }
+        [promptNames.overwriteDestinationName]: { hide: !addOverwrite, ...promptOptions?.overwriteDestinationName }
     };
 
     DeploymentGenerator.logger?.debug(t('cfGen.debug.promptOptions', { options: JSON.stringify(options) }));

--- a/packages/cf-deploy-config-sub-generator/src/app/questions.ts
+++ b/packages/cf-deploy-config-sub-generator/src/app/questions.ts
@@ -70,7 +70,7 @@ export async function getCFQuestions({
         },
         [promptNames.addManagedAppRouter]: { hide: true, ...promptOptions?.addManagedAppRouter },
         [promptNames.routerType]: { hide: mtaYamlExists || isCap, ...promptOptions?.routerType },
-        [promptNames.overwriteDestinationName]: { hide: !addOverwrite, ...promptOptions?.overwriteDestinationName }
+        [promptNames.overwriteCfConfig]: { hide: !addOverwrite, ...promptOptions?.overwriteCfConfig }
     };
 
     DeploymentGenerator.logger?.debug(t('cfGen.debug.promptOptions', { options: JSON.stringify(options) }));

--- a/packages/deploy-config-sub-generator/test/app/app.test.ts
+++ b/packages/deploy-config-sub-generator/test/app/app.test.ts
@@ -270,7 +270,7 @@ describe('Deployment Generator', () => {
                     hint: false,
                     useAutocomplete: true
                 },
-                overwrite: {
+                overwriteDestinationName: {
                     hide: true
                 },
                 routerType: {

--- a/packages/deploy-config-sub-generator/test/app/app.test.ts
+++ b/packages/deploy-config-sub-generator/test/app/app.test.ts
@@ -270,7 +270,7 @@ describe('Deployment Generator', () => {
                     hint: false,
                     useAutocomplete: true
                 },
-                overwriteDestinationName: {
+                overwriteCfConfig: {
                     hide: true
                 },
                 routerType: {


### PR DESCRIPTION
Internal high bug 35240

Reverts change made here https://github.com/SAP/open-ux-tools/pull/3444/files#diff-24301133b22fc485c7fb65d11b3e76c2150400123d73802940fe378e8b378ebdR13

`overwrite` prompt causing conflict as there is an existing prompt in ABAP deploy config inquirer with same name

Added a note to help prevent such case in the future