### PR TITLE
Fix: Remove Default Index Logic from getAggregationPathPrompt in FPM Writers

### DIFF
--- a/.changeset/pink-worms-applaud.md
+++ b/.changeset/pink-worms-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Remove default Index logic from getAggregationPathPrompt of fpm writers

--- a/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
+++ b/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
@@ -237,7 +237,6 @@ export function getAggregationPathPrompt(
         ...properties,
         type: 'list',
         name: 'aggregationPath',
-        defaultIndex: 0,
         choices: project
             ? (answers: Answers) => {
                   const { viewOrFragmentPath } = answers;

--- a/packages/fe-fpm-writer/test/unit/building-block/prompts/utils/__snapshots__/questions.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/building-block/prompts/utils/__snapshots__/questions.test.ts.snap
@@ -51,7 +51,6 @@ Array [
 exports[`utils - questions getAggregationPathPrompt 1`] = `
 Object {
   "choices": [Function],
-  "defaultIndex": 0,
   "guiOptions": Object {
     "placeholder": "Select an aggregation path",
     "selectType": "dynamic",
@@ -82,7 +81,6 @@ Array [
 exports[`utils - questions getAggregationPathPrompt 3`] = `
 Object {
   "choices": [Function],
-  "defaultIndex": 0,
   "guiOptions": Object {
     "placeholder": "Select an aggregation path",
     "selectType": "dynamic",
@@ -95,7 +93,6 @@ Object {
 exports[`utils - questions getAggregationPathPrompt with page macro 1`] = `
 Object {
   "choices": [Function],
-  "defaultIndex": 0,
   "guiOptions": Object {
     "placeholder": "Select an aggregation path",
     "selectType": "dynamic",

--- a/packages/fe-fpm-writer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -149,7 +149,6 @@ Object {
     },
     Object {
       "choices": Array [],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "chartBuildingBlockProperties",
         "mandatory": true,
@@ -360,7 +359,6 @@ Object {
     },
     Object {
       "choices": Array [],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "filterBarBuildingBlockProperties",
         "mandatory": true,
@@ -446,7 +444,6 @@ Object {
     },
     Object {
       "choices": Array [],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "mandatory": true,
         "placeholder": "Select an aggregation path",
@@ -601,7 +598,6 @@ Object {
     },
     Object {
       "choices": Array [],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "tableBuildingBlockProperties",
         "mandatory": true,
@@ -1166,7 +1162,6 @@ Object {
     },
     Object {
       "choices": [Function],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "chartBuildingBlockProperties",
         "mandatory": true,
@@ -1599,7 +1594,6 @@ Object {
     },
     Object {
       "choices": [Function],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "filterBarBuildingBlockProperties",
         "mandatory": true,
@@ -1685,7 +1679,6 @@ Object {
     },
     Object {
       "choices": [Function],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "mandatory": true,
         "placeholder": "Select an aggregation path",
@@ -1840,7 +1833,6 @@ Object {
     },
     Object {
       "choices": [Function],
-      "defaultIndex": 0,
       "guiOptions": Object {
         "groupId": "tableBuildingBlockProperties",
         "mandatory": true,


### PR DESCRIPTION
Currently, the `getAggregationPathPrompt` function in FPM writers sets a default index for aggregation paths. Bug was introduced in [PR](https://github.com/SAP/open-ux-tools/pull/3491) where Default index logic is shared across building blocks, leading to incorrect aggregation path selection.

Fix:
Removed the default index assignment from `getAggregationPathPrompt`.