### PR TITLE
fix: ADP Generator templates / sub-generator resolution

### DIFF
--- a/.changeset/tiny-eels-invent.md
+++ b/.changeset/tiny-eels-invent.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/generator-adp': patch
+'@sap-ux/adp-tooling': patch
+---
+
+fix: ADP Generator templates / sub-generator resolution problem

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -99,6 +99,10 @@ export interface AdpWriterConfig {
          * Optional: if set to true then the generated project will support typescript
          */
         enableTypeScript?: boolean;
+        /**
+         * Optional: path to the template files to be used for generation
+         */
+        templatePathOverwrite?: string;
     };
 }
 

--- a/packages/adp-tooling/src/writer/index.ts
+++ b/packages/adp-tooling/src/writer/index.ts
@@ -75,9 +75,10 @@ export async function generate(basePath: string, config: AdpWriterConfig, fs?: E
     }
 
     const fullConfig = setDefaults(config);
+    const templatePath = config.options?.templatePathOverwrite ?? baseTmplPath;
 
     writeI18nModels(basePath, fullConfig.app.i18nModels, fs);
-    writeTemplateToFolder(baseTmplPath, join(basePath), fullConfig, fs);
+    writeTemplateToFolder(templatePath, join(basePath), fullConfig, fs);
     await writeUI5DeployYaml(basePath, fullConfig, fs);
     await writeUI5Yaml(basePath, fullConfig, fs);
 

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -49,7 +49,6 @@
         "@sap-ux/system-access": "workspace:*",
         "@sap-ux/project-input-validator": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
-        "@sap-ux/adp-flp-config-sub-generator": "workspace:*",
         "@sap-ux/odata-service-writer": "workspace:*",
         "i18next": "25.3.0",
         "yeoman-generator": "5.10.0",

--- a/packages/generator-adp/src/add-annotations-to-odata/index.ts
+++ b/packages/generator-adp/src/add-annotations-to-odata/index.ts
@@ -14,6 +14,7 @@ import { t } from '../utils/i18n';
 import { GeneratorTypes } from '../types';
 import SubGeneratorWithAuthBase from '../base/sub-gen-auth-base';
 import type { GeneratorOpts } from '../utils/opts';
+import { getTemplatesOverwritePath } from '../utils/templates'
 import path from 'path';
 
 /**
@@ -75,7 +76,7 @@ class AddAnnotationsToDataGenerator extends SubGeneratorWithAuthBase {
             ChangeType.ADD_ANNOTATIONS_TO_ODATA,
             changeData,
             this.fs,
-            path.join(__dirname, 'templates')
+            getTemplatesOverwritePath()
         );
         this.logger.log('Change written to changes folder');
 

--- a/packages/generator-adp/src/add-annotations-to-odata/index.ts
+++ b/packages/generator-adp/src/add-annotations-to-odata/index.ts
@@ -14,8 +14,7 @@ import { t } from '../utils/i18n';
 import { GeneratorTypes } from '../types';
 import SubGeneratorWithAuthBase from '../base/sub-gen-auth-base';
 import type { GeneratorOpts } from '../utils/opts';
-import { getTemplatesOverwritePath } from '../utils/templates'
-import path from 'path';
+import { getTemplatesOverwritePath } from '../utils/templates';
 
 /**
  * Generator for adding annotations to OData services.

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -39,6 +39,7 @@ import { getDefaultNamespace, getDefaultProjectName } from './questions/helper/d
 import { type AdpGeneratorOptions, type AttributePromptOptions, type JsonInput } from './types';
 import { getWizardPages, updateFlpWizardSteps, updateWizardSteps, getDeployPage } from '../utils/steps';
 import { existsInWorkspace, showWorkspaceFolderWarning, handleWorkspaceFolderChoice } from '../utils/workspace';
+import { getTemplatesOverwritePath } from '../utils/templates';
 
 const generatorTitle = 'Adaptation Project';
 
@@ -283,6 +284,10 @@ export default class extends Generator {
                 packageJson,
                 logger: this.toolsLogger
             });
+
+            if (config.options) {
+                config.options.templatePathOverwrite = getTemplatesOverwritePath();
+            }
 
             await generate(this._getProjectPath(), config, this.fs);
         } catch (e) {

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -138,7 +138,7 @@ export default class extends Generator {
 
         if (!this.jsonInput) {
             this.env.lookup({
-                packagePatterns: ['@sap/generator-fiori', '@sap-ux/adp-flp-config-sub-generator']
+                packagePatterns: ['@sap/generator-fiori']
             });
             setHeaderTitle(opts, this.logger, generatorTitle);
 

--- a/packages/generator-adp/src/utils/subgenHelpers.ts
+++ b/packages/generator-adp/src/utils/subgenHelpers.ts
@@ -64,9 +64,9 @@ export function addFlpGen(
 ): void {
     try {
         /**
-         * We are using this namespace for now because '@sap-ux/adp-flp-config-sub-generator' is not yet bundled in '@sap/generator-fiori'.
+         * We are using this namespace for now because '@sap/fiori:adp-flp-config' is not yet bundled in '@sap/generator-fiori'.
          */
