### PR TITLE
Fix/preview middleware/lrep connector

### DIFF
--- a/.changeset/plenty-foxes-cheat.md
+++ b/.changeset/plenty-foxes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+fix: error when loading ObjectStorageConnector from npmjs for UI5 version 1.76

--- a/packages/preview-middleware-client/types/sap.ui.fl.d.ts
+++ b/packages/preview-middleware-client/types/sap.ui.fl.d.ts
@@ -103,9 +103,14 @@ declare module 'sap/ui/fl/Utils' {
     export default Utils;
 }
 
+declare module 'sap/ui/fl/apply/_internal/connectors/ObjectStorageConnector' {
+    export * from 'sap/ui/fl/write/api/connectors/ObjectStorageConnector';
+    export { default } from 'sap/ui/fl/write/api/connectors/ObjectStorageConnector';
+}
+
 declare module 'sap/ui/fl/write/api/connectors/ObjectStorageConnector' {
     import type { Layer } from 'sap/ui/fl';
-    interface Features {
+    export interface Features {
         isCondensingEnabled?: boolean;
         isContextSharingEnabled?: boolean;
         isKeyUser?: boolean;


### PR DESCRIPTION
Follow-up to #3363

Error: Preview with UI5 1.76 from npmjs still not working because of a 404 for `ObjectStorageConnector`.

Solution: We need to use dynamic imports because `ObjectStorageConnector` is located at a different place in UI5 1.76 (and uses slightly different property names).