### PR TITLE
fix: add missing referential constraints

### DIFF
--- a/packages/fiori-annotation-api/src/avt/metadata.ts
+++ b/packages/fiori-annotation-api/src/avt/metadata.ts
@@ -209,7 +209,7 @@ class MetadataConverter {
                         isCollection: !!element.isCollectionValued,
                         containsTarget: false,
                         partner: '',
-                        referentialConstraint: []
+                        referentialConstraint: subElement.referentialConstraints ?? []
                     };
                     complexTypeNavProperties.push(navProp);
                 }
@@ -282,7 +282,7 @@ class MetadataConverter {
                 isCollection: !!element.isCollectionValued,
                 containsTarget: false,
                 partner: '',
-                referentialConstraint: []
+                referentialConstraint: element.referentialConstraints ?? []
             };
             navigationProperties.push(property);
         }

--- a/packages/fiori-annotation-api/test/unit/avt/__snapshots__/metadata.test.ts.snap
+++ b/packages/fiori-annotation-api/test/unit/avt/__snapshots__/metadata.test.ts.snap
@@ -1225,7 +1225,14 @@ Object {
           "isCollection": false,
           "name": "category",
           "partner": "",
-          "referentialConstraint": Array [],
+          "referentialConstraint": Array [
+            Object {
+              "sourceProperty": "category_code",
+              "sourceTypeName": "IncidentService.Incidents",
+              "targetProperty": "code",
+              "targetTypeName": "IncidentService.Category",
+            },
+          ],
           "targetTypeName": "IncidentService.Category",
         },
       ],
@@ -1611,7 +1618,14 @@ Object {
           "isCollection": false,
           "name": "category",
           "partner": "",
-          "referentialConstraint": Array [],
+          "referentialConstraint": Array [
+            Object {
+              "sourceProperty": "category_code",
+              "sourceTypeName": "IncidentService.Incidents",
+              "targetProperty": "code",
+              "targetTypeName": "IncidentService.Category",
+            },
+          ],
           "targetTypeName": "IncidentService.Category",
         },
       ],

