### PR TITLE
fix(annotation-generator): annotations are not generated if navigation property can't be resolved

### DIFF
--- a/.changeset/tricky-ways-beam.md
+++ b/.changeset/tricky-ways-beam.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/annotation-generator': patch
+---
+
+fix: Annotations are not generated if navigation property can't be resolved.

--- a/packages/annotation-generator/jest.setup.js
+++ b/packages/annotation-generator/jest.setup.js
@@ -6,6 +6,7 @@ const fiveMinutes = 5 * 60000;
 const TEST_DATA_ROOT = join(__dirname, 'test', 'data');
 const CDS_PROJECTS = [
     join(TEST_DATA_ROOT, 'cds-generation'),
+    join(TEST_DATA_ROOT, 'cds-incidents'),
 ];
 
 function npmInstall(projectPath) {

--- a/packages/annotation-generator/test/data/cds-incidents/.gitignore
+++ b/packages/annotation-generator/test/data/cds-incidents/.gitignore
@@ -1,0 +1,34 @@
+# CAP incident-management
+_out
+*.db
+*.sqlite
+connection.properties
+default-*.json
+.cdsrc-private.json
+gen/
+node_modules/
+target/
+
+# Web IDE, App Studio
+.che/
+.gen/
+
+# MTA
+*_mta_build_tmp
+*.mtar
+mta_archives/
+
+# Other
+.DS_Store
+*.orig
+*.log
+
+*.iml
+*.flattened-pom.xml
+
+# IDEs
+# .vscode
+# .idea
+
+# @cap-js/cds-typer
+@cds-models

--- a/packages/annotation-generator/test/data/cds-incidents/app/project1/annotations.cds
+++ b/packages/annotation-generator/test/data/cds-incidents/app/project1/annotations.cds
@@ -1,0 +1,1 @@
+using ProcessorService as service from '../../srv/services';

--- a/packages/annotation-generator/test/data/cds-incidents/app/project1/package.json
+++ b/packages/annotation-generator/test/data/cds-incidents/app/project1/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "project1",
+  "version": "0.0.1",
+  "description": "An SAP Fiori application.",
+  "keywords": [
+    "ui5",
+    "openui5",
+    "sapui5"
+  ],
+  "main": "webapp/index.html",
+  "dependencies": {},
+  "devDependencies": {
+    "@ui5/cli": "^4.0.16",
+    "@sap/ux-ui5-tooling": "1"
+  },
+  "scripts": {
+    "deploy-config": "npx -p @sap/ux-ui5-tooling fiori add deploy-config cf"
+  }
+}

--- a/packages/annotation-generator/test/data/cds-incidents/app/project1/ui5.yaml
+++ b/packages/annotation-generator/test/data/cds-incidents/app/project1/ui5.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://sap.github.io/ui5-tooling/schema/ui5.yaml.json
+
+specVersion: "3.1"
+metadata:
+  name: project1
+type: application
+server:
+  customMiddleware:
+    - name: fiori-tools-proxy
+      afterMiddleware: compression
+      configuration:
+        ignoreCertError: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+        ui5:
+          path:
+            - /resources
+            - /test-resources
+          url: https://sapui5.hana.ondemand.com
+    - name: fiori-tools-appreload
+      afterMiddleware: compression
+      configuration:
+        port: 35729
+        path: webapp
+        delay: 300

--- a/packages/annotation-generator/test/data/cds-incidents/app/project1/webapp/i18n/i18n.properties
+++ b/packages/annotation-generator/test/data/cds-incidents/app/project1/webapp/i18n/i18n.properties
@@ -1,0 +1,9 @@
+# This is the resource bundle for project1
+
+#Texts for manifest.json
+
+#XTIT: Application name
+appTitle=App Title
+
+#YDES: Application description
+appDescription=An SAP Fiori application.

