### PR TITLE
feat(mcp-server): enhance list fiori apps tool

### DIFF
--- a/packages/fiori-mcp-server/src/tools/list-fiori-apps.ts
+++ b/packages/fiori-mcp-server/src/tools/list-fiori-apps.ts
@@ -28,7 +28,7 @@ export async function listFioriApps(params: ListFioriAppsInput): Promise<ListFio
                         appPath: app.appRoot,
                         projectPath: app.projectRoot,
                         projectType,
-                        oDataVersion: app.manifest['sap.app']?.dataSources?.mainService?.settings?.odataVersion ?? '4.0'
+                        odataVersion: app.manifest['sap.app']?.dataSources?.mainService?.settings?.odataVersion ?? '4.0'
                     };
                 })
             )) ?? []

--- a/packages/fiori-mcp-server/src/tools/output-schema/list-fiori-apps.json
+++ b/packages/fiori-mcp-server/src/tools/output-schema/list-fiori-apps.json
@@ -25,12 +25,12 @@
                             "enum": ["EDMXBackend", "CAPJava", "CAPNodejs"],
                             "description": "Type of project the application belongs to."
                         },
-                        "oDataVersion": {
+                        "odataVersion": {
                             "type": "string",
                             "description": "OData protocol version used by the application's main service."
                         }
                     },
-                    "required": ["name", "appPath", "projectRoot", "projectType", "oDataVersion"],
+                    "required": ["name", "appPath", "projectPath", "projectType", "odataVersion"],
                     "additionalProperties": false
                 }
             }

--- a/packages/fiori-mcp-server/src/tools/output-schema/list-fiori-apps.json
+++ b/packages/fiori-mcp-server/src/tools/output-schema/list-fiori-apps.json
@@ -1,33 +1,41 @@
 {
-  "type": "object",
-  "properties": {
     "type": "object",
     "properties": {
-      "applications": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "path": {
-              "type": "string"
-            },
-            "type": {
-              "type": "string",
-              "enum": ["list-report", "freestyle", "analytical", "overview-page"]
-            },
-            "version": {
-              "type": "string"
+        "type": "object",
+        "properties": {
+            "applications": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Fiori application. Usually derived from the `sap.app/id` field in the application's manifest.json."
+                        },
+                        "appPath": {
+                            "type": "string",
+                            "description": "Absolute path to the Fiori application's root directory."
+                        },
+                        "projectPath": {
+                            "type": "string",
+                            "description": "Absolute path to the root directory of the project containing this Fiori application. For EDMXBackend (standalone) projects, this is the same as `appPath`. For CAP projects, this points to the CAP project root, which may contain multiple Fiori applications."
+                        },
+                        "projectType": {
+                            "type": "string",
+                            "enum": ["EDMXBackend", "CAPJava", "CAPNodejs"],
+                            "description": "Type of project the application belongs to."
+                        },
+                        "oDataVersion": {
+                            "type": "string",
+                            "description": "OData protocol version used by the application's main service."
+                        }
+                    },
+                    "required": ["name", "appPath", "projectRoot", "projectType", "oDataVersion"],
+                    "additionalProperties": false
+                }
             }
-          },
-          "required": ["name", "path", "type", "version"],
-          "additionalProperties": false
-        }
-      }
-    },
-    "required": ["applications"],
-    "additionalProperties": false
-  }
+        },
+        "required": ["applications"],
+        "additionalProperties": false
+    }
 }

--- a/packages/fiori-mcp-server/src/types.ts
+++ b/packages/fiori-mcp-server/src/types.ts
@@ -116,7 +116,7 @@ export interface FioriApp {
     /** Type of the Fiori project */
     projectType: ProjectType;
     /** OData version of the Fiori application */
-    oDataVersion: string;
+    odataVersion: string;
 }
 
 /**

--- a/packages/fiori-mcp-server/src/types.ts
+++ b/packages/fiori-mcp-server/src/types.ts
@@ -1,4 +1,4 @@
-import type { ApplicationAccess } from '@sap-ux/project-access';
+import type { ApplicationAccess, ProjectType } from '@sap-ux/project-access';
 
 /**
  * Types for Fiori functionality
@@ -110,11 +110,13 @@ export interface FioriApp {
     /** Name of the Fiori application */
     name: string;
     /** Path to the Fiori application */