--- a/packages/odata-annotation-core-types/src/edm.ts
+++ b/packages/odata-annotation-core-types/src/edm.ts
@@ -2,7 +2,10 @@ export const enum Edm {
     Action = 'Action',
     ActionImport = 'ActionImport',
     Add = 'Add',
-    Alias = 'Alias', // as attribute name only
+    /**
+     * as attribute name only
+     */
+    Alias = 'Alias',
     And = 'And',
     Annotation = 'Annotation',
     Annotations = 'Annotations',
@@ -49,8 +52,14 @@ export const enum Edm {
     Member = 'Member',
     ModelElementPath = 'ModelElementPath',
     Mul = 'Mul',
-    Name = 'Name', // as attribute name only
-    Namespace = 'Namespace', // as attribute name only
+    /**
+     * as attribute name only
+     */
+    Name = 'Name',
+    /**
+     * as attribute name only
+     */
+    Namespace = 'Namespace',
     NavigationProperty = 'NavigationProperty',
     NavigationPropertyPath = 'NavigationPropertyPath',
     Ne = 'Ne',
@@ -64,19 +73,32 @@ export const enum Edm {
     PropertyPath = 'PropertyPath',
     PropertyValue = 'PropertyValue',
     Or = 'Or',
-    Qualifier = 'Qualifier', // as attribute name only
+    /**
+     * as attribute name only
+     */
+    Qualifier = 'Qualifier',
     Record = 'Record',
     Reference = 'Reference',
     ReferentialConstraint = 'ReferentialConstraint',
+    /**
+     * as attribute name only
+     */
+    ReferencedProperty = 'ReferencedProperty',
     ReturnType = 'ReturnType',
     Schema = 'Schema',
     Singleton = 'Singleton',
     String = 'String',
     Sub = 'Sub',
-    Target = 'Target', // as attribute name only
+    /**
+     * as attribute name only
+     */
+    Target = 'Target',
     Term = 'Term',
     TimeOfDay = 'TimeOfDay',
-    Type = 'Type', // as attribute name only
+    /**
+     * as attribute name only
+     */
+    Type = 'Type',
     TypeDefinition = 'TypeDefinition',
     UrlRef = 'UrlRef'
 }

--- a/packages/odata-annotation-core-types/src/index.ts
+++ b/packages/odata-annotation-core-types/src/index.ts
@@ -15,7 +15,8 @@ export {
     EnumValue,
     MetadataElementVisitor,
     MetadataElement,
-    MetadataElementProperties
+    MetadataElementProperties,
+    ReferentialConstraint
 } from './types';
 
 export { Constraints, Facets } from './types/vocabularies';

--- a/packages/odata-annotation-core-types/src/types/metadata.ts
+++ b/packages/odata-annotation-core-types/src/types/metadata.ts
@@ -24,6 +24,13 @@ export interface EnumValue {
     value: unknown;
 }
 
+export interface ReferentialConstraint {
+    sourceTypeName: FullyQualifiedName;
+    sourceProperty: string;
+    targetTypeName: FullyQualifiedName;
+    targetProperty: string;
+}
+
 /**
  * Properties of a metadata element
  * e.g. for reuse in representation of metadata file content
@@ -89,6 +96,10 @@ export interface MetadataElementProperties {
     keys?: ElementName[];
 
     targetKinds: TargetKind[];
+    /**
+     * Only relevant for NavigationProperty kind
+     */
+    referentialConstraints?: ReferentialConstraint[];
 }
 
 /**

--- a/packages/xml-odata-annotation-converter/test/parser/metadata.test.ts
+++ b/packages/xml-odata-annotation-converter/test/parser/metadata.test.ts
@@ -265,6 +265,7 @@ describe('parse', () => {
                         },
                         "name": "DEPARTMENT_2_TEAMS",
                         "path": "com.sap.gateway.default.iwbep.tea_busi.v0001.Department/DEPARTMENT_2_TEAMS",
+                        "referentialConstraints": Array [],
                         "structuredType": "com.sap.gateway.default.iwbep.tea_busi.v0001.TEAM",
                         "targetKinds": Array [
                           "NavigationProperty",
@@ -548,7 +549,66 @@ describe('parse', () => {
                   },
                   "name": "to_Currency",
                   "path": "Z2SEPMRA_C_PD_PRODUCT_CDS.Z4SEPMRA_C_PD_PRODUCTSALESDATAType/to_Currency",
+                  "referentialConstraints": Array [],
                   "structuredType": "Z2SEPMRA_C_PD_PRODUCT_CDS.I_CurrencyType",
+                  "targetKinds": Array [
+                    "NavigationProperty",
+                  ],
+                }
+            `);
+        });
+
+        test('navigation property with constraint', () => {
+            const result = parseWithMarkup(
+                `<EntityType Name="BookingsType">
+                <Key>
+                    <PropertyRef Name="UUID"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="UUID" Type="Edm.Guid" Nullable="false"/>
+                <Property Name="ParentUUID" Type="Edm.Guid" Nullable="false"/>
+                <NavigationProperty Name="_Travels" Type="Z2SEPMRA_C_PD_PRODUCT_CDS.TravelsType" Nullable="false" Partner="_Bookings">
+                    <ReferentialConstraint Property="ParentUUID" ReferencedProperty="UUID"/>
+                </NavigationProperty>
+            </EntityType>`
+            );
+            expect(
+                result
+                    .find((element) => element.name === 'Z2SEPMRA_C_PD_PRODUCT_CDS.BookingsType')
+                    ?.content.find((element) => element.name === '_Travels')
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "content": Array [],
+                  "edmPrimitiveType": "Z2SEPMRA_C_PD_PRODUCT_CDS.TravelsType",
+                  "isAnnotatable": true,
+                  "isCollectionValued": false,
+                  "isComplexType": false,
+                  "isEntityType": true,
+                  "kind": "NavigationProperty",
+                  "location": Object {
+                    "range": Object {
+                      "end": Object {
+                        "character": 37,
+                        "line": 13,
+                      },
+                      "start": Object {
+                        "character": 16,
+                        "line": 11,
+                      },
+                    },
+                    "uri": "file://annotations.xml",
+                  },
+                  "name": "_Travels",
+                  "path": "Z2SEPMRA_C_PD_PRODUCT_CDS.BookingsType/_Travels",
+                  "referentialConstraints": Array [
+                    Object {
+                      "sourceProperty": "ParentUUID",
+                      "sourceTypeName": "Z2SEPMRA_C_PD_PRODUCT_CDS.BookingsType",
+                      "targetProperty": "UUID",
+                      "targetTypeName": "Z2SEPMRA_C_PD_PRODUCT_CDS.TravelsType",
+                    },
+                  ],
+                  "structuredType": "Z2SEPMRA_C_PD_PRODUCT_CDS.TravelsType",
                   "targetKinds": Array [
                     "NavigationProperty",
                   ],


### PR DESCRIPTION
Added missing referential constraints for navigation properties in `MetadataElement` interface.
Added missing referential constraints when converting to AVT types in Fiori Annotation API.