### PR TITLE
feat(ui-prompting): Support index-based default values for 'list' type questions.

### DIFF
--- a/.changeset/strong-adults-mix.md
+++ b/.changeset/strong-adults-mix.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-prompting': patch
+---
+
+Support index-based default values for 'list' type questions.

--- a/.changeset/strong-adults-mix.md
+++ b/.changeset/strong-adults-mix.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui-prompting': patch
 ---
 
-Support index-based default values for 'list' type questions.
+Support index-based default values for 'list' type questions. New property 'defaultIndex' for 'list' question.

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -26,7 +26,7 @@ export const Select = (props: SelectProps) => {
         !options.some((option) => option.key === defaultValue) &&
         options[defaultValue]
     ) {
-        defaultValue = options[defaultValue].data?.value ?? defaultValue;
+        defaultValue = options[defaultValue].data?.value;
     }
     useEffect(() => {
         if (defaultValue !== undefined && value !== defaultValue) {

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -27,16 +27,10 @@ export const Select = (props: SelectProps) => {
         }
 
         // Handle numeric default that isn't a key = it could be an index
-        if (
-            typeof props.default === 'number' &&
-            !options.some((option) => option.key === props.default) &&
-            options[props.default]
-        ) {
-            return options[props.default].data?.value;
+        if (props.defaultIndex !== undefined && options[props.defaultIndex]) {
+            return options[props.defaultIndex].data?.value;
         }
-
-        return props.default;
-    }, [props.default, options]);
+    }, [props.defaultIndex, options]);
 
     useEffect(() => {
         if (defaultValue !== undefined && value !== defaultValue) {

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { ChoiceOptions } from 'inquirer';
 import { UIComboBox, UIComboBoxLoaderType, UITextInput } from '@sap-ux/ui-components';
 import type { ITextField, UIComboBoxRef, UISelectableOption } from '@sap-ux/ui-components';
@@ -20,14 +20,24 @@ export const Select = (props: SelectProps) => {
     const [value, setValue] = useValue('', props.value ?? '');
     const inputRef = React.createRef<ITextField>();
     const options = useOptions(props, dynamicChoices);
-    let defaultValue = options.length === 1 ? options[0].data?.value : props.default;
-    if (
-        typeof defaultValue === 'number' &&
-        !options.some((option) => option.key === defaultValue) &&
-        options[defaultValue]
-    ) {
-        defaultValue = options[defaultValue].data?.value;
-    }
+    const defaultValue = useMemo(() => {
+        // Single option - auto-select
+        if (options.length === 1) {
+            return options[0].data?.value;
+        }
+
+        // Handle numeric default that isn't a key = it could be an index
+        if (
+            typeof props.default === 'number' &&
+            !options.some((option) => option.key === props.default) &&
+            options[props.default]
+        ) {
+            return options[props.default].data?.value;
+        }
+
+        return props.default;
+    }, [props.default, options]);
+
     useEffect(() => {
         if (defaultValue !== undefined && value !== defaultValue) {
             setValue(defaultValue);

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -20,7 +20,14 @@ export const Select = (props: SelectProps) => {
     const [value, setValue] = useValue('', props.value ?? '');
     const inputRef = React.createRef<ITextField>();
     const options = useOptions(props, dynamicChoices);
-    const defaultValue = options.length === 1 ? options[0].data?.value : undefined;
+    let defaultValue = options.length === 1 ? options[0].data?.value : props.default;
+    if (
+        typeof defaultValue === 'number' &&
+        !options.some((option) => option.key === defaultValue) &&
+        options[defaultValue]
+    ) {
+        defaultValue = options[defaultValue].data?.value ?? defaultValue;
+    }
     useEffect(() => {
         if (defaultValue !== undefined && value !== defaultValue) {
             setValue(defaultValue);

--- a/packages/ui-prompting/src/types.ts
+++ b/packages/ui-prompting/src/types.ts
@@ -95,6 +95,10 @@ export interface ListPromptQuestion<T extends Answers = Answers> extends ListQue
      * Additional properties for ui.
      */
     guiOptions?: ListGuiOptions;
+    /**
+     * Default selection index.
+     */
+    defaultIndex?: number;
 }
 
 /**

--- a/packages/ui-prompting/stories/List.story.tsx
+++ b/packages/ui-prompting/stories/List.story.tsx
@@ -54,6 +54,13 @@ const questions: PromptQuestion[] = [
         choices
     },
     {
+        message: 'With default value as index',
+        name: 'defaultValueAsIndex',
+        type: 'list',
+        default: 3,
+        choices
+    },
+    {
         message: 'With external value',
         name: 'external',
         type: 'list',

--- a/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
@@ -348,7 +348,7 @@ describe('Select', () => {
 
     it('Select default value as index', async () => {
         const onChangeFn = jest.fn();
-        render(<Select {...props} onChange={onChangeFn} default={1} />);
+        render(<Select {...props} onChange={onChangeFn} defaultIndex={1} />);
         const input = screen.getByRole('combobox');
         expect(input).toBeDefined();
         expect(onChangeFn).toHaveBeenCalledWith('select', 'testValue1');

--- a/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
@@ -345,4 +345,12 @@ describe('Select', () => {
         expect(input).toBeDefined();
         expect(onChangeFn).toHaveBeenCalledWith('select', 111);
     });
+
+    it('Select default value as index', async () => {
+        const onChangeFn = jest.fn();
+        render(<Select {...props} onChange={onChangeFn} default={1} />);
+        const input = screen.getByRole('combobox');
+        expect(input).toBeDefined();
+        expect(onChangeFn).toHaveBeenCalledWith('select', 'testValue1');
+    });
 });


### PR DESCRIPTION
Currently in questions we set default value like -> https://github.com/SAP/open-ux-tools/blob/main/packages/fe-fpm-writer/src/building-block/prompts/questions/table.ts#L83
where default is actual value.
Request was that we should allow to pass index based value for `list` type question, like:
```
return {
        type: 'list',
        name: 'aggregationPath',
        defaultIndex: 1,
        choices: project
}
```