### PR TITLE
fix: sonar issue for prompting storybook examples

### DIFF
--- a/packages/ui-prompting/.storybook/addons/preview.tsx
+++ b/packages/ui-prompting/.storybook/addons/preview.tsx
@@ -7,7 +7,7 @@ function getCurrentAnswers(): string {
     return window.localStorage.getItem(storageKey) ?? '{}';
 }
 
-export const render = (props: { active?: boolean }): React.ReactElement => {
+export const CodePreview = (props: { active?: boolean }): React.ReactElement => {
     const { active = false } = props;
     const [answers, setAnswers] = useState(getCurrentAnswers());
     useEffect(() => {

--- a/packages/ui-prompting/.storybook/addons/register.ts
+++ b/packages/ui-prompting/.storybook/addons/register.ts
@@ -1,22 +1,22 @@
 import { addons, types } from '@storybook/addons';
-import { render as renderPreview } from './preview';
+import { CodePreview } from './preview';
 
 const ADDONS = [
     {
         id: 'code-preview',
         title: 'Answers preview',
-        render: renderPreview
+        component: CodePreview
     }
 ];
 
 for (const addon of ADDONS) {
-    const { id, render, title } = addon;
+    const { id, component, title } = addon;
     addons.register(id, () => {
         addons.add(id, {
             title: title,
             type: types.PANEL,
             match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
-            render: render
+            render: component
         });
     });
 }


### PR DESCRIPTION
Issue to fix sonar issue:
<img width="1451" height="620" alt="image" src="https://github.com/user-attachments/assets/b6299581-20a8-4b53-9a89-8c8ead0d6077" />


Solution - use component name approach:

<img width="679" height="241" alt="image" src="https://github.com/user-attachments/assets/5b1d090b-6973-41a7-8b47-ca6106bf9ce8" />


No changelog - it does not affect release code, only related to storybook examples(storybook addon to see answers preview) 