### PR TITLE
Add instructions for VS Code global MCP server file

### DIFF
--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -53,6 +53,26 @@ Then, configure your MCP client to start the server with command `fiori-mcp`. He
 }
 ```
 
+You can create a global configuration [mcp.json](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) within Visual Studio Code:
+GitHub Copilot uses the `mcp.json` file as source for it's Agent mode.
+```json
+{
+	"servers": {
+		"fiori-mcp": {
+			"type": "stdio",
+			"timeout": 600,
+			"command": "npx",
+			"args": [
+				"--yes",
+				"@sap-ux/fiori-mcp-server@latest",
+				"fiori-mcp"
+			]
+		}
+	"inputs": []
+}
+```
+
+
 ## [Rules](#rules)
 
 The following rules help guide the LLM to use the server correctly:


### PR DESCRIPTION
This PR adds instructions for the configuration of the MCP server within the `mcp.json` file which can be used as global MCP server list within Visual Studio Code.