### PR TITLE
MCP - more consistent tool names

### DIFF
--- a/.changeset/seven-dolphins-teach.md
+++ b/.changeset/seven-dolphins-teach.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+Update MCP to use snake case instead of kebab case in MCP tool names. Rename doc_search to search_docs.

--- a/packages/fiori-mcp-server/CHANGELOG.md
+++ b/packages/fiori-mcp-server/CHANGELOG.md
@@ -75,7 +75,7 @@
 
 ### Patch Changes
 
--   4fad77a: Regenerate output schema for 'get-functionality-details' tool
+-   4fad77a: Regenerate output schema for 'get_functionality_details' tool
 
 ## 0.0.2
 

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -76,7 +76,7 @@ The following rules help guide the LLM to use the server correctly:
 
 #### `search_docs`
 Searches Fiori Elements, Annotations, SAPUI5, Fiori tools documentation for the given query.
-Note: the results are based on the the most recent indexed version of SAPUI5 documentation
+Note: the results are based on the most recent indexed version of SAPUI5 documentation
 
 
 #### `list_fiori_apps`

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -74,7 +74,7 @@ The following rules help guide the LLM to use the server correctly:
 
 ## [Available Tools](#available-tools)
 
-#### `doc-search`
+#### `search_docs`
 Searches Fiori Elements, Annotations, SAPUI5, Fiori tools documentation for the given query.
 Note: the results are based on the the most recent indexed version of SAPUI5 documentation
 

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -82,7 +82,7 @@ Note: the results are based on the the most recent indexed version of SAPUI5 doc
 #### `list_fiori_apps`
 Scans a specified directory to find existing SAP Fiori applications that can be modified.
 
-#### `list-functionalities` (Step 1 of 3)
+#### `list_functionalities` (Step 1 of 3)
 Gets the list of supported functionalities to create a new or modify an existing SAP Fiori application.
 
 The main functionalities are:

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -75,8 +75,8 @@ The following rules help guide the LLM to use the server correctly:
 ## [Available Tools](#available-tools)
 
 #### `search_docs`
-Searches Fiori Elements, Annotations, SAPUI5, Fiori tools documentation for the given query.
-Note: the results are based on the most recent indexed version of SAPUI5 documentation
+Searches Fiori Elements, Annotations, UI5, Fiori tools documentation for the given query.
+Note: the results are based on the most recent indexed version of UI5 documentation
 
 
 #### `list_fiori_apps`

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -79,7 +79,7 @@ Searches Fiori Elements, Annotations, SAPUI5, Fiori tools documentation for the 
 Note: the results are based on the the most recent indexed version of SAPUI5 documentation
 
 
-#### `list-fiori-apps`
+#### `list_fiori_apps`
 Scans a specified directory to find existing SAP Fiori applications that can be modified.
 
 #### `list-functionalities` (Step 1 of 3)
@@ -92,10 +92,10 @@ The main functionalities are:
 - Adding and modifying controller extensions
 - Modifying `manifest.json` properties depending on the app (e.g. adding Flexible Column Layout, enabling initial load)
 
-#### `get-functionality-details` (Step 2 of 3)
+#### `get_functionality_details` (Step 2 of 3)
 Gets the required parameters and detailed information for a specific functionality to create a new or modify an existing SAP Fiori application.
 
-#### `execute-functionality` (Step 3 of 3)
+#### `execute_functionality` (Step 3 of 3)
 Executes a specific functionality to create a new or modify an existing SAP Fiori application with provided parameters.
 
 ## Code of Conduct

