### PR TITLE
Feat/set default aggregation path when macro page

### DIFF
--- a/.changeset/empty-jokes-pump.md
+++ b/.changeset/empty-jokes-pump.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-fpm-writer': minor
+'@sap-ux/ui-prompting': minor
+---
+
+add support for checked property in Select choices for default selection

--- a/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
+++ b/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
@@ -245,7 +245,7 @@ export function getAggregationPathPrompt(
                           join(appPath, viewOrFragmentPath),
                           fs
                       );
-                      const key = `/mvc:View/${pageMacroDefinition}`;
+                      const key = Object.keys(inputChoices).find((k) => k.endsWith(`/${pageMacroDefinition}`));
                       const choices = transformChoices(inputChoices, false, key);
                       if (!choices.length) {
                           throw new Error('Failed while fetching the aggregation path.');

--- a/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
+++ b/packages/fe-fpm-writer/src/building-block/prompts/utils/questions.ts
@@ -245,7 +245,8 @@ export function getAggregationPathPrompt(
                           join(appPath, viewOrFragmentPath),
                           fs
                       );
-                      const choices = transformChoices(inputChoices, false, pageMacroDefinition);
+                      const key = `/mvc:View/${pageMacroDefinition}`;
+                      const choices = transformChoices(inputChoices, false, key);
                       if (!choices.length) {
                           throw new Error('Failed while fetching the aggregation path.');
                       }
@@ -267,19 +268,19 @@ export function getAggregationPathPrompt(
  *
  * @param obj - object to be converted to choices
  * @param sort - apply alphabetical sort(default is "true")
- * @param pageMacroDefinition - the page macro definition to check against
+ * @param defaultKey - default key to be checked in choices
  * @returns the list of choices.
  */
 export function transformChoices(
     obj: Record<string, string> | string[],
     sort = true,
-    pageMacroDefinition?: string
+    defaultKey?: string
 ): PromptListChoices {
     let choices: PromptListChoices = [];
     if (!Array.isArray(obj)) {
         choices = Object.entries(obj).map(([key, value]) => {
-            // Add checked if value matches Page macro choice definition example: `/mvc:View/macro:Page/`
-            if (key.endsWith(`/${pageMacroDefinition}`)) {
+            // Add checked if value matches defaultKey example: `/mvc:View/macro:Page/`
+            if (key === defaultKey) {
                 return { name: key, value, checked: true };
             }
             return { name: key, value };

--- a/packages/fe-fpm-writer/src/building-block/prompts/utils/xml.ts
+++ b/packages/fe-fpm-writer/src/building-block/prompts/utils/xml.ts
@@ -35,10 +35,14 @@ const augmentXpathWithLocalNames = (path: string): string => {
  *
  * @param xmlFilePath - the xml file path
  * @param fs - the file system object for reading files
- * @returns the list of xpath strings.
+ * @returns the list of xpath strings & page macro definition if page macro has been added by user.
  */
-export function getXPathStringsForXmlFile(xmlFilePath: string, fs: Editor): Record<string, string> {
+export function getXPathStringsForXmlFile(
+    xmlFilePath: string,
+    fs: Editor
+): { inputChoices: Record<string, string>; pageMacroDefinition?: string } {
     const result: Record<string, string> = {};
+    let pageMacroDefinition: string | undefined;
     try {
         const xmlContent = fs.read(xmlFilePath);
         const errorHandler = (level: string, message: string) => {
@@ -49,7 +53,7 @@ export function getXPathStringsForXmlFile(xmlFilePath: string, fs: Editor): Reco
 
         // check macros namespace and page macro definition
         const macrosNamespace = getOrAddMacrosNamespace(xmlDocument);
-        const pageMacroDefinition = macrosNamespace ? `${macrosNamespace}:Page` : 'macros:Page';
+        pageMacroDefinition = macrosNamespace ? `${macrosNamespace}:Page` : 'macros:Page';
         let hasPageMacroChild = false;
 
         while (nodes && nodes.length > 0) {
@@ -82,7 +86,7 @@ export function getXPathStringsForXmlFile(xmlFilePath: string, fs: Editor): Reco
     } catch (error) {
         throw new Error(`An error occurred while parsing the view or fragment xml. Details: ${getErrorMessage(error)}`);
     }
-    return result;
+    return { inputChoices: result, pageMacroDefinition };
 }
 
 /**

--- a/packages/fe-fpm-writer/test/unit/building-block/prompts/utils/__snapshots__/questions.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/building-block/prompts/utils/__snapshots__/questions.test.ts.snap
@@ -106,6 +106,7 @@ Object {
 exports[`utils - questions getAggregationPathPrompt with page macro 2`] = `
 Array [
   Object {
+    "checked": true,
     "name": "/mvc:View/macros:Page",
     "value": "/mvc:View/macros:Page",
   },

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -3,7 +3,7 @@ import type { ChoiceOptions } from 'inquirer';
 import { UIComboBox, UIComboBoxLoaderType, UITextInput } from '@sap-ux/ui-components';
 import type { ITextField, UIComboBoxRef, UISelectableOption } from '@sap-ux/ui-components';
 import { useValue, getLabelRenderer, useOptions } from '../../../utilities';
-import type { AnswerValue, ListPromptQuestion, PromptListChoices, UICheckableChoice } from '../../../types';
+import type { AnswerValue, ListPromptQuestion, PromptListChoices } from '../../../types';
 
 export interface SelectProps extends ListPromptQuestion {
     id?: string;
@@ -27,7 +27,7 @@ export const Select = (props: SelectProps) => {
         }
 
         // Use the first checked option as default
-        const checkedOption = options.find((opt) => opt.data && (opt.data as UICheckableChoice).checked);
+        const checkedOption = options.find((opt) => opt.data && 'checked' in opt.data && opt.data.checked === true);
         if (checkedOption) {
             return checkedOption.data?.value;
         }

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -3,7 +3,7 @@ import type { ChoiceOptions } from 'inquirer';
 import { UIComboBox, UIComboBoxLoaderType, UITextInput } from '@sap-ux/ui-components';
 import type { ITextField, UIComboBoxRef, UISelectableOption } from '@sap-ux/ui-components';
 import { useValue, getLabelRenderer, useOptions } from '../../../utilities';
-import type { AnswerValue, ListPromptQuestion, PromptListChoices, UICheckableChoice } from '../../../types';
+import type { AnswerValue, ListPromptQuestion, PromptListChoices } from '../../../types';
 
 export interface SelectProps extends ListPromptQuestion {
     id?: string;
@@ -27,7 +27,7 @@ export const Select = (props: SelectProps) => {
         }
 
         // Use the first checked option as default
-        const checkedOption = options.find((opt) => opt.data && (opt.data as UICheckableChoice).checked);
+        const checkedOption = options.find((opt) => opt.data && 'checked' in opt.data && (opt.data as any).checked);
         if (checkedOption) {
             return checkedOption.data?.value;
         }

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -3,7 +3,7 @@ import type { ChoiceOptions } from 'inquirer';
 import { UIComboBox, UIComboBoxLoaderType, UITextInput } from '@sap-ux/ui-components';
 import type { ITextField, UIComboBoxRef, UISelectableOption } from '@sap-ux/ui-components';
 import { useValue, getLabelRenderer, useOptions } from '../../../utilities';
-import type { AnswerValue, ListPromptQuestion, PromptListChoices } from '../../../types';
+import type { AnswerValue, ListPromptQuestion, PromptListChoices, UICheckableChoice } from '../../../types';
 
 export interface SelectProps extends ListPromptQuestion {
     id?: string;
@@ -27,7 +27,7 @@ export const Select = (props: SelectProps) => {
         }
 
         // Use the first checked option as default
-        const checkedOption = options.find((opt) => opt.data && 'checked' in opt.data && (opt.data as any).checked);
+        const checkedOption = options.find((opt) => opt.data && (opt.data as UICheckableChoice).checked);
         if (checkedOption) {
             return checkedOption.data?.value;
         }

--- a/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
+++ b/packages/ui-prompting/src/components/Inputs/Select/Select.tsx
@@ -3,7 +3,7 @@ import type { ChoiceOptions } from 'inquirer';
 import { UIComboBox, UIComboBoxLoaderType, UITextInput } from '@sap-ux/ui-components';
 import type { ITextField, UIComboBoxRef, UISelectableOption } from '@sap-ux/ui-components';
 import { useValue, getLabelRenderer, useOptions } from '../../../utilities';
-import type { AnswerValue, ListPromptQuestion, PromptListChoices } from '../../../types';
+import type { AnswerValue, ListPromptQuestion, PromptListChoices, UICheckableChoice } from '../../../types';
 
 export interface SelectProps extends ListPromptQuestion {
     id?: string;
@@ -26,11 +26,15 @@ export const Select = (props: SelectProps) => {
             return options[0].data?.value;
         }
 
-        // Handle numeric default that isn't a key = it could be an index
-        if (props.defaultIndex !== undefined && options[props.defaultIndex]) {
-            return options[props.defaultIndex].data?.value;
+        // Use the first checked option as default
+        const checkedOption = options.find((opt) => opt.data && (opt.data as UICheckableChoice).checked);
+        if (checkedOption) {
+            return checkedOption.data?.value;
         }
-    }, [props.defaultIndex, options]);
+
+        // do not preselect any value by default
+        return undefined;
+    }, [options]);
 
     useEffect(() => {
         if (defaultValue !== undefined && value !== defaultValue) {

--- a/packages/ui-prompting/src/types.ts
+++ b/packages/ui-prompting/src/types.ts
@@ -133,6 +133,7 @@ export interface ValidationResults {
     [questionName: string]: ValidationResult;
 }
 
+export type UICheckableChoice = DistinctChoice & { checked?: boolean };
 export type PromptListChoices = ReadonlyArray<DistinctChoice>;
 
 export interface DynamicChoices {

--- a/packages/ui-prompting/src/types.ts
+++ b/packages/ui-prompting/src/types.ts
@@ -133,7 +133,6 @@ export interface ValidationResults {
     [questionName: string]: ValidationResult;
 }
 
-export type UICheckableChoice = DistinctChoice & { checked?: boolean };
 export type PromptListChoices = ReadonlyArray<DistinctChoice>;
 
 export interface DynamicChoices {

--- a/packages/ui-prompting/src/types.ts
+++ b/packages/ui-prompting/src/types.ts
@@ -133,8 +133,7 @@ export interface ValidationResults {
     [questionName: string]: ValidationResult;
 }
 
-export type UICheckableChoice = DistinctChoice & { checked?: boolean };
-export type PromptListChoices = ReadonlyArray<UICheckableChoice>;
+export type PromptListChoices = ReadonlyArray<DistinctChoice>;
 
 export interface DynamicChoices {
     [key: string]: PromptListChoices;

--- a/packages/ui-prompting/src/types.ts
+++ b/packages/ui-prompting/src/types.ts
@@ -95,10 +95,6 @@ export interface ListPromptQuestion<T extends Answers = Answers> extends ListQue
      * Additional properties for ui.
      */
     guiOptions?: ListGuiOptions;
-    /**
-     * Default selection index.
-     */
-    defaultIndex?: number;
 }
 
 /**
@@ -137,7 +133,8 @@ export interface ValidationResults {
     [questionName: string]: ValidationResult;
 }
 
-export type PromptListChoices = ReadonlyArray<DistinctChoice>;
+export type UICheckableChoice = DistinctChoice & { checked?: boolean };
+export type PromptListChoices = ReadonlyArray<UICheckableChoice>;
 
 export interface DynamicChoices {
     [key: string]: PromptListChoices;

--- a/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
@@ -338,7 +338,7 @@ describe('Select', () => {
         });
     });
 
-    it('Auto select single option', () => {
+    it('Auto-selects the option with checked=true as the default value', () => {
         const onChangeFn = jest.fn();
         render(<Select {...props} onChange={onChangeFn} choices={[{ name: 'Dummy', value: 111 }]} />);
         const input = screen.getByRole('combobox');

--- a/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
@@ -345,12 +345,4 @@ describe('Select', () => {
         expect(input).toBeDefined();
         expect(onChangeFn).toHaveBeenCalledWith('select', 111);
     });
-
-    it('Select default value as index', async () => {
-        const onChangeFn = jest.fn();
-        render(<Select {...props} onChange={onChangeFn} defaultIndex={1} />);
-        const input = screen.getByRole('combobox');
-        expect(input).toBeDefined();
-        expect(onChangeFn).toHaveBeenCalledWith('select', 'testValue1');
-    });
 });

--- a/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
+++ b/packages/ui-prompting/test/unit/components/Inputs/Select.test.tsx
@@ -345,4 +345,19 @@ describe('Select', () => {
         expect(input).toBeDefined();
         expect(onChangeFn).toHaveBeenCalledWith('select', 111);
     });
+
+    it('Select checked value as default', async () => {
+        const onChangeFn = jest.fn();
+        const promptsWithChecked = {
+            ...props,
+            choices: [
+                { name: 'testText0', value: 'testValue0' },
+                { name: 'testText1', value: 'testValue1', checked: true }
+            ]
+        };
+        render(<Select {...promptsWithChecked} onChange={onChangeFn} />);
+        const input = screen.getByRole('combobox');
+        expect(input).toBeDefined();
+        expect(onChangeFn).toHaveBeenCalledWith('select', 'testValue1');
+    });
 });


### PR DESCRIPTION
Linked open source PR https://github.com/SAP/open-ux-tools/pull/3509
https://github.com/SAP/open-ux-tools/pull/3520

- Introduced support for a [checked](https://github.com/SAP/open-ux-tools/pull/3523/files#diff-b76a61a01c9bdd992807705a419c87838dc5950f0bb47153b4c28fba743b6caeR30) value on choices used by the Select component.
- When a choice in the choices array has checked: true, the Select component will automatically preselect that option as the default value.
- This enables marking a default option directly in the choices array
- Sets [default AggregationPath prompt](https://github.com/SAP/open-ux-tools/pull/3523/files#diff-cca1db6d02995dd35490e22d87425fa5113ebea58607454f7f62095e2a302036R282) to macro page in fe-fpm-writers  if macro Page is present in choices


