### PR TITLE
fix: Deploy Config generator does not show cloud-specific prompts for ADP when login is required

### DIFF
--- a/.changeset/angry-panthers-wash.md
+++ b/.changeset/angry-panthers-wash.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+fix: Deploy Config generator does not show cloud-specific prompts for ADP when login is required

--- a/.changeset/angry-panthers-wash.md
+++ b/.changeset/angry-panthers-wash.md
@@ -1,5 +1,7 @@
 ---
 '@sap-ux/abap-deploy-config-inquirer': patch
+'@sap-ux/adp-tooling': patch
+'@sap-ux/generator-adp': patch
 ---
 
 fix: Deploy Config generator does not show cloud-specific prompts for ADP when login is required

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/auth.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/auth.ts
@@ -44,7 +44,12 @@ function getPasswordPrompt(options: AbapDeployConfigPromptOptions): Question<Aba
             input: string,
             previousAnswers: AbapDeployConfigAnswersInternal
         ): Promise<boolean | string | IValidationLink> =>
-            await validateCredentials(input, previousAnswers, options.backendTarget)
+            await validateCredentials(
+                input,
+                previousAnswers,
+                options.backendTarget,
+                options.targetSystem?.additionalValidation?.shouldRestrictDifferentSystemType
+            )
     } as PasswordQuestion<AbapDeployConfigAnswersInternal>;
 }
 

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -1,6 +1,6 @@
 import type { IValidationLink } from '@sap-devx/yeoman-ui-types';
 import { AdaptationProjectType } from '@sap-ux/axios-extension';
-import { isAbapEnvironmentOnBtp, isS4HC, type Destinations } from '@sap-ux/btp-utils';
+import { isAbapEnvironmentOnBtp, isAppStudio, isS4HC, type Destinations } from '@sap-ux/btp-utils';
 import { ErrorHandler } from '@sap-ux/inquirer-common';
 import { AuthenticationType } from '@sap-ux/store';
 import { DEFAULT_PACKAGE_ABAP } from '../constants';
