### PR TITLE
feat(fiori-mcp-server): add generate-fiori-ui-odata-app functionality

### DIFF
--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -24,6 +24,7 @@
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
+        "start": "npx -y supergateway --port 9881 --sessionTimeout 30000 --stdio \"node ./dist/index.js\"",
         "test": "jest --ci --forceExit --detectOpenHandles --colors"
     },
     "files": [

--- a/packages/fiori-mcp-server/src/constant.ts
+++ b/packages/fiori-mcp-server/src/constant.ts
@@ -1,4 +1,5 @@
 export const LATEST_UI5_VERSION = '1.136.7';
 export const GENERATE_FIORI_UI_APP_ID = 'generate-fiori-ui-app';
+export const GENERATE_FIORI_UI_ODATA_APP_ID = 'generate-fiori-ui-odata-app';
 export const ADD_PAGE = 'add-page';
 export const DELETE_PAGE = 'delete-page';

--- a/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
@@ -2,9 +2,12 @@ import type { FunctionalityHandlers } from '../../types';
 import { ADD_PAGE_FUNCTIONALITY, addPageHandlers, DELETE_PAGE_FUNCTIONALITY, deletePageHandlers } from './page';
 import { CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY, createControllerExtensionHandlers } from './controller-extension';
 import { GENERATE_FIORI_UI_APP, generateFioriUIAppHandlers } from './generate-fiori-ui-app';
+import { GENERATE_FIORI_UI_ODATA_APP, generateFioriUIodataAppHandlers } from './generate-fiori-ui-odata-app';
+
 export const FUNCTIONALITIES_DETAILS = [
     ADD_PAGE_FUNCTIONALITY,
     GENERATE_FIORI_UI_APP,
+    GENERATE_FIORI_UI_ODATA_APP,
     DELETE_PAGE_FUNCTIONALITY,
     CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY
 ];
@@ -13,5 +16,6 @@ export const FUNCTIONALITIES_HANDLERS: Map<string, FunctionalityHandlers> = new 
     [ADD_PAGE_FUNCTIONALITY.id, addPageHandlers],
     [DELETE_PAGE_FUNCTIONALITY.id, deletePageHandlers],
     [GENERATE_FIORI_UI_APP.id, generateFioriUIAppHandlers],
+    [GENERATE_FIORI_UI_ODATA_APP.id, generateFioriUIodataAppHandlers],
     [CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id, createControllerExtensionHandlers]
 ]);

--- a/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/command.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/command.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+import { promises } from 'fs';
+import { promisify } from 'util';
+import { exec as execAsync } from 'child_process';
+import { dirname, join } from 'path';
+import type { ExecuteFunctionalitiesInput, ExecuteFunctionalityOutput } from '../../../types';
+import { GENERATE_FIORI_UI_ODATA_APP_ID } from '../../../constant';
+const exec = promisify(execAsync);
+
+/**
+ * Method to generate fiori app.
+ *
+ * @param params Input parameters for application generation.
+ * @returns Application generation execution output.
+ */
+export async function command(params: ExecuteFunctionalitiesInput): Promise<ExecuteFunctionalityOutput> {
+    const { appGenConfig = {} } = params.parameters;
+    let { projectPath = '' } = params.parameters;
+    if (!projectPath) {
+        projectPath = params.appPath;
+    }
+
+    console.log('Starting Fiori UI generation...');
+    console.log('Project path is:' + projectPath);
+
+    if (!projectPath || typeof projectPath !== 'string') {
+        throw new Error('Please provide a valid path to the non-CAP project folder.');
+    }
+    if (!appGenConfig || typeof appGenConfig !== 'object') {
+        throw new Error('Invalid appGenConfig. Please provide a valid configuration object.');
+    }
+    const project = 'project' in appGenConfig && typeof appGenConfig.project === 'object' ? appGenConfig.project : {};
+    const appName = project && 'name' in project && typeof project.name === 'string' ? project.name : 'default';
+    const appPath = join(projectPath, 'app', appName);
+    try {
+        const targetDir = projectPath;
+        const generatorConfig = appGenConfig;
+
+        const configPath = `.fiori-ai/${appName}-generator-config.json`;
+        const outputPath = join(targetDir, configPath);
+        const content = JSON.stringify(generatorConfig, null, 4);
+        const configDir = dirname(outputPath);
+
+        await promises.mkdir(configDir, { recursive: true });
+        await promises.writeFile(outputPath, content, { encoding: 'utf8' });
+        const command = `npx -y yo@4 @sap/fiori:headless ${configPath} --force --skipInstall`.trim();
+
+        const { stdout, stderr } = await exec(command, { cwd: targetDir });
+        console.log(stdout);
+        if (stderr) {
+            console.error(stderr);
+        }
+    } catch (error) {
+        console.error('Error generating application:', error);
+        return {
+            functionalityId: GENERATE_FIORI_UI_ODATA_APP_ID,
+            status: 'Error',
+            message: 'Error generating application: ' + error.message,
+            parameters: params.parameters,
+            appPath,
+            changes: [],
+            timestamp: new Date().toISOString()
+        };
+    }
+
+    return {
+        functionalityId: GENERATE_FIORI_UI_ODATA_APP_ID,
+        status: 'Success',
+        message: 'Generation completed successfully: ' + appPath,
+        parameters: params.parameters,
+        appPath,
+        changes: [],
+        timestamp: new Date().toISOString()
+    };
+}

