### PR TITLE
feat: rename property `id` to `functionalityId`

### DIFF
--- a/packages/fiori-mcp-server/src/tools/functionalities/controller-extension/index.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/controller-extension/index.ts
@@ -42,7 +42,7 @@ function getParameters(): { pageType: Parameter; pageId: Parameter; controllerNa
 }
 
 export const CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY: GetFunctionalityDetailsOutput = {
-    id: 'create-controller-extension',
+    functionalityId: 'create-controller-extension',
     name: 'Add new controller extension by creating javascript or typescript file and updates manifest.json with entry',
     description:
         'Add new controller extension by creating javascript or typescript file and updates manifest.json with entry. Controller extensions allow users to extensiate default behaviour with custom controllers code.',

--- a/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
@@ -10,8 +10,8 @@ export const FUNCTIONALITIES_DETAILS = [
 ];
 
 export const FUNCTIONALITIES_HANDLERS: Map<string, FunctionalityHandlers> = new Map([
-    [ADD_PAGE_FUNCTIONALITY.id, addPageHandlers],
-    [DELETE_PAGE_FUNCTIONALITY.id, deletePageHandlers],
-    [GENERATE_FIORI_UI_APP.id, generateFioriUIAppHandlers],
-    [CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id, createControllerExtensionHandlers]
+    [ADD_PAGE_FUNCTIONALITY.functionalityId, addPageHandlers],
+    [DELETE_PAGE_FUNCTIONALITY.functionalityId, deletePageHandlers],
+    [GENERATE_FIORI_UI_APP.functionalityId, generateFioriUIAppHandlers],
+    [CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId, createControllerExtensionHandlers]
 ]);

--- a/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-app/generate-fiori-ui-app.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/generate-fiori-ui-app/generate-fiori-ui-app.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../types';
 
 export const GENERATE_FIORI_UI_APP: GetFunctionalityDetailsOutput = {
-    id: GENERATE_FIORI_UI_APP_ID,
+    functionalityId: GENERATE_FIORI_UI_APP_ID,
     name: 'Generate SAP Fiori UI Application',
     description: `Creates (generates) a new SAP Fiori UI application within an existing CAP project.
                 Crucially, you must first construct the appGenConfig JSON argument.

--- a/packages/fiori-mcp-server/src/tools/functionalities/page/add-page.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/page/add-page.ts
@@ -22,7 +22,7 @@ async function getFunctionalityDetails(params: GetFunctionalityDetailsInput): Pr
     const appDetails = await resolveApplication(appPath);
     if (!appDetails?.applicationAccess) {
         return {
-            id: ADD_PAGE,
+            functionalityId: ADD_PAGE,
             name: 'Invalid Project Root or Application Path',
             description: `To add a new page, provide a valid project root or application path. "${appPath}" is not valid`,
             parameters: []

--- a/packages/fiori-mcp-server/src/tools/functionalities/page/application.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/page/application.ts
@@ -17,13 +17,13 @@ import type { Application as ApplicationConfig, CustomExtensionData, v4 } from '
 import { getDefaultExtensionFolder } from '../../utils';
 
 export const ADD_PAGE_FUNCTIONALITY: GetFunctionalityDetailsOutput = {
-    id: ADD_PAGE,
+    functionalityId: ADD_PAGE,
     name: 'Add new page to application by updating manifest.json',
     description: 'Create new fiori elements page like ListReport, ObjectPage, CustomPage',
     parameters: []
 };
 export const DELETE_PAGE_FUNCTIONALITY: GetFunctionalityDetailsOutput = {
-    id: DELETE_PAGE,
+    functionalityId: DELETE_PAGE,
     name: 'Delete page from application by updating manifest.json',
     description: 'Remove existing fiori elements page from the application',
     parameters: []

--- a/packages/fiori-mcp-server/src/tools/functionalities/page/delete-page.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/page/delete-page.ts
@@ -21,7 +21,7 @@ async function getFunctionalityDetails(params: GetFunctionalityDetailsInput): Pr
     const appDetails = await resolveApplication(appPath);
     if (!appDetails?.applicationAccess) {
         return {
-            id: DELETE_PAGE,
+            functionalityId: DELETE_PAGE,
             name: 'Invalid Project Root or Application Path',
             description: `To delete a page, provide a valid project root or application path. "${appPath}" is not valid`,
             parameters: []

--- a/packages/fiori-mcp-server/src/tools/get-functionality-details.ts
+++ b/packages/fiori-mcp-server/src/tools/get-functionality-details.ts
@@ -83,7 +83,7 @@ function getPropertyDetails(page: TreeNode, propertyPath: PropertyPath): GetFunc
         // Property was found by path
         const parameters = getParameters([property]);
         details = {
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             // There is issue in cline by applying values with undefined - throws error "Invalid JSON argument".
             // As workaround - I am using approach with null as currently there is no use case where null is real value.
@@ -97,7 +97,7 @@ function getPropertyDetails(page: TreeNode, propertyPath: PropertyPath): GetFunc
             parameters = parameters.concat(getParameters([property]));
         }
         details = {
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             // There is issue in cline by applying values with undefined - throws error "Invalid JSON argument".
             // As workaround - I am using approach with null as currently there is no use case where null is real value.

--- a/packages/fiori-mcp-server/src/tools/index.ts
+++ b/packages/fiori-mcp-server/src/tools/index.ts
@@ -32,8 +32,8 @@ export const tools = [
         description: `**(Step 1 of 3)**
                     Gets the complete and exclusive list of supported functionalities to create a new or modify an existing SAP Fiori application.
                     This is the **first mandatory step** to begin the workflow and requires a valid absolute path to a SAP Fiori application as input.
-                    You MUST use a functionality_id from this tool's output to request details to the functionality in 'get-functionality-details' (Step 2).
-                    You MUST not use a functionality_id as name of a tool.
+                    You MUST use a functionalityId from this tool's output to request details to the functionality in 'get-functionality-details' (Step 2).
+                    You MUST not use a functionalityId as name of a tool.
                     Do not guess, assume, or use any functionality not present in this list, as it is invalid and will cause the operation to fail.
                     **Note: If the target application is not known, use the list-fiori-apps tool first to identify it.**`,
         inputSchema: listFunctionalityInputSchema,
@@ -43,7 +43,7 @@ export const tools = [
         name: 'get-functionality-details',
         description: `**(Step 2 of 3)**
                     Gets the required parameters and detailed information for a specific functionality to create a new or modify an existing SAP Fiori application.
-                    You MUST provide a functionality_id obtained from 'list-functionality' (Step 1).
+                    You MUST provide a functionalityId obtained from 'list-functionality' (Step 1).
                     The output of this tool is required for the final step 'execute-functionality' (Step 3).`,
         inputSchema: getFunctionalityDetailsInputSchema,
         outputSchema: getFunctionalityDetailsOutputSchema

--- a/packages/fiori-mcp-server/src/tools/list-functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/list-functionalities.ts
@@ -20,7 +20,7 @@ export async function listFunctionalities(
         // If we need dynamic handlers then we can add additional method in interface of FUNCTIONALITIES_HANDLERS
         for (const functionality of FUNCTIONALITIES_DETAILS) {
             functionalities.push({
-                id: functionality.id,
+                functionalityId: functionality.id,
                 description: functionality.description
             });
         }
@@ -164,7 +164,7 @@ function getPropertyFunctionality(property: TreeNodeProperty, pageName?: string)
     }
     path.push(...property.schemaPath);
     return {
-        id: path,
+        functionalityId: path,
         description: property.description || property.displayName || property.name || 'No description available'
     };
 }

--- a/packages/fiori-mcp-server/src/tools/list-functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/list-functionalities.ts
@@ -20,7 +20,7 @@ export async function listFunctionalities(
         // If we need dynamic handlers then we can add additional method in interface of FUNCTIONALITIES_HANDLERS
         for (const functionality of FUNCTIONALITIES_DETAILS) {
             functionalities.push({
-                functionalityId: functionality.id,
+                functionalityId: functionality.functionalityId,
                 description: functionality.description
             });
         }

--- a/packages/fiori-mcp-server/src/tools/output-schema/get-functionality-details.json
+++ b/packages/fiori-mcp-server/src/tools/output-schema/get-functionality-details.json
@@ -1,8 +1,19 @@
 {
   "type": "object",
   "properties": {
-    "id": {
-      "type": "string"
+    "functionalityId": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Identifier to pass as the `functionalityId` parameter when calling `get-functionality-details` or `execute-functionality`"
     },
     "name": {
       "type": "string"

--- a/packages/fiori-mcp-server/src/tools/output-schema/list-functionality.json
+++ b/packages/fiori-mcp-server/src/tools/output-schema/list-functionality.json
@@ -9,7 +9,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "id": {
+          "functionalityId": {
             "anyOf": [
               {
                 "type": "array",
@@ -27,7 +27,7 @@
             "type": "string"
           }
         },
-        "required": ["id", "description"],
+        "required": ["functionalityId", "description"],
         "additionalProperties": false
       }
     }

--- a/packages/fiori-mcp-server/src/types.ts
+++ b/packages/fiori-mcp-server/src/types.ts
@@ -52,8 +52,7 @@ export interface GetFunctionalityDetailsInput {
  */
 export interface GetFunctionalityDetailsOutput {
     /** ID of the functionality */
-    // ToDo???
-    id: string;
+    functionalityId: string;
     /** Name of the functionality */
     name: string;
     /** Description of the functionality */

--- a/packages/fiori-mcp-server/src/types.ts
+++ b/packages/fiori-mcp-server/src/types.ts
@@ -52,6 +52,7 @@ export interface GetFunctionalityDetailsInput {
  */
 export interface GetFunctionalityDetailsOutput {
     /** ID of the functionality */
+    // ToDo???
     id: string;
     /** Name of the functionality */
     name: string;
@@ -122,7 +123,7 @@ export interface FioriApp {
  */
 export interface Functionality {
     /** ID or array of IDs for the functionality */
-    id: Array<string | number> | string;
+    functionalityId: Array<string | number> | string;
     /** Description of the functionality */
     description: string;
 }

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -104,11 +104,11 @@ describe('FioriFunctionalityServer', () => {
                 applicationPath: 'app1',
                 functionalities: [
                     {
-                        id: 'add-page',
+                        functionalityId: 'add-page',
                         description: 'Add page...'
                     },
                     {
-                        id: 'delete-page',
+                        functionalityId: 'delete-page',
                         description: 'Delete page...'
                     }
                 ]
@@ -131,11 +131,11 @@ describe('FioriFunctionalityServer', () => {
                 functionalities: [
                     {
                         description: 'Add page...',
-                        id: 'add-page'
+                        functionalityId: 'add-page'
                     },
                     {
                         description: 'Delete page...',
-                        id: 'delete-page'
+                        functionalityId: 'delete-page'
                     }
                 ]
             });

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -149,7 +149,7 @@ describe('FioriFunctionalityServer', () => {
 
         test('get-functionality-details', async () => {
             const getFunctionalityDetailsSpy = jest.spyOn(tools, 'getFunctionalityDetails').mockResolvedValue({
-                id: 'add-page',
+                functionalityId: 'add-page',
                 description: 'Add page...',
                 name: 'add-page',
                 parameters: []
@@ -170,7 +170,7 @@ describe('FioriFunctionalityServer', () => {
             const structuredContent = result.structuredContent;
             expect(structuredContent).toEqual({
                 description: 'Add page...',
-                id: 'add-page',
+                functionalityId: 'add-page',
                 name: 'add-page',
                 parameters: []
             });

--- a/packages/fiori-mcp-server/test/unit/tools/__snapshots__/list-functionalities.test.ts.snap
+++ b/packages/fiori-mcp-server/test/unit/tools/__snapshots__/list-functionalities.test.ts.snap
@@ -4,7 +4,7 @@ exports[`listFunctionalities call with valid app and data 1`] = `
 Array [
   Object {
     "description": "Create new fiori elements page like ListReport, ObjectPage, CustomPage",
-    "id": "add-page",
+    "functionalityId": "add-page",
   },
   Object {
     "description": "Creates (generates) a new SAP Fiori UI application within an existing CAP project.
@@ -12,68 +12,68 @@ Array [
                 To do this, you **MUST** use the ***CDS MCP*** to search the model for service definitions, entities, associations, and UI annotations.
                 As a fallback, only if no such tool is available, you should manually read and parse all .cds files in the projectPath to extract this information.
                 The data obtained from either method must then be formatted into a JSON object and passed as the appGenConfig parameter.",
-    "id": "generate-fiori-ui-app",
+    "functionalityId": "generate-fiori-ui-app",
   },
   Object {
     "description": "Remove existing fiori elements page from the application",
-    "id": "delete-page",
+    "functionalityId": "delete-page",
   },
   Object {
     "description": "Add new controller extension by creating javascript or typescript file and updates manifest.json with entry. Controller extensions allow users to extensiate default behaviour with custom controllers code.",
-    "id": "create-controller-extension",
+    "functionalityId": "create-controller-extension",
   },
   Object {
     "description": "Represents a prefix that is prepended in front of the viewName",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "path",
     ],
   },
   Object {
     "description": "standard view type of views",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "viewType",
     ],
   },
   Object {
     "description": "Defines the title for the application.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "title",
     ],
   },
   Object {
     "description": "Defines the description for the application.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "description",
     ],
   },
   Object {
     "description": "Enables key user adaptation for an application.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "flexEnabled",
     ],
   },
   Object {
     "description": "Represents the release status for the developer adaptation in the cloud (relevant for SAP internal only). The supported types are released, deprecated, obsolete, no value means not released.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "cloudDevAdaptationStatus",
     ],
   },
   Object {
     "description": "The flexible column layout allows users to see more details on the page, and to expand and collapse the screen areas.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "flexibleColumnLayout",
     ],
   },
   Object {
     "description": "Determines whether the Flexible Column Layout is limited to two columns. If set to true, the third level will be displayed in full screen mode rather than a third column.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "flexibleColumnLayout",
       "limitFCLToTwoColumns",
@@ -81,7 +81,7 @@ Array [
   },
   Object {
     "description": "Default Two Column Layout Type",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "flexibleColumnLayout",
       "defaultTwoColumnLayoutType",
@@ -89,7 +89,7 @@ Array [
   },
   Object {
     "description": "Default Three Column Layout Type",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "flexibleColumnLayout",
       "defaultThreeColumnLayoutType",
@@ -97,21 +97,21 @@ Array [
   },
   Object {
     "description": "Controller extensions allow users to extensiate default behaviour with custom controllers code.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "controllerExtensions",
     ],
   },
   Object {
     "description": "Hidden draft features.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "hideDraft",
     ],
   },
   Object {
     "description": "All features related to draft handling can be hidden from the UI while the draft functionality remains active in the background. To achieve this, enable the 'Hide Draft' property.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "hideDraft",
       "enabled",
@@ -120,7 +120,7 @@ Array [
   Object {
     "description": "Determines whether to stay on the current page after saving an object.
 To ensure a consistent experience, set this and 'Stay On Current Page After Cancel' to the same value.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "hideDraft",
       "stayOnCurrentPageAfterSave",
@@ -129,7 +129,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Canc
   Object {
     "description": "Determines whether to stay on the current page after canceling an object.
 To ensure a consistent experience, set this and 'Stay On Current Page After Save' to the same value.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "hideDraft",
       "stayOnCurrentPageAfterCancel",
@@ -137,7 +137,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Controls the visibility of the 'Create Next' button.",
-    "id": Array [
+    "functionalityId": Array [
       "settings",
       "hideDraft",
       "hideCreateNext",
@@ -147,14 +147,14 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
     "description": "variantManagement defines how the variant management of page personalizations is controlled.
 - None - No variant management by default.
 - Control - Individual personalizations for each control.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "variantManagement",
     ],
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -164,7 +164,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -174,7 +174,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -184,7 +184,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -194,7 +194,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines the position of the action relative to other actions.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -204,7 +204,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "TestHeaderAction",
@@ -214,7 +214,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "TestHeaderAction",
@@ -224,7 +224,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -234,7 +234,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -244,7 +244,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -254,7 +254,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -264,7 +264,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines the position of the action relative to other actions.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "header",
       "actions",
@@ -274,7 +274,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "TestHeaderAction2",
@@ -284,7 +284,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "TestHeaderAction2",
@@ -294,7 +294,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Allows you to hide the filter bar.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "hideFilterBar",
@@ -302,7 +302,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "A static or i18n binding string.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "selectionFields",
@@ -312,7 +312,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The full path to the property to be filtered.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "selectionFields",
@@ -322,7 +322,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The path to the XML template containing the filter control.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "selectionFields",
@@ -332,7 +332,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Determines whether the filter field requires a value.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "selectionFields",
@@ -342,7 +342,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines the position of the filter field relative to another filter field.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "filterBar",
       "selectionFields",
@@ -352,7 +352,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The key of another filter field is to be used as a placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "filterBar",
       "selectionFields",
       "CustomFilterField",
@@ -362,7 +362,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Define the placement, either before or after the anchor filter field.",
-    "id": Array [
+    "functionalityId": Array [
       "filterBar",
       "selectionFields",
       "CustomFilterField",
@@ -375,7 +375,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
 - Auto (default): Data is loaded automatically if a default filter value has been set in the filter bar.
 - Enabled: Data is loaded automatically, as defined by the standard variant
 - Disabled: Data is not loaded automatically. Users have to click the Go button.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "initialLoad",
@@ -383,7 +383,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines the table type. Note: Grid tables, analytical tables, and tree tables aren't rendered on small-screen devices. Responsive tables are shown instead.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "type",
@@ -395,7 +395,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
 - Multi (default): This type allows multiple table selections if relevant actions are available in the toolbar.
 - Single: This type allows single table selection if relevant actions are available in the toolbar.
 - None: No table selection is possible in display mode.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "selectionMode",
@@ -403,7 +403,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "The selectAll configuration overrides the selectionLimit and allows the user to select all the items. When set to true, the select all feature is enabled: a checkbox in the table header is displayed which selects all items when clicked.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "selectAll",
@@ -411,7 +411,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "You can define how many items can be selected at a time using the selectionLimit.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "selectionLimit",
@@ -419,7 +419,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Defines whether the Export button is displayed in the table toolbar. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "enableExport",
@@ -427,7 +427,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Determines whether the content density for ui.table is condensed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "condensedTableLayout",
@@ -435,7 +435,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Leading property that decides between either a recursive hierarchy or data aggregation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "hierarchyQualifier",
@@ -443,7 +443,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Determines whether the column header is included in the column width calculation. By default, the column width is calculated based on the type of the content.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "widthIncludingColumnHeader",
@@ -451,7 +451,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Determines the visibility of the Copy to Clipboard button. By default, the Copy to Clipboard button is displayed in the table toolbar if the selection mode is configured.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "disableCopyToClipboard",
@@ -459,7 +459,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
   },
   Object {
     "description": "Mass editing allows end users to simultaneously change multiple objects that share the same editable properties.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "enableMassEdit",
@@ -469,7 +469,7 @@ To ensure a consistent experience, set this and 'Stay On Current Page After Save
     "description": "Defines the personalization mode, currently only effective if variant management on page is either set to Page or Control.
 By default all table settings are enabled. You can change this for the different parts of the table by setting the properties \\"Column\\", \\"Sort\\" and \\"Filter\\" accordingly.
 Omitting a property is treated as false, this allows apps to avoid getting new features like grouping in upcoming releases.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "personalization",
@@ -477,7 +477,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can add and remove columns to a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "personalization",
       "column",
@@ -485,7 +485,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can sort a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "personalization",
       "sort",
@@ -493,7 +493,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can filter data of a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "personalization",
       "filter",
@@ -501,7 +501,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "With quickVariantSelection you can switch to multiple views (single table mode). It links to a SelectionVariant (filters) or SelectionPresentationVariant (filters and sorters) that you have added to your annotations.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "quickVariantSelection",
@@ -509,7 +509,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Determines whether the table title is hidden and the tab titles are displayed.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "hideTableTitle",
@@ -517,7 +517,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Determines whether the entry view counts are shown.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "showCounts",
@@ -525,7 +525,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "List of annotation paths referring to SelectionVariant annotations.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "paths",
@@ -533,7 +533,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "0",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "paths",
@@ -542,7 +542,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Annotation Path",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "paths",
@@ -552,7 +552,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "1",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "paths",
@@ -561,7 +561,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Annotation Path",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "quickVariantSelection",
       "paths",
@@ -571,7 +571,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "enableMassEdit",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "enableMassEdit",
@@ -579,7 +579,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The 'visibleFields' property lets you specify which fields are available in the mass edit dialog.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "enableMassEdit",
       "visibleFields",
@@ -587,7 +587,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The 'ignoredFields' property lets you hide specific fields from the mass edit dialog, even if these fields are displayed in the table.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "enableMassEdit",
       "ignoredFields",
@@ -595,7 +595,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -606,7 +606,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -617,7 +617,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -628,7 +628,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -639,7 +639,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -650,7 +650,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -661,7 +661,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -672,7 +672,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -683,7 +683,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -694,7 +694,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -705,7 +705,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -716,7 +716,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -727,7 +727,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Indicates whether the action requires a selection of items.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -738,7 +738,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -749,7 +749,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -760,7 +760,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -771,7 +771,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -782,7 +782,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines the position of the action relative to other actions.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -793,7 +793,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -804,7 +804,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -815,7 +815,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -826,7 +826,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -837,7 +837,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -848,7 +848,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -859,7 +859,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -870,7 +870,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -881,7 +881,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -892,7 +892,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -903,7 +903,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -914,7 +914,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -925,7 +925,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -936,7 +936,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -947,7 +947,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Enables single selection for a bound action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -958,7 +958,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "toolBar",
@@ -969,7 +969,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -980,7 +980,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "toolBar",
       "actions",
@@ -992,7 +992,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1005,7 +1005,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1015,7 +1015,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1026,7 +1026,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1039,7 +1039,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1049,7 +1049,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1059,7 +1059,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The header is shown on the table as header, as well as in the add/remove dialog.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1070,7 +1070,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1080,7 +1080,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Defines a target fragment.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1090,7 +1090,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Aligns the header as well as the content horizontally.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1103,7 +1103,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 - Default: it will be shown by default in the table.
 - Adaptation: it will initially not be shown in the table but be available via end user adaptation
 - Hidden: the column is neither available in the table nor in adaptation",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1113,7 +1113,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Defines the position of the column relative to other columns.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1123,7 +1123,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "The key of another column to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "columns",
       "TestCustomColumn",
@@ -1133,7 +1133,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Define the placement, either before or after the anchor column.",
-    "id": Array [
+    "functionalityId": Array [
       "table",
       "columns",
       "TestCustomColumn",
@@ -1144,7 +1144,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   Object {
     "description": "If provided and sorting for the table is enabled, the custom column header can be clicked.
 Once clicked, a list of properties that can be sorted by are displayed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1155,7 +1155,7 @@ Once clicked, a list of properties that can be sorted by are displayed.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1168,7 +1168,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1178,7 +1178,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1189,7 +1189,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1202,7 +1202,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1212,7 +1212,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1223,7 +1223,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1236,7 +1236,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1246,7 +1246,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1257,7 +1257,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1270,7 +1270,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1280,7 +1280,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1291,7 +1291,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1304,7 +1304,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1314,7 +1314,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1325,7 +1325,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1338,7 +1338,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1348,7 +1348,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelList",
       "table",
       "columns",
@@ -1360,14 +1360,14 @@ Hidden: the column is neither available in the table nor in adaptation.",
     "description": "Determines whether variant management is enabled for tables:
 - None (default): Variant management is disabled.
 - Control: Variant management can be enabled individually for each control using personalization.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "variantManagement",
     ],
   },
   Object {
     "description": "Set editableHeaderContent to true to make the header fields editable.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "editableHeaderContent",
@@ -1375,7 +1375,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Set visible to true to make the header visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "visible",
@@ -1383,7 +1383,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Determines whether the anchor bar is displayed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "anchorBarVisible",
@@ -1391,7 +1391,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1401,7 +1401,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.setToBooked::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1411,7 +1411,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.setToBooked::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1421,7 +1421,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1431,7 +1431,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1441,7 +1441,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1451,7 +1451,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1461,7 +1461,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the position of the action relative to the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1471,7 +1471,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "HeaderAction",
@@ -1481,7 +1481,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "HeaderAction",
@@ -1491,7 +1491,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1501,7 +1501,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.setToNew::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1511,7 +1511,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.setToNew::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1521,7 +1521,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1531,7 +1531,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.Check::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1541,7 +1541,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.Check::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1551,7 +1551,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1561,7 +1561,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.createBookingDraft::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1571,7 +1571,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.createBookingDraft::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1581,7 +1581,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Settings that control the behavior after creating a new entry.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1591,7 +1591,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to disable the navigation. By default, navigation is automatically triggered after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.deductDiscount::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1601,7 +1601,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Allows you to scroll to the newly created or changed item after you have performed an action.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "actions",
       "DataFieldForAction::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.deductDiscount::com.sap.gateway.srvd.dmo.sd_travel_mdsk.v0001.TravelType",
@@ -1611,7 +1611,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Set showRelatedApps to true to show the navigation button for related apps.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "actions",
@@ -1621,7 +1621,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Header facets marked as stashed are initially not visible on the UI. Key users can add these header facets via key user adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1631,7 +1631,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the key user adaptation behavior of the header facet.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1641,7 +1641,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines which settings are available for key user adaptation at design time.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "sections",
       "@com.sap.vocabularies.UI.v1.FieldGroup#HeaderFormSection",
@@ -1651,7 +1651,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Subtitle of header section.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1661,7 +1661,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The fragment for the editable version of the header facet.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1671,7 +1671,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the loading behavior of the Object Page header.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1681,7 +1681,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the header facet is displayed in the header area.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1691,7 +1691,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The path to the XML template containing the section control.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1701,7 +1701,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Use the key of another section as a placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1711,7 +1711,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor section.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1721,7 +1721,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The label of a custom section, preferably as an i18n key.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1731,7 +1731,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Header facets marked as stashed are initially not visible on the UI. Key users can add these header facets via key user adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1741,7 +1741,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the key user adaptation behavior of the header facet.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "header",
       "sections",
@@ -1751,7 +1751,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines which settings are available for key user adaptation at design time.",
-    "id": Array [
+    "functionalityId": Array [
       "header",
       "sections",
       "HeaderCustomSection",
@@ -1763,7 +1763,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
     "description": "Defines the layout of the sections.
 - Page (default): In this mode, all the sections and subsections are added to the same page.
 - Tabs: In this mode, the sections are represented as tabs under the header facet.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "layout",
       "sectionLayout",
@@ -1771,7 +1771,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The path to the XML template containing the section control.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1780,7 +1780,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Use the key of another section as a placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1789,7 +1789,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor section.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1798,7 +1798,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The label of a custom section, preferably as an i18n key.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1808,7 +1808,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "Defines the path of the context used in the current page or block.
 This setting is defined by the framework.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1819,7 +1819,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "If true, the search is triggered automatically when a filter value is changed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1830,7 +1830,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines the relative path of the property in the metamodel, based on the current contextPath.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1841,7 +1841,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Handles the visibility of the 'Clear' button on the FilterBar.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1852,7 +1852,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Displays possible errors during the search in a message box",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1863,7 +1863,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Parameter which sets the visibility of the FilterBar building block",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1874,7 +1874,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Unique id of control",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1885,7 +1885,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "This event is fired when the 'Clear' button is pressed. This is only possible when the 'Clear' button is enabled.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1896,7 +1896,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "This event is fired after either a filter value or the visibility of a filter item has been changed. The event contains conditions that will be used as filters.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1907,7 +1907,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "This event is fired when the 'Go' button is pressed or after a condition change.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1918,7 +1918,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1929,7 +1929,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1940,7 +1940,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1951,7 +1951,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1962,7 +1962,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines the position of the action relative to the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "CustomSection",
@@ -1973,7 +1973,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "CustomSection",
       "actions",
@@ -1984,7 +1984,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "CustomSection",
       "actions",
@@ -1995,7 +1995,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines the table type. Note: Grid tables, analytical tables, and tree tables aren't rendered on small-screen devices. Responsive tables are shown instead.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2005,7 +2005,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Enables full screen mode for this table. This adds a button to the table toolbar which opens the table in a full screen dialog.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2015,7 +2015,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "In the Object Page tables, it is possible to add several items at a time by copying and pasting data from an excel file, if this property is set to true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2025,7 +2025,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Mass editing allows end users to simultaneously change multiple objects that share the same editable properties.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2039,7 +2039,7 @@ This setting is defined by the framework.",
 - Multi (default): This type allows multiple table selections if relevant actions are available in the toolbar.
 - Single: This type allows single table selection if relevant actions are available in the toolbar.
 - None: No table selection is possible in display mode.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2049,7 +2049,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "The selectAll configuration overrides the selectionLimit and allows the user to select all the items. When set to true, the select all feature is enabled: a checkbox in the table header is displayed which selects all items when clicked.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2059,7 +2059,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "You can define how many items can be selected at a time using the selectionLimit.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2069,7 +2069,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines whether the Export button is displayed in the table toolbar. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2079,7 +2079,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Determines whether the content density for ui.table is condensed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2089,7 +2089,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Leading property that decides between either a recursive hierarchy or data aggregation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2099,7 +2099,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Determines whether the column header is included in the column width calculation. By default, the column width is calculated based on the type of the content.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2109,7 +2109,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Determines the visibility of the Copy to Clipboard button. By default, the Copy to Clipboard button is displayed in the table toolbar if the selection mode is configured.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2121,7 +2121,7 @@ This setting is defined by the framework.",
     "description": "Defines how the table handles the visible rows. Does not apply to responsive tables. Allowed values are Auto and Fixed.
  - Fixed: The table always has as many rows as defined in the rowCount property.
  - Auto (default): The number of rows is changed by the table automatically. It will then adjust its row count to the space it is allowed to cover (limited by the surrounding container) but it cannot have less than defined in the rowCount property.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2131,7 +2131,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Number of rows to be displayed in the table.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2141,7 +2141,7 @@ This setting is defined by the framework.",
   },
   Object {
     "description": "Defines the page behavior when a new record is created.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2155,7 +2155,7 @@ This setting is defined by the framework.",
 - InlineCreationRows: No create button will be rendered, an empty row is directly given.
 - Inline: The create action leads to a new row at the table (not recommended, use InlineCreationRows instead).
 The default is \\"NewPage\\".",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2165,7 +2165,7 @@ The default is \\"NewPage\\".",
   },
   Object {
     "description": "In case of inline creation mode you can decide if the new row will be created at the end of the table, or direcly after the currently selected table. The default value is \\"true\\".",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2175,7 +2175,7 @@ The default is \\"NewPage\\".",
   },
   Object {
     "description": "Supported starting SAPUI5 version 1.111.0, If set to 'true', the empty rows will be hidden when editing an existing object. Selecting the table's Create button will display the empty rows. The default value is \\"true\\".",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2187,7 +2187,7 @@ The default is \\"NewPage\\".",
     "description": "Defines the personalization mode, currently only effective if variant management on page is either set to Page or Control.
 By default all table settings are enabled. You can change this for the different parts of the table by setting the properties \\"Column\\", \\"Sort\\" and \\"Filter\\" accordingly.
 Omitting a property is treated as false, this allows apps to avoid getting new features like grouping in upcoming releases.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2197,7 +2197,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can add and remove columns to a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2207,7 +2207,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can sort a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2217,7 +2217,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "Defines whether the user can filter data of a given table.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2227,7 +2227,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "With quickVariantSelection, you can switch to multiple views (single table mode). It links to a SelectionVariant (filters) or SelectionPresentationVariant (filters and sorters) that you have added to your annotations.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2237,7 +2237,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "You can hide the table and display only the titles of the tabs. To do so, add the hideTableTitle option and set it to true.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2247,7 +2247,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "You can show the counts of entries of each view. To do so, add the showCounts option and set it to true.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2257,7 +2257,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "List of annotation paths referring to SelectionVariant annotations.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2267,7 +2267,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "enableMassEdit",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2277,7 +2277,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The 'visibleFields' property lets you specify which fields are available in the mass edit dialog.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2287,7 +2287,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   },
   Object {
     "description": "The 'ignoredFields' property lets you hide specific fields from the mass edit dialog, even if these fields are displayed in the table.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2298,7 +2298,7 @@ Omitting a property is treated as false, this allows apps to avoid getting new f
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2313,7 +2313,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2325,7 +2325,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2338,7 +2338,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2353,7 +2353,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2365,7 +2365,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2377,7 +2377,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The header is shown on the table as header, as well as in the add/remove dialog.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2390,7 +2390,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2402,7 +2402,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Defines a target fragment.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2414,7 +2414,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Aligns the header as well as the content horizontally.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2429,7 +2429,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 - Default: it will be shown by default in the table.
 - Adaptation: it will initially not be shown in the table but be available via end user adaptation
 - Hidden: the column is neither available in the table nor in adaptation",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2441,7 +2441,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Defines the position of the column relative to the anchor column.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2453,7 +2453,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "The key of another column to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2465,7 +2465,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   },
   Object {
     "description": "Define the placement, either before or after the anchor column.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
       "table",
@@ -2478,7 +2478,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
   Object {
     "description": "If provided and sorting for the table is enabled, the custom column header can be clicked.
 Once clicked, a list of properties that can be sorted by are displayed.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2491,7 +2491,7 @@ Once clicked, a list of properties that can be sorted by are displayed.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2506,7 +2506,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2518,7 +2518,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2531,7 +2531,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2546,7 +2546,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2558,7 +2558,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2571,7 +2571,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2586,7 +2586,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2598,7 +2598,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2611,7 +2611,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2626,7 +2626,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2638,7 +2638,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2651,7 +2651,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   Object {
     "description": "A string type that represents CSS size values.
 Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2666,7 +2666,7 @@ Refer to https://ui5.sap.com/api/sap.ui.core.CSSSize",
 Default: it will be shown by default in the table.
 Adaptation: it will initially not be shown in the table but be available via end user adaptation.
 Hidden: the column is neither available in the table nor in adaptation.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2678,7 +2678,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "By default, the column width is calculated based on the type of the content. You can include the column header in the width calculation using the widthIncludingColumnHeader setting in the manifest.json.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "_Booking::@com.sap.vocabularies.UI.v1.LineItem",
@@ -2690,7 +2690,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2704,7 +2704,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2718,7 +2718,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2732,7 +2732,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2746,7 +2746,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the position of the action relative to the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2760,7 +2760,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "GroupSection",
       "subsections",
@@ -2774,7 +2774,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "sections",
       "GroupSection",
       "subsections",
@@ -2788,7 +2788,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The path to the XML template containing the section control.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2799,7 +2799,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Use the key of another section as a placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2810,7 +2810,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor section.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2821,7 +2821,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The label of a custom section, preferably as an i18n key.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "sections",
       "GroupSection",
@@ -2832,7 +2832,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The text that is displayed on the button (typically a binding to an i18n entry).",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "footer",
       "actions",
@@ -2842,7 +2842,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Relevant for extension actions; allows the definition of a target action handler.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "footer",
       "actions",
@@ -2852,7 +2852,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action button is visible.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "footer",
       "actions",
@@ -2862,7 +2862,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines if the action is enabled. The default value is true.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "footer",
       "actions",
@@ -2872,7 +2872,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Defines the position of the action relative to the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "TravelObjectPage",
       "footer",
       "actions",
@@ -2882,7 +2882,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "The key of another action to be used as placement anchor.",
-    "id": Array [
+    "functionalityId": Array [
       "footer",
       "actions",
       "CustomFooterAction",
@@ -2892,7 +2892,7 @@ Hidden: the column is neither available in the table nor in adaptation.",
   },
   Object {
     "description": "Define the placement, either before or after the anchor action.",
-    "id": Array [
+    "functionalityId": Array [
       "footer",
       "actions",
       "CustomFooterAction",

--- a/packages/fiori-mcp-server/test/unit/tools/functionalities/controller-extension/index.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/functionalities/controller-extension/index.test.ts
@@ -62,12 +62,12 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.getFunctionalityDetails({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId
             });
             expect(details).toEqual({
                 description:
                     'Add new controller extension by creating javascript or typescript file and updates manifest.json with entry. Controller extensions allow users to extensiate default behaviour with custom controllers code.',
-                id: 'create-controller-extension',
+                functionalityId: 'create-controller-extension',
                 name: 'Add new controller extension by creating javascript or typescript file and updates manifest.json with entry',
                 parameters: [
                     {
@@ -102,7 +102,7 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.getFunctionalityDetails({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId
             });
             expect(details).toEqual({
                 ...CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY,
@@ -119,7 +119,7 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.executeFunctionality({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id,
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageType: 'ListReport',
                     controllerName: 'Dummy'
@@ -158,7 +158,7 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.executeFunctionality({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id,
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'TravelObjectPage',
                     controllerName: 'Dummy'
@@ -198,7 +198,7 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.executeFunctionality({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id,
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'TravelObjectPage',
                     controllerName: 'Dummy'
@@ -227,7 +227,7 @@ describe('create-controller-extension', () => {
             mockSpecificationImport(importProjectMock);
             const details = await createControllerExtensionHandlers.executeFunctionality({
                 appPath: appPath,
-                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.id,
+                functionalityId: CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'TravelObjectPage',
                     controllerName: 'Dummy'

--- a/packages/fiori-mcp-server/test/unit/tools/functionalities/generate-fiori-ui-app/generate-fiori-ui-app.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/functionalities/generate-fiori-ui-app/generate-fiori-ui-app.test.ts
@@ -17,7 +17,7 @@ describe('getFunctionalityDetails', () => {
     test('getFunctionalityDetails', async () => {
         const details = await generateFioriUIAppHandlers.getFunctionalityDetails({
             appPath: 'app1',
-            functionalityId: GENERATE_FIORI_UI_APP.id
+            functionalityId: GENERATE_FIORI_UI_APP.functionalityId
         });
         expect(details).toEqual(GENERATE_FIORI_UI_APP);
     });
@@ -30,7 +30,7 @@ describe('executeFunctionality', () => {
         });
         const result = await generateFioriUIAppHandlers.executeFunctionality({
             appPath: 'app1',
-            functionalityId: GENERATE_FIORI_UI_APP.id,
+            functionalityId: GENERATE_FIORI_UI_APP.functionalityId,
             parameters: {
                 projectPath: join(testOutputDir, 'app1'),
                 appGenConfig: {}
@@ -58,7 +58,7 @@ describe('executeFunctionality', () => {
         });
         const result = await generateFioriUIAppHandlers.executeFunctionality({
             appPath: 'app1',
-            functionalityId: GENERATE_FIORI_UI_APP.id,
+            functionalityId: GENERATE_FIORI_UI_APP.functionalityId,
             parameters: {
                 projectPath: join(testOutputDir, 'app1'),
                 appGenConfig: {}
@@ -87,7 +87,7 @@ describe('executeFunctionality', () => {
         await expect(
             generateFioriUIAppHandlers.executeFunctionality({
                 appPath: '',
-                functionalityId: GENERATE_FIORI_UI_APP.id,
+                functionalityId: GENERATE_FIORI_UI_APP.functionalityId,
                 parameters: {}
             })
         ).rejects.toThrow('Please provide a valid path to the CAP project folder.');
@@ -100,7 +100,7 @@ describe('executeFunctionality', () => {
         await expect(
             generateFioriUIAppHandlers.executeFunctionality({
                 appPath: 'app1',
-                functionalityId: GENERATE_FIORI_UI_APP.id,
+                functionalityId: GENERATE_FIORI_UI_APP.functionalityId,
                 parameters: {
                     projectPath: 'app1',
                     appGenConfig: 'dummy'

--- a/packages/fiori-mcp-server/test/unit/tools/functionalities/page/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-mcp-server/test/unit/tools/functionalities/page/__snapshots__/index.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`add-page getFunctionalityDetails case 2: empty page 1`] = `
 Object {
   "description": "Create new fiori elements page like ListReport, ObjectPage, CustomPage",
-  "id": "add-page",
+  "functionalityId": "add-page",
   "name": "Add new page to application by updating manifest.json",
   "parameters": Array [
     Object {
@@ -44,7 +44,7 @@ Object {
 exports[`add-page getFunctionalityDetails case 3: one or more pages 1`] = `
 Object {
   "description": "Create new fiori elements page like ListReport, ObjectPage, CustomPage",
-  "id": "add-page",
+  "functionalityId": "add-page",
   "name": "Add new page to application by updating manifest.json",
   "parameters": Array [
     Object {
@@ -96,7 +96,7 @@ Object {
 exports[`delete-page getFunctionalityDetails case 2: zero or more pages 1`] = `
 Object {
   "description": "Remove existing fiori elements page from the application",
-  "id": "delete-page",
+  "functionalityId": "delete-page",
   "name": "Delete page from application by updating manifest.json",
   "parameters": Array [
     Object {

--- a/packages/fiori-mcp-server/test/unit/tools/functionalities/page/index.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/functionalities/page/index.test.ts
@@ -70,7 +70,7 @@ describe('add-page', () => {
             const appPath = join(__dirname, 'invalid', 'app', 'path');
             const result = await addPageHandlers.getFunctionalityDetails({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId
             });
             expect(result.name).toBe('Invalid Project Root or Application Path');
             expect(result.description).toContain(
@@ -93,7 +93,7 @@ describe('add-page', () => {
             ]);
             const result = await addPageHandlers.getFunctionalityDetails({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId
             });
             expect(result).toMatchSnapshot();
         });
@@ -107,7 +107,7 @@ describe('add-page', () => {
             ]);
             const result = await addPageHandlers.getFunctionalityDetails({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId
             });
             expect(result).toMatchSnapshot();
         });
@@ -117,7 +117,7 @@ describe('add-page', () => {
             const appPath = join(__dirname, 'invalid', 'app', 'path');
             const result = await addPageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id,
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageType: 'ListReport'
                 }
@@ -143,7 +143,7 @@ describe('add-page', () => {
             ]);
             const result = await addPageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id,
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     entitySet: 'Travels',
                     pageType: 'ListReport'
@@ -173,7 +173,7 @@ describe('add-page', () => {
             ]);
             const result = await addPageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: ADD_PAGE_FUNCTIONALITY.id,
+                functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     parentPage: 'TravelsObjectPage',
                     pageNavigation: 'Expenses',
@@ -199,7 +199,7 @@ describe('add-page', () => {
             await expect(
                 addPageHandlers.executeFunctionality({
                     appPath,
-                    functionalityId: ADD_PAGE_FUNCTIONALITY.id,
+                    functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId,
                     parameters: {}
                 })
             ).rejects.toThrow('Missing or invalid parameter "pageType"');
@@ -210,7 +210,7 @@ describe('add-page', () => {
             await expect(
                 addPageHandlers.executeFunctionality({
                     appPath,
-                    functionalityId: ADD_PAGE_FUNCTIONALITY.id,
+                    functionalityId: ADD_PAGE_FUNCTIONALITY.functionalityId,
                     parameters: {
                         pageType: 'Dummy'
                     }
@@ -226,7 +226,7 @@ describe('delete-page', () => {
             const appPath = join(__dirname, 'invalid', 'app', 'path');
             const result = await deletePageHandlers.getFunctionalityDetails({
                 appPath,
-                functionalityId: DELETE_PAGE_FUNCTIONALITY.id
+                functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId
             });
             expect(result.name).toBe('Invalid Project Root or Application Path');
             expect(result.description).toContain(
@@ -245,7 +245,7 @@ describe('delete-page', () => {
             ]);
             const result = await deletePageHandlers.getFunctionalityDetails({
                 appPath,
-                functionalityId: DELETE_PAGE_FUNCTIONALITY.id
+                functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId
             });
             expect(result).toMatchSnapshot();
         });
@@ -255,7 +255,7 @@ describe('delete-page', () => {
             const appPath = join(__dirname, 'invalid', 'app', 'path');
             const result = await deletePageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: DELETE_PAGE_FUNCTIONALITY.id,
+                functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'dummy'
                 }
@@ -281,7 +281,7 @@ describe('delete-page', () => {
             ]);
             const result = await deletePageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: DELETE_PAGE_FUNCTIONALITY.id,
+                functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'nothing'
                 }
@@ -303,7 +303,7 @@ describe('delete-page', () => {
             ]);
             const result = await deletePageHandlers.executeFunctionality({
                 appPath,
-                functionalityId: DELETE_PAGE_FUNCTIONALITY.id,
+                functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId,
                 parameters: {
                     pageId: 'TravelsList'
                 }
@@ -320,7 +320,7 @@ describe('delete-page', () => {
             await expect(
                 deletePageHandlers.executeFunctionality({
                     appPath,
-                    functionalityId: DELETE_PAGE_FUNCTIONALITY.id,
+                    functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId,
                     parameters: {}
                 })
             ).rejects.toThrow('Missing or invalid parameter "pageId"');
@@ -330,7 +330,7 @@ describe('delete-page', () => {
             await expect(
                 deletePageHandlers.executeFunctionality({
                     appPath,
-                    functionalityId: DELETE_PAGE_FUNCTIONALITY.id,
+                    functionalityId: DELETE_PAGE_FUNCTIONALITY.functionalityId,
                     parameters: {
                         pageId: {}
                     }

--- a/packages/fiori-mcp-server/test/unit/tools/get-functionality-details.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/get-functionality-details.test.ts
@@ -59,7 +59,7 @@ describe('getFunctionalityDetails', () => {
         expect(details).toEqual({
             description:
                 "Change a property. To reset, remove, or restore it to its default value, set the value to null. If the property's description does not specify how to disable the related feature, setting it to null is typically the appropriate way to disable or clear it.",
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             parameters: [
                 {
@@ -90,7 +90,7 @@ describe('getFunctionalityDetails', () => {
         expect(details).toEqual({
             description:
                 "Change a property. To reset, remove, or restore it to its default value, set the value to null. If the property's description does not specify how to disable the related feature, setting it to null is typically the appropriate way to disable or clear it.",
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             pageName: 'TravelObjectPage',
             parameters: [
@@ -114,7 +114,7 @@ describe('getFunctionalityDetails', () => {
         expect(details).toEqual({
             description:
                 "Change a property. To reset, remove, or restore it to its default value, set the value to null. If the property's description does not specify how to disable the related feature, setting it to null is typically the appropriate way to disable or clear it.",
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             pageName: 'TravelObjectPage',
             parameters: [
@@ -168,7 +168,7 @@ describe('getFunctionalityDetails', () => {
         expect(details).toEqual({
             description:
                 "Change a property. To reset, remove, or restore it to its default value, set the value to null. If the property's description does not specify how to disable the related feature, setting it to null is typically the appropriate way to disable or clear it.",
-            id: 'change-property',
+            functionalityId: 'change-property',
             name: 'Change property',
             parameters: [
                 {

--- a/packages/fiori-mcp-server/test/unit/tools/list-functionalities.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/list-functionalities.test.ts
@@ -44,7 +44,7 @@ describe('listFunctionalities', () => {
             appPath
         })) as ListFunctionalitiesOutput;
         expect(functionalities.applicationPath).toEqual(appPath);
-        expect(functionalities.functionalities.map((functionality) => functionality.id)).toEqual([
+        expect(functionalities.functionalities.map((functionality) => functionality.functionalityId)).toEqual([
             'add-page',
             'generate-fiori-ui-app',
             'delete-page',
@@ -69,7 +69,7 @@ describe('listFunctionalities', () => {
         })) as ListFunctionalitiesOutput;
         expect(importProjectMock).toHaveBeenCalledTimes(0);
         expect(functionalities.applicationPath).toEqual(appPath);
-        expect(functionalities.functionalities.map((functionality) => functionality.id)).toEqual([
+        expect(functionalities.functionalities.map((functionality) => functionality.functionalityId)).toEqual([
             'add-page',
             'generate-fiori-ui-app',
             'delete-page',


### PR DESCRIPTION
We noticed that sometimes tools are called with functionality id. As enhancement - we can be more precise and rename property `id` to `functionalityId` for tool `list-functionality` and `get-functionality-details`.