### PR TITLE
fix(adp)(vscode): SAP Fiori Launchpad Configuration step appears multiple times.

### DIFF
--- a/.changeset/thick-yaks-juggle.md
+++ b/.changeset/thick-yaks-juggle.md
@@ -1,0 +1,7 @@
+---
+'@sap-ux/adp-flp-config-sub-generator': patch
+'@sap-ux/generator-adp': patch
+'@sap-ux/adp-tooling': patch
+---
+
+fix(adp)(vscode) Add notion for a stable id for a Yeoman wizard page. When we add/remove pages we filter them by stable id not the localizable name attribute which can have different values for the same page. This can happen if the name is localized with a parameter.

--- a/packages/adp-flp-config-sub-generator/src/app/index.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/index.ts
@@ -47,7 +47,7 @@ import type { AbapTarget, UrlAbapTarget } from '@sap-ux/system-access';
 import { isAppStudio } from '@sap-ux/btp-utils';
 import type { ManifestNamespace, UI5FlexLayer } from '@sap-ux/project-access';
 import { initAppWizardCache, addToCache, getFromCache, deleteCache } from '../utils/appWizardCache';
-import { wizardPageFactory } from './steps';
+import { flpPageFactory } from './steps';
 
 /**
  * Generator for adding a FLP configuration to an adaptation project.
@@ -221,7 +221,7 @@ export default class AdpFlpConfigGenerator extends Generator {
         }
 
         this.prompts.splice(0, 0, [
-            wizardPageFactory.create({
+            flpPageFactory.create({
                 localId: 'flpCredentials',
                 name: t('yuiNavSteps.flpCredentialsName'),
                 description: t('yuiNavSteps.flpCredentialsDesc', { system: systemName })
@@ -262,7 +262,7 @@ export default class AdpFlpConfigGenerator extends Generator {
         // if launched as a sub-generator, the navigation steps will be set by the parent generator
         if (!this.launchAsSubGen) {
             this.prompts.splice(0, 0, [
-                wizardPageFactory.create({
+                flpPageFactory.create({
                     localId: 'flpConfig',
                     name: t('yuiNavSteps.flpConfigName', { projectName: path.basename(this.projectRootPath) }),
                     description: ''
@@ -389,7 +389,7 @@ export default class AdpFlpConfigGenerator extends Generator {
         }
         const promptsIndex = this.prompts.size() === 1 ? 0 : 1;
         this.prompts.splice(promptsIndex, 0, [
-            wizardPageFactory.create({
+            flpPageFactory.create({
                 localId: 'tileSettings',
                 name: t('yuiNavSteps.tileSettingsName', {
                     projectName: path.basename(this.projectRootPath)

--- a/packages/adp-flp-config-sub-generator/src/app/index.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/index.ts
@@ -47,6 +47,8 @@ import type { AbapTarget, UrlAbapTarget } from '@sap-ux/system-access';
 import { isAppStudio } from '@sap-ux/btp-utils';
 import type { ManifestNamespace, UI5FlexLayer } from '@sap-ux/project-access';
 import { initAppWizardCache, addToCache, getFromCache, deleteCache } from '../utils/appWizardCache';
+import { wizardPageFactory } from './steps';
+
 /**
  * Generator for adding a FLP configuration to an adaptation project.
  *
@@ -219,10 +221,11 @@ export default class AdpFlpConfigGenerator extends Generator {
         }
 
         this.prompts.splice(0, 0, [
-            {
+            wizardPageFactory.create({
+                localId: 'flpCredentials',
                 name: t('yuiNavSteps.flpCredentialsName'),
                 description: t('yuiNavSteps.flpCredentialsDesc', { system: systemName })
-            }
+            })
         ]);
         await this.prompt(prompts);
     }
@@ -259,10 +262,11 @@ export default class AdpFlpConfigGenerator extends Generator {
         // if launched as a sub-generator, the navigation steps will be set by the parent generator
         if (!this.launchAsSubGen) {
             this.prompts.splice(0, 0, [
-                {
+                wizardPageFactory.create({
+                    localId: 'flpConfig',
                     name: t('yuiNavSteps.flpConfigName', { projectName: path.basename(this.projectRootPath) }),
                     description: ''
-                }
+                })
             ]);
         }
     }
@@ -385,12 +389,13 @@ export default class AdpFlpConfigGenerator extends Generator {
         }
         const promptsIndex = this.prompts.size() === 1 ? 0 : 1;
         this.prompts.splice(promptsIndex, 0, [
-            {
+            wizardPageFactory.create({
+                localId: 'tileSettings',
                 name: t('yuiNavSteps.tileSettingsName', {
                     projectName: path.basename(this.projectRootPath)
                 }),
                 description: ''
-            }
+            })
         ]);
     }
 

--- a/packages/adp-flp-config-sub-generator/src/app/steps.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/steps.ts
@@ -1,0 +1,5 @@
+import { WizardPageFactory } from '@sap-ux/adp-tooling';
+
+type PageLocalId = 'flpCredentials' | 'flpConfig' | 'tileSettings';
+
+export const wizardPageFactory = new WizardPageFactory<PageLocalId>('@sap-ux/adp-flp-config-sub-generator');

--- a/packages/adp-flp-config-sub-generator/src/app/steps.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/steps.ts
@@ -1,5 +1,5 @@
 import { WizardPageFactory } from '@sap-ux/adp-tooling';
 
-type PageLocalId = 'flpCredentials' | 'flpConfig' | 'tileSettings';
+type FlpPageLocalId = 'flpCredentials' | 'flpConfig' | 'tileSettings';
 
-export const wizardPageFactory = new WizardPageFactory<PageLocalId>('@sap-ux/adp-flp-config-sub-generator');
+export const flpPageFactory = new WizardPageFactory<FlpPageLocalId>('@sap-ux/adp-flp-config-sub-generator');

--- a/packages/adp-tooling/src/base/wizard-page-factory.ts
+++ b/packages/adp-tooling/src/base/wizard-page-factory.ts
@@ -1,0 +1,73 @@
+import type { IPrompt } from '@sap-devx/yeoman-ui-types';
+
+/**
+ * An interface representing a page configuration inside a wizard step.
+ */
+export interface IPage extends IPrompt {
+    /**
+     * The unique page id.
+     */
+    id: string;
+}
+
+/**
+ * A model to a wizard page internally used by the {@link WizardPageFactory}.
+ */
+interface PageModel<PageLocalId> {
+    localId: PageLocalId;
+    name: string;
+    description: string;
+}
+
+/**
+ * A factory for creation of wizard pages.
+ *
+ * @template PageLocalId - The type of the local identifier for each wizard page.
+ * Typically a string literal union type representing all possible local page IDs.
+ */
+export class WizardPageFactory<PageLocalId extends string> {
+    /**
+     *
+     * @param {string} packageName - The name of the package in which we create wizard pages.
+     */
+    constructor(private readonly packageName: string) {}
+
+    /**
+     * Creates a wizard page object with a unique ID, name, and description.
+     *
+     * @param {PageModel<PageLocalId>} pageModel - The model containing the localId, name, and description for the page.
+     * @param {PageLocalId} pageModel.localId - The local id for the page.
+     * @param {string} pageModel.name - The name of the page.
+     * @param {string} pageModel.description - The page description.
+     * @returns {IPage} An {@link IPage}  object representing the wizard page.
+     */
+    create({ localId, name, description }: PageModel<PageLocalId>): IPage {
+        return {
+            id: this.getPageId(localId),
+            name,
+            description
+        };
+    }
+
+    /**
+     * Helper method for creation a list of pages.
+     *
+     * @param {PageModel<PageLocalId>[]} pageModels - The list of page models.
+     * @returns {IPage[]} A list of {@link IPage} objects.
+     */
+    createMany(pageModels: PageModel<PageLocalId>[]): IPage[] {
+        return pageModels.map((model) => this.create(model));
+    }
+
+    /**
+     * Constructs an unique page id in the format <paackageName>:<localId>.
+     * An example id is '@sap-ux/generator-adp:configuration' for the configuration page
+     * inside the adp generator package.
+     *
+     * @param {string} localId - The page local id.
+     * @returns {string} The unique page id.
+     */
+    getPageId(localId: string): string {
+        return `${this.packageName}:${localId}`;
+    }
+}