--- a/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/generate-fiori-ui-odata-app.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/generate-fiori-ui-odata-app.ts
@@ -1,0 +1,218 @@
+import { command } from './command';
+import { GENERATE_FIORI_UI_ODATA_APP_ID, LATEST_UI5_VERSION } from '../../../constant';
+import type {
+    ExecuteFunctionalitiesInput,
+    ExecuteFunctionalityOutput,
+    FunctionalityHandlers,
+    GetFunctionalityDetailsOutput
+} from '../../../types';
+
+export const GENERATE_FIORI_UI_ODATA_APP: GetFunctionalityDetailsOutput = {
+    id: GENERATE_FIORI_UI_ODATA_APP_ID,
+    name: 'Generate SAP Fiori UI Application for non-CAP Projects',
+    description: `Creates (generates) a new SAP Fiori UI application within an existing project (RAP or other non-CAP).
+                Crucially, you must first construct the appGenConfig JSON argument.
+                If not provided - you **MUST** ask the user for the servicePath and host of the OData service they want to use.
+                Then, you **MUST** query the service metadata endpoint to retrieve the list of available entities.
+                (**IMPORTANT**: service metadata endpoint URL must end with "$metadata". If the provided servicePath does not end with "$metadata", you **MUST** append it.)
+                Lastly, using the service $metadata response xml, figure out the data model structure, entities, and associations.`,
+    parameters: [
+        {
+            id: 'projectPath',
+            type: 'string',
+            description:
+                'The path to the non-CAP project folder. By default the currently opened project folder should be used.',
+            required: true
+        },
+        {
+            id: 'appGenConfig',
+            type: 'object',
+            description: `The configuration that will be used for the Application UI generation.
+                The configuration **MUST** be a valid JSON object corresponding to the inputSchema of the tool.
+                The configuration **MUST** be based on the project files in the projectPath.`,
+            parameters: [
+                {
+                    id: 'version',
+                    type: 'string',
+                    options: ['0.2'],
+                    description: 'Config schema version.',
+                    required: true
+                },
+                {
+                    id: 'floorplan',
+                    type: 'string',
+                    options: ['FE_LROP', 'FE_FEOP', 'FE_FPM'],
+                    description: 'SAP Fiori Elements floor plan type.',
+                    required: true
+                },
+                {
+                    id: 'projectType',
+                    type: 'string',
+                    options: ['LIST_REPORT_OBJECT_PAGE', 'FORM_ENTRY_OBJECT_PAGE', 'FLEXIBLE_PROGRAMMING_MODEL'],
+                    description: 'Corresponds to the SAP Fiori Elements floor plan.',
+                    required: true
+                },
+                {
+                    id: 'project',
+                    type: 'object',
+                    parameters: [
+                        {
+                            id: 'name',
+                            type: 'string',
+                            description: "Must be lowercase with dashes, e.g., 'sales-order-management'.",
+                            pattern: '^[a-z0-9-]+$',
+                            required: true
+                        },
+                        {
+                            id: 'title',
+                            type: 'string',
+                            required: false
+                        },
+                        {
+                            id: 'description',
+                            type: 'string',
+                            required: true
+                        },
+                        {
+                            id: 'targetFolder',
+                            type: 'string',
+                            description: 'Absolute path to the non-CAP project folder (projectPath).',
+                            required: true
+                        },
+                        {
+                            id: 'ui5Version',
+                            type: 'string',
+                            options: [LATEST_UI5_VERSION],
+                            required: true
+                        },
+                        {
+                            id: 'localUI5Version',
+                            type: 'string',
+                            options: ['1.82.2'],
+                            required: true
+                        },
+                        {
+                            id: 'sapux',
+                            type: 'boolean',
+                            defaultValue: true,
+                            required: true
+                        }
+                    ],
+                    required: true
+                },
+                {
+                    id: 'service',
+                    type: 'object',
+                    parameters: [
+                        {
+                            id: 'servicePath',
+                            type: 'string',
+                            examples: [
+                                'odata/v4/<servicename>/',
+                                'odata/v4/MyRiskService/',
+                                'odata/v2/MyOdataV2Service/',
+                                'odata/v4/MyOdataV4Service/',
+                                "odata/v4/<relative '@path' annotation from service cds file>/",
+                                "<absolute '@path' annotation from service cds file>/",
+                                'myAbsolutePathFromServiceCdsFile/'
+                            ],
+                            description:
+                                'The odata endpoint as provided by the cds mcp. If the parameter is not provided, the agent should ask the user for it.',
+                            required: true
+                        },
+                        {
+                            id: 'host',
+                            type: 'string',
+                            description:
+                                'The host of the OData service. Must be an HTTPS endpoint. If the parameter is not provided, the agent should ask the user for it.',
+                            required: true
+                        },
+                        {
+                            id: 'edmx',
+                            type: 'string',
+                            description:
+                                'The service metadata in the stringified XML format. Response from querying the $metadata endpoint of the OData service.',
+                            required: true
+                        }
+                    ],
+                    required: true
+                },
+                {
+                    id: 'entityConfig',
+                    type: 'object',
+                    parameters: [
+                        {
+                            id: 'mainEntity',
+                            type: 'object',
+                            parameters: [
+                                {
+                                    id: 'entityName',
+                                    type: 'string',
+                                    examples: ["'SalesOrder'", "'PurchaseOrderHeader'", "'MyEntity'"],
+                                    description: "The name of the main entity, e.g. 'SalesOrder'",
+                                    required: true
+                                }
+                            ],
+                            required: true
+                        },
+                        {
+                            id: 'generateFormAnnotations',
+                            type: 'boolean',
+                            required: true
+                        },
+                        {
+                            id: 'generateLROPAnnotations',
+                            type: 'boolean',
+                            required: true
+                        }
+                    ],
+                    required: true
+                },
+                {
+                    id: 'telemetryData',
+                    type: 'object',
+                    parameters: [
+                        {
+                            id: 'generationSourceName',
+                            type: 'string',
+                            options: ['AI Headless MCP'],
+                            required: true
+                        },
+                        {
+                            id: 'generationSourceVersion',
+                            type: 'string',
+                            options: ['1.0.0'],
+                            required: true
+                        }
+                    ],
+                    required: true
+                }
+            ],
+            required: true
+        }
+    ]
+};
+
+/**
+ * Retrieves the details of the Generate SAP Fiori UI Application functionality.
+ *
+ * @returns A promise that resolves to the functionality details output.
+ */
+async function getFunctionalityDetails(): Promise<GetFunctionalityDetailsOutput> {
+    return GENERATE_FIORI_UI_ODATA_APP;
+}
+
+/**
+ * Executes the Generate SAP Fiori UI Application functionality.
+ *
+ * @param params - The input parameters for executing the functionality.
+ * @returns A promise that resolves to the execution output.
+ */
+async function executeFunctionality(params: ExecuteFunctionalitiesInput): Promise<ExecuteFunctionalityOutput> {
+    return command(params);
+}
+
+export const generateFioriUIodataAppHandlers: FunctionalityHandlers = {
+    getFunctionalityDetails,
+    executeFunctionality
+};

--- a/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/index.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-odata-app/index.ts
@@ -1,0 +1,1 @@
+export { GENERATE_FIORI_UI_ODATA_APP, generateFioriUIodataAppHandlers } from './generate-fiori-ui-odata-app';


### PR DESCRIPTION
add the `generate-fiori-ui-odata-app` functionality that allows the user to generate a non-cap project & app from a service URL.