### PR TITLE
Revert "feat: remove service key addition support in application generator (#3564)"

### DIFF
--- a/packages/odata-service-inquirer/src/index.ts
+++ b/packages/odata-service-inquirer/src/index.ts
@@ -43,7 +43,7 @@ import { getPromptHostEnvironment, PromptState } from './utils';
  * @param enableGuidedAnswers - if true, the prompts will use guided answers to help users with validation errors
  * @param telemetryClient - the telemetry client to use for sending telemetry data
  * @param isYUI - if true, the prompt is being called from the Yeoman UI extension host
- * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket connection types
+ * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
  * @returns the prompts used to provide input for odata service generation and a reference to the answers object which will be populated with the user's responses once `inquirer.prompt` returns
  */
 async function getPrompts(
@@ -133,7 +133,7 @@ function getEntityRelatedPrompts(
  * @param enableGuidedAnswers - if true, the prompts will use guided answers to help users with validation errors
  * @param telemetryClient - the telemetry client to use for sending telemetry data
  * @param isYUI - if true, the prompt is being called from the Yeoman UI extension host
- * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket connection types
+ * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
  * @returns the prompt answers
  */
 async function prompt(

--- a/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
+++ b/packages/odata-service-inquirer/src/prompts/connectionValidator.ts
@@ -506,8 +506,8 @@ export class ConnectionValidator {
     }): Promise<void> {
         this.resetConnectionState();
         this.resetValidity();
-        // Handle existing stored service keys for backward compatibility
-        if (this.systemAuthType === 'reentranceTicket' || serviceInfo) {
+
+        if (this.systemAuthType === 'reentranceTicket' || this.systemAuthType === 'serviceKey') {
             this._serviceProvider = this.getAbapOnCloudServiceProvider(url, serviceInfo, refreshToken);
         } else if (destination) {
             // Assumption: the destination configured URL is a valid URL, will be needed later for basic auth error handling
@@ -629,7 +629,6 @@ export class ConnectionValidator {
             });
         }
 
-        // Remains for existing stored service keys (backward compatibility)
         if (this.systemAuthType === 'serviceKey' && serviceInfo) {
             return createForAbapOnCloud({
                 environment: AbapCloudEnvironment.Standalone,
@@ -668,7 +667,6 @@ export class ConnectionValidator {
             return this.getValidationResultFromStatusCode(200);
         }
         try {
-            // Remains for backwards compatibility with existing systems
             this.systemAuthType = 'serviceKey';
             await this.createSystemConnection({ serviceInfo, odataVersion, refreshToken });
             // Cache the user info

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-btp/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-btp/questions.ts
@@ -5,7 +5,13 @@ import {
     generateABAPCloudDestinationName
 } from '@sap-ux/btp-utils';
 import { hostEnvironment } from '@sap-ux/fiori-generator-shared';
-import { type ListQuestion, ERROR_TYPE, getCFAbapInstanceChoices, withCondition } from '@sap-ux/inquirer-common';
+import {
+    type FileBrowserQuestion,
+    type ListQuestion,
+    ERROR_TYPE,
+    getCFAbapInstanceChoices,
+    withCondition
+} from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { type ServiceInstanceInfo, apiGetInstanceCredentials } from '@sap/cf-tools';
 import type { Answers, ListChoiceOptions, Question } from 'inquirer';
@@ -25,6 +31,7 @@ import { newSystemPromptNames } from '../new-system/types';
 import { type ServiceAnswer, getSystemServiceQuestion } from '../service-selection';
 import { getSystemUrlQuestion, getUserSystemNameQuestion } from '../shared-prompts/shared-prompts';
 import { connectWithDestination } from '../system-selection/prompt-helpers';
+import { validateServiceKey } from '../validators';
 
 const abapOnBtpPromptNamespace = 'abapOnBtp';
 const systemUrlPromptName = `${abapOnBtpPromptNamespace}:${newSystemPromptNames.newSystemUrl}` as const;
@@ -32,22 +39,24 @@ const cliCfAbapServicePromptName = 'cliCfAbapService';
 
 const abapOnBtpPromptNames = {
     'abapOnBtpAuthType': 'abapOnBtpAuthType',
+    'serviceKey': 'serviceKey',
     'cloudFoundryAbapSystem': 'cloudFoundryAbapSystem'
 } as const;
 
-export type AbapOnBTPType = 'cloudFoundry' | 'reentranceTicket';
+export type AbapOnBTPType = 'cloudFoundry' | 'serviceKey' | 'reentranceTicket';
 
 interface AbapOnBtpAnswers extends Partial<OdataServiceAnswers> {
     [abapOnBtpPromptNames.abapOnBtpAuthType]?: AbapOnBTPType;
     [systemUrlPromptName]?: string;
+    [abapOnBtpPromptNames.serviceKey]?: string;
     [abapOnBtpPromptNames.cloudFoundryAbapSystem]?: ServiceInstanceInfo;
 }
 
 /**
- * Get the questions for the ABAP on BTP system within the VSCode platform. The questions will prompt the user for the system type (Cloud Foundry, Re-entrance Ticket).
+ * Get the questions for the ABAP on BTP system within the VSCode platform. The questions will prompt the user for the system type (Cloud Foundry, Service Key, Re-entrance Ticket).
  *
  * @param promptOptions The prompt options which control the service selection and system name]
- * @param cachedConnectedSystem if available passing an already connected system connection will prevent re-authentication for re-entrance ticket connection types
+ * @param cachedConnectedSystem if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
  * @returns The list of questions for the ABAP on BTP system
  */
 export function getAbapOnBTPSystemQuestions(
@@ -62,6 +71,7 @@ export function getAbapOnBTPSystemQuestions(
         name: abapOnBtpPromptNames.abapOnBtpAuthType,
         choices: [
             { name: t('prompts.abapOnBTPType.choiceCloudFoundry'), value: 'cloudFoundry' as AbapOnBTPType },
+            { name: t('prompts.abapOnBTPType.choiceServiceKey'), value: 'serviceKey' as AbapOnBTPType },
             { name: t('prompts.abapOnBTPType.choiceReentranceTicket'), value: 'reentranceTicket' as AbapOnBTPType }
         ],
         message: t('prompts.abapOnBTPType.message'),
@@ -90,6 +100,14 @@ export function getAbapOnBTPSystemQuestions(
                 }
                 return false;
             }
+        )[0]
+    );
+
+    // Service Key file prompt
+    questions.push(
+        withCondition(
+            [getServiceKeyPrompt(connectValidator, cachedConnectedSystem)],
+            (answers: AbapOnBtpAnswers) => answers?.abapOnBtpAuthType === 'serviceKey'
         )[0]
     );
 
@@ -122,8 +140,8 @@ export function getAbapOnBTPSystemQuestions(
 }
 
 /**
- * Validate the service info (returned from cf-tools APIs) for an ABAP on BTP system. This function will validate the connection to the ABAP system and on BAS will create a new destination.
- * Updates the prompt state with the connected system to be later used for catalog service selection.
+ * Validate the service info (returned from cf-tools APIs) for an ABAP on BTP system. This function will validate the service key file, or on BAS will create a new destination,
+ * and validate the connection to the ABAP system. Updates the prompt state with the connected system to be later used for catalog service selection.
  *
  * @param abapService the abap service as provided by CF tools {@link ServiceInstanceInfo}
  * @param connectionValidator connection validator instance
@@ -211,7 +229,7 @@ async function validateCFServiceInfo(
  * @param connectionValidator The connection validator
  * @param promptNamespace
  * @param requiredOdataVersion
- * @param cachedConnectedSystem if available passing an already connected system connection will prevent re-authentication for re-entrance ticket connection types
+ * @param cachedConnectedSystem if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
  * @returns The Cloud Foundry ABAP system discovery prompt
  */
 export function getCFDiscoverPrompts(
@@ -279,4 +297,54 @@ export function getCFDiscoverPrompts(
     }
 
     return questions;
+}
+
+/**
+ * Get the service key prompt for the ABAP on BTP system. This prompt will allow the user to select a service key file from the file system.
+ *
+ * @param connectionValidator a connection validator instance
+ * @param cachedConnectedSystem if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
+ * @returns The service key prompt
+ */
+function getServiceKeyPrompt(
+    connectionValidator: ConnectionValidator,
+    cachedConnectedSystem?: ConnectedSystem
+): FileBrowserQuestion {
+    const question = {
+        type: 'input',
+        name: abapOnBtpPromptNames.serviceKey,
+        message: t('prompts.serviceKey.message'),
+        guiType: 'file-browser',
+        guiOptions: {
+            hint: t('prompts.serviceKey.hint'),
+            mandatory: true
+        },
+        validate: async (keyPath) => {
+            PromptState.resetConnectedSystem();
+            const serviceKeyValResult = validateServiceKey(keyPath);
+            if (typeof serviceKeyValResult === 'string' || typeof serviceKeyValResult === 'boolean') {
+                return serviceKeyValResult;
+            }
+            // Backend systems validation supports using a cached connections from a previous step execution to prevent re-authentication (e.g. re-opening a browser window)
+            // In case the user has changed the URL, do not use the cached connection.
+            if (
+                cachedConnectedSystem &&
+                cachedConnectedSystem.backendSystem?.url === serviceKeyValResult.url &&
+                JSON.stringify((cachedConnectedSystem.backendSystem.serviceKeys as ServiceInfo).uaa) ===
+                    JSON.stringify(serviceKeyValResult.uaa)
+            ) {
+                connectionValidator.setConnectedSystem(cachedConnectedSystem);
+            }
+            const connectValResult = await connectionValidator.validateServiceInfo(serviceKeyValResult);
+
+            if (connectValResult === true && connectionValidator.serviceProvider) {
+                PromptState.odataService.connectedSystem = {
+                    serviceProvider: removeCircularFromServiceProvider(connectionValidator.serviceProvider)
+                };
+            }
+            return connectValResult;
+        }
+    } as FileBrowserQuestion;
+
+    return question;
 }

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -66,7 +66,6 @@ export async function connectWithBackendSystem(
                 systemAuthType: 'reentranceTicket'
             });
         } else if (backendSystem.serviceKeys) {
-            // Handle existing stored service keys for backward compatibility
             connectValResult = await connectionValidator.validateServiceInfo(
                 backendSystem.serviceKeys as ServiceInfo,
                 convertODataVersionType(requiredOdataVersion),

--- a/packages/odata-service-inquirer/src/prompts/prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/prompts.ts
@@ -20,7 +20,7 @@ import { getDatasourceTypeChoices } from './prompt-helpers';
  * Get the prompts for the OData service inquirer.
  *
  * @param promptOptions - options that can control some of the prompt behavior. See {@link OdataServicePromptOptions} for details
- * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket connection types
+ * @param connectedSystem - if available passing an already connected system connection will prevent re-authentication for re-entrance ticket and service keys connection types
  * @returns the prompts used to provide input for OData service generation
  */
 export async function getQuestions(

--- a/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
+++ b/packages/odata-service-inquirer/src/translations/odata-service-inquirer.i18n.json
@@ -110,7 +110,14 @@
         "abapOnBTPType": {
             "message": "ABAP environment definition source",
             "choiceReentranceTicket": "Use Reentrance Ticket",
+            "choiceServiceKey": "Upload a Service Key File",
             "choiceCloudFoundry": "Discover a Cloud Foundry Service"
+        },
+        "serviceKey": {
+            "message": "Service Key File Path",
+            "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
+            "incompleteServiceKeyInfo": "The service keys file does not contain the required information. Check the file is valid and try again.",
+            "unparseableServiceKey": "The service keys file does not contain a valid JSON format. Check the formatting and try again."
         },
         "cloudFoundryAbapSystem": {
             "message": "ABAP environment",

--- a/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`API tests getPrompts, i18n is loaded 1`] = `
 [
@@ -218,6 +218,10 @@ exports[`API tests getPrompts, i18n is loaded 1`] = `
         "value": "cloudFoundry",
       },
       {
+        "name": "Upload a Service Key File",
+        "value": "serviceKey",
+      },
+      {
         "name": "Use Reentrance Ticket",
         "value": "reentranceTicket",
       },
@@ -237,6 +241,18 @@ exports[`API tests getPrompts, i18n is loaded 1`] = `
     },
     "message": "System URL",
     "name": "abapOnBtp:newSystemUrl",
+    "type": "input",
+    "validate": [Function],
+    "when": [Function],
+  },
+  {
+    "guiOptions": {
+      "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
+      "mandatory": true,
+    },
+    "guiType": "file-browser",
+    "message": "Service Key File Path",
+    "name": "serviceKey",
     "type": "input",
     "validate": [Function],
     "when": [Function],

--- a/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getQuestions getQuestions 1`] = `
 [
@@ -230,6 +230,10 @@ exports[`getQuestions getQuestions 1`] = `
         "value": "cloudFoundry",
       },
       {
+        "name": "Upload a Service Key File",
+        "value": "serviceKey",
+      },
+      {
         "name": "Use Reentrance Ticket",
         "value": "reentranceTicket",
       },
@@ -249,6 +253,18 @@ exports[`getQuestions getQuestions 1`] = `
     },
     "message": "System URL",
     "name": "abapOnBtp:newSystemUrl",
+    "type": "input",
+    "validate": [Function],
+    "when": [Function],
+  },
+  {
+    "guiOptions": {
+      "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
+      "mandatory": true,
+    },
+    "guiType": "file-browser",
+    "message": "Service Key File Path",
+    "name": "serviceKey",
     "type": "input",
     "validate": [Function],
     "when": [Function],

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/questions.test.ts
@@ -120,6 +120,10 @@ describe('questions', () => {
                     "value": "cloudFoundry",
                   },
                   {
+                    "name": "Upload a Service Key File",
+                    "value": "serviceKey",
+                  },
+                  {
                     "name": "Use Reentrance Ticket",
                     "value": "reentranceTicket",
                   },
@@ -139,6 +143,18 @@ describe('questions', () => {
                 },
                 "message": "System URL",
                 "name": "abapOnBtp:newSystemUrl",
+                "type": "input",
+                "validate": [Function],
+                "when": [Function],
+              },
+              {
+                "guiOptions": {
+                  "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
+                  "mandatory": true,
+                },
+                "guiType": "file-browser",
+                "message": "Service Key File Path",
+                "name": "serviceKey",
                 "type": "input",
                 "validate": [Function],
                 "when": [Function],

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/__snapshots__/questions.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/__snapshots__/questions.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Test system selection prompts should return system selection prompts and choices based on development environment, BAS or non-BAS 1`] = `
 [
@@ -296,6 +296,10 @@ exports[`Test system selection prompts should return system selection prompts an
         "value": "cloudFoundry",
       },
       {
+        "name": "Upload a Service Key File",
+        "value": "serviceKey",
+      },
+      {
         "name": "Use Reentrance Ticket",
         "value": "reentranceTicket",
       },
@@ -315,6 +319,18 @@ exports[`Test system selection prompts should return system selection prompts an
     },
     "message": "System URL",
     "name": "abapOnBtp:newSystemUrl",
+    "type": "input",
+    "validate": [Function],
+    "when": [Function],
+  },
+  {
+    "guiOptions": {
+      "hint": "Select a local file that defines the service connection for an ABAP Environment on SAP Business Technology Platform.",
+      "mandatory": true,
+    },
+    "guiType": "file-browser",
+    "message": "Service Key File Path",
+    "name": "serviceKey",
     "type": "input",
     "validate": [Function],
     "when": [Function],


### PR DESCRIPTION
#3561

This reverts commit 2d11a6d6aed70ab846b555e8c4e08518c75c921b.
- The service key question in the generator is the only way to add BTP cloud systems until compatibility with re-entrance tickets is added
	- In addition to the revert, the service key question will be feature toggled for the moment