--- a/packages/adp-tooling/src/base/wizard-page-factory.ts
+++ b/packages/adp-tooling/src/base/wizard-page-factory.ts
@@ -43,7 +43,7 @@ export class WizardPageFactory<PageLocalId extends string> {
      */
     create({ localId, name, description }: PageModel<PageLocalId>): IPage {
         return {
-            id: this.getPageId(localId),
+            id: WizardPageFactory.getPageId(this.packageName, localId),
             name,
             description
         };
@@ -64,10 +64,11 @@ export class WizardPageFactory<PageLocalId extends string> {
      * An example id is '@sap-ux/generator-adp:configuration' for the configuration page
      * inside the adp generator package.
      *
+     * @param {str} packageName - The name of the package.
      * @param {string} localId - The page local id.
      * @returns {string} The unique page id.
      */
-    getPageId(localId: string): string {
-        return `${this.packageName}:${localId}`;
+    static getPageId(packageName: string, localId: string): string {
+        return `${packageName}:${localId}`;
     }
 }

--- a/packages/adp-tooling/src/index.ts
+++ b/packages/adp-tooling/src/index.ts
@@ -8,6 +8,7 @@ export * from './base/cf';
 export * from './base/helper';
 export * from './base/constants';
 export * from './base/project-builder';
+export * from './base/wizard-page-factory';
 export * from './base/abap/manifest-service';
 export { promptGeneratorInput, PromptDefaults } from './base/prompt';
 export * from './preview/adp-preview';

--- a/packages/adp-tooling/test/unit/base/wizard-page-factory.test.ts
+++ b/packages/adp-tooling/test/unit/base/wizard-page-factory.test.ts
@@ -1,0 +1,47 @@
+import { WizardPageFactory } from '../../../src/base/wizard-page-factory';
+
+describe('WizardPageFactory', () => {
+    const packageName = 'test-package';
+    let factory: WizardPageFactory<'page1' | 'page2'>;
+
+    beforeEach(() => {
+        factory = new WizardPageFactory<'page1' | 'page2'>(packageName);
+    });
+
+    describe('getPageId', () => {
+        it('should return the correct page id', () => {
+            expect(factory.getPageId('page1')).toBe('test-package:page1');
+            expect(factory.getPageId('page2')).toBe('test-package:page2');
+        });
+    });
+
+    describe('create', () => {
+        it('should create an IPage with correct id, name, and description', () => {
+            const pageModel = {
+                localId: 'page1' as const,
+                name: 'Page One',
+                description: 'First page'
+            };
+            const page = factory.create(pageModel);
+            expect(page).toEqual({
+                id: 'test-package:page1',
+                name: 'Page One',
+                description: 'First page'
+            });
+        });
+    });
+
+    describe('createMany', () => {
+        it('should create multiple IPage objects', () => {
+            const pageModels = [
+                { localId: 'page1' as const, name: 'Page One', description: 'First page' },
+                { localId: 'page2' as const, name: 'Page Two', description: 'Second page' }
+            ];
+            const pages = factory.createMany(pageModels);
+            expect(pages).toEqual([
+                { id: 'test-package:page1', name: 'Page One', description: 'First page' },
+                { id: 'test-package:page2', name: 'Page Two', description: 'Second page' }
+            ]);
+        });
+    });
+});

--- a/packages/adp-tooling/test/unit/base/wizard-page-factory.test.ts
+++ b/packages/adp-tooling/test/unit/base/wizard-page-factory.test.ts
@@ -10,8 +10,8 @@ describe('WizardPageFactory', () => {
 
     describe('getPageId', () => {
         it('should return the correct page id', () => {
-            expect(factory.getPageId('page1')).toBe('test-package:page1');
-            expect(factory.getPageId('page2')).toBe('test-package:page2');
+            expect(WizardPageFactory.getPageId(packageName, 'page1')).toBe('test-package:page1');
+            expect(WizardPageFactory.getPageId(packageName, 'page2')).toBe('test-package:page2');
         });
     });
 

--- a/packages/generator-adp/src/add-component-usages/index.ts
+++ b/packages/generator-adp/src/add-component-usages/index.ts
@@ -6,7 +6,7 @@ import { GeneratorTypes } from '../types';
 import { initI18n, t } from '../utils/i18n';
 import type { GeneratorOpts } from '../utils/opts';
 import SubGeneratorBase from '../base/sub-gen-base';
-import { wizardPageFactory } from '../utils/steps';
+import { adpPageFactory } from '../utils/steps';
 
 /**
  * Generator for adding component usages to a project.
@@ -44,7 +44,7 @@ class AddComponentUsagesGenerator extends SubGeneratorBase {
         try {
             this._registerPrompts(
                 new Prompts([
-                    wizardPageFactory.create({
+                    adpPageFactory.create({
                         localId: 'addComponentUsages',
                         name: t('yuiNavSteps.addComponentUsagesName'),
                         description: t('yuiNavSteps.addComponentUsagesDescr')

--- a/packages/generator-adp/src/add-component-usages/index.ts
+++ b/packages/generator-adp/src/add-component-usages/index.ts
@@ -6,6 +6,7 @@ import { GeneratorTypes } from '../types';
 import { initI18n, t } from '../utils/i18n';
 import type { GeneratorOpts } from '../utils/opts';
 import SubGeneratorBase from '../base/sub-gen-base';
+import { wizardPageFactory } from '../utils/steps';
 
 /**
  * Generator for adding component usages to a project.
@@ -43,10 +44,11 @@ class AddComponentUsagesGenerator extends SubGeneratorBase {
         try {
             this._registerPrompts(
                 new Prompts([
-                    {
+                    wizardPageFactory.create({
+                        localId: 'addComponentUsages',
                         name: t('yuiNavSteps.addComponentUsagesName'),
                         description: t('yuiNavSteps.addComponentUsagesDescr')
-                    }
+                    })
                 ])
             );
 

--- a/packages/generator-adp/src/add-new-model/index.ts
+++ b/packages/generator-adp/src/add-new-model/index.ts
@@ -6,6 +6,7 @@ import { GeneratorTypes } from '../types';
 import { initI18n, t } from '../utils/i18n';
 import type { GeneratorOpts } from '../utils/opts';
 import SubGeneratorBase from '../base/sub-gen-base';
+import { wizardPageFactory } from '../utils/steps';
 
 /**
  * Generator for adding a new model to an OData service.
@@ -43,7 +44,11 @@ class AddNewModelGenerator extends SubGeneratorBase {
         try {
             this._registerPrompts(
                 new Prompts([
-                    { name: t('yuiNavSteps.addNewModelName'), description: t('yuiNavSteps.addNewModelDescr') }
+                    wizardPageFactory.create({
+                        localId: 'addNewModel',
+                        name: t('yuiNavSteps.addNewModelName'),
+                        description: t('yuiNavSteps.addNewModelDescr')
+                    })
                 ])
             );
 

--- a/packages/generator-adp/src/add-new-model/index.ts
+++ b/packages/generator-adp/src/add-new-model/index.ts
@@ -6,7 +6,7 @@ import { GeneratorTypes } from '../types';
 import { initI18n, t } from '../utils/i18n';
 import type { GeneratorOpts } from '../utils/opts';
 import SubGeneratorBase from '../base/sub-gen-base';
-import { wizardPageFactory } from '../utils/steps';
+import { adpPageFactory } from '../utils/steps';
 
 /**
  * Generator for adding a new model to an OData service.
@@ -44,7 +44,7 @@ class AddNewModelGenerator extends SubGeneratorBase {
         try {
             this._registerPrompts(
                 new Prompts([
-                    wizardPageFactory.create({
+                    adpPageFactory.create({
                         localId: 'addNewModel',
                         name: t('yuiNavSteps.addNewModelName'),
                         description: t('yuiNavSteps.addNewModelDescr')

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -35,7 +35,7 @@ import { initI18n, t } from '../utils/i18n';
 import AdpGeneratorLogger from '../utils/logger';
 import { setHeaderTitle } from '../utils/opts';
 import { getFirstArgAsString, parseJsonInput } from '../utils/parse-json-input';
-import { getDeployPage, getWizardPages, updateFlpWizardSteps, updateWizardSteps } from '../utils/steps';
+import { getDeployPage, getWizardPages, updateFlpWizardSteps, updateWizardSteps, adpPackageName } from '../utils/steps';
 import { addDeployGen, addExtProjectGen, addFlpGen } from '../utils/subgenHelpers';
 import { getTemplatesOverwritePath } from '../utils/templates';
 import { existsInWorkspace, handleWorkspaceFolderChoice, showWorkspaceFolderWarning } from '../utils/workspace';
@@ -463,7 +463,7 @@ export default class extends Generator {
             updateWizardSteps(
                 this.prompts,
                 getDeployPage(),
-                'projectAttributes',
+                { localId: 'projectAttributes', packageName: adpPackageName },
                 this.attributeAnswers.addDeployConfig
             );
         }

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -463,7 +463,7 @@ export default class extends Generator {
             updateWizardSteps(
                 this.prompts,
                 getDeployPage(),
-                t('yuiNavSteps.projectAttributesName'),
+                'projectAttributes',
                 this.attributeAnswers.addDeployConfig
             );
         }

--- a/packages/generator-adp/src/app/questions/attributes.ts
+++ b/packages/generator-adp/src/app/questions/attributes.ts
@@ -24,7 +24,7 @@ import { t } from '../../utils/i18n';
 import { attributePromptNames } from '../types';
 import { getProjectNameTooltip } from './helper/tooltip';
 import { getVersionAdditionalMessages } from './helper/additional-messages';
-import { updateWizardSteps, getDeployPage, updateFlpWizardSteps } from '../../utils/steps';
+import { updateWizardSteps, getDeployPage, updateFlpWizardSteps, adpPackageName } from '../../utils/steps';
 import { getDefaultProjectName, getDefaultNamespace, getDefaultVersion } from './helper/default-values';
 
 interface Config {
@@ -277,7 +277,12 @@ export function getAddDeployConfigPrompt(prompts: YeomanUiSteps, _?: AddDeployCo
             breadcrumb: true
         },
         validate: (value: boolean) => {
-            updateWizardSteps(prompts, getDeployPage(), 'projectAttributes', value);
+            updateWizardSteps(
+                prompts,
+                getDeployPage(),
+                { localId: 'projectAttributes', packageName: adpPackageName },
+                value
+            );
             return true;
         }
     } as ConfirmQuestion<AttributesAnswers>;

--- a/packages/generator-adp/src/app/questions/attributes.ts
+++ b/packages/generator-adp/src/app/questions/attributes.ts
@@ -277,7 +277,7 @@ export function getAddDeployConfigPrompt(prompts: YeomanUiSteps, _?: AddDeployCo
             breadcrumb: true
         },
         validate: (value: boolean) => {
-            updateWizardSteps(prompts, getDeployPage(), t('yuiNavSteps.projectAttributesName'), value);
+            updateWizardSteps(prompts, getDeployPage(), 'projectAttributes', value);
             return true;
         }
     } as ConfirmQuestion<AttributesAnswers>;

--- a/packages/generator-adp/src/utils/steps.ts
+++ b/packages/generator-adp/src/utils/steps.ts
@@ -124,6 +124,9 @@ interface PageId {
  * If the step exists and needs to be moved (based on desired insertion point),
  * it is repositioned accordingly.
  *
+ * If we attempt to add already existing page but which changes in content(name or
+ * description) the content gets updated only.
+ *
  * @param {YeomanUiSteps} prompts - The Yeoman UI Prompts container object.
  * @param {IPage} page - The page to add or remove.
  * @param {PageId} [insertAfter] - Optional page id counterparts of the step after which to insert.
@@ -138,6 +141,9 @@ export function updateWizardSteps(
     const pages: IPage[] = prompts['items'];
 
     const existingIdx = pages.findIndex((p) => p.id === page.id);
+
+    // If page exists update its name and description only.
+    updateExistingPageContentIfNeeded(prompts, page);
 
     if (shouldAdd) {
         const afterId = insertAfter ? WizardPageFactory.getPageId(insertAfter.packageName, insertAfter.localId) : '';
@@ -160,6 +166,30 @@ export function updateWizardSteps(
     } else if (existingIdx !== -1) {
         prompts.splice(existingIdx, 1, []);
     }
+}
+
+/**
+ * Updates the content of an existing {@link IPage} if there is a change in the content.
+ *
+ * @param {YeomanUiSteps} prompts - The Yeoman UI Prompts container object.
+ * @param {IPage} page - The page to be updated eventually.
+ */
+function updateExistingPageContentIfNeeded(prompts: YeomanUiSteps, page: IPage): void {
+    const pages: IPage[] = prompts['items'];
+
+    const existingIdx = pages.findIndex((p) => p.id === page.id);
+
+    if (existingIdx === -1) {
+        return;
+    }
+
+    const existingPage = pages[existingIdx];
+    if (existingPage.name === page.name && existingPage.description === page.description) {
+        return;
+    }
+
+    existingPage.name = page.name;
+    existingPage.description = page.description;
 }
 
 /**

--- a/packages/generator-adp/src/utils/steps.ts
+++ b/packages/generator-adp/src/utils/steps.ts
@@ -177,13 +177,12 @@ export function updateWizardSteps(
 function updateExistingPageContentIfNeeded(prompts: YeomanUiSteps, page: IPage): void {
     const pages: IPage[] = prompts['items'];
 
-    const existingIdx = pages.findIndex((p) => p.id === page.id);
+    const existingPage = pages.find((p) => p.id === page.id);
 
-    if (existingIdx === -1) {
+    if (!existingPage) {
         return;
     }
 
-    const existingPage = pages[existingIdx];
     if (existingPage.name === page.name && existingPage.description === page.description) {
         return;
     }

--- a/packages/generator-adp/test/unit/utils/steps.test.ts
+++ b/packages/generator-adp/test/unit/utils/steps.test.ts
@@ -10,10 +10,11 @@ import {
     updateFlpWizardSteps,
     getSubGenErrorPage,
     getSubGenAuthPages,
-    wizardPageFactory
+    adpPackageName,
+    flpPackageName
 } from '../../../src/utils/steps';
 import { initI18n, t } from '../../../src/utils/i18n';
-import type { IPage } from '@sap-ux/adp-tooling';
+import { WizardPageFactory, type IPage } from '@sap-ux/adp-tooling';
 
 describe('Wizard Steps Utility', () => {
     let prompts: Prompts;
@@ -28,7 +29,7 @@ describe('Wizard Steps Utility', () => {
 
     it('should add a new step when it does not exist', () => {
         const flpStep = getFlpPages(false, 'TestProject')[0];
-        updateWizardSteps(prompts, flpStep, 'projectAttributes', true);
+        updateWizardSteps(prompts, flpStep, { localId: 'projectAttributes', packageName: adpPackageName }, true);
 
         const steps = prompts['items'] as IPage[];
         expect(steps.map((s) => s.id)).toContain(flpStep.id);
@@ -36,8 +37,8 @@ describe('Wizard Steps Utility', () => {
 
     it('should not add the step twice if it already exists', () => {
         const flpStep = getFlpPages(false, 'TestProject')[0];
-        updateWizardSteps(prompts, flpStep, 'projectAttributes', true);
-        updateWizardSteps(prompts, flpStep, 'projectAttributes', true);
+        updateWizardSteps(prompts, flpStep, { localId: 'projectAttributes', packageName: adpPackageName }, true);
+        updateWizardSteps(prompts, flpStep, { localId: 'projectAttributes', packageName: adpPackageName }, true);
 
         const steps = prompts['items'] as IPage[];
         const count = steps.filter((s) => s.id === flpStep.id).length;
@@ -46,8 +47,8 @@ describe('Wizard Steps Utility', () => {
 
     it('should remove an existing step', () => {
         const flpStep = getFlpPages(false, 'TestProject')[0];
-        updateWizardSteps(prompts, flpStep, '', true); // Add
-        updateWizardSteps(prompts, flpStep, '', false); // Remove
+        updateWizardSteps(prompts, flpStep); // Add
+        updateWizardSteps(prompts, flpStep, undefined, false); // Remove
 
         const steps = prompts['items'] as IPage[];
         expect(steps.find((s) => s.id === flpStep.id)).toBeUndefined();
@@ -55,8 +56,8 @@ describe('Wizard Steps Utility', () => {
 
     it('should move an existing step to a new position', () => {
         const deployStep = getDeployPage();
-        updateWizardSteps(prompts, deployStep, 'configuration', true); // Insert after Configuration
-        updateWizardSteps(prompts, deployStep, 'projectAttributes', true); // Move after Attributes
+        updateWizardSteps(prompts, deployStep, { localId: 'configuration', packageName: adpPackageName }, true); // Insert after Configuration
+        updateWizardSteps(prompts, deployStep, { localId: 'projectAttributes', packageName: adpPackageName }, true); // Move after Attributes
 
         const steps = prompts['items'] as IPage[];
         const names = steps.map((s) => s.name);
@@ -68,13 +69,13 @@ describe('Wizard Steps Utility', () => {
         const flpStep = getFlpPages(false, 'TestProject')[0];
 
         // Add FLP first → step order: Configuration, Project Attributes, FLP
-        updateWizardSteps(prompts, flpStep, 'projectAttributes', true);
+        updateWizardSteps(prompts, flpStep, { localId: 'projectAttributes', packageName: adpPackageName }, true);
 
         // Add Deploy after FLP → now it's at the end
-        updateWizardSteps(prompts, deployStep, 'flpConfig', true);
+        updateWizardSteps(prompts, deployStep, { localId: 'flpConfig', packageName: flpPackageName }, true);
 
         // Now move Deploy to after Configuration
-        updateWizardSteps(prompts, deployStep, 'configuration', true);
+        updateWizardSteps(prompts, deployStep, { localId: 'configuration', packageName: adpPackageName }, true);
 
         const steps = prompts['items'] as IPage[];
         const names = steps.map((s) => s.name);
@@ -125,7 +126,12 @@ describe('updateFlpWizardSteps', () => {
         });
 
         it('should insert tile settings page after deploy config name', () => {
-            updateWizardSteps(prompts, getDeployPage(), 'configuration', true);
+            updateWizardSteps(
+                prompts,
+                getDeployPage(),
+                { localId: 'configuration', packageName: adpPackageName },
+                true
+            );
             updateFlpWizardSteps(true, prompts, 'TestProject', true);
 
             const steps = prompts['items'] as IPrompt[];
@@ -196,7 +202,12 @@ describe('updateFlpWizardSteps', () => {
         });
 
         it('should insert FLP config page after deploy config name', () => {
-            updateWizardSteps(prompts, getDeployPage(), 'configuration', true);
+            updateWizardSteps(
+                prompts,
+                getDeployPage(),
+                { localId: 'configuration', packageName: adpPackageName },
+                true
+            );
             updateFlpWizardSteps(false, prompts, 'TestProject', true);
 
             const steps = prompts['items'] as IPrompt[];
@@ -281,7 +292,7 @@ describe('updateFlpWizardSteps', () => {
 
 describe('getSubGenErrorPage', () => {
     beforeEach(() => {
-        jest.spyOn(wizardPageFactory, 'getPageId').mockImplementation((localId) => localId);
+        jest.spyOn(WizardPageFactory, 'getPageId').mockImplementation((_: string, localId: string) => localId);
     });
 
     it('should return error page for ADD_ANNOTATIONS_TO_DATA', () => {
@@ -313,7 +324,7 @@ describe('getSubGenAuthPages', () => {
     const system = 'SYS_010';
 
     beforeEach(() => {
-        jest.spyOn(wizardPageFactory, 'getPageId').mockImplementation((localId) => localId);
+        jest.spyOn(WizardPageFactory, 'getPageId').mockImplementation((_: string, localId: string) => localId);
     });
 
     it('should return auth pages for ADD_ANNOTATIONS_TO_DATA', () => {

--- a/packages/generator-adp/test/unit/utils/steps.test.ts
+++ b/packages/generator-adp/test/unit/utils/steps.test.ts
@@ -160,20 +160,25 @@ describe('updateFlpWizardSteps', () => {
         });
 
         it('should handle multiple calls correctly', () => {
-            updateFlpWizardSteps(true, prompts, 'TestProject', true);
-            updateFlpWizardSteps(true, prompts, 'TestProject', true);
+            updateFlpWizardSteps(true, prompts, 'TestProject1', true);
+            updateFlpWizardSteps(true, prompts, 'TestProject2', true);
 
             const steps = prompts['items'] as IPrompt[];
             const stepNames = steps.map((s) => s.name);
 
             // Should only have one instance of each page
-            const tileSettingsCount = stepNames.filter(
-                (name) => name === t('yuiNavSteps.tileSettingsName', { projectName: 'TestProject' })
-            ).length;
+            const tileSettingsNames = stepNames.filter(
+                (name) =>
+                    name === t('yuiNavSteps.tileSettingsName', { projectName: 'TestProject2' }) ||
+                    name === t('yuiNavSteps.tileSettingsName', { projectName: 'TestProject1' })
+            );
+            const tileSettingsCount = tileSettingsNames.length;
             const flpConfigCount = stepNames.filter((name) => name === t('yuiNavSteps.flpConfigName')).length;
 
             expect(tileSettingsCount).toBe(1);
             expect(flpConfigCount).toBe(1);
+            // The second call to updateFlpWizardSteps updates the tileSettings page title only.
+            expect(tileSettingsNames[0]).toEqual(t('yuiNavSteps.tileSettingsName', { projectName: 'TestProject2' }));
         });
     });
 


### PR DESCRIPTION
#3633 

There is a drawback in the way we manage wizard pages. When we add/remove pages we filter existing pages by name which is wrong. The name is localized string which can have parameters, practically makes the name dynamic value. In our case when the user changes the project name, the `SAP Fiori Launchpad Configuration` step receives a new name so the previous page with the older name is treated as entirely different page. As a result for every new name we enter we end up with new page.

Add a notion for a stable id for a wizard page. When we add/remove pages we filter pages by the id not the name. The convention for the id is `<packageName>:<localPageId>`. The packageName is included to avoid collisions since a wizard can have pages from different packages with same localPageIds.

<img width="1850" height="1522" alt="steps" src="https://github.com/user-attachments/assets/9f860b54-e3ef-4cbb-a679-8214de831868" />

Testing done:
* Unit tests.
* Manually verified.

![dynamic-page](https://github.com/user-attachments/assets/e09e589c-6488-4283-a2b4-0d63d8c21dc6)

