### PR TITLE
fix: Deploy Config generator does not allow package with CloudReady and OnPremise project types

### DIFF
--- a/.changeset/itchy-crabs-bake.md
+++ b/.changeset/itchy-crabs-bake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+fix: Deploy Config generator does not allow package with CloudReady and OnPremise project types

--- a/.changeset/itchy-crabs-bake.md
+++ b/.changeset/itchy-crabs-bake.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux/abap-deploy-config-inquirer': patch
+'@sap-ux/adp-tooling': patch
 ---
 
 fix: Deploy Config generator does not allow package with CloudReady and OnPremise project types

--- a/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/validators.ts
@@ -660,9 +660,12 @@ async function validatePackageType(input: string, backendTarget?: BackendTarget)
         return true;
     }
 
-    const systemInfo = systemInfoResult.systemInfo;
-    const isValidPackageType =
-        systemInfo?.adaptationProjectTypes?.length === 1 && systemInfo?.adaptationProjectTypes[0] === packageType;
+    const types = systemInfoResult.systemInfo?.adaptationProjectTypes;
+    if (types && types?.length > 1) {
+        return true;
+    }
+
+    const isValidPackageType = types?.length === 1 && types[0] === packageType;
 
     return isValidPackageType ? true : errorMsg;
 }

--- a/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/validators.test.ts
@@ -565,6 +565,20 @@ describe('Test validators', () => {
             expect(result).toBe(true);
         });
 
+        it('should return true when there are more than one project type for a package', async () => {
+            jest.spyOn(serviceProviderUtils, 'getSystemInfo').mockResolvedValueOnce({
+                apiExist: true,
+                systemInfo: {
+                    adaptationProjectTypes: [AdaptationProjectType.CLOUD_READY, AdaptationProjectType.ON_PREMISE],
+                    activeLanguages: []
+                }
+            });
+            const result = await validatePackage('ZPACKAGE', previousAnswers, {
+                additionalValidation: { shouldValidatePackageType: true }
+            });
+            expect(result).toBe(true);
+        });
+
         it('should return true when package base validation passes and there are no additional validation', async () => {
             const result = await validatePackage('ZPACKAGE', previousAnswers);
             expect(result).toBe(true);

--- a/packages/adp-tooling/src/base/constants/index.ts
+++ b/packages/adp-tooling/src/base/constants/index.ts
@@ -17,7 +17,6 @@ export const BASE_I18N_DESCRIPTION =
 export const S4HANA_APPS_PARAMS = {
     'sap.app/type': 'application',
     'sap.fiori/cloudDevAdaptationStatus': 'released',
-    'fileType': 'appdescr',
     'fields':
         'sap.app/id,repoName,sap.fiori/cloudDevAdaptationStatus,sap.app/ach,sap.fiori/registrationIds,sap.app/title,url,fileType'
 };


### PR DESCRIPTION
Fix for #3594.
- Adds a check when the package has two project types. Then, we allow the user to continue with deployment.

Also,
- Removes this temporary fix, hiding application variants from the application list. Due to an issue in the App Index API (which is now fixed), application variants are listed as available for the Adaptation Project. This will cause issues if users select such an application variant.