### PR TITLE
fixes for multiple issues:

### DIFF
--- a/.changeset/beige-cheetahs-look.md
+++ b/.changeset/beige-cheetahs-look.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/fiori-app-sub-generator': patch
+'@sap-ux/odata-service-inquirer': patch
+'@sap-ux/axios-extension': patch
+---
+
+Use `ZLOCAL` to determine local packages and multiple minor bug fixes

--- a/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
+++ b/packages/axios-extension/src/abap/adt-catalog/services/transportcheck-service.ts
@@ -130,7 +130,7 @@ export class TransportChecksService extends AdtService {
         } else if (LocalPackageText.includes(localPackage)) {
             throw new Error(TransportChecksService.LocalPackageError);
         } else {
-            throw new Error('Unable to parse ADT response');
+            throw new Error('Unsupported ADT transport response content');
         }
     }
 

--- a/packages/axios-extension/src/abap/types/adt-types.ts
+++ b/packages/axios-extension/src/abap/types/adt-types.ts
@@ -110,7 +110,7 @@ export type AdtTransportStatus = 'S' | 'E';
 // In XML response of ADT TransportChecks service,
 // the <DLVUNIT/> element contain text that indicate it is local package.
 // No transport number required for deploying to local pacakge.
-export const LocalPackageText = ['LOCAL_PACKAGE', 'LOCAL'];
+export const LocalPackageText = ['LOCAL_PACKAGE', 'LOCAL', 'ZLOCAL'];
 
 export interface ArchiveFileNode {
     /**

--- a/packages/axios-extension/src/base/service-provider.ts
+++ b/packages/axios-extension/src/base/service-provider.ts
@@ -33,11 +33,29 @@ export interface ServiceProviderExtension {
  * Basic service provider class containing generic functionality to create and keep service instances as well as logging
  */
 export class ServiceProvider extends Axios implements ServiceProviderExtension {
-    public readonly log: Logger = new ToolsLogger();
+    public _log: Logger = new ToolsLogger();
 
     public readonly cookies: Cookies = new Cookies();
 
     protected readonly services: { [path: string]: Service } = {};
+
+    /**
+     * Set the logger for the service provider. Loggers may need to be restored after serialization/deserialization since they contain circular references.
+     *
+     * @param logger - Logger instance to be set
+     */
+    public set log(logger: Logger) {
+        this._log = logger;
+    }
+
+    /**
+     * Get the logger for the service provider.
+     *
+     * @returns Logger instance
+     */
+    public get log(): Logger {
+        return this._log;
+    }
 
     /**
      * Create a service instance or return an existing one for the given path.

--- a/packages/axios-extension/test/abap/mockResponses/transportChecks-3.xml
+++ b/packages/axios-extension/test/abap/mockResponses/transportChecks-3.xml
@@ -12,7 +12,7 @@
             <KORRFLAG/>
             <AS4USER>SAP</AS4USER>
             <PDEVCLASS/>
-            <DLVUNIT>LOCAL</DLVUNIT>
+            <DLVUNIT>ZLOCAL</DLVUNIT>
             <NAMESPACE>/*/</NAMESPACE>
             <SUPER_PACKAGE/>
             <RESULT>S</RESULT>

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -51,6 +51,7 @@ import {
     hasStep,
     initAppWizardCache,
     initI18nFioriAppSubGenerator,
+    restoreServiceProviderLoggers,
     t,
     updateDependentStep
 } from '../utils';
@@ -167,6 +168,11 @@ export class FioriAppGenerator extends Generator {
 
             if (hasStep(this.fioriSteps, STEP_DATASOURCE_AND_SERVICE)) {
                 const cachedService = getFromCache<Service>(this.appWizard, 'service', FioriAppGenerator.logger);
+
+                restoreServiceProviderLoggers(
+                    FioriAppGenerator.logger as Logger,
+                    cachedService?.connectedSystem?.serviceProvider
+                );
                 const options: OdataServiceInquirerOptions = {
                     capService: cachedService?.capService ?? this.state.service?.capService,
                     requiredOdataVersion: getRequiredOdataVersion(this.state.floorplan),
@@ -203,6 +209,11 @@ export class FioriAppGenerator extends Generator {
                         FioriAppGenerator.logger?.error(t('error.fatalError'));
                     }
                 }
+
+                restoreServiceProviderLoggers(
+                    FioriAppGenerator.logger as Logger,
+                    serviceAnswers?.connectedSystem?.serviceProvider
+                );
                 /** END: Back button temp fix */
                 this.state.service = { ...this.state?.service, ...serviceAnswers };
             }

--- a/packages/odata-service-inquirer/package.json
+++ b/packages/odata-service-inquirer/package.json
@@ -46,6 +46,7 @@
         "@sap-ux/store": "workspace:*",
         "axios": "1.8.2",
         "axios-logger": "2.8.0",
+        "circular-reference-remover": "2.1.0",
         "fast-xml-parser": "4.4.1",
         "i18next": "25.3.0",
         "inquirer-autocomplete-prompt": "2.0.1",

--- a/packages/odata-service-inquirer/src/prompts/logger-helper.ts
+++ b/packages/odata-service-inquirer/src/prompts/logger-helper.ts
@@ -47,14 +47,13 @@ export default class LoggerHelper {
             (request) => {
                 // Due to a bug in `axios-logger`, the `baseURL` is not logged if the `url` is falsey.
                 if (!request.url) {
-                    debugLogger(`[@sap-ux/odata-service-inquirer] Request URL: ${request.baseURL}`);
+                    debugLogger(`Request URL: ${request.baseURL}`);
                 }
                 return AxiosLogger.requestLogger(request, {
                     url: true,
                     data: true,
                     params: true,
                     method: true,
-                    prefixText: '@sap-ux/odata-service-inquirer',
                     headers: true,
                     logger: debugLogger
                 });
@@ -69,7 +68,6 @@ export default class LoggerHelper {
             (response) => {
                 return AxiosLogger.responseLogger(response, {
                     data: logResponseData,
-                    prefixText: '@sap-ux/odata-service-inquirer',
                     status: true,
                     headers: true,
                     logger: debugLogger

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2831,6 +2831,9 @@ importers:
       axios-logger:
         specifier: 2.8.0
         version: 2.8.0
+      circular-reference-remover:
+        specifier: 2.1.0
+        version: 2.1.0
       fast-xml-parser:
         specifier: 4.4.1
         version: 4.4.1
@@ -13160,6 +13163,10 @@ packages:
     resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /circular-reference-remover@2.1.0:
+    resolution: {integrity: sha512-Q6HXB2XhbBECi1/5jqe4XwZTyHpweFORve1ATPMEMdi6kWPAwbMau5mLpASZAB+hfZ/OUjY+va1wEx5qwCH8MQ==}
+    dev: false
 
   /cjs-module-lexer@1.3.1:
     resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}


### PR DESCRIPTION
https://github.com/SAP/open-ux-tools/issues/3498

- Using a package that has a DLVUNIT value of ZLOCAL is not being detected as a local package.
- Loggers are not defined once the serviceProvider has be serialized and irs circular refs removed
- A misleading error is returned when the getTransportList call returns something other than one of the three conditions supported. The ADT response was successfully parsed but we log an error to the contrary: Unable to parse ADT response
- The axios interceptor prefix is set in odata-service-inquirer but will continue to be used when logging from downstream generators with the same prefix via the passed serviceProvider references. This is useful but the prefix is misleading.
- updates tests