### PR TITLE
feat(serve-static-middleware): make servestatic ignore cachebuster in URLs

### DIFF
--- a/.changeset/flat-suits-allow.md
+++ b/.changeset/flat-suits-allow.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/serve-static-middleware': minor
+---
+
+feat: by default the cache buster part of the URL will be ignored

--- a/packages/serve-static-middleware/README.md
+++ b/packages/serve-static-middleware/README.md
@@ -6,10 +6,13 @@ It can be used either with the `ui5 serve` or the `fiori run` commands.
 
 ## Configuration Options
 
-| Option       | Type | Description |
-| ------------ | ------------- | ----------- |
-| `paths`        | `array`      | List of mount paths and local paths that should be handled by the serve static middleware. |
-| `[option]`    | `string \| number \| boolean`   | Configuration options of [serve-static](https://www.npmjs.com/package/serve-static#options). Excluding `setHeaders`! Alternatively you can add each option on a specific path |
+| Option                        | Type                          | Description                                                                                                                                                                                   |
+|-------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `paths`                       | `array`                       | List of mount paths and local paths that should be handled by the serve static middleware.                                                                                                    |
+| `paths.[serve-static option]` | `string \| number \| boolean` | You can use any configuration options of [serve-static](https://www.npmjs.com/package/serve-static#options). Excluding `setHeaders`! Alternatively you can add each option on a specific path |
+| `paths.path`                  | `string`                      | specific path                                                                                                                                                                                 |
+| `paths.src`                   | `string`                      | specific src                                                                                                                                                                                  |
+| `paths.keepCacheBusterInUrl`  | `boolean`                     | By default the cache buster part of the URL (e.g. `/~6D08668CD2688B304F0130340DE601EA~5/`) is being ignored. This property can be used to keep it part of the serve static path.              |
 
 ## Configuration Examples
 

--- a/packages/serve-static-middleware/README.md
+++ b/packages/serve-static-middleware/README.md
@@ -12,7 +12,7 @@ It can be used either with the `ui5 serve` or the `fiori run` commands.
 | `paths.[serve-static option]` | `string \| number \| boolean` | You can use any configuration options of [serve-static](https://www.npmjs.com/package/serve-static#options). Excluding `setHeaders`! Alternatively you can add each option on a specific path |
 | `paths.path`                  | `string`                      | specific path                                                                                                                                                                                 |
 | `paths.src`                   | `string`                      | specific src                                                                                                                                                                                  |
-| `paths.keepCacheBusterInUrl`  | `boolean`                     | By default the cache buster part of the URL (e.g. `/~6D08668CD2688B304F0130340DE601EA~5/`) is being ignored. This property can be used to keep it part of the serve static path.              |
+| `paths.keepCacheBusterInUrl`  | `boolean`                     | (optional) By default the cache buster part of the URL (e.g. `/~6D08668CD2688B304F0130340DE601EA~5/`) is being ignored. This property can be used to keep it part of the serve static path.   |
 
 ## Configuration Examples
 

--- a/packages/serve-static-middleware/src/base/servestatic.ts
+++ b/packages/serve-static-middleware/src/base/servestatic.ts
@@ -35,15 +35,13 @@ export const serveStaticMiddleware = (
                 serveStaticOptions
             )}`
         );
-        //router.use(pathConfig.path, serveStatic(srcPath, serveStaticOptions));
+
         // Use a custom handler to rewrite the URL before serving the file
         router.use(pathConfig.path, (req, res, next) => {
-            // This is the regex to find and remove the cache-buster segment
             const cacheBusterRegex = /\/~[0-9A-F]{32}~\d+\//;
             if (cacheBusterRegex.test(req.url)) {
                 req.url = req.url.replace(cacheBusterRegex, '/');
             }
-            // After potentially rewriting the URL, pass control to the file server
             fileServer(req, res, next);
         });
     }

--- a/packages/serve-static-middleware/src/base/servestatic.ts
+++ b/packages/serve-static-middleware/src/base/servestatic.ts
@@ -38,7 +38,7 @@ export const serveStaticMiddleware = (
 
         // Use a custom handler to rewrite the URL before serving the file
         router.use(pathConfig.path, (req, res, next) => {
-            if (pathConfig.keepCacheBusterInUrl) {
+            if (!pathConfig.keepCacheBusterInUrl) {
                 const cacheBusterRegex = /\/~[0-9A-F]{32}~\d+\//;
                 if (cacheBusterRegex.test(req.url)) {
                     req.url = req.url.replace(cacheBusterRegex, '/');

--- a/packages/serve-static-middleware/src/base/servestatic.ts
+++ b/packages/serve-static-middleware/src/base/servestatic.ts
@@ -38,9 +38,11 @@ export const serveStaticMiddleware = (
 
         // Use a custom handler to rewrite the URL before serving the file
         router.use(pathConfig.path, (req, res, next) => {
-            const cacheBusterRegex = /\/~[0-9A-F]{32}~\d+\//;
-            if (cacheBusterRegex.test(req.url)) {
-                req.url = req.url.replace(cacheBusterRegex, '/');
+            if (pathConfig.keepCacheBusterInUrl) {
+                const cacheBusterRegex = /\/~[0-9A-F]{32}~\d+\//;
+                if (cacheBusterRegex.test(req.url)) {
+                    req.url = req.url.replace(cacheBusterRegex, '/');
+                }
             }
             fileServer(req, res, next);
         });

--- a/packages/serve-static-middleware/src/base/types.ts
+++ b/packages/serve-static-middleware/src/base/types.ts
@@ -3,6 +3,7 @@ import type { ServeStaticOptions } from 'serve-static';
 export interface PathConfig extends ServeStaticOptions {
     path: string;
     src: string;
+    keepCacheBusterInUrl?: boolean;
 }
 
 export interface ServeStaticPathConfig {

--- a/packages/serve-static-middleware/test/ui5/middleware.test.ts
+++ b/packages/serve-static-middleware/test/ui5/middleware.test.ts
@@ -44,6 +44,7 @@ describe('Start server with serve-static-middleware', () => {
         expect(await server.get(CORE)).toMatchObject({ status: 200 });
         expect(await server.get(SANDBOX)).toMatchObject({ status: 200 });
         expect(await server.get(USERAPI)).toMatchObject({ status: 200 });
+        expect(await server.get(CACHEBUSTER_CORE)).toMatchObject({ status: 200 });
     });
 
     test('fallthrough: false', async () => {
@@ -83,10 +84,17 @@ describe('Start server with serve-static-middleware', () => {
         );
     });
 
-    test('ignore cache buster part of url', async () => {
+    test('keepCacheBusterInUrl (cache buster URL)', async () => {
         const server = await getTestServer({
             paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false, keepCacheBusterInUrl: true }]
         });
-        expect(await server.get(CACHEBUSTER_CORE)).toMatchObject({ status: 200 });
+        expect(await server.get(CACHEBUSTER_CORE)).toMatchObject({ status: 404 });
+    });
+
+    test('keepCacheBusterInUrl (normal URL)', async () => {
+        const server = await getTestServer({
+            paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false, keepCacheBusterInUrl: true }]
+        });
+        expect(await server.get(CORE)).toMatchObject({ status: 200 });
     });
 });

--- a/packages/serve-static-middleware/test/ui5/middleware.test.ts
+++ b/packages/serve-static-middleware/test/ui5/middleware.test.ts
@@ -81,4 +81,11 @@ describe('Start server with serve-static-middleware', () => {
             'No configuration found for the serve-static-middleware'
         );
     });
+
+    test('ignore cachebuster part of url', async () => {
+        const server = await getTestServer({
+            paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false }]
+        } as any);
+        expect(await server.get('/resources/~6D08668CD2688B304F0130340DE601EA~5/sap-ui-core.js')).toMatchObject({ status: 200 });
+    });
 });

--- a/packages/serve-static-middleware/test/ui5/middleware.test.ts
+++ b/packages/serve-static-middleware/test/ui5/middleware.test.ts
@@ -27,6 +27,7 @@ async function getTestServer(configuration: ServeStaticConfig): Promise<any> {
 
 describe('Start server with serve-static-middleware', () => {
     const CORE = '/resources/sap-ui-core.js';
+    const CACHEBUSTER_CORE = '/resources/~6D08668CD2688B304F0130340DE601EA~5/sap-ui-core.js';
     const SANDBOX = '/test-resources/sandbox.js';
     const USERAPI = '/services/userapi/currentUser';
 
@@ -86,6 +87,6 @@ describe('Start server with serve-static-middleware', () => {
         const server = await getTestServer({
             paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false }]
         } as any);
-        expect(await server.get('/resources/~6D08668CD2688B304F0130340DE601EA~5/sap-ui-core.js')).toMatchObject({ status: 200 });
+        expect(await server.get(CACHEBUSTER_CORE)).toMatchObject({ status: 200 });
     });
 });

--- a/packages/serve-static-middleware/test/ui5/middleware.test.ts
+++ b/packages/serve-static-middleware/test/ui5/middleware.test.ts
@@ -37,7 +37,7 @@ describe('Start server with serve-static-middleware', () => {
             { path: '/test-resources', src: join(localUI5Path, 'test-resources') },
             { path: USERAPI, src: 'webapp/mock/user.json', index: false, fallthrough: false, redirect: false }
         ]
-    };
+    } satisfies ServeStaticConfig;
 
     test('serve local UI5', async () => {
         const server = await getTestServer(config as any);
@@ -83,10 +83,10 @@ describe('Start server with serve-static-middleware', () => {
         );
     });
 
-    test('ignore cachebuster part of url', async () => {
+    test('ignore cache buster part of url', async () => {
         const server = await getTestServer({
-            paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false }]
-        } as any);
+            paths: [{ path: '/resources', src: join(localUI5Path, 'resources'), fallthrough: false, keepCacheBusterInUrl: true }]
+        });
         expect(await server.get(CACHEBUSTER_CORE)).toMatchObject({ status: 200 });
     });
 });


### PR DESCRIPTION
Add a new config option `keepCacheBusterInUrl` to the serve-static-middleware to revert the new default that ignores the cache buster part of the URL.