### PR TITLE
feat(odata-service-inq): move entity helpers to inq-common

### DIFF
--- a/.changeset/smooth-bobcats-watch.md
+++ b/.changeset/smooth-bobcats-watch.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+'@sap-ux/inquirer-common': patch
+---
+
+move aggregration entity helpers to inq-common

--- a/packages/inquirer-common/package.json
+++ b/packages/inquirer-common/package.json
@@ -31,7 +31,9 @@
     ],
     "dependencies": {
         "@sap/cf-tools": "3.2.2",
+        "@sap-ux/annotation-converter": "0.10.2",
         "@sap-ux/btp-utils": "workspace:*",
+        "@sap-ux/edmx-parser": "0.9.1",
         "@sap-ux/feature-toggle": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/guided-answers-helper": "workspace:*",
@@ -48,6 +50,7 @@
         "semver": "7.5.4"
     },
     "devDependencies": {
+        "@sap-ux/vocabularies-types": "0.13.0",
         "@sap-devx/yeoman-ui-types": "1.14.4",
         "@types/inquirer": "8.2.6",
         "@types/semver": "7.5.4",

--- a/packages/inquirer-common/src/translations/inquirer-common.i18n.json
+++ b/packages/inquirer-common/src/translations/inquirer-common.i18n.json
@@ -46,7 +46,9 @@
         "internalServerError": "Internal server error{{-errorMsg, addMsgWithColonFormatter}}",
         "badGateway": "Bad gateway{{- errorMsg, addMsgWithColonFormatter}}",
         "badRequest": "Bad request{{- errorMsg, addMsgWithColonFormatter}}",
-        "cannotBeEmpty": "{{- field}} cannot be empty."
+        "cannotBeEmpty": "{{- field}} cannot be empty.",
+        "unparseableMetadata": "Unable to parse entities from the metadata document: {{-error}}.",
+        "unparseableOdataVersion": "Unable to parse the OData version from the metadata."
     },
     "guidedAnswers": {
         "validationErrorHelpText": "Need help with this error?"

--- a/packages/inquirer-common/test/unit/prompts/fixtures/metadataV4WithAggregateTransforms.xml
+++ b/packages/inquirer-common/test/unit/prompts/fixtures/metadataV4WithAggregateTransforms.xml
@@ -1,0 +1,4355 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml">
+    <edmx:Include Alias="Aggregation" Namespace="Org.OData.Aggregation.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Analytics.xml">
+    <edmx:Include Alias="Analytics" Namespace="com.sap.vocabularies.Analytics.v1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Alias="Capabilities" Namespace="Org.OData.Capabilities.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Communication.xml">
+    <edmx:Include Alias="Communication" Namespace="com.sap.vocabularies.Communication.v1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml">
+    <edmx:Include Alias="Measures" Namespace="Org.OData.Measures.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/PersonalData.xml">
+    <edmx:Include Alias="PersonalData" Namespace="com.sap.vocabularies.PersonalData.v1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Alias="UI" Namespace="com.sap.vocabularies.UI.v1" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="com.c_salesordermanage_sd_aggregate" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="BillingBlockReason" EntityType="com.c_salesordermanage_sd_aggregate.BillingBlockReason" />
+        <EntitySet Name="CreditLimitDetails" EntityType="com.c_salesordermanage_sd_aggregate.CreditLimitDetails" />
+        <EntitySet Name="Customer" EntityType="com.c_salesordermanage_sd_aggregate.Customer" />
+        <EntitySet Name="CustomerPaymentTerms" EntityType="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms" />
+        <EntitySet
+                    Name="CustomerPurchaseOrderType"
+                    EntityType="com.c_salesordermanage_sd_aggregate.CustomerPurchaseOrderType"
+                />
+        <EntitySet Name="DeliveryBlockReason" EntityType="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason" />
+        <EntitySet Name="DeliveryPriority" EntityType="com.c_salesordermanage_sd_aggregate.DeliveryPriority" />
+        <EntitySet Name="DistributionChannel" EntityType="com.c_salesordermanage_sd_aggregate.DistributionChannel" />
+        <EntitySet Name="HeaderPartner" EntityType="com.c_salesordermanage_sd_aggregate.HeaderPartner">
+          <NavigationPropertyBinding Path="owner" Target="SalesOrderManage" />
+        </EntitySet>
+        <EntitySet Name="HeaderShipToParty" EntityType="com.c_salesordermanage_sd_aggregate.HeaderShipToParty">
+          <NavigationPropertyBinding Path="_ShipToPartyVH" Target="Customer" />
+        </EntitySet>
+        <EntitySet
+                    Name="IncotermsClassification"
+                    EntityType="com.c_salesordermanage_sd_aggregate.IncotermsClassification"
+                />
+        <EntitySet Name="IncotermsVersion" EntityType="com.c_salesordermanage_sd_aggregate.IncotermsVersion" />
+        <EntitySet Name="Material" EntityType="com.c_salesordermanage_sd_aggregate.Material">
+          <NavigationPropertyBinding Path="_MaterialGroup" Target="MaterialGroup" />
+          <NavigationPropertyBinding Path="_MaterialRatings" Target="MaterialRatings" />
+        </EntitySet>
+        <EntitySet Name="MaterialCategory" EntityType="com.c_salesordermanage_sd_aggregate.MaterialCategory" />
+        <EntitySet Name="MaterialCountry" EntityType="com.c_salesordermanage_sd_aggregate.MaterialCountry" />
+        <EntitySet Name="MaterialDetails" EntityType="com.c_salesordermanage_sd_aggregate.MaterialDetails">
+          <NavigationPropertyBinding Path="material" Target="Material" />
+          <NavigationPropertyBinding Path="_ModelYear" Target="MaterialYears" />
+          <NavigationPropertyBinding Path="_WarrantyYear" Target="MaterialYears" />
+          <NavigationPropertyBinding Path="_MaterialCountry" Target="MaterialCountry" />
+          <NavigationPropertyBinding Path="_MaterialCategory" Target="MaterialCategory" />
+          <NavigationPropertyBinding Path="owner" Target="SalesOrderItem" />
+          <NavigationPropertyBinding Path="_MaterialRatings" Target="MaterialRatings" />
+        </EntitySet>
+        <EntitySet Name="MaterialGroup" EntityType="com.c_salesordermanage_sd_aggregate.MaterialGroup" />
+        <EntitySet Name="MaterialRatings" EntityType="com.c_salesordermanage_sd_aggregate.MaterialRatings">
+          <NavigationPropertyBinding Path="_Rating" Target="Rating" />
+          <NavigationPropertyBinding Path="material" Target="Material" />
+          <NavigationPropertyBinding Path="materialdetail" Target="MaterialDetails" />
+          <NavigationPropertyBinding Path="_MaterialRatingsDetails" Target="MaterialRatingsDetails" />
+        </EntitySet>
+        <EntitySet
+                    Name="MaterialRatingsDetails"
+                    EntityType="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails">
+          <NavigationPropertyBinding Path="material" Target="Material" />
+          <NavigationPropertyBinding Path="materialrating" Target="MaterialRatings" />
+        </EntitySet>
+        <EntitySet Name="MaterialYears" EntityType="com.c_salesordermanage_sd_aggregate.MaterialYears" />
+        <EntitySet Name="OrganizationDivision" EntityType="com.c_salesordermanage_sd_aggregate.OrganizationDivision" />
+        <EntitySet
+                    Name="OverallBillingBlockStatus"
+                    EntityType="com.c_salesordermanage_sd_aggregate.OverallBillingBlockStatus"
+                />
+        <EntitySet
+                    Name="OverallDeliveryBlockStatus"
+                    EntityType="com.c_salesordermanage_sd_aggregate.OverallDeliveryBlockStatus"
+                />
+        <EntitySet
+                    Name="OverallSDProcessStatus"
+                    EntityType="com.c_salesordermanage_sd_aggregate.OverallSDProcessStatus"
+                />
+        <EntitySet Name="Rating" EntityType="com.c_salesordermanage_sd_aggregate.Rating" />
+        <EntitySet Name="SDDocumentReason" EntityType="com.c_salesordermanage_sd_aggregate.SDDocumentReason" />
+        <EntitySet Name="SalesDistrict" EntityType="com.c_salesordermanage_sd_aggregate.SalesDistrict" />
+        <EntitySet Name="SalesGroup" EntityType="com.c_salesordermanage_sd_aggregate.SalesGroup" />
+        <EntitySet Name="SalesOffice" EntityType="com.c_salesordermanage_sd_aggregate.SalesOffice" />
+        <EntitySet Name="SalesOrderItem" EntityType="com.c_salesordermanage_sd_aggregate.SalesOrderItem">
+          <NavigationPropertyBinding Path="_CustomerPaymentTerms" Target="CustomerPaymentTerms" />
+          <NavigationPropertyBinding Path="_DeliveryPriority" Target="DeliveryPriority" />
+          <NavigationPropertyBinding Path="_IncotermsClassification" Target="IncotermsClassification" />
+          <NavigationPropertyBinding Path="_IncotermsVersion" Target="IncotermsVersion" />
+          <NavigationPropertyBinding Path="_ItemBillingBlockReason" Target="BillingBlockReason" />
+          <NavigationPropertyBinding Path="_ItemCategory" Target="SalesOrderItemCategory" />
+          <NavigationPropertyBinding Path="_Material" Target="Material" />
+          <NavigationPropertyBinding Path="_MaterialGroup" Target="MaterialGroup" />
+          <NavigationPropertyBinding Path="_RequestedQuantityUnit" Target="UnitOfMeasure" />
+          <NavigationPropertyBinding Path="_SalesOrder" Target="SalesOrderType" />
+          <NavigationPropertyBinding Path="_ShippingPoint" Target="ShippingPoint" />
+          <NavigationPropertyBinding Path="_ShippingType" Target="ShippingType" />
+          <NavigationPropertyBinding Path="_ReferencedSalesOrder" Target="SalesOrderManage" />
+          <NavigationPropertyBinding Path="_ReferencedSalesOrderItem" Target="SalesOrderItem" />
+          <NavigationPropertyBinding Path="owner" Target="SalesOrderManage" />
+          <NavigationPropertyBinding Path="_MaterialDetails" Target="MaterialDetails" />
+        </EntitySet>
+        <EntitySet
+                    Name="SalesOrderItemCategory"
+                    EntityType="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory"
+                />
+        <EntitySet Name="SalesOrderManage" EntityType="com.c_salesordermanage_sd_aggregate.SalesOrderManage">
+          <NavigationPropertyBinding Path="_CustomerPaymentTerms" Target="CustomerPaymentTerms" />
+          <NavigationPropertyBinding Path="_CustomerPurchaseOrderType" Target="CustomerPurchaseOrderType" />
+          <NavigationPropertyBinding Path="_DeliveryBlockReason" Target="DeliveryBlockReason" />
+          <NavigationPropertyBinding Path="_DistributionChannel" Target="DistributionChannel" />
+          <NavigationPropertyBinding Path="_HeaderBillingBlockReason" Target="BillingBlockReason" />
+          <NavigationPropertyBinding Path="_IncotermsClassification" Target="IncotermsClassification" />
+          <NavigationPropertyBinding Path="_IncotermsVersion" Target="IncotermsVersion" />
+          <NavigationPropertyBinding Path="_OrganizationDivision" Target="OrganizationDivision" />
+          <NavigationPropertyBinding Path="_OverallBillingBlockStatus" Target="OverallBillingBlockStatus" />
+          <NavigationPropertyBinding Path="_OverallDeliveryBlockStatus" Target="OverallDeliveryBlockStatus" />
+          <NavigationPropertyBinding Path="_OverallSDProcessStatus" Target="OverallSDProcessStatus" />
+          <NavigationPropertyBinding Path="_CreditLimitDetails" Target="CreditLimitDetails" />
+          <NavigationPropertyBinding Path="_SalesDistrict" Target="SalesDistrict" />
+          <NavigationPropertyBinding Path="_SalesGroup" Target="SalesGroup" />
+          <NavigationPropertyBinding Path="_SalesOffice" Target="SalesOffice" />
+          <NavigationPropertyBinding Path="_SalesOrderType" Target="SalesOrderType" />
+          <NavigationPropertyBinding Path="_SalesOrganization" Target="SalesOrganization" />
+          <NavigationPropertyBinding Path="_SDDocumentReason" Target="SDDocumentReason" />
+          <NavigationPropertyBinding Path="_ShippingCondition" Target="ShippingCondition" />
+          <NavigationPropertyBinding Path="_ShippingType" Target="ShippingType" />
+          <NavigationPropertyBinding Path="_ShipToParty" Target="HeaderShipToParty" />
+          <NavigationPropertyBinding Path="_SoldToParty" Target="Customer" />
+          <NavigationPropertyBinding Path="_ReferencedSalesOrder" Target="SalesOrderManage" />
+          <NavigationPropertyBinding Path="_Item" Target="SalesOrderItem" />
+          <NavigationPropertyBinding Path="_Partner" Target="HeaderPartner" />
+        </EntitySet>
+        <EntitySet Name="SalesOrderType" EntityType="com.c_salesordermanage_sd_aggregate.SalesOrderType" />
+        <EntitySet Name="SalesOrganization" EntityType="com.c_salesordermanage_sd_aggregate.SalesOrganization" />
+        <EntitySet Name="ShippingCondition" EntityType="com.c_salesordermanage_sd_aggregate.ShippingCondition" />
+        <EntitySet Name="ShippingPoint" EntityType="com.c_salesordermanage_sd_aggregate.ShippingPoint" />
+        <EntitySet Name="ShippingType" EntityType="com.c_salesordermanage_sd_aggregate.ShippingType" />
+        <EntitySet Name="UnitOfMeasure" EntityType="com.c_salesordermanage_sd_aggregate.UnitOfMeasure" />
+      </EntityContainer>
+      <EntityType Name="BillingBlockReason">
+        <Key>
+          <PropertyRef Name="BillingBlockReason" />
+        </Key>
+        <Property Name="BillingBlockReason" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="BillingBlockReason_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="CreditLimitDetails">
+        <Key>
+          <PropertyRef Name="SalesDocument" />
+        </Key>
+        <Property Name="SalesDocument" Type="Edm.String" MaxLength="10" Nullable="false" />
+        <Property Name="CustomerCreditExposureAmount" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="Delivered" Type="Edm.Boolean" />
+        <Property Name="CustomerCreditExposureAmountHidden" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="CustomerCreditForecast" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="CustomerCreditExposureAmount_text" Type="Edm.String" MaxLength="15" />
+        <Property Name="CustomerCreditLimitAmount" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="MaximumCreditValue" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="CustomerCreditLimitAmount_text" Type="Edm.String" MaxLength="15" />
+        <Property Name="TransactionCurrency" Type="Edm.String" MaxLength="5" />
+        <Property Name="CustomerIsAboveThreshold" Type="Edm.Int32" />
+        <Property Name="ToleranceRangeLow" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="ToleranceRangeHigh" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="DeviationRangeLow" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="DeviationRangeHigh" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="AcceptanceRangeLow" Type="Edm.Decimal" Scale="2" Precision="23" />
+        <Property Name="AcceptanceRangeHigh" Type="Edm.Decimal" Scale="2" Precision="23" />
+      </EntityType>
+      <EntityType Name="Customer">
+        <Key>
+          <PropertyRef Name="Customer" />
+        </Key>
+        <Property Name="Customer" Type="Edm.String" MaxLength="10" Nullable="false" />
+        <Property Name="CustomerName" Type="Edm.String" MaxLength="80" />
+        <Property Name="Initials" Type="Edm.String" MaxLength="10" />
+        <Property Name="Delivered" Type="Edm.Boolean" />
+        <Property Name="OrganizationBPName1" Type="Edm.String" MaxLength="35" />
+        <Property Name="OrganizationBPName2" Type="Edm.String" MaxLength="35" />
+        <Property Name="BusinessPartnerImageURL" Type="Edm.String" />
+        <Property Name="StreetName" Type="Edm.String" />
+        <Property Name="HouseNumber" Type="Edm.String" />
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+        <Property Name="CityName" Type="Edm.String" MaxLength="40" />
+        <Property Name="Country" Type="Edm.String" MaxLength="3" />
+        <Property Name="InternationalPhoneNumber" Type="Edm.String" MaxLength="30" />
+        <Property Name="EmailAddress" Type="Edm.String" MaxLength="241" />
+      </EntityType>
+      <EntityType Name="CustomerPaymentTerms">
+        <Key>
+          <PropertyRef Name="CustomerPaymentTerms" />
+        </Key>
+        <Property Name="CustomerPaymentTerms" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="CustomerPaymentTerms_Text" Type="Edm.String" MaxLength="30" />
+      </EntityType>
+      <EntityType Name="CustomerPurchaseOrderType">
+        <Key>
+          <PropertyRef Name="CustomerPurchaseOrderType" />
+        </Key>
+        <Property Name="CustomerPurchaseOrderType" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="CustomerPurchaseOrderType_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="DeliveryBlockReason">
+        <Key>
+          <PropertyRef Name="DeliveryBlockReason" />
+        </Key>
+        <Property Name="DeliveryBlockReason" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="DeliveryBlockReason_Text" Type="Edm.String" MaxLength="20" />
+        <Property Name="DeliveryDueListBlock" Type="Edm.Boolean" />
+      </EntityType>
+      <EntityType Name="DeliveryPriority">
+        <Key>
+          <PropertyRef Name="DeliveryPriority" />
+        </Key>
+        <Property Name="DeliveryPriority" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="DeliveryPriority_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="DistributionChannel">
+        <Key>
+          <PropertyRef Name="DistributionChannel" />
+        </Key>
+        <Property Name="DistributionChannel" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="DistributionChannel_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="HeaderPartner">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="SalesOrder" Type="Edm.String" MaxLength="10" Nullable="false" />
+        <Property Name="PartnerFunction" Type="Edm.String" MaxLength="2" />
+        <Property Name="BusinessPartner" Type="Edm.String" MaxLength="10" />
+        <Property Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4" />
+        <Property Name="Progress" Type="Edm.Decimal" Scale="1" Precision="4" />
+        <Property Name="SemanticObject" Type="Edm.String" MaxLength="15" />
+        <Property Name="AddressID" Type="Edm.String" MaxLength="10" />
+        <Property Name="FullName" Type="Edm.String" MaxLength="80" />
+        <Property Name="PhoneNumber" Type="Edm.String" MaxLength="30" />
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+        <Property Name="CityName" Type="Edm.String" MaxLength="40" />
+        <Property Name="Country" Type="Edm.String" MaxLength="3" />
+        <Property Name="isVerified" Type="Edm.Boolean" />
+        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" Partner="_Partner">
+          <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <Property Name="owner_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="HeaderShipToParty">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="BusinessPartner" Type="Edm.String" MaxLength="10" />
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+        <Property Name="fieldReadOnly" Type="Edm.Int32" />
+        <Property Name="CityName" Type="Edm.String" MaxLength="40" />
+        <Property Name="isHidden" Type="Edm.Boolean" />
+        <Property Name="isUpdatable" Type="Edm.Boolean" />
+        <Property Name="Country" Type="Edm.String" MaxLength="3" />
+        <Property Name="StreetName" Type="Edm.String" MaxLength="60" />
+        <Property Name="HouseNumber" Type="Edm.String" MaxLength="10" />
+        <Property Name="isVerified" Type="Edm.Boolean" />
+        <Property Name="isDelivered" Type="Edm.Boolean" />
+        <NavigationProperty Name="_ShipToPartyVH" Type="com.c_salesordermanage_sd_aggregate.Customer">
+          <ReferentialConstraint Property="BusinessPartner" ReferencedProperty="Customer" />
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="IncotermsClassification">
+        <Key>
+          <PropertyRef Name="IncotermsClassification" />
+        </Key>
+        <Property Name="IncotermsClassification" Type="Edm.String" MaxLength="3" Nullable="false" />
+        <Property Name="IncotermsClassification_Text" Type="Edm.String" MaxLength="30" />
+        <Property Name="LocationIsMandatory" Type="Edm.Boolean" />
+      </EntityType>
+      <EntityType Name="IncotermsVersion">
+        <Key>
+          <PropertyRef Name="IncotermsVersion" />
+        </Key>
+        <Property Name="IncotermsVersion" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="IncotermsVersion_Text" Type="Edm.String" MaxLength="30" />
+      </EntityType>
+      <EntityType Name="Material">
+        <Key>
+          <PropertyRef Name="Material" />
+        </Key>
+        <Property Name="Material" Type="Edm.String" MaxLength="18" Nullable="false" />
+        <Property Name="isHidden" Type="Edm.Boolean" />
+        <Property Name="isUpdatable" Type="Edm.Boolean" />
+        <Property Name="Material_Text" Type="Edm.String" MaxLength="40" />
+        <NavigationProperty Name="_MaterialGroup" Type="com.c_salesordermanage_sd_aggregate.MaterialGroup">
+          <ReferentialConstraint Property="_MaterialGroup_MaterialGroup" ReferencedProperty="MaterialGroup" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_MaterialRatings"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.MaterialRatings)"
+                    Partner="material">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Property Name="_MaterialGroup_MaterialGroup" Type="Edm.String" MaxLength="9" />
+      </EntityType>
+      <EntityType Name="MaterialCategory">
+        <Key>
+          <PropertyRef Name="Category" />
+        </Key>
+        <Property Name="Category" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="Category_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="MaterialCountry">
+        <Key>
+          <PropertyRef Name="Country" />
+        </Key>
+        <Property Name="Country" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="Country_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="MaterialDetails">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="ModelYear" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="WarrantyYear" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="BrandCategory" Type="Edm.String" MaxLength="20" Nullable="false" />
+        <Property Name="FabricationCountry" Type="Edm.String" MaxLength="20" Nullable="false" />
+        <NavigationProperty Name="material" Type="com.c_salesordermanage_sd_aggregate.Material">
+          <ReferentialConstraint Property="material_Material" ReferencedProperty="Material" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ModelYear" Type="com.c_salesordermanage_sd_aggregate.MaterialYears">
+          <ReferentialConstraint Property="ModelYear" ReferencedProperty="Model_Year" />
+        </NavigationProperty>
+        <NavigationProperty Name="_WarrantyYear" Type="com.c_salesordermanage_sd_aggregate.MaterialYears">
+          <ReferentialConstraint Property="_WarrantyYear_Model_Year" ReferencedProperty="Model_Year" />
+        </NavigationProperty>
+        <NavigationProperty Name="_MaterialCountry" Type="com.c_salesordermanage_sd_aggregate.MaterialCountry">
+          <ReferentialConstraint Property="FabricationCountry" ReferencedProperty="Country" />
+        </NavigationProperty>
+        <NavigationProperty Name="_MaterialCategory" Type="com.c_salesordermanage_sd_aggregate.MaterialCategory">
+          <ReferentialConstraint Property="BrandCategory" ReferencedProperty="Category" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="owner"
+                    Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem"
+                    Partner="_MaterialDetails">
+          <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_MaterialRatings"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.MaterialRatings)"
+                    Partner="materialdetail">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Property Name="material_Material" Type="Edm.String" MaxLength="18" />
+        <Property Name="_WarrantyYear_Model_Year" Type="Edm.String" MaxLength="4" />
+        <Property Name="owner_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="MaterialGroup">
+        <Key>
+          <PropertyRef Name="MaterialGroup" />
+        </Key>
+        <Property Name="MaterialGroup" Type="Edm.String" MaxLength="9" Nullable="false" />
+        <Property Name="MaterialGroup_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="MaterialRatings">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4" Nullable="false" />
+        <Property Name="Title" Type="Edm.String" MaxLength="25" Nullable="false" />
+        <NavigationProperty Name="_Rating" Type="com.c_salesordermanage_sd_aggregate.Rating">
+          <ReferentialConstraint Property="Rating" ReferencedProperty="Rating" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="material"
+                    Type="com.c_salesordermanage_sd_aggregate.Material"
+                    Partner="_MaterialRatings">
+          <ReferentialConstraint Property="material_Material" ReferencedProperty="Material" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="materialdetail"
+                    Type="com.c_salesordermanage_sd_aggregate.MaterialDetails"
+                    Partner="_MaterialRatings">
+          <ReferentialConstraint Property="materialdetail_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_MaterialRatingsDetails"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails)"
+                    Partner="materialrating">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Property Name="material_Material" Type="Edm.String" MaxLength="18" />
+        <Property Name="materialdetail_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="MaterialRatingsDetails">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="Comments" Type="Edm.String" MaxLength="1000" Nullable="false" />
+        <Property Name="CREATEDAT" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="MODIFIEDAT" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="MODIFIEDBY" Type="Edm.String" MaxLength="241" Nullable="false" />
+        <NavigationProperty Name="material" Type="com.c_salesordermanage_sd_aggregate.Material">
+          <ReferentialConstraint Property="material_Material" ReferencedProperty="Material" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="materialrating"
+                    Type="com.c_salesordermanage_sd_aggregate.MaterialRatings"
+                    Partner="_MaterialRatingsDetails">
+          <ReferentialConstraint Property="materialrating_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <Property Name="material_Material" Type="Edm.String" MaxLength="18" />
+        <Property Name="materialrating_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="MaterialYears">
+        <Key>
+          <PropertyRef Name="Model_Year" />
+        </Key>
+        <Property Name="Model_Year" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="Warranty_Expiration" Type="Edm.String" MaxLength="4" />
+      </EntityType>
+      <EntityType Name="OrganizationDivision">
+        <Key>
+          <PropertyRef Name="Division" />
+        </Key>
+        <Property Name="Division" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="Division_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="OverallBillingBlockStatus">
+        <Key>
+          <PropertyRef Name="OverallBillingBlockStatus" />
+        </Key>
+        <Property Name="OverallBillingBlockStatus" Type="Edm.String" MaxLength="1" Nullable="false" />
+        <Property Name="OverallBillingBlockStatus_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="OverallDeliveryBlockStatus">
+        <Key>
+          <PropertyRef Name="OverallDeliveryBlockStatus" />
+        </Key>
+        <Property Name="OverallDeliveryBlockStatus" Type="Edm.String" MaxLength="1" Nullable="false" />
+        <Property Name="OverallDeliveryBlockStatus_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="OverallSDProcessStatus">
+        <Key>
+          <PropertyRef Name="OverallSDProcessStatus" />
+        </Key>
+        <Property Name="OverallSDProcessStatus" Type="Edm.String" MaxLength="1" Nullable="false" />
+        <Property Name="OverallSDProcessStatus_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="Rating">
+        <Key>
+          <PropertyRef Name="Rating" />
+        </Key>
+        <Property Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4" Nullable="false" />
+        <Property Name="Rating_Text" Type="Edm.String" MaxLength="25" />
+      </EntityType>
+      <EntityType Name="SDDocumentReason">
+        <Key>
+          <PropertyRef Name="SDDocumentReason" />
+        </Key>
+        <Property Name="SDDocumentReason" Type="Edm.String" MaxLength="3" Nullable="false" />
+        <Property Name="SDDocumentReason_Text" Type="Edm.String" MaxLength="40" />
+      </EntityType>
+      <EntityType Name="SalesDistrict">
+        <Key>
+          <PropertyRef Name="SalesDistrict" />
+        </Key>
+        <Property Name="SalesDistrict" Type="Edm.String" MaxLength="6" Nullable="false" />
+        <Property Name="SalesDistrict_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="SalesGroup">
+        <Key>
+          <PropertyRef Name="SalesGroup" />
+        </Key>
+        <Property Name="SalesGroup" Type="Edm.String" MaxLength="3" Nullable="false" />
+        <Property Name="SalesGroup_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="SalesOffice">
+        <Key>
+          <PropertyRef Name="SalesOffice" />
+        </Key>
+        <Property Name="SalesOffice" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="SalesOffice_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="SalesOrderItem">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="SalesOrder" Type="Edm.String" MaxLength="10" Nullable="false" />
+        <Property Name="SalesOrderItem" Type="Edm.Int32" Nullable="false" />
+        <Property Name="HigherLevelItem" Type="Edm.Int32" />
+        <Property Name="SalesOrderItemCategory" Type="Edm.String" MaxLength="4" />
+        <Property Name="fieldControlType_item" Type="Edm.Int32" />
+        <Property Name="Material" Type="Edm.String" MaxLength="40" />
+        <Property Name="PurchaseOrderByCustomer" Type="Edm.String" MaxLength="35" />
+        <Property Name="RequestedDeliveryDate" Type="Edm.Date" />
+        <Property Name="ConfirmedDeliveryDate" Type="Edm.Date" />
+        <Property Name="RequestedQuantity" Type="Edm.Decimal" Scale="3" Precision="15" />
+        <Property Name="RequestedQuantityUnit" Type="Edm.String" MaxLength="40" />
+        <Property Name="PricingDate" Type="Edm.Date" />
+        <Property Name="MaterialGroup" Type="Edm.String" MaxLength="9" />
+        <Property Name="Batch" Type="Edm.String" MaxLength="10" />
+        <Property Name="Plant" Type="Edm.String" MaxLength="4" />
+        <Property Name="StorageLocation" Type="Edm.String" MaxLength="4" />
+        <Property Name="ShippingPoint" Type="Edm.String" MaxLength="4" />
+        <Property Name="ShippingType" Type="Edm.String" MaxLength="2" />
+        <Property Name="DeliveryPriority" Type="Edm.String" MaxLength="2" />
+        <Property Name="IncotermsClassification" Type="Edm.String" MaxLength="3" />
+        <Property Name="IncotermsLocation1" Type="Edm.String" MaxLength="70" />
+        <Property Name="IncotermsLocation2" Type="Edm.String" MaxLength="70" />
+        <Property Name="IncotermsVersion" Type="Edm.String" MaxLength="4" />
+        <Property Name="CustomerPaymentTerms" Type="Edm.String" MaxLength="4" />
+        <Property Name="ItemBillingBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="TransactionCurrency" Type="Edm.String" MaxLength="5" />
+        <Property Name="NetAmount" Type="Edm.Decimal" Scale="2" Precision="15" />
+        <Property Name="NetAmountHidden" Type="Edm.Decimal" Scale="10" Precision="15" />
+        <Property Name="NetAmount_text" Type="Edm.String" MaxLength="10" />
+        <Property Name="Delivered" Type="Edm.Boolean" />
+        <Property Name="CFhidden" Type="Edm.Boolean" />
+        <Property Name="CF2hidden" Type="Edm.Boolean" />
+        <Property Name="isVerified" Type="Edm.Boolean" />
+        <Property Name="ToleranceRangeLow" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="ToleranceRangeHigh" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="DeviationRangeLow" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="DeviationRangeHigh" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="AcceptanceRangeLow" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="AcceptanceRangeHigh" Type="Edm.Decimal" Scale="0" Precision="23" />
+        <Property Name="Criticality" Type="Edm.Int32" />
+        <Property Name="SalesOrganization" Type="Edm.String" MaxLength="4" />
+        <Property Name="DistributionChannel" Type="Edm.String" MaxLength="2" />
+        <Property Name="ReferencedSalesOrderID" Type="Edm.Guid" />
+        <Property Name="ReferencedSalesOrderItemID" Type="Edm.Guid" />
+        <NavigationProperty
+                    Name="_CustomerPaymentTerms"
+                    Type="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms">
+          <ReferentialConstraint
+                        Property="_CustomerPaymentTerms_CustomerPaymentTerms"
+                        ReferencedProperty="CustomerPaymentTerms"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_DeliveryPriority" Type="com.c_salesordermanage_sd_aggregate.DeliveryPriority">
+          <ReferentialConstraint Property="_DeliveryPriority_DeliveryPriority" ReferencedProperty="DeliveryPriority" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_IncotermsClassification"
+                    Type="com.c_salesordermanage_sd_aggregate.IncotermsClassification">
+          <ReferentialConstraint
+                        Property="_IncotermsClassification_IncotermsClassification"
+                        ReferencedProperty="IncotermsClassification"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_IncotermsVersion" Type="com.c_salesordermanage_sd_aggregate.IncotermsVersion">
+          <ReferentialConstraint Property="_IncotermsVersion_IncotermsVersion" ReferencedProperty="IncotermsVersion" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_ItemBillingBlockReason"
+                    Type="com.c_salesordermanage_sd_aggregate.BillingBlockReason">
+          <ReferentialConstraint
+                        Property="_ItemBillingBlockReason_BillingBlockReason"
+                        ReferencedProperty="BillingBlockReason"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_ItemCategory" Type="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory">
+          <ReferentialConstraint
+                        Property="_ItemCategory_SalesDocumentItemCategory"
+                        ReferencedProperty="SalesDocumentItemCategory"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_Material" Type="com.c_salesordermanage_sd_aggregate.Material">
+          <ReferentialConstraint Property="Material" ReferencedProperty="Material" />
+        </NavigationProperty>
+        <NavigationProperty Name="_MaterialGroup" Type="com.c_salesordermanage_sd_aggregate.MaterialGroup">
+          <ReferentialConstraint Property="_MaterialGroup_MaterialGroup" ReferencedProperty="MaterialGroup" />
+        </NavigationProperty>
+        <NavigationProperty Name="_RequestedQuantityUnit" Type="com.c_salesordermanage_sd_aggregate.UnitOfMeasure">
+          <ReferentialConstraint Property="RequestedQuantityUnit" ReferencedProperty="UnitOfMeasure" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesOrder" Type="com.c_salesordermanage_sd_aggregate.SalesOrderType">
+          <ReferentialConstraint Property="_SalesOrder_SalesOrderType" ReferencedProperty="SalesOrderType" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ShippingPoint" Type="com.c_salesordermanage_sd_aggregate.ShippingPoint">
+          <ReferentialConstraint Property="_ShippingPoint_ShippingPoint" ReferencedProperty="ShippingPoint" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ShippingType" Type="com.c_salesordermanage_sd_aggregate.ShippingType">
+          <ReferentialConstraint Property="_ShippingType_ShippingType" ReferencedProperty="ShippingType" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ReferencedSalesOrder" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage">
+          <ReferentialConstraint Property="ReferencedSalesOrderID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ReferencedSalesOrderItem" Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem">
+          <ReferentialConstraint Property="ReferencedSalesOrderItemID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <Property Name="SalesOrderItemText" Type="Edm.String" MaxLength="40" />
+        <Property Name="TargetAmount" Type="Edm.Decimal" Scale="2" Precision="15" />
+        <NavigationProperty Name="owner" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" Partner="_Item">
+          <ReferentialConstraint Property="owner_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_MaterialDetails"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.MaterialDetails)"
+                    Partner="owner">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Property Name="_CustomerPaymentTerms_CustomerPaymentTerms" Type="Edm.String" MaxLength="4" />
+        <Property Name="_DeliveryPriority_DeliveryPriority" Type="Edm.String" MaxLength="2" />
+        <Property Name="_IncotermsClassification_IncotermsClassification" Type="Edm.String" MaxLength="3" />
+        <Property Name="_IncotermsVersion_IncotermsVersion" Type="Edm.String" MaxLength="4" />
+        <Property Name="_ItemBillingBlockReason_BillingBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="_ItemCategory_SalesDocumentItemCategory" Type="Edm.String" MaxLength="4" />
+        <Property Name="_MaterialGroup_MaterialGroup" Type="Edm.String" MaxLength="9" />
+        <Property Name="_SalesOrder_SalesOrderType" Type="Edm.String" MaxLength="4" />
+        <Property Name="_ShippingPoint_ShippingPoint" Type="Edm.String" MaxLength="4" />
+        <Property Name="_ShippingType_ShippingType" Type="Edm.String" MaxLength="2" />
+        <Property Name="owner_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="SalesOrderItemCategory">
+        <Key>
+          <PropertyRef Name="SalesDocumentItemCategory" />
+        </Key>
+        <Property Name="SalesDocumentItemCategory" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="SalesDocumentItemCategory_Text" Type="Edm.String" MaxLength="20" />
+        <Property Name="ScheduleLineIsAllowed" Type="Edm.Boolean" />
+      </EntityType>
+      <EntityType Name="SalesOrderManage">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="SalesOrder" Type="Edm.String" MaxLength="10" Nullable="false" />
+        <Property Name="Delivered" Type="Edm.Boolean" />
+        <Property Name="CFhidden" Type="Edm.Boolean" />
+        <Property Name="CF2hidden" Type="Edm.Boolean" />
+        <Property Name="ReturnInProcess" Type="Edm.Boolean" />
+        <Property Name="SalesOrderType" Type="Edm.String" MaxLength="4" />
+        <Property Name="ImageUrl" Type="Edm.String" />
+        <Property Name="SoldToParty" Type="Edm.String" MaxLength="10" />
+        <Property Name="SalesOrganization" Type="Edm.String" MaxLength="4" />
+        <Property Name="Rating" Type="Edm.Decimal" Scale="2" Precision="4" />
+        <Property Name="Progress" Type="Edm.Decimal" Scale="1" Precision="4" />
+        <Property Name="DistributionChannel" Type="Edm.String" MaxLength="2" />
+        <Property Name="OrganizationDivision" Type="Edm.String" MaxLength="2" />
+        <Property Name="SalesOffice" Type="Edm.String" MaxLength="4" />
+        <Property Name="SalesGroup" Type="Edm.String" MaxLength="3" />
+        <Property Name="SalesDistrict" Type="Edm.String" MaxLength="6" />
+        <Property Name="PurchaseOrderByCustomer" Type="Edm.String" MaxLength="35" />
+        <Property Name="CustomerPurchaseOrderType" Type="Edm.String" MaxLength="4" />
+        <Property Name="CustomerPurchaseOrderDate" Type="Edm.Date" />
+        <Property Name="SDDocumentReason" Type="Edm.String" MaxLength="3" />
+        <Property Name="PricingDate" Type="Edm.Date" />
+        <Property Name="ShippingCondition" Type="Edm.String" MaxLength="2" />
+        <Property Name="CompleteDeliveryIsDefined" Type="Edm.Boolean" />
+        <Property Name="ShippingType" Type="Edm.String" MaxLength="2" />
+        <Property Name="IncotermsClassification" Type="Edm.String" MaxLength="3" />
+        <Property Name="IncotermsVersion" Type="Edm.String" MaxLength="4" />
+        <Property Name="fieldControlType_item" Type="Edm.Int32" />
+        <Property Name="fieldControlType" Type="Edm.Int32" />
+        <Property Name="TrialInt64" Type="Edm.Int64" />
+        <Property Name="TrialDouble" Type="Edm.Double" />
+        <Property Name="TrialTOD" Type="Edm.TimeOfDay" />
+        <Property Name="IncotermsLocation1" Type="Edm.String" MaxLength="70" />
+        <Property Name="IncotermsLocation2" Type="Edm.String" MaxLength="70" />
+        <Property Name="HeaderBillingBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="DeliveryBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="CustomerPaymentTerms" Type="Edm.String" MaxLength="4" />
+        <Property Name="TotalNetAmount" Type="Edm.Decimal" Scale="10" Precision="15" />
+        <Property Name="TotalNetAmount2" Type="Edm.Decimal" Scale="10" Precision="15" />
+        <Property Name="TransactionCurrency" Type="Edm.String" MaxLength="5" />
+        <Property Name="OverallSDProcessStatus" Type="Edm.String" MaxLength="1" />
+        <Property Name="StatusCriticality" Type="Edm.Int32" />
+        <Property Name="OverallDeliveryBlockStatus" Type="Edm.String" MaxLength="1" />
+        <Property Name="OverallBillingBlockStatus" Type="Edm.String" MaxLength="1" />
+        <Property Name="LastChangedDateTime" Type="Edm.DateTimeOffset" />
+        <Property Name="SalesOrderDate" Type="Edm.Date" />
+        <Property Name="SalesOrderTypeName" Type="Edm.String" MaxLength="20" />
+        <Property Name="DeliveryBlockCriticality" Type="Edm.Int32" />
+        <Property Name="BillingBlockCriticality" Type="Edm.Int32" />
+        <Property Name="DescriptionFieldForOPACleanup" Type="Edm.String" MaxLength="40" />
+        <Property Name="ReferencedSalesOrderID" Type="Edm.Guid" />
+        <Property Name="isVerified" Type="Edm.Boolean" />
+        <Property Name="isDeletable" Type="Edm.Boolean" />
+        <Property Name="isDeleteHidden" Type="Edm.Boolean" />
+        <Property Name="isCreateHidden" Type="Edm.Boolean" />
+        <Property Name="editActionIsEnabled" Type="Edm.Boolean" />
+        <Property Name="editActionIsDisabled" Type="Edm.Boolean" />
+        <NavigationProperty
+                    Name="_CustomerPaymentTerms"
+                    Type="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms">
+          <ReferentialConstraint Property="CustomerPaymentTerms" ReferencedProperty="CustomerPaymentTerms" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_CustomerPurchaseOrderType"
+                    Type="com.c_salesordermanage_sd_aggregate.CustomerPurchaseOrderType">
+          <ReferentialConstraint
+                        Property="_CustomerPurchaseOrderType_CustomerPurchaseOrderType"
+                        ReferencedProperty="CustomerPurchaseOrderType"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_DeliveryBlockReason" Type="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason">
+          <ReferentialConstraint
+                        Property="_DeliveryBlockReason_DeliveryBlockReason"
+                        ReferencedProperty="DeliveryBlockReason"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_DistributionChannel" Type="com.c_salesordermanage_sd_aggregate.DistributionChannel">
+          <ReferentialConstraint
+                        Property="_DistributionChannel_DistributionChannel"
+                        ReferencedProperty="DistributionChannel"
+                    />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_HeaderBillingBlockReason"
+                    Type="com.c_salesordermanage_sd_aggregate.BillingBlockReason">
+          <ReferentialConstraint
+                        Property="_HeaderBillingBlockReason_BillingBlockReason"
+                        ReferencedProperty="BillingBlockReason"
+                    />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_IncotermsClassification"
+                    Type="com.c_salesordermanage_sd_aggregate.IncotermsClassification">
+          <ReferentialConstraint Property="IncotermsClassification" ReferencedProperty="IncotermsClassification" />
+        </NavigationProperty>
+        <NavigationProperty Name="_IncotermsVersion" Type="com.c_salesordermanage_sd_aggregate.IncotermsVersion">
+          <ReferentialConstraint Property="IncotermsVersion" ReferencedProperty="IncotermsVersion" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_OrganizationDivision"
+                    Type="com.c_salesordermanage_sd_aggregate.OrganizationDivision">
+          <ReferentialConstraint Property="_OrganizationDivision_Division" ReferencedProperty="Division" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_OverallBillingBlockStatus"
+                    Type="com.c_salesordermanage_sd_aggregate.OverallBillingBlockStatus">
+          <ReferentialConstraint
+                        Property="_OverallBillingBlockStatus_OverallBillingBlockStatus"
+                        ReferencedProperty="OverallBillingBlockStatus"
+                    />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_OverallDeliveryBlockStatus"
+                    Type="com.c_salesordermanage_sd_aggregate.OverallDeliveryBlockStatus">
+          <ReferentialConstraint
+                        Property="_OverallDeliveryBlockStatus_OverallDeliveryBlockStatus"
+                        ReferencedProperty="OverallDeliveryBlockStatus"
+                    />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_OverallSDProcessStatus"
+                    Type="com.c_salesordermanage_sd_aggregate.OverallSDProcessStatus">
+          <ReferentialConstraint Property="OverallSDProcessStatus" ReferencedProperty="OverallSDProcessStatus" />
+        </NavigationProperty>
+        <NavigationProperty Name="_CreditLimitDetails" Type="com.c_salesordermanage_sd_aggregate.CreditLimitDetails">
+          <ReferentialConstraint Property="SalesOrder" ReferencedProperty="SalesDocument" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesDistrict" Type="com.c_salesordermanage_sd_aggregate.SalesDistrict">
+          <ReferentialConstraint Property="_SalesDistrict_SalesDistrict" ReferencedProperty="SalesDistrict" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesGroup" Type="com.c_salesordermanage_sd_aggregate.SalesGroup">
+          <ReferentialConstraint Property="_SalesGroup_SalesGroup" ReferencedProperty="SalesGroup" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesOffice" Type="com.c_salesordermanage_sd_aggregate.SalesOffice">
+          <ReferentialConstraint Property="_SalesOffice_SalesOffice" ReferencedProperty="SalesOffice" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesOrderType" Type="com.c_salesordermanage_sd_aggregate.SalesOrderType">
+          <ReferentialConstraint Property="SalesOrderType" ReferencedProperty="SalesOrderType" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SalesOrganization" Type="com.c_salesordermanage_sd_aggregate.SalesOrganization">
+          <ReferentialConstraint
+                        Property="_SalesOrganization_SalesOrganization"
+                        ReferencedProperty="SalesOrganization"
+                    />
+        </NavigationProperty>
+        <NavigationProperty Name="_SDDocumentReason" Type="com.c_salesordermanage_sd_aggregate.SDDocumentReason">
+          <ReferentialConstraint Property="_SDDocumentReason_SDDocumentReason" ReferencedProperty="SDDocumentReason" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ShippingCondition" Type="com.c_salesordermanage_sd_aggregate.ShippingCondition">
+          <ReferentialConstraint Property="ShippingCondition" ReferencedProperty="ShippingCondition" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ShippingType" Type="com.c_salesordermanage_sd_aggregate.ShippingType">
+          <ReferentialConstraint Property="_ShippingType_ShippingType" ReferencedProperty="ShippingType" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ShipToParty" Type="com.c_salesordermanage_sd_aggregate.HeaderShipToParty">
+          <OnDelete Action="Cascade" />
+          <ReferentialConstraint Property="_ShipToParty_ID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <NavigationProperty Name="_SoldToParty" Type="com.c_salesordermanage_sd_aggregate.Customer">
+          <ReferentialConstraint Property="SoldToParty" ReferencedProperty="Customer" />
+        </NavigationProperty>
+        <NavigationProperty Name="_ReferencedSalesOrder" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage">
+          <ReferentialConstraint Property="ReferencedSalesOrderID" ReferencedProperty="ID" />
+        </NavigationProperty>
+        <Property Name="SalesOrderText" Type="Edm.String" MaxLength="20" Nullable="false" />
+        <Property Name="CustomerName" Type="Edm.String" MaxLength="50" />
+        <Property Name="OrganizationName" Type="Edm.String" MaxLength="30" />
+        <Property Name="PaymentMethod" Type="Edm.String" MaxLength="1" />
+        <Property Name="NetPricing" Type="Edm.Decimal" Scale="10" Precision="15" />
+        <NavigationProperty
+                    Name="_Item"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.SalesOrderItem)"
+                    Partner="owner">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <NavigationProperty
+                    Name="_Partner"
+                    Type="Collection(com.c_salesordermanage_sd_aggregate.HeaderPartner)"
+                    Partner="owner">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Property Name="_CustomerPurchaseOrderType_CustomerPurchaseOrderType" Type="Edm.String" MaxLength="4" />
+        <Property Name="_DeliveryBlockReason_DeliveryBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="_DistributionChannel_DistributionChannel" Type="Edm.String" MaxLength="2" />
+        <Property Name="_HeaderBillingBlockReason_BillingBlockReason" Type="Edm.String" MaxLength="2" />
+        <Property Name="_OrganizationDivision_Division" Type="Edm.String" MaxLength="2" />
+        <Property Name="_OverallBillingBlockStatus_OverallBillingBlockStatus" Type="Edm.String" MaxLength="1" />
+        <Property Name="_OverallDeliveryBlockStatus_OverallDeliveryBlockStatus" Type="Edm.String" MaxLength="1" />
+        <Property Name="_SalesDistrict_SalesDistrict" Type="Edm.String" MaxLength="6" />
+        <Property Name="_SalesGroup_SalesGroup" Type="Edm.String" MaxLength="3" />
+        <Property Name="_SalesOffice_SalesOffice" Type="Edm.String" MaxLength="4" />
+        <Property Name="_SalesOrganization_SalesOrganization" Type="Edm.String" MaxLength="4" />
+        <Property Name="_SDDocumentReason_SDDocumentReason" Type="Edm.String" MaxLength="3" />
+        <Property Name="_ShippingType_ShippingType" Type="Edm.String" MaxLength="2" />
+        <Property Name="_ShipToParty_ID" Type="Edm.Guid" />
+      </EntityType>
+      <EntityType Name="SalesOrderType">
+        <Key>
+          <PropertyRef Name="SalesOrderType" />
+        </Key>
+        <Property Name="SalesOrderType" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="SalesOrderType_Text" Type="Edm.String" MaxLength="20" />
+        <Property Name="SalesOrderProcessingType" Type="Edm.String" MaxLength="1" />
+        <Property Name="OrderTypeForBillingRequest" Type="Edm.String" MaxLength="4" />
+      </EntityType>
+      <EntityType Name="SalesOrganization">
+        <Key>
+          <PropertyRef Name="SalesOrganization" />
+        </Key>
+        <Property Name="SalesOrganization" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="SalesOrganization_Text" Type="Edm.String" MaxLength="20" />
+        <Property Name="SalesOrganizationCurrency" Type="Edm.String" MaxLength="5" />
+        <Property Name="CompanyCode" Type="Edm.String" MaxLength="4" />
+        <Property Name="IntercompanyBillingCustomer" Type="Edm.String" MaxLength="10" />
+      </EntityType>
+      <EntityType Name="ShippingCondition">
+        <Key>
+          <PropertyRef Name="ShippingCondition" />
+        </Key>
+        <Property Name="ShippingCondition" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="ShippingCondition_Text" Type="Edm.String" MaxLength="20" />
+        <Property Name="SoldToParty" Type="Edm.String" MaxLength="10" />
+      </EntityType>
+      <EntityType Name="ShippingPoint">
+        <Key>
+          <PropertyRef Name="ShippingPoint" />
+        </Key>
+        <Property Name="ShippingPoint" Type="Edm.String" MaxLength="4" Nullable="false" />
+        <Property Name="ShippingPoint_Text" Type="Edm.String" MaxLength="30" />
+      </EntityType>
+      <EntityType Name="ShippingType">
+        <Key>
+          <PropertyRef Name="ShippingType" />
+        </Key>
+        <Property Name="ShippingType" Type="Edm.String" MaxLength="2" Nullable="false" />
+        <Property Name="ShippingType_Text" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <EntityType Name="UnitOfMeasure">
+        <Key>
+          <PropertyRef Name="UnitOfMeasure" />
+        </Key>
+        <Property Name="UnitOfMeasure" Type="Edm.String" MaxLength="40" Nullable="false" />
+        <Property Name="UnitOfMeasure_Text" Type="Edm.String" MaxLength="30" />
+        <Property Name="UnitOfMeasureDimension" Type="Edm.String" MaxLength="6" />
+        <Property Name="UnitOfMeasureISOCode" Type="Edm.String" MaxLength="3" />
+        <Property Name="UnitOfMeasureNumberOfDecimals" Type="Edm.Int32" />
+        <Property Name="UnitOfMeasureDspNmbrOfDcmls" Type="Edm.Int32" />
+      </EntityType>
+      <Action Name="DummyBoundAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem" />
+      </Action>
+      <Action Name="DummyBoundAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="IdentificationFormAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderItem" />
+      </Action>
+      <Action Name="OPAvailableTrueAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="OPAvailableFalseAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="OPAvailableNullAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="EnableEditAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="CreateWithSalesOrderType" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="ChangeOrderStatus" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Action Name="FacetFormAction" IsBound="true" EntitySetPath="_it">
+        <Parameter Name="_it" Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+        <ReturnType Type="com.c_salesordermanage_sd_aggregate.SalesOrderManage" />
+      </Action>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.BillingBlockReason">
+        <Annotation Term="Common.Label" String="Value Help for Billing Block Reason" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.BillingBlockReason/BillingBlockReason">
+        <Annotation Term="Common.Heading" String="Block" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Billing Block" />
+        <Annotation Term="Common.Text" Path="BillingBlockReason_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.BillingBlockReason/BillingBlockReason_Text">
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails">
+        <Annotation Term="Common.Label" String="Bullet Chart" />
+        <Annotation Term="UI.Chart" Qualifier="CreditLimitChart">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Bullet" />
+            <PropertyValue Property="Description" String="Credit Exposure" />
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="CustomerCreditExposureAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#CustomerCreditExposureAmount" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>CustomerCreditExposureAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Credit Limit Consumption" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="HarveyBallCriticalityPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Pie" />
+            <PropertyValue Property="Description" String="Testing HarveyBall MicroChart" />
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="CustomerCreditExposureAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#HarveyBallValuePath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>CustomerCreditExposureAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Credit Limit HarveyBall MicroChart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="RadialCriticalityPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Donut" />
+            <PropertyValue Property="Description" String="Testing Radial MicroChart" />
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="CustomerCreditExposureAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#RadialValuePath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>CustomerCreditExposureAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Credit Limit Radial MicroChart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="RadialCriticalityPathHidden">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Donut" />
+            <PropertyValue Property="Description" String="Testing Radial MicroChart Hidden" />
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="CustomerCreditExposureAmountHidden" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#RadialValuePathHidden" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>CustomerCreditExposureAmountHidden</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Credit Limit Radial MicroChart Hidden" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="CustomerCreditExposureAmount">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="CriticalityCalculation">
+              <Record Type="UI.CriticalityCalculationType">
+                <PropertyValue Property="AcceptanceRangeHighValue" Path="AcceptanceRangeHigh" />
+                <PropertyValue Property="AcceptanceRangeLowValue" Path="AcceptanceRangeLow" />
+                <PropertyValue Property="DeviationRangeHighValue" Path="DeviationRangeHigh" />
+                <PropertyValue Property="DeviationRangeLowValue" Path="DeviationRangeLow" />
+                <PropertyValue Property="ImprovementDirection" EnumMember="UI.ImprovementDirectionType/Maximize" />
+                <PropertyValue Property="ToleranceRangeHighValue" Path="ToleranceRangeHigh" />
+                <PropertyValue Property="ToleranceRangeLowValue" Path="ToleranceRangeLow" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Description" String="Bullet Micro Chart" />
+            <PropertyValue Property="ForecastValue" Path="CustomerCreditForecast" />
+            <PropertyValue Property="MaximumValue" Decimal="7000" />
+            <PropertyValue Property="MinimumValue" Decimal="200" />
+            <PropertyValue Property="TargetValue" Path="CustomerCreditLimitAmount" />
+            <PropertyValue Property="Title" String="Exposure Amount" />
+            <PropertyValue Property="Value" Path="CustomerCreditExposureAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="HarveyBallValuePath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" Path="CustomerIsAboveThreshold" />
+            <PropertyValue Property="MaximumValue" Path="CustomerCreditLimitAmount" />
+            <PropertyValue Property="Value" Path="CustomerCreditExposureAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="RadialValuePath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" Path="CustomerIsAboveThreshold" />
+            <PropertyValue Property="TargetValue" Path="CustomerCreditLimitAmount" />
+            <PropertyValue Property="Value" Path="CustomerCreditExposureAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="RadialValuePathHidden">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" Path="CustomerIsAboveThreshold" />
+            <PropertyValue Property="TargetValue" Path="CustomerCreditLimitAmount" />
+            <PropertyValue Property="Value" Path="CustomerCreditExposureAmountHidden" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails/CustomerCreditExposureAmount">
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails/Delivered">
+        <Annotation Term="Common.Label" String="Delivery Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails/CustomerCreditExposureAmountHidden">
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+        <Annotation Term="UI.Hidden" Path="Delivered" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails/CustomerCreditForecast">
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CreditLimitDetails/CustomerCreditLimitAmount">
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer">
+        <Annotation Term="Common.IsNaturalPerson" Bool="true" />
+        <Annotation Term="Common.Label" String="Sold-to Party" />
+        <Annotation Term="Communication.Contact">
+          <Record Type="Communication.ContactType">
+            <PropertyValue Property="adr">
+              <Collection>
+                <Record Type="Communication.AddressType">
+                  <PropertyValue Property="type" EnumMember="Communication.ContactInformationType/work" />
+                  <PropertyValue Property="uri" Path="InternationalPhoneNumber" />
+                  <PropertyValue Property="code" Path="PostalCode" />
+                  <PropertyValue Property="country" Path="Country" />
+                  <PropertyValue Property="locality" Path="CityName" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="email">
+              <Collection>
+                <Record Type="Communication.EmailAddressType">
+                  <PropertyValue Property="type" EnumMember="Communication.ContactInformationType/work" />
+                  <PropertyValue Property="address" Path="EmailAddress" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="fn" Path="CustomerName" />
+            <PropertyValue Property="tel">
+              <Collection>
+                <Record Type="Communication.PhoneNumberType">
+                  <PropertyValue Property="type" EnumMember="Communication.PhoneType/fax" />
+                  <PropertyValue Property="uri" Path="InternationalPhoneNumber" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.CollectionFacet">
+              <PropertyValue Property="Label" String="Header" />
+              <PropertyValue Property="ID" String="HeaderInfo" />
+              <PropertyValue Property="Facets">
+                <Collection>
+                  <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="GeneralInfo" />
+                    <PropertyValue Property="Label" String="General Information" />
+                    <PropertyValue Property="Facets">
+                      <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                          <PropertyValue Property="Label" String="Adress" />
+                          <PropertyValue Property="ID" String="Adress" />
+                          <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#SoldToQuickView" />
+                          <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                          <Annotation Term="UI.Hidden" Bool="false" />
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                          <PropertyValue Property="Label" String="Contact" />
+                          <PropertyValue Property="ID" String="Partner" />
+                          <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Contact" />
+                          <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                          <Annotation Term="UI.Hidden" Bool="false" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                    <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="SoldToQuickView">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="PostalCode" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="CityName" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="Country" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="CustomerName" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Initials" Path="Initials" />
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="Customer" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Customer" />
+            <PropertyValue Property="TypeNamePlural" String="Customers" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Customer" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="CustomerName" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Delivered" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="OrganizationBPName1" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="OrganizationBPName2" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="BusinessPartnerImageURL" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="PostalCode" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="CityName" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Country" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="InternationalPhoneNumber" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="EmailAddress" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Customer" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Delivered" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.QuickViewFacets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Address" />
+              <PropertyValue Property="Target" AnnotationPath="@Communication.Contact" />
+              <Annotation Term="UI.Hidden" Bool="false" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Address" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#SoldToQuickView" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/Customer">
+        <Annotation Term="Common.Heading" String="Customer" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Customer" />
+        <Annotation Term="Common.QuickInfo" String="Customer Number" />
+        <Annotation Term="Common.Text" Path="CustomerName" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/CustomerName">
+        <Annotation Term="Common.Heading" String="Customer" />
+        <Annotation Term="Common.Label" String="Name" />
+        <Annotation Term="Common.QuickInfo" String="Name of Customer" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="Customer" />
+            <PropertyValue Property="Label" String="Customer" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="Customer" />
+                  <PropertyValue Property="ValueListProperty" String="Customer" />
+                </Record>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="CustomerName" />
+                  <PropertyValue Property="ValueListProperty" String="CustomerName" />
+                </Record>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="CityName" />
+                  <PropertyValue Property="ValueListProperty" String="CityName" />
+                </Record>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="Country" />
+                  <PropertyValue Property="ValueListProperty" String="Country" />
+                </Record>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="EmailAddress" />
+                  <PropertyValue Property="ValueListProperty" String="EmailAddress" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/Delivered">
+        <Annotation Term="Common.Label" String="Delivery Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/OrganizationBPName1">
+        <Annotation Term="Common.Heading" String="Name 1" />
+        <Annotation Term="Common.Label" String="Name" />
+        <Annotation Term="Common.QuickInfo" String="Name 1" />
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/OrganizationBPName2">
+        <Annotation Term="Common.Label" String="Name 2" />
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/BusinessPartnerImageURL">
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/StreetName">
+        <Annotation Term="Common.Label" String="Street" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/HouseNumber">
+        <Annotation Term="Common.Label" String="House Number" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/PostalCode">
+        <Annotation Term="Common.Heading" String="Post. Code" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Postal Code" />
+        <Annotation Term="Common.QuickInfo" String="City Postal Code" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/CityName">
+        <Annotation Term="Common.Label" String="City" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/Country">
+        <Annotation Term="Common.Heading" String="Ctr" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Country Key" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/InternationalPhoneNumber">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Telephone Number" />
+        <Annotation Term="Common.QuickInfo" String="Complete Number: Dialling Code+Number+Extension" />
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Customer/EmailAddress">
+        <Annotation Term="Common.Label" String="Email Address" />
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms">
+        <Annotation Term="Common.Label" String="Customer Payment Terms" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms/CustomerPaymentTerms">
+        <Annotation Term="Common.Heading" String="PayT" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Payment Terms" />
+        <Annotation Term="Common.QuickInfo" String="Terms of Payment Key" />
+        <Annotation Term="Common.Text" Path="CustomerPaymentTerms_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CustomerPaymentTerms/CustomerPaymentTerms_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Common.QuickInfo" String="Description of terms of payment" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CustomerPurchaseOrderType">
+        <Annotation Term="Common.Label" String="Customer Purchase Order Type" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.CustomerPurchaseOrderType/CustomerPurchaseOrderType">
+        <Annotation Term="Common.Heading" String="POtyp" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Purchase Order Type" />
+        <Annotation Term="Common.QuickInfo" String="Customer Purchase Order Type" />
+        <Annotation Term="Common.Text" Path="CustomerPurchaseOrderType_Text" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.CustomerPurchaseOrderType/CustomerPurchaseOrderType_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason">
+        <Annotation Term="Common.Label" String="Delivery Block Reason" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason/DeliveryBlockReason">
+        <Annotation Term="Common.Heading" String="DB" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Delivery Block" />
+        <Annotation Term="Common.QuickInfo" String="Default Delivery Block" />
+        <Annotation Term="Common.Text" Path="DeliveryBlockReason_Text" />
+        <Annotation Term="UI.HiddenFilter" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason/DeliveryBlockReason_Text">
+        <Annotation Term="Common.Heading" String="Delivery Block Description" />
+        <Annotation Term="Common.Label" String="Delivery Block Desc." />
+        <Annotation Term="Common.QuickInfo" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="UI.HiddenFilter" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryBlockReason/DeliveryDueListBlock">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Delv. Due List Block" />
+        <Annotation Term="Common.QuickInfo" String="Delivery Due List Block" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryPriority">
+        <Annotation Term="Common.Label" String="Delivery Priority" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryPriority/DeliveryPriority">
+        <Annotation Term="Common.Heading" String="DPrio" />
+        <Annotation Term="Common.IsDigitSequence" Bool="true" />
+        <Annotation Term="Common.Label" String="Delivery Priority" />
+        <Annotation Term="Common.Text" Path="DeliveryPriority_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DeliveryPriority/DeliveryPriority_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DistributionChannel">
+        <Annotation Term="Common.Label" String="Distribution Channel" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DistributionChannel/DistributionChannel">
+        <Annotation Term="Common.Heading" String="DChl" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Distribution Channel" />
+        <Annotation Term="Common.Text" Path="DistributionChannel_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.DistributionChannel/DistributionChannel_Text">
+        <Annotation Term="Common.Label" String="Distribution Channel Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner">
+        <Annotation Term="Common.Label" String="Manage Sales Order Header Partner" />
+        <Annotation Term="Communication.Contact">
+          <Record Type="Communication.ContactType">
+            <PropertyValue Property="email">
+              <Collection>
+                <Record Type="Communication.EmailAddressType">
+                  <PropertyValue Property="type" EnumMember="Communication.ContactInformationType/work" />
+                  <PropertyValue Property="address" Path="BusinessPartner" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="fn" Path="FullName" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="Progress2">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="TargetValue" Int="100" />
+            <PropertyValue Property="Title" String="Progress" />
+            <PropertyValue Property="Value" Path="Progress" />
+            <PropertyValue Property="Visualization" EnumMember="UI.VisualizationType/Progress" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="Rating2">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="TargetValue" Int="5" />
+            <PropertyValue Property="Title" String="Rating" />
+            <PropertyValue Property="Value" Path="Rating" />
+            <PropertyValue Property="Visualization" EnumMember="UI.VisualizationType/Rating" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="multipleActionFields">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="PartnerFunction" />
+                </Record>
+                <Record Type="UI.DataFieldForAnnotation">
+                  <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating2" />
+                </Record>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Change Order Status (Parent)" />
+                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.ParentBasedAction" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Dummy Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.ChangeOrderStatus" />
+            </Record>
+            <Record Type="UI.DataFieldForAnnotation">
+              <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#multipleActionFields" />
+              <PropertyValue Property="Label" String="Partner function" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Label" String="IBN" />
+              <PropertyValue Property="RequiresContext" Bool="false" />
+            </Record>
+            <Record Type="UI.DataFieldForAnnotation">
+              <PropertyValue Property="Target" AnnotationPath="@Communication.Contact" />
+              <PropertyValue Property="Label" String="Supplier" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="BusinessPartner" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="FullName" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="isVerified" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/HeaderPartner">
+        <Annotation Term="UI.CreateHidden" Path="owner/isCreateHidden" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/ID">
+        <Annotation Term="Common.Label" String="Partner UUID" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/SalesOrder">
+        <Annotation Term="Common.Label" String="Sales Order No." />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/PartnerFunction">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Partner function" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/BusinessPartner">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="ID" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/Rating">
+        <Annotation Term="Common.Label" String="Rating" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/Progress">
+        <Annotation Term="Common.Label" String="Progress" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/AddressID">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Address" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/FullName">
+        <Annotation Term="Common.Label" String="Full Name" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/PhoneNumber">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Telephone" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/PostalCode">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Postal Code" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderPartner/Country">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Country Key" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty">
+        <Annotation Term="UI.FieldGroup" Qualifier="AddressData">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Label" String="Ship To Party" />
+                  <PropertyValue Property="Value" Path="BusinessPartner" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="StreetName" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataFieldWithUrl">
+                  <PropertyValue Property="Label" String="FLP" />
+                  <PropertyValue
+                                        Property="Url"
+                                        String="http://veui5infra.dhcp.wdf.sap.corp:8080/sapui5-sdk-internal/test-resources/sap/fe/templates/internal/demokit/flpSandbox.html?useBackendUrl=http://veui5server.dhcp.wdf.sap.corp:30000/databinding/proxy/http/10.236.138.74:8080#Shell-home"
+                                    />
+                  <PropertyValue Property="Value" String="Shell Home" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="HouseNumber" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="PostalCode" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="CityName" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="Country" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/ID">
+        <Annotation Term="Common.Label" String="ID" />
+        <Annotation Term="Core.Computed" Bool="true" />
+        <Annotation Term="UI.HiddenFilter" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/BusinessPartner">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Customer" />
+        <Annotation Term="Common.QuickInfo" String="Customer Number" />
+        <Annotation Term="Common.SemanticObject" String="SalesOrder" />
+        <Annotation Term="Common.SemanticObject" Qualifier="customer" String="Customer" />
+        <Annotation Term="Common.SemanticObjectMapping">
+          <Collection>
+            <Record Type="Common.SemanticObjectMappingType">
+              <PropertyValue Property="LocalProperty" PropertyPath="SoldToParty" />
+              <PropertyValue Property="SemanticObjectProperty" String="SoldToParty" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.SemanticObjectMapping" Qualifier="customer">
+          <Collection>
+            <Record Type="Common.SemanticObjectMappingType">
+              <PropertyValue Property="LocalProperty" PropertyPath="BusinessPartner" />
+              <PropertyValue Property="SemanticObjectProperty" String="Customer" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Text" Path="_ShipToPartyVH/CustomerName">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="Customer" />
+            <PropertyValue Property="Label" String="Ship-to Party" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="BusinessPartner" />
+                  <PropertyValue Property="ValueListProperty" String="Customer" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="CustomerName" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="OrganizationBPName1" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="OrganizationBPName2" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="BusinessPartnerImageURL" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="PostalCode" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="CityName" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Country" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="InternationalPhoneNumber" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="EmailAddress" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/PostalCode">
+        <Annotation Term="Common.FieldControl" Path="fieldReadOnly" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Postal Code" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/CityName">
+        <Annotation Term="Common.Label" String="City" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/isHidden">
+        <Annotation Term="Common.Label" String="Is Hidden" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/isUpdatable">
+        <Annotation Term="Common.Label" String="Is Updatable" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/Country">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Country Key" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/StreetName">
+        <Annotation Term="Common.Label" String="Street" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.HeaderShipToParty/HouseNumber">
+        <Annotation Term="Common.Label" String="House Number" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsClassification">
+        <Annotation Term="Common.Label" String="Incoterms Classification" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsClassification/IncotermsClassification">
+        <Annotation Term="Common.Heading" String="IncoT" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Incoterms" />
+        <Annotation Term="Common.QuickInfo" String="Incoterms (Part 1)" />
+        <Annotation Term="Common.Text" Path="IncotermsClassification_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsClassification/IncotermsClassification_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsClassification/LocationIsMandatory">
+        <Annotation Term="Common.Heading" String="Cty" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Location Mandatory" />
+        <Annotation Term="Common.QuickInfo" String="Location is mandatory" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsVersion">
+        <Annotation Term="Common.Label" String="Incoterms Version" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsVersion/IncotermsVersion">
+        <Annotation Term="Common.Heading" String="IncoV" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Incoterms version" />
+        <Annotation Term="Common.Text" Path="IncotermsVersion_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.IncotermsVersion/IncotermsVersion_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Material">
+        <Annotation Term="Common.Label" String="Material" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/Material">
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record Type="Capabilities.DeleteRestrictionsType">
+            <PropertyValue Property="Deletable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record Type="Capabilities.InsertRestrictionsType">
+            <PropertyValue Property="Insertable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record Type="Capabilities.UpdateRestrictionsType">
+            <PropertyValue Property="Updatable" Bool="false" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Material/Material">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Material" />
+        <Annotation Term="Common.Text" Path="Material_Text" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Material/isHidden">
+        <Annotation Term="Common.Label" String="Is Hidden" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Material/isUpdatable">
+        <Annotation Term="Common.Label" String="Is Updatable" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Material/Material_Text">
+        <Annotation Term="Common.Label" String="Material Description" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCategory">
+        <Annotation Term="Common.Label" String="Material category" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCategory/Category">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Category" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCategory/Category_Text">
+        <Annotation Term="Common.Label" String="Category Code" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCountry">
+        <Annotation Term="Common.Label" String="Material country" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCountry/Country">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Country Code" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialCountry/Country_Text">
+        <Annotation Term="Common.Label" String="Fabrication Country" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails">
+        <Annotation Term="Common.Label" String="Material Details" />
+        <Annotation Term="Common.SemanticKey">
+          <Collection>
+            <PropertyPath>owner/SalesOrder</PropertyPath>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="MaterialDetailsModelYearChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>ModelYear</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>WarrantyYear</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Material Information" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.Identification" />
+              <PropertyValue Property="ID" String="MaterialDetailsFacet" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Material Reviews" />
+              <PropertyValue Property="ID" String="MaterialRatingsFacet" />
+              <PropertyValue Property="Target" AnnotationPath="_MaterialRatings/@UI.LineItem" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="material/Material_Text" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="material/Material" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Material Details" />
+            <PropertyValue Property="TypeNamePlural" String="Material Details" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Change Material Category" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialCategoryFormAction" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ModelYear" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="WarrantyYear" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="BrandCategory" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="FabricationCountry" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ModelYear" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="WarrantyYear" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="BrandCategory" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="FabricationCountry" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Material Details Bound Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialDetailsBoundAction" />
+              <Annotation Term="UI.Hidden" Path="owner/owner/ReturnInProcess" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails/ID">
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails/ModelYear">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Model Year" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="MaterialYears" />
+            <PropertyValue Property="Label" String="Model Year" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="ModelYear" />
+                  <PropertyValue Property="ValueListProperty" String="Model_Year" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Warranty_Expiration" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails/WarrantyYear">
+        <Annotation Term="Common.Core">
+          <Record>
+            <PropertyValue Property="Immutable" Bool="true" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Warranty Expiration" />
+        <Annotation Term="Common.Text" Path="_WarrantyYear/Warranty_Expiration" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails/BrandCategory">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Material Category" />
+        <Annotation Term="Common.Text" Path="_MaterialCategory/Category_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="MaterialCategory" />
+            <PropertyValue Property="Label" String="Category for the Material" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="BrandCategory" />
+                  <PropertyValue Property="ValueListProperty" String="Category" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Category_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialDetails/FabricationCountry">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Fabrication Country" />
+        <Annotation Term="Common.Text" Path="_MaterialCountry/Country_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="MaterialCountry" />
+            <PropertyValue Property="Label" String="Fabrication Country for the Material" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="FabricationCountry" />
+                  <PropertyValue Property="ValueListProperty" String="Country" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Country_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialGroup">
+        <Annotation Term="Common.Label" String="Material Group" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialGroup/MaterialGroup">
+        <Annotation Term="Common.Heading" String="Prd Group" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Product Group" />
+        <Annotation Term="Common.Text" Path="MaterialGroup_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialGroup/MaterialGroup_Text">
+        <Annotation Term="Common.Label" String="Product Group Desc." />
+        <Annotation Term="Common.QuickInfo" String="Product Group Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatings">
+        <Annotation Term="Common.Label" String="Material Rating" />
+        <Annotation Term="Common.SemanticKey">
+          <Collection>
+            <PropertyPath>materialdetail/owner_ID</PropertyPath>
+            <PropertyPath>materialdetail/FabricationCountry</PropertyPath>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="Rating">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="TargetValue" Int="5" />
+            <PropertyValue Property="Title" String="Rating" />
+            <PropertyValue Property="Value" Path="Rating" />
+            <PropertyValue Property="Visualization" EnumMember="UI.VisualizationType/Rating" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Material Review" />
+              <PropertyValue Property="ID" String="MaterialRatingsFacet" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.Identification" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Material Review Details" />
+              <PropertyValue Property="ID" String="MaterialRatingsDetailsFacet" />
+              <PropertyValue Property="Target" AnnotationPath="_MaterialRatingsDetails/@UI.LineItem" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="material/Material" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="Title" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Material Rating" />
+            <PropertyValue Property="TypeNamePlural" String="Material Ratings" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Change Current Rating" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.RatingFormAction" />
+            </Record>
+            <Record Type="UI.DataFieldForAnnotation">
+              <PropertyValue Property="Value" Path="Rating" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating" />
+              <PropertyValue Property="Label" String="Rating" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Title" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataFieldForAnnotation">
+              <PropertyValue Property="Value" Path="Rating" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating" />
+              <PropertyValue Property="Label" String="Rating" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Title" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Material Ratings Bound Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialRatingsBoundAction" />
+              <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatings/ID">
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatings/Rating">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Rating" />
+        <Annotation Term="Common.Text" Path="_Rating/Rating_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="Rating" />
+            <PropertyValue Property="Label" String="Rating for the Material" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="Rating" />
+                  <PropertyValue Property="ValueListProperty" String="Rating" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Rating_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatings/Title">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Title" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails">
+        <Annotation Term="Common.Label" String="Material Rating Details" />
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="ID" String="Facet" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.Identification" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="material/Material_Text" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="material/Material" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Review Details" />
+            <PropertyValue Property="TypeNamePlural" String="Review Details" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Change Current Comments" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.RatingCommentsFormAction" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="CREATEDAT" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="MODIFIEDAT" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="MODIFIEDBY" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Comments" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="CREATEDAT" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="MODIFIEDAT" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="MODIFIEDBY" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Comments" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Ratings Details Bound Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd.MaterialRatingsDetailsBoundAction" />
+              <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails/ID">
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails/Comments">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Comments" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails/CREATEDAT">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Created At" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails/MODIFIEDAT">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Modified At" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialRatingsDetails/MODIFIEDBY">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Modified By" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialYears">
+        <Annotation Term="Common.Label" String="Material years" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialYears/Model_Year">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Model Year" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.MaterialYears/Warranty_Expiration">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Warranty Expiration" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OrganizationDivision">
+        <Annotation Term="Common.Label" String="Division" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OrganizationDivision/Division">
+        <Annotation Term="Common.Heading" String="Dv" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Division" />
+        <Annotation Term="Common.Text" Path="Division_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OrganizationDivision/Division_Text">
+        <Annotation Term="Common.Label" String="Division Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallBillingBlockStatus">
+        <Annotation Term="Common.Label" String="Overall Billing Block Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallBillingBlockStatus/OverallBillingBlockStatus">
+        <Annotation Term="Common.Text" Path="_OverallBillingBlockStatus/OverallBillingBlockStatus_Text" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.OverallBillingBlockStatus/OverallBillingBlockStatus_Text">
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallDeliveryBlockStatus">
+        <Annotation Term="Common.Label" String="Overall Delivery Block Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus">
+        <Annotation Term="Common.Text" Path="OverallDeliveryBlockStatus_Text" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.OverallDeliveryBlockStatus/OverallDeliveryBlockStatus_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Common.QuickInfo" String="Status Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallSDProcessStatus">
+        <Annotation Term="Common.Label" String="Overall SD Process Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallSDProcessStatus/OverallSDProcessStatus">
+        <Annotation Term="Common.Label" String="Overall Status" />
+        <Annotation Term="Common.Text" Path="OverallSDProcessStatus_Text">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.OverallSDProcessStatus/OverallSDProcessStatus_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Common.QuickInfo" String="Status Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Rating">
+        <Annotation Term="Common.Label" String="Rating" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Rating/Rating">
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Label" String="Material Rating" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.Rating/Rating_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SDDocumentReason">
+        <Annotation Term="Common.Label" String="SD Document Reason" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SDDocumentReason/SDDocumentReason">
+        <Annotation Term="Common.Heading" String="OrdRs" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Order Reason" />
+        <Annotation Term="Common.QuickInfo" String="Order Reason (Reason for the Business Transaction)" />
+        <Annotation Term="Common.Text" Path="SDDocumentReason_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SDDocumentReason/SDDocumentReason_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesDistrict">
+        <Annotation Term="Common.Label" String="Sales District" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesDistrict/SalesDistrict">
+        <Annotation Term="Common.Heading" String="SDst" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales District" />
+        <Annotation Term="Common.Text" Path="SalesDistrict_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesDistrict/SalesDistrict_Text">
+        <Annotation Term="Common.Label" String="District name" />
+        <Annotation Term="Common.QuickInfo" String="Name of the district" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesGroup">
+        <Annotation Term="Common.Label" String="Sales Group" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesGroup/SalesGroup">
+        <Annotation Term="Common.Heading" String="SGrp" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales Group" />
+        <Annotation Term="Common.Text" Path="SalesGroup_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesGroup/SalesGroup_Text">
+        <Annotation Term="Common.Label" String="Sales Group Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOffice">
+        <Annotation Term="Common.Label" String="Sales Office" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOffice/SalesOffice">
+        <Annotation Term="Common.Heading" String="SOff." />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales Office" />
+        <Annotation Term="Common.Text" Path="SalesOffice_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOffice/SalesOffice_Text">
+        <Annotation Term="Common.Label" String="Sales Office Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/SalesOrderItem">
+        <Annotation Term="Aggregation.ApplySupported">
+          <Record Type="Aggregation.ApplySupportedType">
+            <PropertyValue Property="CustomAggregationMethods">
+              <Collection>
+                <String>Custom.concat</String>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="PropertyRestrictions" Bool="true" />
+            <PropertyValue Property="Rollup" EnumMember="Aggregation.RollupType/None" />
+            <PropertyValue Property="Transformations">
+              <Collection>
+                <String>aggregate</String>
+                <String>topcount</String>
+                <String>bottomcount</String>
+                <String>identity</String>
+                <String>concat</String>
+                <String>groupby</String>
+                <String>filter</String>
+                <String>expand</String>
+                <String>top</String>
+                <String>skip</String>
+                <String>orderby</String>
+                <String>search</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Analytics.AggregatedProperties">
+          <Collection>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="minAmount" />
+              <PropertyValue Property="AggregationMethod" String="min" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetAmount" />
+              <Annotation Term="Common.Label" String="Minimal Net Amount" />
+            </Record>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="maxAmount" />
+              <PropertyValue Property="AggregationMethod" String="max" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetAmount" />
+              <Annotation Term="Common.Label" String="Maximal Net Amount" />
+            </Record>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="avgAmount" />
+              <PropertyValue Property="AggregationMethod" String="average" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetAmount" />
+              <Annotation Term="Common.Label" String="Average Net Amount" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Label" String="Manage Sales Order Item (Transacl Procg)" />
+        <Annotation Term="Common.SemanticKey">
+          <Collection>
+            <PropertyPath>SalesOrder</PropertyPath>
+            <PropertyPath>SalesOrderItem</PropertyPath>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="ItemRequestedQuantityChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>RequestedQuantity</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>NetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="MaterialDetailsModelYearChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>_MaterialDetails/ModelYear</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>_MaterialDetails/WarrantyYear</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="AreaMaxPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Area" />
+            <PropertyValue Property="Description" String="Testing Area Chart" />
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#AreaMaxPath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Area Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="BarStackedPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/BarStacked" />
+            <PropertyValue Property="Description" String="Testing Stacked Bar Chart" />
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#BarStackedPath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Stacked Bar Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="ColumnMaxPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column" />
+            <PropertyValue Property="Description" String="Testing Column Chart" />
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#ColumnMaxPath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Column Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="ComparisonPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Bar" />
+            <PropertyValue Property="Description" String="Testing Comparison Chart" />
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#ComparisonPath" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Comparison Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="LineMaxPath">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line" />
+            <PropertyValue Property="Description" String="Testing Line Chart" />
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#LineValueCriticality" />
+                </Record>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="TargetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#LineTargetCriticality" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmount</PropertyPath>
+                <PropertyPath>TargetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Line Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="LineMaxPathHidden">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line" />
+            <PropertyValue Property="Description" String="Testing Line Chart" />
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="NetAmountHidden" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#LineValueCriticalityHidden" />
+                </Record>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="TargetAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                  <PropertyValue Property="DataPoint" AnnotationPath="@UI.DataPoint#LineTargetCriticalityHidden" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>NetAmountHidden</PropertyPath>
+                <PropertyPath>TargetAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Items Line Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="Actions">
+              <Collection>
+                <Record Type="UI.DataFieldForIntentBasedNavigation">
+                  <PropertyValue Property="SemanticObject" String="v4Freestyle" />
+                  <PropertyValue Property="Action" String="Inbound" />
+                  <PropertyValue Property="Label" String="IBN" />
+                  <PropertyValue Property="RequiresContext" Bool="true" />
+                </Record>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Dummy Bound Action" />
+                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.DummyBoundAction" />
+                  <Annotation Term="UI.Hidden" Path="owner/Delivered" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column" />
+            <PropertyValue Property="Description" String="Testing Line Chart" />
+            <PropertyValue Property="DimensionAttributes">
+              <Collection>
+                <Record Type="UI.ChartDimensionAttributeType">
+                  <PropertyValue Property="Dimension" PropertyPath="SalesOrderItem" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartDimensionRoleType/Axis1" />
+                </Record>
+                <Record Type="UI.ChartDimensionAttributeType">
+                  <PropertyValue Property="Dimension" PropertyPath="SalesOrderItemCategory" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartDimensionRoleType/Axis1" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrderItem</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="maxAmount" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>maxAmount</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Amount Line Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="AreaMaxPath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="CriticalityCalculation">
+              <Record Type="UI.CriticalityCalculationType">
+                <PropertyValue Property="AcceptanceRangeHighValue" Path="AcceptanceRangeHigh" />
+                <PropertyValue Property="AcceptanceRangeLowValue" Path="AcceptanceRangeLow" />
+                <PropertyValue Property="DeviationRangeHighValue" Path="DeviationRangeHigh" />
+                <PropertyValue Property="DeviationRangeLowValue" Path="DeviationRangeLow" />
+                <PropertyValue Property="ImprovementDirection" EnumMember="UI.ImprovementDirectionType/Target" />
+                <PropertyValue Property="ToleranceRangeHighValue" Path="ToleranceRangeHigh" />
+                <PropertyValue Property="ToleranceRangeLowValue" Path="ToleranceRangeLow" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Description" String="Area Micro Chart" />
+            <PropertyValue Property="TargetValue" Path="TargetAmount" />
+            <PropertyValue Property="Title" String="Data" />
+            <PropertyValue Property="Value" Path="NetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="BarStackedPath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" Path="Criticality" />
+            <PropertyValue Property="Title" String="Net Amount" />
+            <PropertyValue Property="Value" Path="NetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="ColumnMaxPath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="CriticalityCalculation">
+              <Record Type="UI.CriticalityCalculationType">
+                <PropertyValue Property="AcceptanceRangeHighValue" Path="AcceptanceRangeHigh" />
+                <PropertyValue Property="AcceptanceRangeLowValue" Path="AcceptanceRangeLow" />
+                <PropertyValue Property="DeviationRangeHighValue" Path="DeviationRangeHigh" />
+                <PropertyValue Property="DeviationRangeLowValue" Path="DeviationRangeLow" />
+                <PropertyValue Property="ImprovementDirection" EnumMember="UI.ImprovementDirectionType/Maximize" />
+                <PropertyValue Property="ToleranceRangeHighValue" Path="ToleranceRangeHigh" />
+                <PropertyValue Property="ToleranceRangeLowValue" Path="ToleranceRangeLow" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Description" String="Column Micro Chart" />
+            <PropertyValue Property="Title" String="Data" />
+            <PropertyValue Property="Value" Path="NetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="ComparisonPath">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" Path="Criticality" />
+            <PropertyValue Property="Title" String="Net Amount" />
+            <PropertyValue Property="Value" Path="NetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="LineTargetCriticality">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Neutral" />
+            <PropertyValue Property="Description" String="Target Amount Line" />
+            <PropertyValue Property="Title" String="Target Amount" />
+            <PropertyValue Property="Value" Path="TargetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="LineTargetCriticalityHidden">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Neutral" />
+            <PropertyValue Property="Description" String="Target Amount Line" />
+            <PropertyValue Property="Title" String="Target Amount" />
+            <PropertyValue Property="Value" Path="TargetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="LineValueCriticality">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive" />
+            <PropertyValue Property="Description" String="Net Amount Line" />
+            <PropertyValue Property="Title" String="Net Amount" />
+            <PropertyValue Property="Value" Path="NetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="LineValueCriticalityHidden">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive" />
+            <PropertyValue Property="Description" String="Net Amount Hidden Line" />
+            <PropertyValue Property="Title" String="Net Amount Hidden" />
+            <PropertyValue Property="Value" Path="NetAmountHidden" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Item Information" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.Identification" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Material Details" />
+              <PropertyValue Property="ID" String="MaterialDetailsFacet" />
+              <PropertyValue Property="Target" AnnotationPath="_MaterialDetails/@UI.LineItem" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="owner/SalesOrder" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="SalesOrderItem" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Sales Order Item" />
+            <PropertyValue Property="TypeNamePlural" String="Sales Order Items" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Identification Form Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.IdentificationFormAction" />
+            </Record>
+            <Record Type="UI.DataFieldWithNavigationPath">
+              <PropertyValue Property="Label" String="Referenced Sales Order" />
+              <PropertyValue Property="Value" Path="_ReferencedSalesOrder/SalesOrder" />
+              <PropertyValue Property="Target" NavigationPropertyPath="SalesOrderManage" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrderItem" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Material" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="RequestedQuantity" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="NetAmount" />
+            </Record>
+            <Record Type="UI.DataFieldWithNavigationPath">
+              <PropertyValue Property="Label" String="Referenced Sales Order Item" />
+              <PropertyValue Property="Value" Path="_ReferencedSalesOrderItem/SalesOrderItem" />
+              <PropertyValue Property="Target" NavigationPropertyPath="SalesOrderItem" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrderItem" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+              <Annotation Term="UI.Hidden" Path="_Material/isHidden" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="HigherLevelItem" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="Material" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="RequestedQuantity" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrderItemCategory" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="RequestedDeliveryDate" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+              <Annotation Term="UI.Hidden" Path="owner/isVerified" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="NetAmount" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="_Material/Material" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="isVerified" />
+            </Record>
+            <Record Type="UI.DataFieldWithNavigationPath">
+              <PropertyValue Property="Label" String="Referenced Sales Order" />
+              <PropertyValue Property="Value" Path="_ReferencedSalesOrder/SalesOrder" />
+              <PropertyValue Property="Target" NavigationPropertyPath="SalesOrderManage" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Label" String="IBN" />
+              <PropertyValue Property="RequiresContext" Bool="false" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Label" String="IBN with context" />
+              <PropertyValue Property="RequiresContext" Bool="true" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="View Return Status" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate/ReturnInProcess" />
+              <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Dummy Bound Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.DummyBoundAction" />
+              <Annotation Term="UI.Hidden" Path="owner/ReturnInProcess" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound Action" />
+              <PropertyValue Property="Inline" Bool="true" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.DummyBoundAction" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Label" String="IBN" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Inline" Bool="true" />
+              <PropertyValue Property="RequiresContext" Bool="true" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.PresentationVariant">
+          <Record Type="UI.PresentationVariantType">
+            <PropertyValue Property="Visualizations">
+              <Collection>
+                <AnnotationPath>@UI.Chart</AnnotationPath>
+                <AnnotationPath>@UI.LineItem</AnnotationPath>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/SalesOrderItem">
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record Type="Capabilities.DeleteRestrictionsType">
+            <PropertyValue Property="Deletable" Path="owner/isVerified" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.InsertRestrictions">
+          <Record Type="Capabilities.InsertRestrictionsType">
+            <PropertyValue Property="Insertable" Bool="false" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.UpdateRestrictions">
+          <Record Type="Capabilities.UpdateRestrictionsType">
+            <PropertyValue Property="Updatable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/ID">
+        <Annotation Term="Common.Label" String="Sales Order Item UUID" />
+        <Annotation Term="Core.Computed" Bool="true" />
+        <Annotation Term="PersonalData.IsPotentiallySensitive" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/SalesOrder">
+        <Annotation Term="Common.Label" String="Sales Order No." />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/SalesOrderItem">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.Label" String="Item" />
+        <Annotation Term="Common.Text" Path="SalesOrderItemText" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/HigherLevelItem">
+        <Annotation Term="Common.Label" String="Higher-Level Item" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/SalesOrderItemCategory">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Item Category" />
+        <Annotation Term="Common.Text" Path="_ItemCategory/SalesDocumentItemCategory_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="SalesOrderItemCategory" />
+            <PropertyValue Property="Label" String="Sales Document Item Category" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="SalesOrderItemCategory" />
+                  <PropertyValue Property="ValueListProperty" String="SalesDocumentItemCategory" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="SalesDocumentItemCategory_Text" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="ScheduleLineIsAllowed" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="UI.ValueCriticality">
+          <Collection>
+            <Record Type="UI.ValueCriticalityType">
+              <PropertyValue Property="Value" String="TAN" />
+              <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Negative" />
+            </Record>
+            <Record Type="UI.ValueCriticalityType">
+              <PropertyValue Property="Value" String="TAG" />
+              <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/fieldControlType_item">
+        <Annotation Term="Common.Label" String="FieldControlType for Items Table" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/Material">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.FieldControl" Path="fieldControlType_item" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Material" />
+        <Annotation Term="Common.Text" Path="_Material/Material_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="C_MaterialBySlsOrgDistrChnl" />
+            <PropertyValue Property="Label" String="Materials for Manage Sales Order" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="Material" />
+                  <PropertyValue Property="ValueListProperty" String="Material" />
+                </Record>
+                <Record Type="Common.ValueListParameterIn">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="owner/DistributionChannel" />
+                  <PropertyValue Property="ValueListProperty" String="DistributionChannel" />
+                </Record>
+                <Record Type="Common.ValueListParameterIn">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="owner/SalesOrganization" />
+                  <PropertyValue Property="ValueListProperty" String="SalesOrganization" />
+                </Record>
+                <Record Type="Common.ValueListParameterOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="RequestedQuantityUnit" />
+                  <PropertyValue Property="ValueListProperty" String="RequestedQuantityUnit" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="MaterialName" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/RequestedDeliveryDate">
+        <Annotation Term="Common.Label" String="Delivery Date" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/RequestedQuantity">
+        <Annotation Term="Common.Label" String="Requested Quantity" />
+        <Annotation Term="Measures.Unit" Path="RequestedQuantityUnit" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/RequestedQuantityUnit">
+        <Annotation Term="Common.FieldControl" Path="owner/fieldControlType_item" />
+        <Annotation Term="Common.Label" String="Requested Qty Unit" />
+        <Annotation Term="Common.Text" Path="_RequestedQuantityUnit/UnitOfMeasure_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="C_ProductUnitsOfMeasureVH" />
+            <PropertyValue Property="Label" String="Requested Quantity Units" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="RequestedQuantityUnit" />
+                  <PropertyValue Property="ValueListProperty" String="AlternativeUnit" />
+                </Record>
+                <Record Type="Common.ValueListParameterIn">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="Material" />
+                  <PropertyValue Property="ValueListProperty" String="Product" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="AlternativeUnit_Text" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="QuantityNumerator" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="QuantityDenominator" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/PricingDate">
+        <Annotation Term="Common.Label" String="Pricing Date" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/NetAmount">
+        <Annotation Term="Aggregation.Aggregatable" Bool="true" />
+        <Annotation Term="Aggregation.RecommendedAggregationMethod" String="average" />
+        <Annotation Term="Aggregation.SupportedAggregationMethods">
+          <Collection>
+            <String>min</String>
+            <String>max</String>
+            <String>average</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Analytics.Measure" Bool="true" />
+        <Annotation Term="Common.FieldControl" Path="owner/fieldControlType_item" />
+        <Annotation Term="Common.Label" String="Net Value" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/NetAmountHidden">
+        <Annotation Term="Common.Label" String="Net Value" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+        <Annotation Term="UI.Hidden" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/isVerified">
+        <Annotation Term="Common.Label" String="Verified Material" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItem/TargetAmount">
+        <Annotation Term="Common.Label" String="Target Value" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+        <Annotation Term="UI.ExcludeFromNavigationContext" Bool="true" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.DummyBoundAction(com.c_salesordermanage_sd_aggregate.SalesOrderItem)">
+        <Annotation Term="Core.OperationAvailable" Path="_it/owner/isVerified" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.IdentificationFormAction(com.c_salesordermanage_sd_aggregate.SalesOrderItem)">
+        <Annotation Term="Common.SideEffects">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>RequestedQuantity</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>_it/RequestedQuantity</String>
+                <String>_it/NetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.OperationAvailable" Path="_it/isVerified" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory">
+        <Annotation Term="Common.Label" String="Sales Document Item Category" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory/SalesDocumentItemCategory">
+        <Annotation Term="Common.Heading" String="ItCa" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Item Category" />
+        <Annotation Term="Common.QuickInfo" String="Sales Document Item Category" />
+        <Annotation Term="Common.Text" Path="SalesDocumentItemCategory" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory/SalesDocumentItemCategory_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderItemCategory/ScheduleLineIsAllowed">
+        <Annotation Term="Common.Heading" String="SchAl" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sched.lines allowed" />
+        <Annotation Term="Common.QuickInfo" String="Schedule lines allowed" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/SalesOrderManage">
+        <Annotation Term="Aggregation.ApplySupported">
+          <Record Type="Aggregation.ApplySupportedType">
+            <PropertyValue Property="CustomAggregationMethods">
+              <Collection>
+                <String>Custom.concat</String>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="PropertyRestrictions" Bool="true" />
+            <PropertyValue Property="Rollup" EnumMember="Aggregation.RollupType/None" />
+            <PropertyValue Property="Transformations">
+              <Collection>
+                <String>aggregate</String>
+                <String>topcount</String>
+                <String>bottomcount</String>
+                <String>identity</String>
+                <String>concat</String>
+                <String>groupby</String>
+                <String>filter</String>
+                <String>expand</String>
+                <String>top</String>
+                <String>skip</String>
+                <String>orderby</String>
+                <String>search</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Analytics.AggregatedProperties">
+          <Collection>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="minPricing" />
+              <PropertyValue Property="AggregationMethod" String="min" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetPricing" />
+              <Annotation Term="Common.Label" String="Minimal Net Amount" />
+            </Record>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="maxPricing" />
+              <PropertyValue Property="AggregationMethod" String="max" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetPricing" />
+              <Annotation Term="Common.Label" String="Maximal Net Amount" />
+            </Record>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="avgPricing" />
+              <PropertyValue Property="AggregationMethod" String="average" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetPricing" />
+              <Annotation Term="Common.Label" String="Average Net Amount" />
+            </Record>
+            <Record Type="Analytics.AggregatedPropertyType">
+              <PropertyValue Property="Name" String="totalPricing" />
+              <PropertyValue Property="AggregationMethod" String="sum" />
+              <PropertyValue Property="AggregatableProperty" PropertyPath="NetPricing" />
+              <Annotation Term="Common.Label" String="Total Net Amount" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Label" String="Manage Sales Order" />
+        <Annotation Term="Common.SemanticKey">
+          <Collection>
+            <PropertyPath>ID</PropertyPath>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="IncotermsChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>IncotermsVersion</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>IncotermsLocation1</String>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TriggerAction" String="com.c_salesordermanage_sd.IncotermsDetermination" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="ItemCreationOrDeletion">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceEntities">
+              <Collection>
+                <NavigationPropertyPath>_Item</NavigationPropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>TotalNetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="ItemMaterialChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>_Item/Material</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetEntities">
+              <Collection>
+                <NavigationPropertyPath>_Item</NavigationPropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>TotalNetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="ItemRequestedQuantityChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>_Item/RequestedQuantity</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetEntities">
+              <Collection>
+                <NavigationPropertyPath>_Item</NavigationPropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>TotalNetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="ShipToPartyChange">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>_ShipToParty/BusinessPartner</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetEntities">
+              <Collection>
+                <NavigationPropertyPath>_ShipToParty</NavigationPropertyPath>
+                <NavigationPropertyPath>_Partner</NavigationPropertyPath>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.SideEffects" Qualifier="SoldToChangeSalesAreaShipTo">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="SourceProperties">
+              <Collection>
+                <PropertyPath>SoldToParty</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetEntities">
+              <Collection>
+                <NavigationPropertyPath>_ShipToParty</NavigationPropertyPath>
+                <NavigationPropertyPath>_Partner</NavigationPropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>SalesOrganization</String>
+                <String>DistributionChannel</String>
+                <String>OrganizationDivision</String>
+                <String>TotalNetAmount</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+          <Record Type="UI.ChartDefinitionType">
+            <PropertyValue Property="Actions">
+              <Collection>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Bound Action with params" />
+                  <PropertyValue
+                                        Property="Action"
+                                        String="com.c_salesordermanage_sd_aggregate.CreateWithSalesOrderType"
+                                    />
+                </Record>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Unbound Action" />
+                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate/UnboundAction" />
+                </Record>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Confirmation Action" />
+                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate/ReturnInProcess" />
+                </Record>
+                <Record Type="UI.DataFieldForIntentBasedNavigation">
+                  <PropertyValue Property="SemanticObject" String="SalesOrder" />
+                  <PropertyValue Property="Action" String="manageInline" />
+                  <PropertyValue Property="Label" String="IBN" />
+                  <PropertyValue Property="RequiresContext" Bool="false" />
+                </Record>
+                <Record Type="UI.DataFieldForIntentBasedNavigation">
+                  <PropertyValue Property="SemanticObject" String="v4Freestyle" />
+                  <PropertyValue Property="Action" String="Inbound" />
+                  <PropertyValue Property="Label" String="IBN with context" />
+                  <PropertyValue Property="RequiresContext" Bool="true" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column" />
+            <PropertyValue Property="Description" String="Testing Line Chart" />
+            <PropertyValue Property="DimensionAttributes">
+              <Collection>
+                <Record Type="UI.ChartDimensionAttributeType">
+                  <PropertyValue Property="Dimension" PropertyPath="SalesOrganization" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartDimensionRoleType/Axis1" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Dimensions">
+              <Collection>
+                <PropertyPath>SalesOrganization</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="MeasureAttributes">
+              <Collection>
+                <Record Type="UI.ChartMeasureAttributeType">
+                  <PropertyValue Property="Measure" PropertyPath="totalPricing" />
+                  <PropertyValue Property="Role" EnumMember="UI.ChartMeasureRoleType/Axis1" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Measures">
+              <Collection>
+                <PropertyPath>totalPricing</PropertyPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Title" String="Height Line Chart" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="NetValue">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive" />
+            <PropertyValue Property="Title" String="Net Amount" />
+            <PropertyValue Property="Value" Path="TotalNetAmount" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="Progress">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="TargetValue" Int="100" />
+            <PropertyValue Property="Title" String="Progress" />
+            <PropertyValue Property="Value" Path="Progress" />
+            <PropertyValue Property="Visualization" EnumMember="UI.VisualizationType/Progress" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.DataPoint" Qualifier="Rating">
+          <Record Type="UI.DataPointType">
+            <PropertyValue Property="TargetValue" Int="5" />
+            <PropertyValue Property="Title" String="Rating" />
+            <PropertyValue Property="Value" Path="Rating" />
+            <PropertyValue Property="Visualization" EnumMember="UI.VisualizationType/Rating" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.CollectionFacet">
+              <PropertyValue Property="Label" String="Header" />
+              <PropertyValue Property="ID" String="HeaderInfo" />
+              <PropertyValue Property="Facets">
+                <Collection>
+                  <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="GeneralInfo" />
+                    <PropertyValue Property="Label" String="General Information" />
+                    <PropertyValue Property="Facets">
+                      <Collection>
+                        <Record Type="UI.ReferenceFacet">
+                          <PropertyValue Property="Label" String="Order Data" />
+                          <PropertyValue Property="ID" String="OrderData" />
+                          <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#OrderData" />
+                          <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                          <Annotation Term="UI.Hidden" Bool="false" />
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                          <PropertyValue Property="Label" String="Ship-To" />
+                          <PropertyValue Property="ID" String="AddressData" />
+                          <PropertyValue Property="Target" AnnotationPath="_ShipToParty/@UI.FieldGroup#AddressData" />
+                          <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                        </Record>
+                        <Record Type="UI.ReferenceFacet">
+                          <PropertyValue Property="Label" String="Terms &amp; Conditions" />
+                          <PropertyValue Property="ID" String="TermsConditions" />
+                          <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#TermsConditions" />
+                          <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                          <Annotation Term="UI.Hidden" Path="Delivered" />
+                        </Record>
+                      </Collection>
+                    </PropertyValue>
+                    <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                  </Record>
+                  <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="Label" String="Business Partners" />
+                    <PropertyValue Property="ID" String="SalesOrderHeaderPartner" />
+                    <PropertyValue Property="Target" AnnotationPath="_Partner/@UI.LineItem" />
+                    <Annotation Term="UI.Importance" Path="High" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Customer Info" />
+              <PropertyValue Property="ID" String="CustomerInfo" />
+              <PropertyValue Property="Target" AnnotationPath="_SoldToParty/@UI.FieldGroup#Customer" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Items" />
+              <PropertyValue Property="ID" String="SalesOrderItems" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.PresentationVariant" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="OrderData">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataFieldForIntentBasedNavigation">
+                  <PropertyValue Property="SemanticObject" String="SalesOrder" />
+                  <PropertyValue Property="Action" String="manageInline" />
+                  <PropertyValue Property="Label" String="IBN" />
+                  <PropertyValue Property="RequiresContext" Bool="false" />
+                </Record>
+                <Record Type="UI.DataFieldForAction">
+                  <PropertyValue Property="Label" String="Facet Form Action" />
+                  <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.FacetFormAction" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataFieldWithNavigationPath">
+                  <PropertyValue Property="Label" String="Referenced Sales Order" />
+                  <PropertyValue Property="Value" Path="_ReferencedSalesOrder/SalesOrder" />
+                  <PropertyValue Property="Target" NavigationPropertyPath="SalesOrderManage" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="SoldToParty" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="ImageUrl" />
+                  <PropertyValue Property="IconUrl" Path="ImageUrl" />
+                  <PropertyValue Property="Label" String="SalesOrder Image" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="PurchaseOrderByCustomer" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="SalesOrderDate" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                  <Annotation Term="UI.Hidden" Path="Delivered" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="ShippingCondition" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="OverallSDProcessStatus" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                  <PropertyValue Property="Criticality" Path="StatusCriticality" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="DescriptionFieldForOPACleanup" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="OrgData">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="SalesOrganization" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="DistributionChannel" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                  <Annotation Term="UI.Hidden" Path="Delivered" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="OrganizationDivision" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="OrgDataHeader">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="TotalNetAmount" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="TransactionCurrency" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="TermsConditions">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="IncotermsClassification" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="IncotermsVersion" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="IncotermsLocation1" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="IncotermsLocation2" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="CustomerPaymentTerms" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="CompleteDeliveryIsDefined" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="PricingDate" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="multipleActionFields">
+          <Record Type="UI.FieldGroupType">
+            <PropertyValue Property="Data">
+              <Collection>
+                <Record Type="UI.DataField">
+                  <PropertyValue Property="Value" Path="_SoldToParty/Customer" />
+                </Record>
+                <Record Type="UI.DataFieldForAnnotation">
+                  <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.HeaderFacets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Sales Area" />
+              <PropertyValue Property="ID" String="OrganizationalDataHeader" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#OrgData" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Net Amount" />
+              <PropertyValue Property="ID" String="NetValueDataHeader" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#NetValue" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Contact Info" />
+              <PropertyValue Property="ID" String="ContactHeader" />
+              <PropertyValue Property="Target" AnnotationPath="_SoldToParty/@Communication.Contact" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="CreditLimitConsumption" />
+              <PropertyValue Property="ID" String="CreditLimitChartHeader" />
+              <PropertyValue Property="Target" AnnotationPath="_CreditLimitDetails/@UI.Chart#CreditLimitChart" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Comparison MicroChart" />
+              <PropertyValue Property="ID" String="ComparisonMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.Chart#ComparisonPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Radial MicroChart" />
+              <PropertyValue Property="ID" String="RadialMicroChart" />
+              <PropertyValue
+                                Property="Target"
+                                AnnotationPath="_CreditLimitDetails/@UI.Chart#RadialCriticalityPathHidden"
+                            />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Rating Value" />
+              <PropertyValue Property="ID" String="RatingHeader" />
+              <PropertyValue Property="Target" AnnotationPath="@UI.DataPoint#Rating" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderFacets" Qualifier="MicroCharts">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Column MicroChart" />
+              <PropertyValue Property="ID" String="ColumnMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.Chart#ColumnMaxPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Area MicroChart" />
+              <PropertyValue Property="ID" String="AreaMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.Chart#AreaMaxPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="HarveyBall MicroChart" />
+              <PropertyValue Property="ID" String="HarveyBallMicroChart" />
+              <PropertyValue
+                                Property="Target"
+                                AnnotationPath="_CreditLimitDetails/@UI.Chart#HarveyBallCriticalityPath"
+                            />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Line MicroChart" />
+              <PropertyValue Property="ID" String="LineMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.Chart#LineMaxPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Radial MicroChart" />
+              <PropertyValue Property="ID" String="RadialMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_CreditLimitDetails/@UI.Chart#RadialCriticalityPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Stacked Bar MicroChart" />
+              <PropertyValue Property="ID" String="BarStackedMicroChart" />
+              <PropertyValue Property="Target" AnnotationPath="_Item/@UI.Chart#BarStackedPath" />
+              <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HeaderInfo">
+          <Record Type="UI.HeaderInfoType">
+            <PropertyValue Property="Description">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="SalesOrderTypeName" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="ImageUrl" Path="ImageUrl" />
+            <PropertyValue Property="Title">
+              <Record Type="UI.DataField">
+                <PropertyValue Property="Value" Path="SalesOrder" />
+              </Record>
+            </PropertyValue>
+            <PropertyValue Property="TypeName" String="Sales Order" />
+            <PropertyValue Property="TypeNamePlural" String="Sales Orders" />
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Enable Edit" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.EnableEditAction" />
+              <Annotation Term="UI.Hidden" Path="editActionIsEnabled" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Change Order Status (Header)" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.ChangeOrderStatus" />
+              <Annotation Term="UI.Hidden" Path="editActionIsDisabled" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Change Order Status (Footer)" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.ChangeOrderStatus" />
+              <PropertyValue Property="Determining" Bool="true" />
+              <Annotation Term="UI.Hidden" Path="editActionIsDisabled" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound Action with params" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.CreateWithSalesOrderType" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Label" String="IBN" />
+              <PropertyValue Property="RequiresContext" Bool="false" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrderType" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SoldToParty" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrganization" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="DistributionChannel" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="OrganizationDivision" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="PurchaseOrderByCustomer" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.LineItem">
+          <Collection>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Bound Action with params" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate.CreateWithSalesOrderType" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Unbound Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate/UnboundAction" />
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Label" String="Confirmation Action" />
+              <PropertyValue Property="Action" String="com.c_salesordermanage_sd_aggregate/ReturnInProcess" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="SalesOrder" />
+              <PropertyValue Property="Action" String="manageInline" />
+              <PropertyValue Property="Label" String="IBN" />
+              <PropertyValue Property="RequiresContext" Bool="false" />
+            </Record>
+            <Record Type="UI.DataFieldForIntentBasedNavigation">
+              <PropertyValue Property="SemanticObject" String="v4Freestyle" />
+              <PropertyValue Property="Action" String="Inbound" />
+              <PropertyValue Property="Label" String="IBN with context" />
+              <PropertyValue Property="RequiresContext" Bool="true" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ID" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ImageUrl" />
+              <PropertyValue Property="Label" String="SalesOrder Image" />
+            </Record>
+            <Record Type="UI.DataFieldForAnnotation">
+              <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#multipleActionFields" />
+              <PropertyValue Property="Label" String="Sold-To Party" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="SalesOrderType" />
+              <Annotation Term="UI.Hidden" Path="_ShipToParty/isHidden" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="OverallSDProcessStatus" />
+              <PropertyValue Property="Criticality" Path="StatusCriticality" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="TotalNetAmount" />
+              <Annotation Term="UI.Hidden" Path="Delivered" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.PresentationVariant">
+          <Record Type="UI.PresentationVariantType">
+            <PropertyValue Property="SortOrder">
+              <Collection>
+                <Record Type="Common.SortOrderType">
+                  <PropertyValue Property="Property" PropertyPath="SalesOrganization" />
+                  <PropertyValue Property="Descending" Bool="false" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Visualizations">
+              <Collection>
+                <AnnotationPath>@UI.LineItem</AnnotationPath>
+                <AnnotationPath>@UI.Chart</AnnotationPath>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="UI.SelectionFields">
+          <Collection>
+            <PropertyPath>SalesOrder</PropertyPath>
+            <PropertyPath>SoldToParty</PropertyPath>
+            <PropertyPath>OverallSDProcessStatus</PropertyPath>
+            <PropertyPath>SalesOrderDate</PropertyPath>
+            <PropertyPath>ShippingCondition</PropertyPath>
+            <PropertyPath>SalesOrganization</PropertyPath>
+            <PropertyPath>DistributionChannel</PropertyPath>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.EntityContainer/SalesOrderManage">
+        <Annotation Term="Capabilities.DeleteRestrictions">
+          <Record Type="Capabilities.DeleteRestrictionsType">
+            <PropertyValue Property="Deletable" Path="isDeletable" />
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.FilterRestrictions">
+          <Record Type="Capabilities.FilterRestrictionsType">
+            <PropertyValue Property="FilterExpressionRestrictions">
+              <Collection>
+                <Record Type="Capabilities.FilterExpressionRestrictionType">
+                  <PropertyValue Property="Property" PropertyPath="SoldToParty" />
+                  <PropertyValue Property="AllowedExpressions" String="SingleValue" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.NavigationRestrictions">
+          <Record Type="Capabilities.NavigationRestrictionsType">
+            <PropertyValue Property="RestrictedProperties">
+              <Collection>
+                <Record Type="Capabilities.NavigationPropertyRestriction">
+                  <PropertyValue Property="NavigationProperty" NavigationPropertyPath="_Item" />
+                  <PropertyValue Property="InsertRestrictions">
+                    <Record Type="Capabilities.InsertRestrictionsType">
+                      <PropertyValue Property="Insertable" Bool="true" />
+                    </Record>
+                  </PropertyValue>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/ID">
+        <Annotation Term="Common.Label" String="Sales Order" />
+        <Annotation Term="Common.Text" Path="SalesOrder">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextOnly" />
+        </Annotation>
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SalesOrder">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales Order" />
+        <Annotation Term="Common.Text" Path="SalesOrderText" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/Delivered">
+        <Annotation Term="Common.Label" String="Delivery Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/CFhidden">
+        <Annotation Term="Common.Label" String="Custom Field Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/CF2hidden">
+        <Annotation Term="Common.Label" String="Custom Field2 Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/ReturnInProcess">
+        <Annotation Term="Common.Label" String="Return Status" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SalesOrderType">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Order Type" />
+        <Annotation Term="Common.Text" Path="SalesOrderTypeName">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+        <Annotation Term="Core.Immutable" Bool="true" />
+        <Annotation Term="UI.ValueCriticality">
+          <Collection>
+            <Record Type="UI.ValueCriticalityType">
+              <PropertyValue Property="Value" String="CCLN" />
+              <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Negative" />
+            </Record>
+            <Record Type="UI.ValueCriticalityType">
+              <PropertyValue Property="Value" String="CR" />
+              <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Critical" />
+            </Record>
+            <Record Type="UI.ValueCriticalityType">
+              <PropertyValue Property="Value" String="OR" />
+              <PropertyValue Property="Criticality" EnumMember="UI.CriticalityType/Positive" />
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/ImageUrl">
+        <Annotation Term="Common.Label" String="Image" />
+        <Annotation Term="UI.IsImageURL" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SoldToParty">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.FieldControl" EnumMember="Common.FieldControlType/Mandatory" />
+        <Annotation Term="Common.Heading" String="Sold-To" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sold-To Party" />
+        <Annotation Term="Common.SemanticObject" String="SalesOrder" />
+        <Annotation Term="Common.SemanticObject" Qualifier="customer" String="Customer" />
+        <Annotation Term="Common.SemanticObjectMapping">
+          <Collection>
+            <Record Type="Common.SemanticObjectMappingType">
+              <PropertyValue Property="LocalProperty" PropertyPath="SoldToParty" />
+              <PropertyValue Property="SemanticObjectProperty" String="SoldToParty" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.SemanticObjectMapping" Qualifier="customer">
+          <Collection>
+            <Record Type="Common.SemanticObjectMappingType">
+              <PropertyValue Property="LocalProperty" PropertyPath="SoldToParty" />
+              <PropertyValue Property="SemanticObjectProperty" String="Customer" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Text" Path="CustomerName">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="Customer" />
+            <PropertyValue Property="Label" String="Sold-to Party" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="SoldToParty" />
+                  <PropertyValue Property="ValueListProperty" String="Customer" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="CustomerName" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="OrganizationBPName1" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="OrganizationBPName2" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="BusinessPartnerImageURL" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="PostalCode" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="CityName" />
+                  <Annotation Term="UI.Importance" EnumMember="UI.ImportanceType/High" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="Country" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="InternationalPhoneNumber" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="EmailAddress" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SalesOrganization">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales Organization" />
+        <Annotation Term="Common.Text" Path="OrganizationName" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/Rating">
+        <Annotation Term="Common.Label" String="Rating" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/Progress">
+        <Annotation Term="Common.Label" String="Progress" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/DistributionChannel">
+        <Annotation Term="Common.Label" String="Distribution Channel" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/OrganizationDivision">
+        <Annotation Term="Common.Label" String="Division" />
+        <Annotation Term="Common.SemanticObject" String="SalesOrder" />
+        <Annotation Term="Common.SemanticObjectMapping">
+          <Collection>
+            <Record Type="Common.SemanticObjectMappingType">
+              <PropertyValue Property="LocalProperty" PropertyPath="OrganizationDivision" />
+              <PropertyValue Property="SemanticObjectProperty" String="OrganizationDivision" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.DataFieldDefault">
+          <Record Type="UI.DataField">
+            <PropertyValue Property="Label" String="Default Division" />
+            <PropertyValue Property="Value" Path="OrganizationDivision" />
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/PurchaseOrderByCustomer">
+        <Annotation Term="Common.Label" String="Customer Reference" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/PricingDate">
+        <Annotation Term="Common.Label" String="Pricing Date" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/ShippingCondition">
+        <Annotation Term="Common.Heading" String="SC" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Shipping Conditions" />
+        <Annotation Term="Common.Text" Path="_ShippingCondition/ShippingCondition_Text">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="ShippingCondition" />
+            <PropertyValue Property="Label" String="Shipping Condition" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="ShippingCondition" />
+                  <PropertyValue Property="ValueListProperty" String="ShippingCondition" />
+                </Record>
+                <Record Type="Common.ValueListParameterIn">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="SoldToParty" />
+                  <PropertyValue Property="ValueListProperty" String="SoldToParty" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="ShippingCondition_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/CompleteDeliveryIsDefined">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Complete Delivery" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/IncotermsClassification">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Incoterms" />
+        <Annotation Term="Common.Text" Path="_IncotermsClassification/IncotermsClassification_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="IncotermsClassification" />
+            <PropertyValue Property="Label" String="Incoterms Classification" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="IncotermsClassification" />
+                  <PropertyValue Property="ValueListProperty" String="IncotermsClassification" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="IncotermsClassification_Text" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="LocationIsMandatory" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/IncotermsVersion">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Incoterms Version" />
+        <Annotation Term="Common.Text" Path="_IncotermsVersion/IncotermsVersion_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="IncotermsVersion" />
+            <PropertyValue Property="Label" String="Incoterms Version" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="IncotermsVersion" />
+                  <PropertyValue Property="ValueListProperty" String="IncotermsVersion" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="IncotermsVersion_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.ValueListForValidation" String="" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/fieldControlType_item">
+        <Annotation Term="Common.Label" String="FieldControlType for Items Table" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/fieldControlType">
+        <Annotation Term="Common.Label" String="fieldControlType" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TrialInt64">
+        <Annotation Term="Common.Label" String="Int64" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TrialDouble">
+        <Annotation Term="Common.Label" String="Double" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TrialTOD">
+        <Annotation Term="Common.Label" String="Time Of Day" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/IncotermsLocation1">
+        <Annotation Term="Common.Label" String="Incoterms Version 1" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/IncotermsLocation2">
+        <Annotation Term="Common.Label" String="Incoterms Location 2" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/CustomerPaymentTerms">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Terms of Payment" />
+        <Annotation Term="Common.Text" Path="_CustomerPaymentTerms/CustomerPaymentTerms_Text">
+          <Annotation Term="UI.TextArrangement" EnumMember="UI.TextArrangementType/TextFirst" />
+        </Annotation>
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="CustomerPaymentTerms" />
+            <PropertyValue Property="Label" String="Customer Payment Terms" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="CustomerPaymentTerms" />
+                  <PropertyValue Property="ValueListProperty" String="CustomerPaymentTerms" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="CustomerPaymentTerms_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Common.ValueListWithFixedValues" Bool="true" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TotalNetAmount">
+        <Annotation Term="Aggregation.Aggregatable" Bool="true" />
+        <Annotation Term="Aggregation.RecommendedAggregationMethod" String="average" />
+        <Annotation Term="Aggregation.SupportedAggregationMethods">
+          <Collection>
+            <String>min</String>
+            <String>max</String>
+            <String>average</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Label" String="Net Amount" />
+        <Annotation Term="Core.Computed" Bool="true" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TotalNetAmount2">
+        <Annotation Term="Common.Label" String="Net Amount2" />
+        <Annotation Term="Core.Computed" Bool="true" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/TransactionCurrency">
+        <Annotation Term="Common.Heading" String="Curr." />
+        <Annotation Term="Common.Label" String="Document Currency" />
+        <Annotation Term="Common.QuickInfo" String="SD document currency" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/OverallSDProcessStatus">
+        <Annotation Term="Aggregation.Groupable" Bool="true" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Overall Status" />
+        <Annotation Term="Common.Text" Path="_OverallSDProcessStatus/OverallSDProcessStatus_Text" />
+        <Annotation Term="Common.ValueList">
+          <Record Type="Common.ValueListType">
+            <PropertyValue Property="CollectionPath" String="OverallSDProcessStatus" />
+            <PropertyValue Property="Label" String="Overall SD Process Status" />
+            <PropertyValue Property="Parameters">
+              <Collection>
+                <Record Type="Common.ValueListParameterInOut">
+                  <PropertyValue Property="LocalDataProperty" PropertyPath="OverallSDProcessStatus" />
+                  <PropertyValue Property="ValueListProperty" String="OverallSDProcessStatus" />
+                </Record>
+                <Record Type="Common.ValueListParameterDisplayOnly">
+                  <PropertyValue Property="ValueListProperty" String="OverallSDProcessStatus_Text" />
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/LastChangedDateTime">
+        <Annotation Term="Common.Label" String="Last Change Date" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SalesOrderDate">
+        <Annotation Term="Common.Label" String="Document Date" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/SalesOrderTypeName">
+        <Annotation Term="Common.Label" String="Sales Document Type" />
+        <Annotation Term="Core.Computed" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/DescriptionFieldForOPACleanup">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderManage/NetPricing">
+        <Annotation Term="Aggregation.Aggregatable" Bool="true" />
+        <Annotation Term="Aggregation.RecommendedAggregationMethod" String="average" />
+        <Annotation Term="Aggregation.SupportedAggregationMethods">
+          <Collection>
+            <String>min</String>
+            <String>max</String>
+            <String>average</String>
+            <String>sum</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Common.Label" String="Net Pricing" />
+        <Annotation Term="Measures.ISOCurrency" Path="TransactionCurrency" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.OPAvailableTrueAction(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Common.IsActionCritical" Bool="true" />
+        <Annotation Term="Core.OperationAvailable" Bool="true" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.OPAvailableFalseAction(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Core.OperationAvailable" Bool="false" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.OPAvailableNullAction(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Core.OperationAvailable">
+          <Null />
+        </Annotation>
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.EnableEditAction(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Common.SideEffects">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>_it/editActionIsEnabled</String>
+                <String>_it/editActionIsDisabled</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.CreateWithSalesOrderType(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Common.IsActionCritical" Bool="true" />
+        <Annotation Term="Core.OperationAvailable" Path="_it/isVerified" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.ChangeOrderStatus(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Core.OperationAvailable" Path="_it/_ShipToParty/isVerified" />
+      </Annotations>
+      <Annotations
+                Target="com.c_salesordermanage_sd_aggregate.FacetFormAction(com.c_salesordermanage_sd_aggregate.SalesOrderManage)">
+        <Annotation Term="Common.SideEffects">
+          <Record Type="Common.SideEffectsType">
+            <PropertyValue Property="TargetProperties">
+              <Collection>
+                <String>_it/ShippingCondition</String>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.OperationAvailable" Path="_it/_ShipToParty/isVerified" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderType">
+        <Annotation Term="Common.Label" String="Sales Order Types" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderType/SalesOrderType">
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Sales Order Type" />
+        <Annotation Term="Common.Text" Path="SalesOrderType_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderType/SalesOrderType_Text">
+        <Annotation Term="Common.Label" String="Sales Document Type" />
+        <Annotation Term="Common.QuickInfo" String="Sales Document Type Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderType/SalesOrderProcessingType">
+        <Annotation Term="Common.Heading" String="C" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Indicator" />
+        <Annotation Term="Common.QuickInfo" String="Sales document indicator (for display in TVAK only)" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrderType/OrderTypeForBillingRequest">
+        <Annotation Term="Common.Heading" String="Req." />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Billing Request" />
+        <Annotation Term="Common.QuickInfo" String="Order type for request for billing" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.SalesOrganization/SalesOrganization">
+        <Annotation Term="Common.Label" String="Sales Organization" />
+        <Annotation Term="Common.Text" Path="SalesOrganization_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingCondition">
+        <Annotation Term="Common.Label" String="Shipping Condition" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingCondition/ShippingCondition">
+        <Annotation Term="Common.Heading" String="SC" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Shipping Conditions" />
+        <Annotation Term="Common.Text" Path="ShippingCondition_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingCondition/ShippingCondition_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Common.QuickInfo" String="Shipping Conditions Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingCondition/SoldToParty">
+        <Annotation Term="Common.Heading" String="Customer" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="SoldToParty" />
+        <Annotation Term="Common.QuickInfo" String="Customer Number" />
+        <Annotation Term="Common.Text" Path="CustomerName" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingPoint">
+        <Annotation Term="Common.Label" String="Shipping Point" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingPoint/ShippingPoint">
+        <Annotation Term="Common.Heading" String="ShPt" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Shipping Point" />
+        <Annotation Term="Common.QuickInfo" String="Shipping Point / Receiving Point" />
+        <Annotation Term="Common.Text" Path="ShippingPoint_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingPoint/ShippingPoint_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingType">
+        <Annotation Term="Common.Label" String="Shipping Type" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingType/ShippingType">
+        <Annotation Term="Common.Heading" String="ST" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Shipping Type" />
+        <Annotation Term="Common.Text" Path="ShippingType_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.ShippingType/ShippingType_Text">
+        <Annotation Term="Common.Label" String="Description" />
+        <Annotation Term="Common.QuickInfo" String="Shipping Type Description" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure">
+        <Annotation Term="Common.Label" String="Unit of Measure" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasure">
+        <Annotation Term="Common.Heading" String="MU" />
+        <Annotation Term="Common.Label" String="Internal UoM" />
+        <Annotation Term="Common.QuickInfo" String="Unit of Measurement" />
+        <Annotation Term="Common.Text" Path="UnitOfMeasure_Text" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasure_Text">
+        <Annotation Term="Common.Heading" String="Measurement unit text" />
+        <Annotation Term="Common.Label" String="UoM Text" />
+        <Annotation Term="Common.QuickInfo" String="Unit of Measurement Text (Maximum 30 Characters)" />
+        <Annotation Term="Core.Immutable" Bool="true" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasureDimension">
+        <Annotation Term="Common.Heading" String="Dimen." />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="Dimension" />
+        <Annotation Term="Common.QuickInfo" String="Dimension Key" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasureISOCode">
+        <Annotation Term="Common.Heading" String="ISO" />
+        <Annotation Term="Common.IsUpperCase" Bool="true" />
+        <Annotation Term="Common.Label" String="ISO Code" />
+        <Annotation Term="Common.QuickInfo" String="ISO Code for Unit of Measurement" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasureNumberOfDecimals">
+        <Annotation Term="Common.Heading" String="DeR" />
+        <Annotation Term="Common.Label" String="Decimal Rounding" />
+        <Annotation Term="Common.QuickInfo" String="Number of Decimal Places for Rounding" />
+      </Annotations>
+      <Annotations Target="com.c_salesordermanage_sd_aggregate.UnitOfMeasure/UnitOfMeasureDspNmbrOfDcmls">
+        <Annotation Term="Common.Heading" String="Dec" />
+        <Annotation Term="Common.Label" String="Decimal Places" />
+        <Annotation Term="Common.QuickInfo" String="Number of Decimal Places for Number Display" />
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
@@ -21,7 +21,7 @@ import {
     type EntityAnswer,
     type EntityChoiceOptions,
     type EntitySetFilter,
-    filterAggregateTransformations,
+    getDefaultTableType,
     getEntityChoices,
     getNavigationEntityChoices,
     type NavigationEntityAnswer
@@ -278,63 +278,6 @@ function getEdmxSizeInKb(edmx: string): number {
         return sizeInBytes / 1024;
     }
     return 0;
-}
-
-/**
- * Get the default table type based on the template type and previous answers.
- *
- * @param templateType the template type of the application to be generated from the prompt answers
- * @param metadata the metadata (edmx) string of the service
- * @param odataVersion the OData version of the service
- * @param mainEntitySetName the name of the main entity set
- * @param currentTableType the current table type selected by the user
- * @returns the default table type and a boolean indicating if AnalyticalTable should be set as default
- */
-function getDefaultTableType(
-    templateType: TemplateType,
-    metadata: ConvertedMetadata,
-    odataVersion: OdataVersion,
-    mainEntitySetName?: string,
-    currentTableType?: TableType
-): { tableType: TableType; setAnalyticalTableDefault: boolean } {
-    let tableType: TableType;
-    let setAnalyticalTableDefault = false;
-    if (
-        (templateType === 'lrop' || templateType === 'worklist') &&
-        odataVersion === OdataVersion.v4 &&
-        hasAggregateTransformationsForEntity(metadata, mainEntitySetName)
-    ) {
-        // For V4, if the selected entity has aggregate transformations, use AnalyticalTable as default
-        tableType = 'AnalyticalTable';
-        setAnalyticalTableDefault = true;
-    } else if (templateType === 'alp') {
-        // For ALP, use AnalyticalTable as default
-        tableType = 'AnalyticalTable';
-    } else if (currentTableType) {
-        // If the user has already selected a table type use it
-        tableType = currentTableType;
-    } else {
-        // Default to ResponsiveTable for other cases
-        tableType = 'ResponsiveTable';
-    }
-    return {
-        tableType,
-        setAnalyticalTableDefault
-    };
-}
-
-/**
- * Checks if the given entity set name has aggregate transformations in the metadata.
- *
- * @param metadata The metadata (edmx) string of the service.
- * @param entitySetName The entity set name to check for aggregate transformations.
- * @returns true if the entity set has aggregate transformations, false otherwise.
- */
-function hasAggregateTransformationsForEntity(metadata: ConvertedMetadata, entitySetName?: string): boolean {
-    if (!entitySetName) {
-        return false;
-    }
-    return filterAggregateTransformations(metadata.entitySets).some((entitySet) => entitySet.name === entitySetName);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2490,9 +2490,15 @@ importers:
 
   packages/inquirer-common:
     dependencies:
+      '@sap-ux/annotation-converter':
+        specifier: 0.10.2
+        version: 0.10.2
       '@sap-ux/btp-utils':
         specifier: workspace:*
         version: link:../btp-utils
+      '@sap-ux/edmx-parser':
+        specifier: 0.9.1
+        version: 0.9.1
       '@sap-ux/feature-toggle':
         specifier: workspace:*
         version: link:../feature-toggle
@@ -2542,6 +2548,9 @@ importers:
       '@sap-devx/yeoman-ui-types':
         specifier: 1.14.4
         version: 1.14.4
+      '@sap-ux/vocabularies-types':
+        specifier: 0.13.0
+        version: 0.13.0
       '@types/inquirer':
         specifier: 8.2.6
         version: 8.2.6
@@ -8741,6 +8750,12 @@ packages:
 
   /@sap-devx/yeoman-ui-types@1.16.9:
     resolution: {integrity: sha512-GpyTtj2RGWopUWROS3dfAV+0MQzARSRpqoWGDLQflCQpQWCkEFUQlj/dgowrEblj+1oJDTYBEdLu7nPc5lkNMA==}
+
+  /@sap-ux/annotation-converter@0.10.2:
+    resolution: {integrity: sha512-3GY8Etb2D+HnCNf2Yy7qfRtZuJ8ITjAGdlnbpmIg5sLtHRfhffEzZOveEWWMJ0apgIedUouvglkw6+oBabTfnA==}
+    dependencies:
+      '@sap-ux/vocabularies-types': 0.13.0
+    dev: false
 
   /@sap-ux/annotation-converter@0.10.3:
     resolution: {integrity: sha512-mLQTJv4SXyxbizE2guXi/m9BuFi+jcn7Vk8pGzkbdjWhBgI2OK0F30GXEsy7lprYFGycCLzXbBj/X7Unz+pIeg==}


### PR DESCRIPTION
internal s4 issue 449

- move entity helpers for filtering aggregation based entities to inquirer common to enable re use by other modules
- moved `getDefaultTableType` from questions.ts to entityHelper.ts as it makes more sense to be there
- no change to functions/logic
- added tests in inq-common for moved helpers