### PR TITLE
fix(abap deploy config inquirer): 33258 asterisk for transport request

### DIFF
--- a/.changeset/hip-wasps-impress.md
+++ b/.changeset/hip-wasps-impress.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-inquirer': patch
+---
+
+Show asterisk for the Transport Request textbox.

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
@@ -120,14 +120,11 @@ export function getTransportRequestPrompts(
                 ),
             type: 'input',
             name: promptNames.transportManual,
-            message: () =>
-                PromptState.transportAnswers.transportRequired
-                    ? t('prompts.config.transport.common.transportRequestMandatory')
-                    : t('prompts.config.transport.common.transportRequest'),
+            message: t('prompts.config.transport.common.transportRequest'),
             guiOptions: {
                 hint: t('prompts.config.transport.common.provideTransportRequest'),
                 breadcrumb: t('prompts.config.transport.common.transportRequest'),
-                mandatory: PromptState.transportAnswers.transportRequired
+                mandatory: true
             },
             default: (previousAnswers: AbapDeployConfigAnswersInternal) =>
                 previousAnswers.transportManual || options.transportManual?.default,

--- a/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
+++ b/packages/abap-deploy-config-inquirer/src/prompts/questions/config/transport.ts
@@ -126,7 +126,8 @@ export function getTransportRequestPrompts(
                     : t('prompts.config.transport.common.transportRequest'),
             guiOptions: {
                 hint: t('prompts.config.transport.common.provideTransportRequest'),
-                breadcrumb: t('prompts.config.transport.common.transportRequest')
+                breadcrumb: t('prompts.config.transport.common.transportRequest'),
+                mandatory: PromptState.transportAnswers.transportRequired
             },
             default: (previousAnswers: AbapDeployConfigAnswersInternal) =>
                 previousAnswers.transportManual || options.transportManual?.default,

--- a/packages/abap-deploy-config-inquirer/test/prompts/questions/config/transport.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/questions/config/transport.test.ts
@@ -63,7 +63,7 @@ describe('getTransportRequestPrompts', () => {
                   "hint": "Provide a transport request for your application.",
                   "mandatory": true,
                 },
-                "message": [Function],
+                "message": "Transport Request",
                 "name": "transportManual",
                 "type": "input",
                 "validate": [Function],
@@ -238,9 +238,7 @@ describe('getTransportRequestPrompts', () => {
                     transportInputChoice: TransportChoices.EnterManualChoice
                 })
             ).toBe(true);
-            expect((transportManualPrompt.message as Function)()).toBe(
-                t('prompts.config.transport.common.transportRequestMandatory')
-            );
+            expect(transportManualPrompt.message).toBe(t('prompts.config.transport.common.transportRequest'));
             const previousAnswers = { transportManual: 'TR1234' };
             expect((transportManualPrompt.default as Function)(previousAnswers)).toBe('TR1234');
             expect((transportManualPrompt.validate as Function)(previousAnswers)).toBe(true);

--- a/packages/abap-deploy-config-inquirer/test/prompts/questions/config/transport.test.ts
+++ b/packages/abap-deploy-config-inquirer/test/prompts/questions/config/transport.test.ts
@@ -61,6 +61,7 @@ describe('getTransportRequestPrompts', () => {
                 "guiOptions": Object {
                   "breadcrumb": "Transport Request",
                   "hint": "Provide a transport request for your application.",
+                  "mandatory": true,
                 },
                 "message": [Function],
                 "name": "transportManual",

--- a/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
@@ -90,7 +90,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
       "hint": "Provide a transport request for your application.",
       "mandatory": true,
     },
-    "message": [Function],
+    "message": "Transport Request",
     "name": "transportManual",
     "type": "input",
     "validate": [Function],

--- a/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui-service-inquirer/test/__snapshots__/prompts.test.ts.snap
@@ -88,6 +88,7 @@ exports[`getSystemQuestions getServiceConfigQuestions 1`] = `
     "guiOptions": {
       "breadcrumb": "Transport Request",
       "hint": "Provide a transport request for your application.",
+      "mandatory": true,
     },
     "message": [Function],
     "name": "transportManual",


### PR DESCRIPTION
Related to the internal issue 33258.

Show an asterisk next to the Transport Request (mandatory) input.

<img width="681" height="678" alt="image" src="https://github.com/user-attachments/assets/c2881383-c2e1-4520-b335-df9e29ed1298" />
