### PR TITLE
fix: add custom table column quick action

### DIFF
--- a/.changeset/smooth-humans-beg.md
+++ b/.changeset/smooth-humans-beg.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+'@sap-ux/preview-middleware': patch
+---
+
+fix: `Add Custom Table Column` Quick Action not using the correct fragment template.

--- a/packages/preview-middleware-client/src/adp/controllers/AddSubpage.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/AddSubpage.controller.ts
@@ -119,9 +119,10 @@ export default class AddSubpage extends BaseDialog<AddSubpageModel> {
      * @param event Event
      */
     async onCreateBtnPress(event: Event) {
-        await super.onCreateBtnPressHandler();
         const source = event.getSource<Button>();
         source.setEnabled(false);
+        await super.onCreateBtnPressHandler();
+
 
         const flexSettings = this.rta.getFlexSettings();
         const navProperty = this.model.getProperty('/selectedNavigation/key');

--- a/packages/preview-middleware-client/src/adp/controllers/AddTableColumnFragments.controller.ts
+++ b/packages/preview-middleware-client/src/adp/controllers/AddTableColumnFragments.controller.ts
@@ -103,9 +103,9 @@ export default class AddTableColumnFragments extends BaseDialog<AddTableColumnsF
      * @param event Event
      */
     async onCreateBtnPress(event: Event) {
-        await super.onCreateBtnPressHandler();
         const source = event.getSource<Button>();
         source.setEnabled(false);
+        await super.onCreateBtnPressHandler();
 
         const columnFragmentName = this.model.getProperty('/newColumnFragmentName');
         const cellFragmentName = this.model.getProperty('/newCellFragmentName');

--- a/packages/preview-middleware-client/src/utils/additional-change-info.ts
+++ b/packages/preview-middleware-client/src/utils/additional-change-info.ts
@@ -21,12 +21,15 @@ export function setAdditionalChangeInfo(change: FlexChange<AddXMLChangeContent> 
     }
 
     let additionalChangeInfo;
+    const key = change.getDefinition().fileName;
     if (change?.getChangeType?.() === 'addXML') {
         additionalChangeInfo = getAddXMLAdditionalInfo(change);
     }
 
-    if (additionalChangeInfo) {
-        additionalChangeInfoMap.set(change.getDefinition().fileName, additionalChangeInfo);
+    if (additionalChangeInfo && !additionalChangeInfoMap.get(key)) {
+        // in certain scenarios we explicitly set additional info e.g template when creating the change 
+        // and that value should not be overwritten
+        additionalChangeInfoMap.set(key, additionalChangeInfo);
     }
 }
 

--- a/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
+++ b/packages/preview-middleware-client/test/unit/utils/additional-change-info.test.ts
@@ -60,6 +60,27 @@ describe('additional-change-info.ts', () => {
 
             expect(getAddXMLAdditionalInfoSpy).not.toHaveBeenCalled();
         });
+
+        it('should not set additional change info if a value is already set', () => {
+            const mockChange = new FlexChange({
+                selector: { id: 'mockSelectorId', idIsLocal: false },
+                changeType: 'addXML',
+                layer: 'CUSTOMER_BASE',
+                fileName: 'mockFileName'
+            });
+            const getAddXMLAdditionalInfoSpy = jest
+                .spyOn(xmlAdditionalInfo, 'getAddXMLAdditionalInfo')
+                .mockReturnValueOnce({ templateName: 'template' })
+                .mockReturnValueOnce({ controlType: 'test' });
+
+            setAdditionalChangeInfo(mockChange);
+            setAdditionalChangeInfo(mockChange);
+
+            expect(getAddXMLAdditionalInfoSpy).toHaveBeenCalledTimes(2);
+
+            const result = getAdditionalChangeInfo(mockChange as unknown as Change);
+            expect(result).toEqual({ templateName: 'template' });
+        });
     });
 
     describe('setAdditionalChangeInfoForChangeFile', () => {


### PR DESCRIPTION
- Fixes regression after #3482
- Fixes crash when clicking `Create` button in the dialog on UI5 version 1.96