### PR TITLE
fix(abap-deploy-config-inquirer): adjust deployment message

### DIFF
--- a/.changeset/large-tips-hang.md
+++ b/.changeset/large-tips-hang.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+Adjust the deployment host info message.

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/abap-target.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/abap-target.ts
@@ -63,7 +63,7 @@ function getDestinationPrompt(
                 if (destinations && destination && isOnPremiseDestination(destinations[destination])) {
                     additionalMessage = {
                         message: t('warnings.virtualHost'),
-                        severity: Severity.warning
+                        severity: Severity.information
                     };
                 }
                 return additionalMessage;

--- a/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
+++ b/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
@@ -108,7 +108,7 @@
         "transportConfigFailure": "Cannot retrieve the transport configuration from the backend. You can still proceed with adding a deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
         "noTransportReqs": "There are no transport requests for the supplied package. You can choose to create a new one now or during deployment.",
         "noExistingTransportReqList": "The transport request list cannot be fetched. Please enter the transport request manually.",
-        "virtualHost": "As the destination is using a virtual host, when viewing your deployed application in the browser, replace the host URL with the internal host that is configured with your SAP Cloud Connector.",
+        "virtualHost": "The destination uses a virtual host. When viewing your deployed application in the browser, replace the host URL with the internal host that is configured with your SAP Cloud Connector.",
         "allowingUnauthorizedCertsNode": "Setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0` makes TLS connections and HTTPS requests insecure by disabling certificate verification. It is important to understand the security risks when using this setting.",
         "certificateError": "A certificate error occurred when connecting to the host: {{-url}}. Certificate error: {{error}}."
     },

--- a/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
+++ b/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
@@ -108,7 +108,7 @@
         "transportConfigFailure": "Cannot retrieve the transport configuration from the backend. You can still proceed with adding deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
         "noTransportReqs": "There are no transport requests for the supplied package. You can choose to create a new one now or during deployment.",
         "noExistingTransportReqList": "The transport request list cannot be fetched. Please enter the transport request manually.",
-        "virtualHost": "The destination is using a virtual host. You need to replace the host in the URL with the internal host that is configured with your SAP Cloud Connector when viewing your deployed application.",
+        "virtualHost": "The destination is using a virtual host. Consider replacing the host URL with the internal host that is configured with your SAP Cloud Connector when viewing your deployed application.",
         "allowingUnauthorizedCertsNode": "Setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0` makes TLS connections and HTTPS requests insecure by disabling certificate verification. It is important to understand the security risks when using this setting.",
         "certificateError": "A certificate error occurred when connecting to the host: {{-url}}. Certificate error: {{error}}."
     },

--- a/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
+++ b/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
@@ -105,10 +105,10 @@
     "warnings": {
         "packageNotFound": "The package list cannot be fetched. Please enter the package manually.",
         "providePackage": "Provide a package.",
-        "transportConfigFailure": "Cannot retrieve the transport configuration from the backend. You can still proceed with adding deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
+        "transportConfigFailure": "Cannot retrieve the transport configuration from the backend. You can still proceed with adding a deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
         "noTransportReqs": "There are no transport requests for the supplied package. You can choose to create a new one now or during deployment.",
         "noExistingTransportReqList": "The transport request list cannot be fetched. Please enter the transport request manually.",
-        "virtualHost": "The destination is using a virtual host. Consider replacing the host URL with the internal host that is configured with your SAP Cloud Connector when viewing your deployed application.",
+        "virtualHost": "As the destination is using a virtual host, when viewing your deployed application in the browser, replace the host URL with the internal host that is configured with your SAP Cloud Connector.",
         "allowingUnauthorizedCertsNode": "Setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable to `0` makes TLS connections and HTTPS requests insecure by disabling certificate verification. It is important to understand the security risks when using this setting.",
         "certificateError": "A certificate error occurred when connecting to the host: {{-url}}. Certificate error: {{error}}."
     },

--- a/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
+++ b/packages/abap-deploy-config-inquirer/src/translations/abap-deploy-config-inquirer.i18n.json
@@ -105,7 +105,7 @@
     "warnings": {
         "packageNotFound": "The package list cannot be fetched. Please enter the package manually.",
         "providePackage": "Provide a package.",
-        "transportConfigFailure": "Cannot retrieve the transport configuration from the backend. You can still proceed with adding a deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
+        "transportConfigFailure": "Cannot retrieve the transport configuration from the ABAP environment. You can still proceed with adding a deployment configuration by manually providing the package and transport request. \nFor more information on this error, please see Guided Answers {{-helpLink}}.",
         "noTransportReqs": "There are no transport requests for the supplied package. You can choose to create a new one now or during deployment.",
         "noExistingTransportReqList": "The transport request list cannot be fetched. Please enter the transport request manually.",
         "virtualHost": "The destination uses a virtual host. When viewing your deployed application in the browser, replace the host URL with the internal host that is configured with your SAP Cloud Connector.",

--- a/packages/abap-deploy-config-inquirer/test/prompts/questions/abap-target.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/questions/abap-target.test.ts
@@ -153,7 +153,7 @@ describe('getAbapTargetPrompts', () => {
             expect(await (destPrompt.validate as Function)()).toEqual(true);
             expect(((destPrompt as ListQuestion).additionalMessages as Function)('mockDestination')).toStrictEqual({
                 message: t('warnings.virtualHost'),
-                severity: Severity.warning
+                severity: Severity.information
             });
             expect(((destPrompt as ListQuestion).choices as Function)()).toMatchInlineSnapshot(`
                 Array [


### PR DESCRIPTION
Related to internal issue 35496

Adjust the message indicating to the user, the host being referenced is a virtual host and shouldn't prevent them from continuing on with the wizard.