--- a/packages/fiori-mcp-server/src/server.ts
+++ b/packages/fiori-mcp-server/src/server.ts
@@ -98,19 +98,19 @@ export class FioriFunctionalityServer {
                 };
 
                 switch (name) {
-                    case 'doc-search':
+                    case 'search_docs':
                         result = await docSearch(args as DocSearchInput);
                         return this.convertResultToCallToolResult(result.results);
-                    case 'list-fiori-apps':
+                    case 'list_fiori_apps':
                         result = await listFioriApps(args as ListFioriAppsInput);
                         break;
-                    case 'list-functionality':
+                    case 'list_functionality':
                         result = await listFunctionalities(args as ListFunctionalitiesInput);
                         break;
-                    case 'get-functionality-details':
+                    case 'get_functionality_details':
                         result = await getFunctionalityDetails(args as GetFunctionalityDetailsInput);
                         break;
-                    case 'execute-functionality':
+                    case 'execute_functionality':
                         result = await executeFunctionality(args as ExecuteFunctionalityInput);
                         break;
                     default:

--- a/packages/fiori-mcp-server/src/server.ts
+++ b/packages/fiori-mcp-server/src/server.ts
@@ -116,7 +116,7 @@ export class FioriFunctionalityServer {
                     default:
                         await TelemetryHelper.sendTelemetry(unknownTool, telemetryProperties, (args as any)?.appPath);
                         throw new Error(
-                            `Unknown tool: ${name}. Try one of: list-fiori-apps, list-functionality, get-functionality-details, execute-functionality.`
+                            `Unknown tool: ${name}. Try one of: list_fiori_apps, list_functionality, get_functionality_details, execute_functionality.`
                         );
                 }
                 await TelemetryHelper.sendTelemetry(name, telemetryProperties, (args as any)?.appPath);

--- a/packages/fiori-mcp-server/src/tools/index.ts
+++ b/packages/fiori-mcp-server/src/tools/index.ts
@@ -11,7 +11,7 @@ export { executeFunctionality } from './execute-functionality';
 
 export const tools = [
     {
-        name: 'doc-search',
+        name: 'search_docs',
         title: 'Search in Fiori Documentation',
         description:
             "Searches code snippets of Fiori Elements, Annotations, SAPUI5, Fiori tools documentation for the given query. You MUST use this tool if you're unsure about Fiori APIs. Optionally returns only code blocks.",
@@ -32,7 +32,7 @@ export const tools = [
         }
     },
     {
-        name: 'list-fiori-apps',
+        name: 'list_fiori_apps',
         description: `Scans a specified directory to find existing SAP Fiori applications that can be modified.
                     This is an optional, preliminary tool.
                     **Use this first ONLY if the target application's name or path is not already known.**
@@ -41,29 +41,29 @@ export const tools = [
         outputSchema: convertToSchema(Output.ListFioriAppsOutputSchema)
     },
     {
-        name: 'list-functionality',
+        name: 'list_functionality',
         description: `**(Step 1 of 3)**
                     Gets the complete and exclusive list of supported functionalities to create a new or modify an existing SAP Fiori application.
                     This is the **first mandatory step** to begin the workflow and requires a valid absolute path to a SAP Fiori application as input.
-                    You MUST use a functionalityId from this tool's output to request details to the functionality in 'get-functionality-details' (Step 2).
+                    You MUST use a functionalityId from this tool's output to request details to the functionality in 'get_functionality_details' (Step 2).
                     You MUST not use a functionalityId as name of a tool.
                     Do not guess, assume, or use any functionality not present in this list, as it is invalid and will cause the operation to fail.
                     **Note: If the target application is not known, use the list-fiori-apps tool first to identify it.**
-                    if the functionality list does not include a functionality to support the current goal, then try using the doc-search tool as a fallback.`,
+                    if the functionality list does not include a functionality to support the current goal, then try using the search_docs tool as a fallback.`,
         inputSchema: convertToSchema(Input.ListFunctionalitiesInputSchema),
         outputSchema: convertToSchema(Output.ListFunctionalitiesOutputSchema)
     },
     {
-        name: 'get-functionality-details',
+        name: 'get_functionality_details',
         description: `**(Step 2 of 3)**
                     Gets the required parameters and detailed information for a specific functionality to create a new or modify an existing SAP Fiori application.
-                    You MUST provide a functionalityId obtained from 'list-functionality' (Step 1).
-                    The output of this tool is required for the final step 'execute-functionality' (Step 3).`,
+                    You MUST provide a functionalityId obtained from 'list_functionality' (Step 1).
+                    The output of this tool is required for the final step 'execute_functionality' (Step 3).`,
         inputSchema: convertToSchema(Input.GetFunctionalityDetailsInputSchema),
         outputSchema: convertToSchema(Output.GetFunctionalityDetailsOutputSchema)
     },
     {
-        name: 'execute-functionality',
+        name: 'execute_functionality',
         description: `**(Step 3 of 3)**
                     Executes a specific functionality to create a new or modify an existing SAP Fiori application with provided parameters.
                     This is the **final step** of the workflow and performs the actual creation or modification.

--- a/packages/fiori-mcp-server/src/tools/index.ts
+++ b/packages/fiori-mcp-server/src/tools/index.ts
@@ -48,7 +48,7 @@ export const tools = [
                     You MUST use a functionalityId from this tool's output to request details to the functionality in 'get_functionality_details' (Step 2).
                     You MUST not use a functionalityId as name of a tool.
                     Do not guess, assume, or use any functionality not present in this list, as it is invalid and will cause the operation to fail.
-                    **Note: If the target application is not known, use the list-fiori-apps tool first to identify it.**
+                    **Note: If the target application is not known, use the list_fiori_apps tool first to identify it.**
                     if the functionality list does not include a functionality to support the current goal, then try using the search_docs tool as a fallback.`,
         inputSchema: convertToSchema(Input.ListFunctionalitiesInputSchema),
         outputSchema: convertToSchema(Output.ListFunctionalitiesOutputSchema)
@@ -67,7 +67,7 @@ export const tools = [
         description: `**(Step 3 of 3)**
                     Executes a specific functionality to create a new or modify an existing SAP Fiori application with provided parameters.
                     This is the **final step** of the workflow and performs the actual creation or modification.
-                    You MUST provide the exact parameter information obtained from get-functionality-details (Step 2).`,
+                    You MUST provide the exact parameter information obtained from get_functionality_details (Step 2).`,
         inputSchema: convertToSchema(Input.ExecuteFunctionalityInputSchema),
         outputSchema: convertToSchema(Output.ExecuteFunctionalityOutputSchema)
     }

--- a/packages/fiori-mcp-server/src/types/basic.ts
+++ b/packages/fiori-mcp-server/src/types/basic.ts
@@ -38,7 +38,7 @@ export type Test = zod.infer<typeof FunctionalityIdSchema>;
  */
 export const FunctionalitySchema = zod.object({
     functionalityId: FunctionalityIdSchema.describe(
-        'Identifier to pass as the `functionalityId` parameter when calling `get-functionality-details` or `execute-functionality`'
+        'Identifier to pass as the `functionalityId` parameter when calling `get_functionality_details` or `execute_functionality`'
     ),
     description: zod.string()
 });

--- a/packages/fiori-mcp-server/src/types/input.ts
+++ b/packages/fiori-mcp-server/src/types/input.ts
@@ -2,7 +2,7 @@ import * as zod from 'zod';
 import { FunctionalityIdSchema } from './basic';
 
 /**
- * Input interface for the 'list-fiori-apps' functionality
+ * Input interface for the 'list_fiori_apps' functionality
  */
 export const ListFioriAppsInputSchema = zod.object({
     /** Array of paths to search for Fiori applications */
@@ -14,7 +14,7 @@ export const ListFioriAppsInputSchema = zod.object({
 });
 
 /**
- * Input interface for the 'list-functionality' functionality
+ * Input interface for the 'list_functionality' functionality
  */
 export const ListFunctionalitiesInputSchema = zod.object({
     /** Path to the Fiori application */
@@ -26,7 +26,7 @@ export const ListFunctionalitiesInputSchema = zod.object({
 });
 
 /**
- * Input interface for the 'get-functionality-details' functionality
+ * Input interface for the 'get_functionality_details' functionality
  */
 export const GetFunctionalityDetailsInputSchema = zod.object({
     /** Path to the Fiori application */
@@ -36,7 +36,7 @@ export const GetFunctionalityDetailsInputSchema = zod.object({
 });
 
 /**
- * Input interface for the 'execute-functionality' functionality
+ * Input interface for the 'execute_functionality' functionality
  */
 export const ExecuteFunctionalityInputSchema = zod.object({
     /** ID or array of IDs of the functionality(ies) to execute */

--- a/packages/fiori-mcp-server/src/types/output.ts
+++ b/packages/fiori-mcp-server/src/types/output.ts
@@ -2,7 +2,7 @@ import * as zod from 'zod';
 import { FioriAppSchema, FunctionalityIdSchema, FunctionalitySchema, ParameterSchema } from './basic';
 
 /**
- * Output interface for the 'list-fiori-apps' functionality
+ * Output interface for the 'list_fiori_apps' functionality
  */
 export const ListFioriAppsOutputSchema = zod.object({
     /** Array of found Fiori applications */
@@ -10,7 +10,7 @@ export const ListFioriAppsOutputSchema = zod.object({
 });
 
 /**
- * Output interface for the 'list-functionality' functionality
+ * Output interface for the 'list_functionality' functionality
  */
 export const ListFunctionalitiesOutputSchema = zod.object({
     /** Path to the Fiori application */
@@ -20,7 +20,7 @@ export const ListFunctionalitiesOutputSchema = zod.object({
 });
 
 /**
- * Output interface for the 'get-functionality-details' functionality
+ * Output interface for the 'get_functionality_details' functionality
  */
 export const GetFunctionalityDetailsOutputSchema = zod.object({
     /** ID of the functionality */
@@ -46,7 +46,7 @@ export const GetFunctionalityDetailsOutputSchema = zod.object({
 });
 
 /**
- * Output interface for the 'execute-functionality' functionality
+ * Output interface for the 'execute_functionality' functionality
  */
 export const ExecuteFunctionalityOutputSchema = zod.object({
     /** ID or array of IDs of the executed functionality(ies) */

--- a/packages/fiori-mcp-server/src/types/output.ts
+++ b/packages/fiori-mcp-server/src/types/output.ts
@@ -25,7 +25,7 @@ export const ListFunctionalitiesOutputSchema = zod.object({
 export const GetFunctionalityDetailsOutputSchema = zod.object({
     /** ID of the functionality */
     functionalityId: FunctionalityIdSchema.describe(
-        'Identifier to pass as the `functionalityId` parameter when calling `get-functionality-details` or `execute-functionality`'
+        'Identifier to pass as the `functionalityId` parameter when calling `get_functionality_details` or `execute_functionality`'
     ),
     /** Name of the functionality */
     name: zod.string(),

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -49,18 +49,18 @@ describe('FioriFunctionalityServer', () => {
         const onRequestCB = setRequestHandlerCall[1];
         const result = await onRequestCB();
         expect(result.tools.map((tool: { name: string }) => tool.name)).toEqual([
-            'doc-search',
-            'list-fiori-apps',
-            'list-functionality',
-            'get-functionality-details',
-            'execute-functionality'
+            'search_docs',
+            'list_fiori_apps',
+            'list_functionality',
+            'get_functionality_details',
+            'execute_functionality'
         ]);
     });
 
     describe('FioriFunctionalityServer', () => {
         const sendTelemetryMock = jest.spyOn(TelemetryHelper, 'sendTelemetry').mockImplementation(jest.fn());
 
-        test('list-fiori-apps', async () => {
+        test('list_fiori_apps', async () => {
             const listFioriAppsSpy = jest.spyOn(tools, 'listFioriApps').mockResolvedValue({
                 applications: [
                     {
@@ -84,7 +84,7 @@ describe('FioriFunctionalityServer', () => {
             const onRequestCB = setRequestHandlerCall[1];
             const result = await onRequestCB({
                 params: {
-                    name: 'list-fiori-apps',
+                    name: 'list_fiori_apps',
                     arguments: {
                         searchPath: []
                     }
@@ -118,13 +118,13 @@ describe('FioriFunctionalityServer', () => {
             ]);
 
             expect(sendTelemetryMock).toHaveBeenLastCalledWith(
-                'list-fiori-apps',
-                { tool: 'list-fiori-apps', functionalityId: undefined },
+                'list_fiori_apps',
+                { tool: 'list_fiori_apps', functionalityId: undefined },
                 undefined
             );
         });
 
-        test('list-functionality', async () => {
+        test('list_functionality', async () => {
             const listFunctionalitiesSpy = jest.spyOn(tools, 'listFunctionalities').mockResolvedValue({
                 applicationPath: 'app1',
                 functionalities: [
@@ -143,7 +143,7 @@ describe('FioriFunctionalityServer', () => {
             const onRequestCB = setRequestHandlerCall[1];
             const result = await onRequestCB({
                 params: {
-                    name: 'list-functionality',
+                    name: 'list_functionality',
                     arguments: {
                         appPath: 'app1'
                     }
@@ -171,13 +171,13 @@ describe('FioriFunctionalityServer', () => {
                 }
             ]);
             expect(sendTelemetryMock).toHaveBeenLastCalledWith(
-                'list-functionality',
-                { tool: 'list-functionality', functionalityId: undefined },
+                'list_functionality',
+                { tool: 'list_functionality', functionalityId: undefined },
                 'app1'
             );
         });
 
-        test('get-functionality-details', async () => {
+        test('get_functionality_details', async () => {
             const getFunctionalityDetailsSpy = jest.spyOn(tools, 'getFunctionalityDetails').mockResolvedValue({
                 functionalityId: 'add-page',
                 description: 'Add page...',
@@ -189,7 +189,7 @@ describe('FioriFunctionalityServer', () => {
             const onRequestCB = setRequestHandlerCall[1];
             const result = await onRequestCB({
                 params: {
-                    name: 'get-functionality-details',
+                    name: 'get_functionality_details',
                     arguments: {
                         appPath: 'app1',
                         functionalityId: 'add-page'
@@ -211,13 +211,13 @@ describe('FioriFunctionalityServer', () => {
                 }
             ]);
             expect(sendTelemetryMock).toHaveBeenLastCalledWith(
-                'get-functionality-details',
-                { tool: 'get-functionality-details', functionalityId: 'add-page' },
+                'get_functionality_details',
+                { tool: 'get_functionality_details', functionalityId: 'add-page' },
                 'app1'
             );
         });
 
-        test('execute-functionality', async () => {
+        test('execute_functionality', async () => {
             const executeFunctionalitySpy = jest.spyOn(tools, 'executeFunctionality').mockResolvedValue({
                 functionalityId: 'add-page',
                 status: 'ok',
@@ -232,7 +232,7 @@ describe('FioriFunctionalityServer', () => {
             const onRequestCB = setRequestHandlerCall[1];
             const result = await onRequestCB({
                 params: {
-                    name: 'execute-functionality',
+                    name: 'execute_functionality',
                     arguments: {
                         appPath: 'app1',
                         functionalityId: 'add-page',
@@ -260,8 +260,8 @@ describe('FioriFunctionalityServer', () => {
                 }
             ]);
             expect(sendTelemetryMock).toHaveBeenLastCalledWith(
-                'execute-functionality',
-                { tool: 'execute-functionality', functionalityId: 'add-page' },
+                'execute_functionality',
+                { tool: 'execute_functionality', functionalityId: 'add-page' },
                 'app1'
             );
         });
@@ -296,7 +296,7 @@ describe('FioriFunctionalityServer', () => {
     });
 
     describe('Run', () => {
-        test('execute-functionality', async () => {
+        test('execute_functionality', async () => {
             const server = new FioriFunctionalityServer();
             await server.run();
             expect(connectMock).toHaveBeenCalledTimes(1);

--- a/packages/fiori-mcp-server/test/unit/server.test.ts
+++ b/packages/fiori-mcp-server/test/unit/server.test.ts
@@ -280,7 +280,7 @@ describe('FioriFunctionalityServer', () => {
             });
             expect(result.content).toEqual([
                 {
-                    text: 'Error: Unknown tool: unknown-tool-id. Try one of: list-fiori-apps, list-functionality, get-functionality-details, execute-functionality.',
+                    text: 'Error: Unknown tool: unknown-tool-id. Try one of: list_fiori_apps, list_functionality, get_functionality_details, execute_functionality.',
                     type: 'text'
                 }
             ]);

--- a/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Tools schemas execute-functionality: Input schema for "execute-functionality" 1`] = `
+exports[`Tools schemas execute_functionality: Input schema for "execute-functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -47,7 +47,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas execute-functionality: Output schema for "execute-functionality" 1`] = `
+exports[`Tools schemas execute_functionality: Output schema for "execute-functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -104,7 +104,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas get-functionality-details: Input schema for "get-functionality-details" 1`] = `
+exports[`Tools schemas get_functionality_details: Input schema for "get-functionality-details" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -142,7 +142,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas get-functionality-details: Output schema for "get-functionality-details" 1`] = `
+exports[`Tools schemas get_functionality_details: Output schema for "get-functionality-details" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -465,7 +465,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list-fiori-apps: Input schema for "list-fiori-apps" 1`] = `
+exports[`Tools schemas list_fiori_apps: Input schema for "list-fiori-apps" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -484,7 +484,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list-fiori-apps: Output schema for "list-fiori-apps" 1`] = `
+exports[`Tools schemas list_fiori_apps: Output schema for "list-fiori-apps" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -537,7 +537,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list-functionality: Input schema for "list-functionality" 1`] = `
+exports[`Tools schemas list_functionality: Input schema for "list-functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -553,7 +553,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list-functionality: Output schema for "list-functionality" 1`] = `
+exports[`Tools schemas list_functionality: Output schema for "list-functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {

--- a/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Tools schemas execute_functionality: Input schema for "execute-functionality" 1`] = `
+exports[`Tools schemas execute_functionality: Input schema for "execute_functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -47,7 +47,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas execute_functionality: Output schema for "execute-functionality" 1`] = `
+exports[`Tools schemas execute_functionality: Output schema for "execute_functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -104,7 +104,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas get_functionality_details: Input schema for "get-functionality-details" 1`] = `
+exports[`Tools schemas get_functionality_details: Input schema for "get_functionality_details" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -142,7 +142,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas get_functionality_details: Output schema for "get-functionality-details" 1`] = `
+exports[`Tools schemas get_functionality_details: Output schema for "get_functionality_details" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -174,7 +174,7 @@ Object {
           "type": "array",
         },
       ],
-      "description": "Identifier to pass as the \`functionalityId\` parameter when calling \`get-functionality-details\` or \`execute-functionality\`",
+      "description": "Identifier to pass as the \`functionalityId\` parameter when calling \`get_functionality_details\` or \`execute_functionality\`",
     },
     "impact": Object {
       "type": "string",
@@ -465,7 +465,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list_fiori_apps: Input schema for "list-fiori-apps" 1`] = `
+exports[`Tools schemas list_fiori_apps: Input schema for "list_fiori_apps" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -484,7 +484,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list_fiori_apps: Output schema for "list-fiori-apps" 1`] = `
+exports[`Tools schemas list_fiori_apps: Output schema for "list_fiori_apps" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -537,7 +537,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list_functionality: Input schema for "list-functionality" 1`] = `
+exports[`Tools schemas list_functionality: Input schema for "list_functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -553,7 +553,7 @@ Object {
 }
 `;
 
-exports[`Tools schemas list_functionality: Output schema for "list-functionality" 1`] = `
+exports[`Tools schemas list_functionality: Output schema for "list_functionality" 1`] = `
 Object {
   "additionalProperties": false,
   "properties": Object {
@@ -586,7 +586,7 @@ Object {
                 "type": "array",
               },
             ],
-            "description": "Identifier to pass as the \`functionalityId\` parameter when calling \`get-functionality-details\` or \`execute-functionality\`",
+            "description": "Identifier to pass as the \`functionalityId\` parameter when calling \`get_functionality_details\` or \`execute_functionality\`",
           },
         },
         "required": Array [

--- a/packages/fiori-mcp-server/test/unit/tools/index.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/index.test.ts
@@ -7,22 +7,22 @@ const executeFunctionaliy = tools.find((tool) => tool.name === 'execute_function
 
 describe('Tools schemas', () => {
     test('list_fiori_apps', async () => {
-        expect(listFioriApps?.inputSchema).toMatchSnapshot('Input schema for "list-fiori-apps"');
-        expect(listFioriApps?.outputSchema).toMatchSnapshot('Output schema for "list-fiori-apps"');
+        expect(listFioriApps?.inputSchema).toMatchSnapshot('Input schema for "list_fiori_apps"');
+        expect(listFioriApps?.outputSchema).toMatchSnapshot('Output schema for "list_fiori_apps"');
     });
 
     test('list_functionality', async () => {
-        expect(listFunctionality?.inputSchema).toMatchSnapshot('Input schema for "list-functionality"');
-        expect(listFunctionality?.outputSchema).toMatchSnapshot('Output schema for "list-functionality"');
+        expect(listFunctionality?.inputSchema).toMatchSnapshot('Input schema for "list_functionality"');
+        expect(listFunctionality?.outputSchema).toMatchSnapshot('Output schema for "list_functionality"');
     });
 
     test('get_functionality_details', async () => {
-        expect(getFunctionalityDetails?.inputSchema).toMatchSnapshot('Input schema for "get-functionality-details"');
-        expect(getFunctionalityDetails?.outputSchema).toMatchSnapshot('Output schema for "get-functionality-details"');
+        expect(getFunctionalityDetails?.inputSchema).toMatchSnapshot('Input schema for "get_functionality_details"');
+        expect(getFunctionalityDetails?.outputSchema).toMatchSnapshot('Output schema for "get_functionality_details"');
     });
 
     test('execute_functionality', async () => {
-        expect(executeFunctionaliy?.inputSchema).toMatchSnapshot('Input schema for "execute-functionality"');
-        expect(executeFunctionaliy?.outputSchema).toMatchSnapshot('Output schema for "execute-functionality"');
+        expect(executeFunctionaliy?.inputSchema).toMatchSnapshot('Input schema for "execute_functionality"');
+        expect(executeFunctionaliy?.outputSchema).toMatchSnapshot('Output schema for "execute_functionality"');
     });
 });

--- a/packages/fiori-mcp-server/test/unit/tools/index.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/index.test.ts
@@ -1,27 +1,27 @@
 import { tools } from '../../../src/tools/index';
 
-const listFioriApps = tools.find((tool) => tool.name === 'list-fiori-apps');
-const listFunctionality = tools.find((tool) => tool.name === 'list-functionality');
-const getFunctionalityDetails = tools.find((tool) => tool.name === 'get-functionality-details');
-const executeFunctionaliy = tools.find((tool) => tool.name === 'execute-functionality');
+const listFioriApps = tools.find((tool) => tool.name === 'list_fiori_apps');
+const listFunctionality = tools.find((tool) => tool.name === 'list_functionality');
+const getFunctionalityDetails = tools.find((tool) => tool.name === 'get_functionality_details');
+const executeFunctionaliy = tools.find((tool) => tool.name === 'execute_functionality');
 
 describe('Tools schemas', () => {
-    test('list-fiori-apps', async () => {
+    test('list_fiori_apps', async () => {
         expect(listFioriApps?.inputSchema).toMatchSnapshot('Input schema for "list-fiori-apps"');
         expect(listFioriApps?.outputSchema).toMatchSnapshot('Output schema for "list-fiori-apps"');
     });
 
-    test('list-functionality', async () => {
+    test('list_functionality', async () => {
         expect(listFunctionality?.inputSchema).toMatchSnapshot('Input schema for "list-functionality"');
         expect(listFunctionality?.outputSchema).toMatchSnapshot('Output schema for "list-functionality"');
     });
 
-    test('get-functionality-details', async () => {
+    test('get_functionality_details', async () => {
         expect(getFunctionalityDetails?.inputSchema).toMatchSnapshot('Input schema for "get-functionality-details"');
         expect(getFunctionalityDetails?.outputSchema).toMatchSnapshot('Output schema for "get-functionality-details"');
     });
 
-    test('execute-functionality', async () => {
+    test('execute_functionality', async () => {
         expect(executeFunctionaliy?.inputSchema).toMatchSnapshot('Input schema for "execute-functionality"');
         expect(executeFunctionaliy?.outputSchema).toMatchSnapshot('Output schema for "execute-functionality"');
     });


### PR DESCRIPTION
Update MCP to use snake case instead of kebab case in MCP tool names. Rename `doc_search` to `search_docs`.