### PR TITLE
fix: Wrong navigation between steps in FLP Configuration generator for ADP

### DIFF
--- a/.changeset/wicked-plums-check.md
+++ b/.changeset/wicked-plums-check.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/adp-flp-config-sub-generator": patch
+---
+
+fix: Wrong navigation between steps in FLP Configuration generator for ADP

--- a/packages/adp-flp-config-sub-generator/src/app/index.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/index.ts
@@ -127,7 +127,9 @@ export default class AdpFlpConfigGenerator extends Generator {
     }
 
     public async prompting(): Promise<void> {
-        if (this.authenticationRequired) {
+        // If authentication was already prompted it should not be skipped as this leads to issues with Yeoman UI navigation
+        const credentialsPrompted = getFromCache<boolean>(this.appWizard, 'credentialsPrompted', this.logger);
+        if (this.authenticationRequired || credentialsPrompted) {
             await this._promptAuthentication();
         }
         if (this.abort) {
@@ -197,7 +199,7 @@ export default class AdpFlpConfigGenerator extends Generator {
                 try {
                     this.provider = await getAbapServiceProvider(this.ui5Yaml, this.toolsLogger, this.credentials);
                     this.inbounds = await getBaseAppInbounds(this.appId, this.provider);
-                    addToCache(this.appWizard, { provider: this.provider }, this.logger);
+                    addToCache(this.appWizard, { provider: this.provider, credentialsPrompted: true }, this.logger);
                 } catch (error) {
                     if (!isAxiosError(error)) {
                         this.logger.error(`Base application inbounds fetching failed: ${error}`);

--- a/packages/adp-flp-config-sub-generator/src/app/types.ts
+++ b/packages/adp-flp-config-sub-generator/src/app/types.ts
@@ -40,4 +40,5 @@ export interface FlpConfigOptions extends Generator.GeneratorOptions {
 
 export interface State {
     provider?: AbapServiceProvider;
+    credentialsPrompted?: boolean;
 }

--- a/packages/adp-flp-config-sub-generator/src/utils/appWizardCache.ts
+++ b/packages/adp-flp-config-sub-generator/src/utils/appWizardCache.ts
@@ -16,7 +16,7 @@ const hostEnv = getHostEnvironment();
  */
 export function initAppWizardCache(logger: ILogWrapper, appWizard?: AppWizardCache): void {
     if (appWizard && !appWizard[ADP_FLP_CONFIG_CACHE]) {
-        appWizard[ADP_FLP_CONFIG_CACHE] = {};
+        appWizard[ADP_FLP_CONFIG_CACHE] = { credentialsPrompted: false };
         logger.debug('AppWizard based cache initialized.');
     }
 }

--- a/packages/adp-flp-config-sub-generator/test/utils/appWizardCache.test.ts
+++ b/packages/adp-flp-config-sub-generator/test/utils/appWizardCache.test.ts
@@ -26,7 +26,7 @@ describe('appWizardCache', () => {
 
             initAppWizardCache(logger, appWizard);
 
-            expect(appWizard[ADP_FLP_CONFIG_CACHE]).toEqual({});
+            expect(appWizard[ADP_FLP_CONFIG_CACHE]).toEqual({ credentialsPrompted: false });
             expect(logger.debug).toHaveBeenCalledWith('AppWizard based cache initialized.');
         });
 


### PR DESCRIPTION
#3692

* Introduces an additional property persisted in AppWizard cache that indicates if credential prompts were already shown. If the property is set to `true` the credential prompts are added as a step in Yeoman UI to prevent issues with the navigation.