### PR TITLE
fix(ui5-app-inquirer): fix typescript and virtual endpoint prompts for cap projects

### DIFF
--- a/.changeset/lemon-tables-smell.md
+++ b/.changeset/lemon-tables-smell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-application-inquirer': patch
+---
+
+fix typescript and virtual endpoint prompts for cap projects

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -115,7 +115,7 @@ export async function getCdsUi5PluginInfo(
     cdsVersionInfo?: CdsVersionInfo
 ): Promise<CdsUi5PluginInfo | undefined> {
     // If the project is a Java project, do not pass cdsVersionInfo.
-    // This ensures that hasMinCdsVersion is false for Java project, preventing getEnableNPMWorkspacesPrompt from being invoked for Java projects.
+    // This ensures that hasMinCdsVersion is false for Java project, preventing certain prompts (e.g typescript, virtual endpoints) from being invoked for Java projects.
     const cdsVersion = (await isCapJavaProject(capProjectPath)) ? undefined : cdsVersionInfo;
     const capCdsInfo = await checkCdsUi5PluginEnabled(capProjectPath, fs, true, cdsVersion);
     return capCdsInfo === false ? undefined : (capCdsInfo as CdsUi5PluginInfo);

--- a/packages/ui5-application-inquirer/src/prompts/index.ts
+++ b/packages/ui5-application-inquirer/src/prompts/index.ts
@@ -72,14 +72,14 @@ export async function getQuestions(
         [promptNames.description]: getDescriptionPrompt(),
         [promptNames.targetFolder]: getTargetFolderPrompt(targetDir, shouldValidateFioriAppFolder),
         [promptNames.ui5Version]: getUI5VersionPrompt(ui5Versions, promptOptions?.ui5Version),
-        [promptNames.enableTypeScript]: getEnableTypeScriptPrompt(),
+        [promptNames.enableTypeScript]: getEnableTypeScriptPrompt(capCdsInfo),
         [promptNames.addDeployConfig]: getAddDeployConfigPrompt(
             targetDir,
             promptOptions?.addDeployConfig,
             isCapProject
         ),
         [promptNames.addFlpConfig]: getAddFlpConfigPrompt(promptOptions?.addFlpConfig),
-        [promptNames.enableVirtualEndpoints]: getEnableVirtualEndpoints(),
+        [promptNames.enableVirtualEndpoints]: getEnableVirtualEndpoints(capCdsInfo),
         [promptNames.showAdvanced]: getShowAdvancedPrompt(),
         [promptNames.ui5Theme]: getUI5ThemePrompt(),
         [promptNames.enableEslint]: getEnableEsLintPrompt(),

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -5,6 +5,7 @@ import { t } from '../i18n';
 import { promptNames } from '../types';
 import { defaultAppName } from './prompt-helpers';
 import { validateAppName } from './validators';
+import type { CdsUi5PluginInfo } from '@sap-ux/project-access';
 import type { UI5Version } from '@sap-ux/ui5-info';
 import type { ListChoiceOptions } from 'inquirer';
 import type { UI5ApplicationAnswers, UI5ApplicationPromptOptions, UI5ApplicationQuestion } from '../types';
@@ -179,10 +180,14 @@ export function getUI5VersionPrompt(
 /**
  * Get the `enableTypeScript` prompt.
  *
+ * @param capCdsInfo CDS UI5 plugin information
  * @returns The `enableTypeScript` prompt
  */
-export function getEnableTypeScriptPrompt(): UI5ApplicationQuestion {
+export function getEnableTypeScriptPrompt(capCdsInfo?: CdsUi5PluginInfo): UI5ApplicationQuestion {
     return {
+        when: (): boolean => {
+            return capCdsInfo ? capCdsInfo.hasMinCdsVersion : true;
+        },
         type: 'confirm',
         name: promptNames.enableTypeScript,
         message: t('prompts.enableTypeScript.message'),
@@ -265,10 +270,14 @@ export function getAddFlpConfigPrompt(
 /**
  * Get the `enableVirtualEndpoints` prompt.
  *
+ * @param capCdsInfo CDS UI5 plugin information
  * @returns the `enableVirtualEndpoints` prompt
  */
-export function getEnableVirtualEndpoints(): UI5ApplicationQuestion {
+export function getEnableVirtualEndpoints(capCdsInfo?: CdsUi5PluginInfo): UI5ApplicationQuestion {
     return {
+        when: (): boolean => {
+            return capCdsInfo ? capCdsInfo.hasMinCdsVersion : true;
+        },
         type: 'confirm',
         name: promptNames.enableVirtualEndpoints,
         guiOptions: {

--- a/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
@@ -80,6 +80,7 @@ exports[`ui5-application-inquirer API getPrompts, no options 1`] = `
     "message": "Enable TypeScript",
     "name": "enableTypeScript",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": [Function],
@@ -111,6 +112,7 @@ exports[`ui5-application-inquirer API getPrompts, no options 1`] = `
     "message": [Function],
     "name": "enableVirtualEndpoints",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": false,

--- a/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -80,6 +80,7 @@ exports[`getQuestions getQuestions, no options 1`] = `
     "message": "Enable TypeScript",
     "name": "enableTypeScript",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": [Function],
@@ -111,6 +112,7 @@ exports[`getQuestions getQuestions, no options 1`] = `
     "message": [Function],
     "name": "enableVirtualEndpoints",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": false,

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -433,8 +433,8 @@ describe('getQuestions', () => {
 
     test('getQuestions, prompt: `enableVirtualEndpoints`', async () => {
         // Edmx project
-        const questions = await getQuestions([]);
-        const enableVirtualEndpointsQuestion = questions.find(
+        let questions = await getQuestions([]);
+        let enableVirtualEndpointsQuestion = questions.find(
             (question) => question.name === promptNames.enableVirtualEndpoints
         );
 
@@ -444,6 +444,25 @@ describe('getQuestions', () => {
         expect((enableVirtualEndpointsQuestion?.message as Function)()).toMatchInlineSnapshot(
             `"Use Virtual Endpoints for Local Preview"`
         );
+        expect((enableVirtualEndpointsQuestion?.when as Function)({})).toBe(true);
+
+        // CAP project with cds version
+        questions = await getQuestions([], {}, mockCdsInfo);
+        enableVirtualEndpointsQuestion = questions.find(
+            (question) => question.name === promptNames.enableVirtualEndpoints
+        );
+        expect((enableVirtualEndpointsQuestion?.when as Function)()).toBe(true);
+
+        // CAP project with cds-ui5 plugin disabled and hasMinCdsVersion is false
+        questions = await getQuestions(
+            [],
+            {},
+            { ...mockCdsInfo, isCdsUi5PluginEnabled: false, hasMinCdsVersion: false }
+        );
+        enableVirtualEndpointsQuestion = questions.find(
+            (question) => question.name === promptNames.enableVirtualEndpoints
+        );
+        expect((enableVirtualEndpointsQuestion?.when as Function)()).toBe(false);
     });
 
     test('getQuestions, prompt: `ui5Theme`', async () => {
@@ -550,6 +569,7 @@ describe('getQuestions', () => {
         let enableTypeScriptQuestion = questions.find((question) => question.name === promptNames.enableTypeScript);
         // default
         expect(enableTypeScriptQuestion?.default).toEqual(false);
+        expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
         const mockCdsInfoFalse = {
             hasCdsUi5Plugin: false,
             isCdsUi5PluginEnabled: false,
@@ -559,7 +579,7 @@ describe('getQuestions', () => {
         enableTypeScriptQuestion = (await getQuestions([], undefined, mockCdsInfoFalse)).find(
             (question) => question.name === promptNames.enableTypeScript
         );
-
+        expect((enableTypeScriptQuestion?.when as Function)()).toEqual(false);
         enableTypeScriptQuestion = (
             await getQuestions([], undefined, {
                 hasCdsUi5Plugin: true,
@@ -568,7 +588,7 @@ describe('getQuestions', () => {
                 hasMinCdsVersion: true
             })
         ).find((question) => question.name === promptNames.enableTypeScript);
-
+        expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
         enableTypeScriptQuestion = (
             await getQuestions([], undefined, {
                 hasCdsUi5Plugin: false,
@@ -577,6 +597,7 @@ describe('getQuestions', () => {
                 hasMinCdsVersion: true
             })
         ).find((question) => question.name === promptNames.enableTypeScript);
+        expect((enableTypeScriptQuestion?.when as Function)()).toEqual(true);
     });
 
     test('getQuestions, advanced prompt grouping', async () => {


### PR DESCRIPTION
Correction required from https://github.com/SAP/open-ux-tools/pull/3522

Typescript and Virtual endpoint prompts should not be shown for CAP JAVA. This is acheived by checking the mid cds version - as described in the updated comment in `packages/fiori-app-sub-generator/src/utils/common.ts`