-    path: string;
-    /** Type of the Fiori application */
-    type: 'list-report' | 'freestyle' | 'analytical' | 'overview-page';
-    /** Version of the Fiori application */
-    version: string;
+    appPath: string;
+    /** Path to project */
+    projectPath: string;
+    /** Type of the Fiori project */
+    projectType: ProjectType;
+    /** OData version of the Fiori application */
+    oDataVersion: string;
 }
 
 /**

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -53,15 +53,17 @@ describe('FioriFunctionalityServer', () => {
                 applications: [
                     {
                         name: 'app1',
-                        path: 'appPath1',
-                        type: 'list-report',
-                        version: '4.0'
+                        appPath: 'appPath1',
+                        projectType: 'EDMXBackend',
+                        projectPath: 'appPath1',
+                        oDataVersion: '4.0'
                     },
                     {
                         name: 'app2',
-                        path: 'appPath2',
-                        type: 'list-report',
-                        version: '4.0'
+                        appPath: 'appPath2',
+                        projectType: 'EDMXBackend',
+                        projectPath: 'appPath2',
+                        oDataVersion: '4.0'
                     }
                 ]
             });
@@ -82,15 +84,17 @@ describe('FioriFunctionalityServer', () => {
                 applications: [
                     {
                         name: 'app1',
-                        path: 'appPath1',
-                        type: 'list-report',
-                        version: '4.0'
+                        appPath: 'appPath1',
+                        projectType: 'EDMXBackend',
+                        projectPath: 'appPath1',
+                        oDataVersion: '4.0'
                     },
                     {
                         name: 'app2',
-                        path: 'appPath2',
-                        type: 'list-report',
-                        version: '4.0'
+                        appPath: 'appPath2',
+                        projectType: 'EDMXBackend',
+                        projectPath: 'appPath2',
+                        oDataVersion: '4.0'
                     }
                 ]
             });

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -56,14 +56,14 @@ describe('FioriFunctionalityServer', () => {
                         appPath: 'appPath1',
                         projectType: 'EDMXBackend',
                         projectPath: 'appPath1',
-                        oDataVersion: '4.0'
+                        odataVersion: '4.0'
                     },
                     {
                         name: 'app2',
                         appPath: 'appPath2',
                         projectType: 'EDMXBackend',
                         projectPath: 'appPath2',
-                        oDataVersion: '4.0'
+                        odataVersion: '4.0'
                     }
                 ]
             });
@@ -87,14 +87,14 @@ describe('FioriFunctionalityServer', () => {
                         appPath: 'appPath1',
                         projectType: 'EDMXBackend',
                         projectPath: 'appPath1',
-                        oDataVersion: '4.0'
+                        odataVersion: '4.0'
                     },
                     {
                         name: 'app2',
                         appPath: 'appPath2',
                         projectType: 'EDMXBackend',
                         projectPath: 'appPath2',
-                        oDataVersion: '4.0'
+                        odataVersion: '4.0'
                     }
                 ]
             });

--- a/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
@@ -136,4 +136,56 @@ describe('listFioriApps', () => {
             ]
         });
     });
+
+    test('call with CAP project', async () => {
+        const projectRoot = 'dummyRoot';
+        const appRoot = 'dummyAppRoot';
+        const appRoot2 = 'dummyAppRoot2';
+        getProjectTypeSpy.mockResolvedValue('CAPJava');
+        findFioriArtifactsSpy.mockReturnValueOnce(
+            Promise.resolve({
+                applications: [
+                    {
+                        appRoot,
+                        projectRoot,
+                        manifest: {
+                            'sap.app': {
+                                id: 'dummyApp1'
+                            }
+                        }
+                    },
+                    {
+                        appRoot: appRoot2,
+                        projectRoot,
+                        manifest: {
+                            'sap.app': {
+                                id: 'dummyApp2'
+                            }
+                        }
+                    }
+                ] as unknown as projectAccess.AllAppResults[]
+            })
+        );
+        const apps = await listFioriApps({
+            searchPath
+        });
+        expect(apps).toEqual({
+            applications: [
+                {
+                    name: 'dummyApp1',
+                    appPath: appRoot,
+                    projectPath: projectRoot,
+                    projectType: 'CAPJava',
+                    odataVersion: '4.0'
+                },
+                {
+                    name: 'dummyApp2',
+                    appPath: appRoot2,
+                    projectPath: projectRoot,
+                    projectType: 'CAPJava',
+                    odataVersion: '4.0'
+                }
+            ]
+        });
+    });
 });

--- a/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
@@ -41,7 +41,7 @@ describe('listFioriApps', () => {
                     appPath: appRoot,
                     projectPath: appRoot,
                     projectType: 'EDMXBackend',
-                    oDataVersion: '4.0'
+                    odataVersion: '4.0'
                 }
             ]
         });
@@ -84,14 +84,14 @@ describe('listFioriApps', () => {
                     appPath: appRoot,
                     projectPath: appRoot,
                     projectType: 'EDMXBackend',
-                    oDataVersion: '4.0'
+                    odataVersion: '4.0'
                 },
                 {
                     name: 'dummyApp2',
                     appPath: appRoot2,
                     projectPath: appRoot2,
                     projectType: 'EDMXBackend',
-                    oDataVersion: '4.0'
+                    odataVersion: '4.0'
                 }
             ]
         });
@@ -131,7 +131,7 @@ describe('listFioriApps', () => {
                     appPath: appRoot,
                     projectPath: appRoot,
                     projectType: 'EDMXBackend',
-                    oDataVersion: '2.0'
+                    odataVersion: '2.0'
                 }
             ]
         });

--- a/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/list-fiori-apps.test.ts
@@ -11,9 +11,11 @@ jest.mock('@sap-ux/project-access', () => ({
 describe('listFioriApps', () => {
     const searchPath = ['testApplicationPath'];
     let findFioriArtifactsSpy: jest.SpyInstance;
+    let getProjectTypeSpy: jest.SpyInstance;
 
     beforeEach(async () => {
         findFioriArtifactsSpy = jest.spyOn(projectAccess, 'findFioriArtifacts');
+        getProjectTypeSpy = jest.spyOn(projectAccess, 'getProjectType').mockResolvedValue('EDMXBackend');
     });
 
     test('call with valid app and empty manifest', async () => {
@@ -23,6 +25,7 @@ describe('listFioriApps', () => {
                 applications: [
                     {
                         appRoot,
+                        projectRoot: appRoot,
                         manifest: {}
                     }
                 ] as unknown as projectAccess.AllAppResults[]
@@ -32,7 +35,15 @@ describe('listFioriApps', () => {
             searchPath
         });
         expect(apps).toEqual({
-            applications: [{ name: 'dummyAppRoot', path: appRoot, type: 'list-report', version: '4.0' }]
+            applications: [
+                {
+                    name: 'dummyAppRoot',
+                    appPath: appRoot,
+                    projectPath: appRoot,
+                    projectType: 'EDMXBackend',
+                    oDataVersion: '4.0'
+                }
+            ]
         });
     });
 
@@ -44,6 +55,7 @@ describe('listFioriApps', () => {
                 applications: [
                     {
                         appRoot,
+                        projectRoot: appRoot,
                         manifest: {
                             'sap.app': {
                                 id: 'dummyApp1'
@@ -52,6 +64,7 @@ describe('listFioriApps', () => {
                     },
                     {
                         appRoot: appRoot2,
+                        projectRoot: appRoot2,
                         manifest: {
                             'sap.app': {
                                 id: 'dummyApp2'
@@ -68,15 +81,17 @@ describe('listFioriApps', () => {
             applications: [
                 {
                     name: 'dummyApp1',
-                    path: appRoot,
-                    type: 'list-report',
-                    version: '4.0'
+                    appPath: appRoot,
+                    projectPath: appRoot,
+                    projectType: 'EDMXBackend',
+                    oDataVersion: '4.0'
                 },
                 {
                     name: 'dummyApp2',
-                    path: appRoot2,
-                    type: 'list-report',
-                    version: '4.0'
+                    appPath: appRoot2,
+                    projectPath: appRoot2,
+                    projectType: 'EDMXBackend',
+                    oDataVersion: '4.0'
                 }
             ]
         });
@@ -89,6 +104,7 @@ describe('listFioriApps', () => {
                 applications: [
                     {
                         appRoot,
+                        projectRoot: appRoot,
                         manifest: {
                             'sap.app': {
                                 id: 'dummyAppId',
@@ -109,7 +125,15 @@ describe('listFioriApps', () => {
             searchPath
         });
         expect(apps).toEqual({
-            applications: [{ name: 'dummyAppId', path: appRoot, type: 'list-report', version: '2.0' }]
+            applications: [
+                {
+                    name: 'dummyAppId',
+                    appPath: appRoot,
+                    projectPath: appRoot,
+                    projectType: 'EDMXBackend',
+                    oDataVersion: '2.0'
+                }
+            ]
         });
     });
 });


### PR DESCRIPTION
enhance output of `list-fiori-apps` tool:
1. Rename `path` -> `appPath` -> in all tools inputs `appPath` name is used;
2. Add `projectPath` property
3. Delete `type` property
4. Add `projectType` property - return if it is CAP or EDMX project
5. rename `version` to `oDataVersion`
6. update output schema based on changes for `list-fiori-apps` output intefrace 