--- a/packages/annotation-generator/test/data/cds-incidents/app/project1/webapp/manifest.json
+++ b/packages/annotation-generator/test/data/cds-incidents/app/project1/webapp/manifest.json
@@ -1,0 +1,141 @@
+{
+  "_version": "1.76.0",
+  "sap.app": {
+    "id": "project1",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "0.0.1"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "resources": "resources.json",
+    "sourceTemplate": {
+      "id": "@sap/generator-fiori:lrop",
+      "version": "1.18.6-pre-20250815074903-08759d38d.0",
+      "toolsId": "d500036e-2eee-47aa-bef7-52c8c5cf81ea"
+    },
+    "dataSources": {
+      "mainService": {
+        "uri": "/odata/v4/processor/",
+        "type": "OData",
+        "settings": {
+          "annotations": [],
+          "odataVersion": "4.0"
+        }
+      }
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "icons": {
+      "icon": "",
+      "favIcon": "",
+      "phone": "",
+      "phone@2": "",
+      "tablet": "",
+      "tablet@2": ""
+    },
+    "deviceTypes": {
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
+  },
+  "sap.ui5": {
+    "flexEnabled": true,
+    "dependencies": {
+      "minUI5Version": "1.139.0",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {},
+        "sap.fe.templates": {}
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "project1.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "mainService",
+        "preload": true,
+        "settings": {
+          "operationMode": "Server",
+          "autoExpandSelect": true,
+          "earlyRequests": true
+        }
+      },
+      "@i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "uri": "i18n/i18n.properties"
+      }
+    },
+    "resources": {
+      "css": []
+    },
+    "routing": {
+      "config": {},
+      "routes": [
+        {
+          "pattern": ":?query:",
+          "name": "IncidentsList",
+          "target": "IncidentsList"
+        },
+        {
+          "pattern": "Incidents({key}):?query:",
+          "name": "IncidentsObjectPage",
+          "target": "IncidentsObjectPage"
+        }
+      ],
+      "targets": {
+        "IncidentsList": {
+          "type": "Component",
+          "id": "IncidentsList",
+          "name": "sap.fe.templates.ListReport",
+          "options": {
+            "settings": {
+              "contextPath": "/Incidents",
+              "variantManagement": "Page",
+              "navigation": {
+                "Incidents": {
+                  "detail": {
+                    "route": "IncidentsObjectPage"
+                  }
+                }
+              },
+              "controlConfiguration": {
+                "@com.sap.vocabularies.UI.v1.LineItem": {
+                  "tableSettings": {
+                    "type": "ResponsiveTable"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "IncidentsObjectPage": {
+          "type": "Component",
+          "id": "IncidentsObjectPage",
+          "name": "sap.fe.templates.ObjectPage",
+          "options": {
+            "settings": {
+              "editableHeaderContent": false,
+              "contextPath": "/Incidents"
+            }
+          }
+        }
+      }
+    }
+  },
+  "sap.fiori": {
+    "registrationIds": [],
+    "archeType": "transactional"
+  }
+}

--- a/packages/annotation-generator/test/data/cds-incidents/app/services.cds
+++ b/packages/annotation-generator/test/data/cds-incidents/app/services.cds
@@ -1,0 +1,2 @@
+
+using from './project1/annotations';

--- a/packages/annotation-generator/test/data/cds-incidents/db/schema.cds
+++ b/packages/annotation-generator/test/data/cds-incidents/db/schema.cds
@@ -1,0 +1,63 @@
+using { cuid, managed, sap.common.CodeList } from '@sap/cds/common';
+namespace sap.capire.incidents; 
+
+/**
+* Incidents created by Customers.
+*/
+entity Incidents : cuid, managed {  
+customer     : Association to Customers;
+title        : String  @title : 'Title';
+urgency        : Association to Urgency default 'M';
+status         : Association to Status default 'N';
+conversation  : Composition of many {
+    key ID    : UUID;
+    timestamp : type of managed:createdAt;
+    author    : type of managed:createdBy;
+    message   : String;
+};
+}
+
+/**
+* Customers entitled to create support Incidents.
+*/
+entity Customers : managed { 
+key ID        : String;
+firstName     : String;
+lastName      : String;
+name          : String = firstName ||' '|| lastName;
+email         : EMailAddress;
+phone         : PhoneNumber;
+incidents     : Association to many Incidents on incidents.customer = $self;
+creditCardNo  : String(16) @assert.format: '^[1-9]\d{15}$';
+addresses     : Composition of many Addresses on addresses.customer = $self;
+}
+
+entity Addresses : cuid, managed {
+customer      : Association to Customers;
+city          : String;
+postCode      : String;
+streetAddress : String;
+}
+
+entity Status : CodeList {
+key code: String enum {
+    new = 'N';
+    assigned = 'A'; 
+    in_process = 'I'; 
+    on_hold = 'H'; 
+    resolved = 'R'; 
+    closed = 'C'; 
+};
+criticality : Integer;
+}
+
+entity Urgency : CodeList {
+key code: String enum {
+    high = 'H';
+    medium = 'M'; 
+    low = 'L'; 
+};
+}
+
+type EMailAddress : String;
+type PhoneNumber : String;

--- a/packages/annotation-generator/test/data/cds-incidents/package.json
+++ b/packages/annotation-generator/test/data/cds-incidents/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "incident-management",
+  "version": "1.0.0",
+  "description": "A simple CAP project.",
+  "repository": "<Add your repository here>",
+  "license": "UNLICENSED",
+  "private": true,
+  "dependencies": {
+    "@sap/cds": "^9",
+    "express": "^4"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "@cap-js/sqlite": "^2",
+    "@cap-js/cds-types": "^0.13.0"
+  },
+  "scripts": {
+    "start": "cds-serve",
+    "watch-project1": "cds watch --open project1/webapp/index.html?sap-ui-xx-viewCache=false"
+  },
+  "sapux": [
+    "app/project1"
+  ]
+}

--- a/packages/annotation-generator/test/data/cds-incidents/srv/services.cds
+++ b/packages/annotation-generator/test/data/cds-incidents/srv/services.cds
@@ -1,0 +1,17 @@
+using { sap.capire.incidents as my } from '../db/schema';
+
+/**
+ * Service used by support personell, i.e. the incidents' 'processors'.
+ */
+service ProcessorService { 
+    entity Incidents as projection on my.Incidents;
+
+    // SERVICE_EDITS_GO_HERE
+}
+
+/**
+ * Service used by administrators to manage customers and incidents.
+ */
+service AdminService {
+    entity Customers as projection on my.Customers;
+}

--- a/packages/annotation-generator/test/unit/__snapshots__/cds-generation.test.ts.snap
+++ b/packages/annotation-generator/test/unit/__snapshots__/cds-generation.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`annotation generation (CDS) example 1`] = `
 "using MainService as service from '../../srv/service';
@@ -325,6 +325,57 @@ annotate service.Capex with @(
         },
     ],
 );
+"
+`;
+
+exports[`annotation generation (CDS) missing navigation property in service 1`] = `
+"using ProcessorService as service from '../../srv/services';
+annotate service.Incidents with @(
+    UI.FieldGroup #GeneratedGroup : {
+        $Type : 'UI.FieldGroupType',
+        Data : [
+            {
+                $Type : 'UI.DataField',
+                Value : title,
+            },
+            {
+                $Type : 'UI.DataField',
+                Label : 'urgency_code',
+                Value : urgency_code,
+            },
+            {
+                $Type : 'UI.DataField',
+                Label : 'status_code',
+                Value : status_code,
+            },
+        ],
+    },
+    UI.Facets : [
+        {
+            $Type : 'UI.ReferenceFacet',
+            ID : 'GeneratedFacet1',
+            Label : 'General Information',
+            Target : '@UI.FieldGroup#GeneratedGroup',
+        },
+    ],
+    UI.LineItem : [
+        {
+            $Type : 'UI.DataField',
+            Value : title,
+        },
+        {
+            $Type : 'UI.DataField',
+            Label : 'urgency_code',
+            Value : urgency_code,
+        },
+        {
+            $Type : 'UI.DataField',
+            Label : 'status_code',
+            Value : status_code,
+        },
+    ],
+);
+
 "
 `;
 

--- a/packages/annotation-generator/test/unit/cds-generation.test.ts
+++ b/packages/annotation-generator/test/unit/cds-generation.test.ts
@@ -102,4 +102,29 @@ describe(`annotation generation (CDS)`, () => {
         const content = fs.read(annotationFilePathAbsolute);
         expect(content).toMatchSnapshot();
     });
+
+    test('missing navigation property in service', async () => {
+        const projectRoot = join(__dirname, '..', testDataFolder, 'cds-incidents');
+        const project = await getProject(projectRoot);
+        const fs = createEditor(createStore());
+        const appName = join('app', 'project1');
+        const editableFileRelative = join(appName, 'annotations.cds');
+
+        const serviceParameters: AnnotationServiceParameters = {
+            project,
+            serviceName: 'ProcessorService',
+            appName
+        };
+
+        const options: GenerateAnnotationsOptions = {
+            entitySetName: 'Incidents',
+            annotationFilePath: editableFileRelative,
+            addValueHelps: true,
+            addFacets: true,
+            addLineItems: true
+        };
+        await generateAnnotations(fs, serviceParameters, options);
+        const content = fs.read(join(projectRoot, editableFileRelative));
+        expect(content).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
There was a type mismatch to what `targetType` of a navigation property was resolved to by `@sap-ux/annotation-converter`. It was returning empty object instead of `EntityType`.