### PR TITLE
fix: "lrep" property is not added when the deploy config is created from within the ADP Generator

### DIFF
--- a/.changeset/hungry-ducks-begin.md
+++ b/.changeset/hungry-ducks-begin.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-sub-generator': patch
+---
+
+fix: "lrep" property is not added when the deploy config is created from within the ADP Generator

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -289,7 +289,12 @@ export default class extends DeploymentGenerator {
         if (this.abort || this.answers.overwrite === false) {
             return;
         }
-        const namespace = await getVariantNamespace(this.destinationPath(), !!this.answers.isS4HC);
+        const namespace = await getVariantNamespace(
+            this.destinationPath(),
+            !!this.answers.isS4HC,
+            this.launchDeployConfigAsSubGenerator,
+            this.fs
+        );
         await generateAbapDeployConfig(
             this.destinationPath(),
             {

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -289,12 +289,7 @@ export default class extends DeploymentGenerator {
         if (this.abort || this.answers.overwrite === false) {
             return;
         }
-        const namespace = await getVariantNamespace(
-            this.destinationPath(),
-            !!this.answers.isS4HC,
-            this.launchDeployConfigAsSubGenerator,
-            this.fs
-        );
+        const namespace = await getVariantNamespace(this.destinationPath(), !!this.answers.isS4HC, this.fs);
         await generateAbapDeployConfig(
             this.destinationPath(),
             {

--- a/packages/abap-deploy-config-sub-generator/src/utils/project.ts
+++ b/packages/abap-deploy-config-sub-generator/src/utils/project.ts
@@ -1,7 +1,6 @@
 import { FileName, getWebappPath } from '@sap-ux/project-access';
 import { join } from 'path';
 import type { Editor } from 'mem-fs-editor';
-import { existsSync, readFileSync } from 'fs';
 import { t } from './i18n';
 import { DeploymentGenerator } from '@sap-ux/deploy-config-generator-shared';
 
@@ -24,34 +23,20 @@ export async function indexHtmlExists(fs: Editor, path: string): Promise<boolean
  *
  * @param path - The path to the project.
  * @param isS4HC - Whether the project is Cloud.
- * @param launchAsSubGen - Whether the project is launched as a sub generator.
  * @param fs - The file system editor.
  * @returns The variant namespace.
  */
-export async function getVariantNamespace(
-    path: string,
-    isS4HC: boolean,
-    launchAsSubGen: boolean,
-    fs: Editor
-): Promise<string | undefined> {
+export async function getVariantNamespace(path: string, isS4HC: boolean, fs: Editor): Promise<string | undefined> {
     if (isS4HC) {
         return undefined;
     }
 
     try {
-        if (launchAsSubGen) {
-            const filePath = join(await getWebappPath(path, fs), FileName.ManifestAppDescrVar);
-            // When launched as sub-generator, prioritize memory-based approach
-            if (fs.exists(filePath)) {
-                const descriptor = fs.readJSON(filePath) as unknown as { namespace: string };
-                return descriptor.namespace;
-            }
-        } else {
-            const filePath = join(await getWebappPath(path), FileName.ManifestAppDescrVar);
-            if (existsSync(filePath)) {
-                const descriptor = JSON.parse(readFileSync(filePath, 'utf-8'));
-                return descriptor.namespace;
-            }
+        const filePath = join(await getWebappPath(path, fs), FileName.ManifestAppDescrVar);
+
+        if (fs.exists(filePath)) {
+            const descriptor = fs.readJSON(filePath) as unknown as { namespace: string };
+            return descriptor.namespace;
         }
     } catch (e) {
         DeploymentGenerator.logger?.debug(t('debug.lrepNamespaceNotFound', { error: e.message }));

--- a/packages/abap-deploy-config-sub-generator/test/unit/utils/project.test.ts
+++ b/packages/abap-deploy-config-sub-generator/test/unit/utils/project.test.ts
@@ -59,35 +59,17 @@ describe('getVariantNamespace', () => {
     });
 
     it('should return undefined for S4HC projects', async () => {
-        const result = await getVariantNamespace(mockPath, true, false, mockFs);
+        const result = await getVariantNamespace(mockPath, true, mockFs);
         expect(result).toBeUndefined();
         expect(mockGetWebappPath).not.toHaveBeenCalled();
     });
 
-    it('should return namespace from disk when launchAsSubGen is false', async () => {
-        const mockManifest = { namespace: 'apps/workcenter/appVariants/customer.app.variant' };
-        mockExistsSync.mockReturnValue(true);
-        mockReadFileSync.mockReturnValue(JSON.stringify(mockManifest));
-
-        const result = await getVariantNamespace(mockPath, false, false, mockFs);
-
-        expect(result).toBe(mockManifest.namespace);
-        expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath);
-        expect(mockExistsSync).toHaveBeenCalledWith(mockManifestPath);
-    });
-
-    it('should return undefined when disk file does not exist', async () => {
-        mockExistsSync.mockReturnValue(false);
-        const result = await getVariantNamespace(mockPath, false, false, mockFs);
-        expect(result).toBeUndefined();
-    });
-
-    it('should return namespace from memory when launchAsSubGen is true', async () => {
+    it('should return namespace from memory', async () => {
         const mockManifest = { namespace: 'apps/workcenter/appVariants/customer.app.variant' };
         mockFsExists.mockReturnValue(true);
         mockFsReadJSON.mockReturnValue(mockManifest);
 
-        const result = await getVariantNamespace(mockPath, false, true, mockFs);
+        const result = await getVariantNamespace(mockPath, false, mockFs);
 
         expect(result).toBe(mockManifest.namespace);
         expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath, mockFs);
@@ -96,7 +78,7 @@ describe('getVariantNamespace', () => {
 
     it('should return undefined when memory file does not exist', async () => {
         mockFsExists.mockReturnValue(false);
-        const result = await getVariantNamespace(mockPath, false, true, mockFs);
+        const result = await getVariantNamespace(mockPath, false, mockFs);
         expect(result).toBeUndefined();
     });
 
@@ -105,7 +87,7 @@ describe('getVariantNamespace', () => {
             throw new Error('Memory filesystem error');
         });
 
-        const result = await getVariantNamespace(mockPath, false, true, mockFs);
+        const result = await getVariantNamespace(mockPath, false, mockFs);
 
         expect(result).toBeUndefined();
         expect(DeploymentGenerator.logger.debug).toHaveBeenCalledWith(

--- a/packages/abap-deploy-config-sub-generator/test/unit/utils/project.test.ts
+++ b/packages/abap-deploy-config-sub-generator/test/unit/utils/project.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import type { Editor } from 'mem-fs-editor';
 import { existsSync, readFileSync } from 'fs';
 
 import { getWebappPath, FileName } from '@sap-ux/project-access';
@@ -36,6 +37,10 @@ describe('getVariantNamespace', () => {
     const mockWebappPath = '/test/project/webapp';
     const mockManifestPath = join(mockWebappPath, FileName.ManifestAppDescrVar);
 
+    let mockFs: Editor;
+    let mockFsExists: jest.Mock;
+    let mockFsReadJSON: jest.Mock;
+
     beforeAll(async () => {
         await initI18n();
     });
@@ -43,57 +48,68 @@ describe('getVariantNamespace', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockGetWebappPath.mockResolvedValue(mockWebappPath);
+
+        mockFsExists = jest.fn();
+        mockFsReadJSON = jest.fn();
+
+        mockFs = {
+            exists: mockFsExists,
+            readJSON: mockFsReadJSON
+        } as unknown as Editor;
     });
 
     it('should return undefined for S4HC projects', async () => {
-        const result = await getVariantNamespace(mockPath, true);
-
+        const result = await getVariantNamespace(mockPath, true, false, mockFs);
         expect(result).toBeUndefined();
         expect(mockGetWebappPath).not.toHaveBeenCalled();
-        expect(mockExistsSync).not.toHaveBeenCalled();
     });
 
-    it('should return namespace from manifest.appdescr_variant file', async () => {
-        const mockManifest = {
-            namespace: 'apps/workcenter/appVariants/customer.app.variant'
-        };
-
+    it('should return namespace from disk when launchAsSubGen is false', async () => {
+        const mockManifest = { namespace: 'apps/workcenter/appVariants/customer.app.variant' };
         mockExistsSync.mockReturnValue(true);
         mockReadFileSync.mockReturnValue(JSON.stringify(mockManifest));
 
-        const result = await getVariantNamespace(mockPath, false);
+        const result = await getVariantNamespace(mockPath, false, false, mockFs);
 
-        expect(result).toBe('apps/workcenter/appVariants/customer.app.variant');
+        expect(result).toBe(mockManifest.namespace);
         expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath);
         expect(mockExistsSync).toHaveBeenCalledWith(mockManifestPath);
-        expect(mockReadFileSync).toHaveBeenCalledWith(mockManifestPath, 'utf-8');
     });
 
-    it('should return undefined when manifest file does not exist', async () => {
+    it('should return undefined when disk file does not exist', async () => {
         mockExistsSync.mockReturnValue(false);
-
-        const result = await getVariantNamespace(mockPath, false);
-
+        const result = await getVariantNamespace(mockPath, false, false, mockFs);
         expect(result).toBeUndefined();
-        expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath);
-        expect(mockExistsSync).toHaveBeenCalledWith(mockManifestPath);
-        expect(mockReadFileSync).not.toHaveBeenCalled();
     });
 
-    it('should handle JSON parsing errors gracefully', async () => {
-        mockExistsSync.mockReturnValue(true);
-        mockReadFileSync.mockReturnValue('invalid json content');
+    it('should return namespace from memory when launchAsSubGen is true', async () => {
+        const mockManifest = { namespace: 'apps/workcenter/appVariants/customer.app.variant' };
+        mockFsExists.mockReturnValue(true);
+        mockFsReadJSON.mockReturnValue(mockManifest);
 
-        const result = await getVariantNamespace(mockPath, false);
+        const result = await getVariantNamespace(mockPath, false, true, mockFs);
+
+        expect(result).toBe(mockManifest.namespace);
+        expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath, mockFs);
+        expect(mockFsExists).toHaveBeenCalledWith(mockManifestPath);
+    });
+
+    it('should return undefined when memory file does not exist', async () => {
+        mockFsExists.mockReturnValue(false);
+        const result = await getVariantNamespace(mockPath, false, true, mockFs);
+        expect(result).toBeUndefined();
+    });
+
+    it('should handle errors gracefully', async () => {
+        mockFsExists.mockImplementation(() => {
+            throw new Error('Memory filesystem error');
+        });
+
+        const result = await getVariantNamespace(mockPath, false, true, mockFs);
 
         expect(result).toBeUndefined();
-        expect(mockGetWebappPath).toHaveBeenCalledWith(mockPath);
-        expect(mockExistsSync).toHaveBeenCalledWith(mockManifestPath);
-        expect(mockReadFileSync).toHaveBeenCalledWith(mockManifestPath, 'utf-8');
         expect(DeploymentGenerator.logger.debug).toHaveBeenCalledWith(
-            t('debug.lrepNamespaceNotFound', {
-                error: 'Unexpected token \'i\', "invalid json content" is not valid JSON'
-            })
+            t('debug.lrepNamespaceNotFound', { error: 'Memory filesystem error' })
         );
     });
 });


### PR DESCRIPTION
Fix for #3616.
- Adds a check to determine whether we are running as a sub-generator or part of the ADP generator and read from disk or from mem-fs, respectively.