@@ -278,12 +278,14 @@ export function validateClient(client: string): boolean | string {
  * @param input - password entered
  * @param previousAnswers - previous answers
  * @param backendTarget - backend target from abap deploy config prompt options
+ * @param shouldCheckSystemType - if the system type should be checked
  * @returns boolean or error message as a string
  */
 export async function validateCredentials(
     input: string,
     previousAnswers: AbapDeployConfigAnswersInternal,
-    backendTarget?: BackendTarget
+    backendTarget?: BackendTarget,
+    shouldCheckSystemType = false
 ): Promise<boolean | string> {
     if (!input || !previousAnswers.username) {
         return t('errors.requireCredentials');
@@ -301,6 +303,11 @@ export async function validateCredentials(
             handleTransportConfigError(e);
         }
     });
+
+    if (isAppStudio() && shouldCheckSystemType) {
+        const isS4HCloud = await isAbapCloud(backendTarget);
+        PromptState.abapDeployConfig.isS4HC = isS4HCloud ?? false;
+    }
 
     PromptState.transportAnswers.transportConfigNeedsCreds = transportConfigNeedsCreds ?? false;
     return transportConfigNeedsCreds ? t('errors.incorrectCredentials') : true;

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -1,6 +1,7 @@
 import { AdaptationProjectType } from '@sap-ux/axios-extension';
 import { GUIDED_ANSWERS_ICON, HELP_NODES, HELP_TREE } from '@sap-ux/guided-answers-helper';
 import { AxiosError } from 'axios';
+import { isAppStudio } from '@sap-ux/btp-utils';
 import { AuthenticationType } from '../../../store/src';
 import { initI18n, t } from '../../src/i18n';
 import { PromptState } from '../../src/prompts/prompt-state';
@@ -28,6 +29,12 @@ import * as utils from '../../src/utils';
 import * as validatorUtils from '../../src/validator-utils';
 import { mockDestinations } from '../fixtures/destinations';
 
+jest.mock('@sap-ux/btp-utils', () => ({
+    isAppStudio: jest.fn(),
+    isS4HC: jest.fn(),
+    isAbapEnvironmentOnBtp: jest.fn()
+}));
+
 jest.mock('../../src/service-provider-utils', () => ({
     getTransportListFromService: jest.fn(),
     getSystemInfo: jest.fn(),
@@ -35,6 +42,8 @@ jest.mock('../../src/service-provider-utils', () => ({
 }));
 
 jest.mock('../../src/service-provider-utils/abap-service-provider');
+
+const mockIsAppStudio = isAppStudio as jest.Mock;
 
 describe('Test validators', () => {
     const previousAnswers = {
@@ -253,6 +262,10 @@ describe('Test validators', () => {
     });
 
     describe('validateCredentials', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
         it('should return error for no credentials', async () => {
             expect(await validateCredentials('', previousAnswers)).toBe(t('errors.requireCredentials'));
         });
@@ -273,6 +286,70 @@ describe('Test validators', () => {
             expect(await validateCredentials('pass1', { ...previousAnswers, username: 'user1' })).toBe(
                 t('errors.incorrectCredentials')
             );
+        });
+
+        it('should check system type when shouldCheckSystemType is true and in App Studio', async () => {
+            mockIsAppStudio.mockReturnValueOnce(true);
+
+            jest.spyOn(utils, 'initTransportConfig').mockResolvedValueOnce({
+                transportConfig: {} as any,
+                transportConfigNeedsCreds: false
+            });
+            jest.spyOn(serviceProviderUtils, 'isAbapCloud').mockResolvedValueOnce(true);
+
+            const result = await validateCredentials(
+                'pass1',
+                { ...previousAnswers, username: 'user1' },
+                undefined,
+                true
+            );
+
+            expect(result).toBe(true);
+            expect(mockIsAppStudio).toHaveBeenCalled();
+            expect(serviceProviderUtils.isAbapCloud).toHaveBeenCalled();
+            expect(PromptState.abapDeployConfig.isS4HC).toBe(true);
+        });
+
+        it('should not check system type when shouldCheckSystemType is false', async () => {
+            mockIsAppStudio.mockReturnValueOnce(true);
+
+            jest.spyOn(utils, 'initTransportConfig').mockResolvedValueOnce({
+                transportConfig: {} as any,
+                transportConfigNeedsCreds: false
+            });
+
+            const result = await validateCredentials(
+                'pass1',
+                { ...previousAnswers, username: 'user1' },
+                undefined,
+                false
+            );
+
+            expect(result).toBe(true);
+            expect(mockIsAppStudio).toHaveBeenCalled();
+            // isAbapCloud should not be called because shouldCheckSystemType is false
+            expect(serviceProviderUtils.isAbapCloud).not.toHaveBeenCalled();
+        });
+
+        it('should not check system type when not in App Studio even if shouldCheckSystemType is true', async () => {
+            mockIsAppStudio.mockReturnValueOnce(false);
+
+            jest.spyOn(utils, 'initTransportConfig').mockResolvedValueOnce({
+                transportConfig: {} as any,
+                transportConfigNeedsCreds: false
+            });
+
+            const result = await validateCredentials(
+                'pass1',
+                { ...previousAnswers, username: 'user1' },
+                undefined,
+                true
+            );
+
+            expect(result).toBe(true);
+            expect(mockIsAppStudio).toHaveBeenCalled();
+            // isAbapCloud should not be called because isAppStudio() returns false
+            expect(serviceProviderUtils.isAbapCloud).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/adp-tooling/src/base/constants/index.ts
+++ b/packages/adp-tooling/src/base/constants/index.ts
@@ -17,6 +17,7 @@ export const BASE_I18N_DESCRIPTION =
 export const S4HANA_APPS_PARAMS = {
     'sap.app/type': 'application',
     'sap.fiori/cloudDevAdaptationStatus': 'released',
+    'fileType': 'appdescr',
     'fields':
         'sap.app/id,repoName,sap.fiori/cloudDevAdaptationStatus,sap.app/ach,sap.fiori/registrationIds,sap.app/title,url,fileType'
 };


### PR DESCRIPTION
Fix for #3562.
- Enhances the password prompt validation (when in BAS and a flag is passed) to update the isS4HC prompt state. This state update makes the cloud-specific prompts visible.

Also, includes this fix:
- Temporarily hide application variants from the application list. Due to an issue in the App Index API, application variants are listed as available for the Adaptation Project. This will cause issues if users select such an application variant.