-        composeWith(require.resolve('@sap-ux/adp-flp-config-sub-generator/generators/app'), {
+        composeWith('@sap/fiori:adp-flp-config', {
             launchAsSubGen: true,
             vscode,
             inbounds,
@@ -74,10 +74,10 @@ export function addFlpGen(
             data: { projectRootPath },
             appWizard
         });
-        logger.info(`'@sap-ux/adp-flp-config-sub-generator' was called.`);
+        logger.info(`'@sap/fiori:adp-flp-config' was called.`);
     } catch (e) {
         logger.error(e);
-        throw new Error(`Could not call '@sap-ux/adp-flp-config-sub-generator' sub-generator: ${e.message}`);
+        throw new Error(`Could not call '@sap/fiori:adp-flp-config' sub-generator: ${e.message}`);
     }
 }
 

--- a/packages/generator-adp/src/utils/templates.ts
+++ b/packages/generator-adp/src/utils/templates.ts
@@ -1,9 +1,15 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 
+/**
+ * This function is used to get the path to the templates directory when this generator is bundled inside `@sap/generator-fiori`.
+ * It is used to overwrite the templates directory.
+ *
+ * @returns {string | undefined} The path to the templates directory.
+ */
 export function getTemplatesOverwritePath(): string | undefined {
     const templatePath = join(__dirname, 'templates');
-    if (existsSync(templatePath)) { 
+    if (existsSync(templatePath)) {
         return templatePath;
     }
     return undefined;

--- a/packages/generator-adp/src/utils/templates.ts
+++ b/packages/generator-adp/src/utils/templates.ts
@@ -1,0 +1,10 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export function getTemplatesOverwritePath(): string | undefined {
+    const templatePath = join(__dirname, 'templates');
+    if (existsSync(templatePath)) { 
+        return templatePath;
+    }
+    return undefined;
+}

--- a/packages/generator-adp/test/unit/add-annotations-to-odata/index.test.ts
+++ b/packages/generator-adp/test/unit/add-annotations-to-odata/index.test.ts
@@ -11,6 +11,7 @@ import {
     SystemLookup,
     AnnotationFileSelectType
 } from '@sap-ux/adp-tooling';
+import { getTemplatesOverwritePath } from '../../../src/utils/templates';
 import type { Manifest } from '@sap-ux/project-access';
 import type { AbapTarget } from '@sap-ux/system-access';
 import type { DescriptorVariant } from '@sap-ux/adp-tooling';
@@ -23,6 +24,10 @@ jest.mock('@sap-ux/adp-tooling', () => ({
     getVariant: jest.fn(),
     getAdpConfig: jest.fn(),
     getAdpProjectData: jest.fn()
+}));
+
+jest.mock('../../../src/utils/templates', () => ({
+    getTemplatesOverwritePath: jest.fn(() => join(__dirname, '../../../src/add-annotations-to-odata/templates'))
 }));
 
 jest.mock('@sap-ux/odata-service-writer', () => ({

--- a/packages/generator-adp/test/unit/utils/subgenHelpers.test.ts
+++ b/packages/generator-adp/test/unit/utils/subgenHelpers.test.ts
@@ -72,7 +72,7 @@ describe('Sub-generator helpers', () => {
             });
 
             expect(() => addFlpGen({} as any, composeWith, logger, wizard)).toThrow(
-                "Could not call '@sap-ux/adp-flp-config-sub-generator' sub-generator: Failed to compose"
+                "Could not call '@sap/fiori:adp-flp-config' sub-generator: Failed to compose"
             );
 
             expect(logger.error).toHaveBeenCalledWith(error);

--- a/packages/generator-adp/test/unit/utils/templates.test.ts
+++ b/packages/generator-adp/test/unit/utils/templates.test.ts
@@ -1,0 +1,37 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getTemplatesOverwritePath } from '../../../src/utils/templates';
+
+jest.mock('fs', () => ({
+    existsSync: jest.fn()
+}));
+
+const existsSyncMock = existsSync as jest.MockedFunction<typeof existsSync>;
+
+describe('getTemplatesOverwritePath', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return template path when templates directory exists', () => {
+        const expectedPath = join(__dirname, '../../../src/utils/templates');
+        existsSyncMock.mockReturnValue(true);
+
+        const result = getTemplatesOverwritePath();
+
+        expect(result).toBe(expectedPath);
+        expect(existsSyncMock).toHaveBeenCalledWith(expectedPath);
+        expect(existsSyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return undefined when templates directory does not exist', () => {
+        const expectedPath = join(__dirname, '../../../src/utils/templates');
+        existsSyncMock.mockReturnValue(false);
+
+        const result = getTemplatesOverwritePath();
+
+        expect(result).toBeUndefined();
+        expect(existsSyncMock).toHaveBeenCalledWith(expectedPath);
+        expect(existsSyncMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/generator-adp/tsconfig.json
+++ b/packages/generator-adp/tsconfig.json
@@ -10,9 +10,6 @@
   },
   "references": [
     {
-      "path": "../adp-flp-config-sub-generator"
-    },
-    {
       "path": "../adp-tooling"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2366,9 +2366,6 @@ importers:
       '@sap-devx/yeoman-ui-types':
         specifier: 1.16.9
         version: 1.16.9
-      '@sap-ux/adp-flp-config-sub-generator':
-        specifier: workspace:*
-        version: link:../adp-flp-config-sub-generator
       '@sap-ux/adp-tooling':
         specifier: workspace:*
         version: link:../adp-tooling


### PR DESCRIPTION
Fix for #3547.
- Changes the composeWith call namespace of `@sap-ux/adp-flp-config-sub-generator` to the bundled `@sap/fiori:adp-flp-config`.
- Fixes the template problem when ADP generator is bundled inside of `@sap/generator-fiori`.