### PR TITLE
fix: Missing build script for ADP onPremise projects leads to error during deployment

### DIFF
--- a/.changeset/gold-boxes-kick.md
+++ b/.changeset/gold-boxes-kick.md
@@ -1,5 +1,7 @@
 ---
 '@sap-ux/abap-deploy-config-writer': patch
+'@sap-ux/abap-deploy-config-sub-generator': patch
+'@sap-ux/create': patch
 ---
 
 fix: Missing build script for ADP onPremise projects leads to error during deployment

--- a/.changeset/gold-boxes-kick.md
+++ b/.changeset/gold-boxes-kick.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/abap-deploy-config-writer': patch
+---
+
+fix: Missing build script for ADP onPremise projects leads to error during deployment

--- a/packages/abap-deploy-config-sub-generator/src/app/index.ts
+++ b/packages/abap-deploy-config-sub-generator/src/app/index.ts
@@ -56,6 +56,7 @@ export default class extends DeploymentGenerator {
     private configExists: boolean;
     private answers: AbapDeployConfigAnswersInternal;
     private projectType: DeployProjectType;
+    private isAdp: boolean;
 
     /**
      * Constructor for the ABAP deploy config generator.
@@ -174,24 +175,24 @@ export default class extends DeploymentGenerator {
         }
         if (!this.launchDeployConfigAsSubGenerator) {
             const appType = await getAppType(this.destinationPath());
-            const isAdp = appType === 'Fiori Adaptation';
+            this.isAdp = appType === 'Fiori Adaptation';
             const packageAdditionalValidation = {
-                shouldValidatePackageForStartingPrefix: isAdp,
-                shouldValidatePackageType: isAdp,
-                shouldValidateFormatAndSpecialCharacters: isAdp
+                shouldValidatePackageForStartingPrefix: this.isAdp,
+                shouldValidatePackageType: this.isAdp,
+                shouldValidateFormatAndSpecialCharacters: this.isAdp
             };
             const promptOptions: AbapDeployConfigPromptOptions = {
-                ui5AbapRepo: { hideIfOnPremise: isAdp },
-                transportInputChoice: { hideIfOnPremise: isAdp },
+                ui5AbapRepo: { hideIfOnPremise: this.isAdp },
+                transportInputChoice: { hideIfOnPremise: this.isAdp },
                 packageAutocomplete: {
                     additionalValidation: packageAdditionalValidation
                 },
                 packageManual: {
                     additionalValidation: packageAdditionalValidation
                 },
-                targetSystem: { additionalValidation: { shouldRestrictDifferentSystemType: isAdp } }
+                targetSystem: { additionalValidation: { shouldRestrictDifferentSystemType: this.isAdp } }
             };
-            const indexGenerationAllowed = this.indexGenerationAllowed && !isAdp;
+            const indexGenerationAllowed = this.indexGenerationAllowed && !this.isAdp;
             const { prompts: abapDeployConfigPrompts, answers: abapAnswers = {} } = await getAbapQuestions({
                 appRootPath: this.destinationRoot(),
                 connectedSystem: this.options.connectedSystem,
@@ -311,7 +312,8 @@ export default class extends DeploymentGenerator {
             } as AbapDeployConfig,
             {
                 baseFile: this.options.base,
-                deployFile: this.options.config
+                deployFile: this.options.config,
+                addBuildToUndeployScript: !this.isAdp
             },
             this.fs
         );

--- a/packages/abap-deploy-config-writer/src/file.ts
+++ b/packages/abap-deploy-config-writer/src/file.ts
@@ -1,8 +1,7 @@
 import { join } from 'path';
 import fg from 'fast-glob';
 import { platform } from 'os';
-import { existsSync } from 'fs';
-import { FileName, type Package, getReuseLibs } from '@sap-ux/project-access';
+import { FileName, type Package, getReuseLibs, getWebappPath } from '@sap-ux/project-access';
 import { UI5_CLI_LIB, UI5_CLI_MIN_VERSION, UI5_REPO_IGNORE, UI5_REPO_TEXT_FILES } from './constants';
 import { coerce, satisfies } from 'semver';
 import type { Editor } from 'mem-fs-editor';
@@ -120,13 +119,13 @@ export async function writeUi5RepositoryIgnore(fs: Editor, path?: string): Promi
 }
 
 /**
- * Checks if the project is a TypeScript project.
+ * Checks if the project is a ADP project.
  *
  * @param fs - the memfs editor instance
  * @param basePath - the base path
  * @returns true if the project is a TypeScript project, false otherwise
  */
-export function isTsProject(fs: Editor, basePath: string): boolean {
-    const tsconfigPath = join(basePath, FileName.Tsconfig);
-    return fs.exists(tsconfigPath) || existsSync(tsconfigPath);
+export async function isAdpProject(fs: Editor, basePath: string): Promise<boolean> {
+    const webappPath = await getWebappPath(basePath, fs);
+    return fs.exists(join(webappPath, FileName.ManifestAppDescrVar));
 }

--- a/packages/abap-deploy-config-writer/src/file.ts
+++ b/packages/abap-deploy-config-writer/src/file.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import fg from 'fast-glob';
 import { platform } from 'os';
-import { FileName, type Package, getReuseLibs, getWebappPath } from '@sap-ux/project-access';
+import { FileName, type Package, getReuseLibs } from '@sap-ux/project-access';
 import { UI5_CLI_LIB, UI5_CLI_MIN_VERSION, UI5_REPO_IGNORE, UI5_REPO_TEXT_FILES } from './constants';
 import { coerce, satisfies } from 'semver';
 import type { Editor } from 'mem-fs-editor';
@@ -116,16 +116,4 @@ export async function writeUi5RepositoryIgnore(fs: Editor, path?: string): Promi
             writeUi5RepositoryFile(fs, path, UI5_REPO_IGNORE, '^.*.ts$\n^.*.ts.map$');
         }
     }
-}
-
-/**
- * Checks if the project is a ADP project.
- *
- * @param fs - the memfs editor instance
- * @param basePath - the base path
- * @returns true if the project is a TypeScript project, false otherwise
- */
-export async function isAdpProject(fs: Editor, basePath: string): Promise<boolean> {
-    const webappPath = await getWebappPath(basePath, fs);
-    return fs.exists(join(webappPath, FileName.ManifestAppDescrVar));
 }

--- a/packages/abap-deploy-config-writer/src/index.ts
+++ b/packages/abap-deploy-config-writer/src/index.ts
@@ -4,13 +4,7 @@ import { create } from 'mem-fs-editor';
 import cloneDeep from 'lodash/cloneDeep';
 import { addPackageDevDependency, FileName, getWebappPath, readUi5Yaml } from '@sap-ux/project-access';
 import { getDeployConfig, updateBaseConfig } from './config';
-import {
-    addUi5Dependency,
-    getLibraryPath,
-    isTsProject,
-    writeUi5RepositoryFiles,
-    writeUi5RepositoryIgnore
-} from './file';
+import { addUi5Dependency, getLibraryPath, writeUi5RepositoryFiles, writeUi5RepositoryIgnore } from './file';
 import { UI5_TASK_FLATTEN_LIB, UI5_TASK_FLATTEN_LIB_VERSION } from './constants';
 import type { DeployConfigOptions } from './types';
 import type { Editor } from 'mem-fs-editor';
@@ -51,8 +45,7 @@ async function generate(
     const deployConfig = await getDeployConfig(abapConfig, baseConfig);
     fs.write(deployFilePath, deployConfig.toString());
 
-    const includeBuildScript = !abapConfig.lrep || isTsProject(fs, basePath);
-    await updateScripts(basePath, deployConfigFile, fs, includeBuildScript);
+    await updateScripts(basePath, deployConfigFile, fs);
 
     if (isLib) {
         // ui5 repo ignore file

--- a/packages/abap-deploy-config-writer/src/index.ts
+++ b/packages/abap-deploy-config-writer/src/index.ts
@@ -45,7 +45,7 @@ async function generate(
     const deployConfig = await getDeployConfig(abapConfig, baseConfig);
     fs.write(deployFilePath, deployConfig.toString());
 
-    await updateScripts(basePath, deployConfigFile, fs);
+    await updateScripts(basePath, deployConfigFile, fs, options);
 
     if (isLib) {
         // ui5 repo ignore file

--- a/packages/abap-deploy-config-writer/src/scripts.ts
+++ b/packages/abap-deploy-config-writer/src/scripts.ts
@@ -2,7 +2,7 @@ import type { Editor } from 'mem-fs-editor';
 
 import { addPackageDevDependency, updatePackageScript } from '@sap-ux/project-access';
 
-import { isAdpProject } from './file';
+import type { DeployConfigOptions } from './types';
 import { BUILD_SCRIPT, DEPLOY_SCRIPT, RIMRAF, RIMRAF_VERSION, UNDEPLOY_SCRIPT } from './constants';
 
 /**
@@ -11,10 +11,15 @@ import { BUILD_SCRIPT, DEPLOY_SCRIPT, RIMRAF, RIMRAF_VERSION, UNDEPLOY_SCRIPT } 
  * @param {string} basePath - The path to the base directory.
  * @param {string} deployConfigFile - The path to the deploy config file.
  * @param {Editor} fs - The file system editor.
+ * @param {DeployConfigOptions} options - The deploy config options.
  */
-export async function updateScripts(basePath: string, deployConfigFile: string, fs: Editor): Promise<void> {
-    const isAdp = await isAdpProject(fs, basePath);
-    const buildPrefix = isAdp ? '' : `${BUILD_SCRIPT} && `;
+export async function updateScripts(
+    basePath: string,
+    deployConfigFile: string,
+    fs: Editor,
+    options?: DeployConfigOptions
+): Promise<void> {
+    const buildPrefix = options?.addBuildToUndeployScript ?? true ? `${BUILD_SCRIPT} && ` : '';
 
     // deploy script
     const deployScript = `${BUILD_SCRIPT} && ${DEPLOY_SCRIPT} --config ${deployConfigFile}`;

--- a/packages/abap-deploy-config-writer/src/scripts.ts
+++ b/packages/abap-deploy-config-writer/src/scripts.ts
@@ -2,6 +2,7 @@ import type { Editor } from 'mem-fs-editor';
 
 import { addPackageDevDependency, updatePackageScript } from '@sap-ux/project-access';
 
+import { isAdpProject } from './file';
 import { BUILD_SCRIPT, DEPLOY_SCRIPT, RIMRAF, RIMRAF_VERSION, UNDEPLOY_SCRIPT } from './constants';
 
 /**
@@ -10,18 +11,13 @@ import { BUILD_SCRIPT, DEPLOY_SCRIPT, RIMRAF, RIMRAF_VERSION, UNDEPLOY_SCRIPT } 
  * @param {string} basePath - The path to the base directory.
  * @param {string} deployConfigFile - The path to the deploy config file.
  * @param {Editor} fs - The file system editor.
- * @param {boolean} includeBuildScript - Whether to include build script in deploy commands.
  */
-export async function updateScripts(
-    basePath: string,
-    deployConfigFile: string,
-    fs: Editor,
-    includeBuildScript: boolean = true
-): Promise<void> {
-    const buildPrefix = includeBuildScript ? `${BUILD_SCRIPT} && ` : '';
+export async function updateScripts(basePath: string, deployConfigFile: string, fs: Editor): Promise<void> {
+    const isAdp = await isAdpProject(fs, basePath);
+    const buildPrefix = isAdp ? '' : `${BUILD_SCRIPT} && `;
 
     // deploy script
-    const deployScript = `${buildPrefix}${DEPLOY_SCRIPT} --config ${deployConfigFile}`;
+    const deployScript = `${BUILD_SCRIPT} && ${DEPLOY_SCRIPT} --config ${deployConfigFile}`;
     await updatePackageScript(basePath, 'deploy', deployScript, fs);
 
     // undeploy script
@@ -29,7 +25,7 @@ export async function updateScripts(
     await updatePackageScript(basePath, 'undeploy', undeployScript, fs);
 
     // test mode script
-    const deployTestModeScript = `${buildPrefix}${DEPLOY_SCRIPT} --config ${deployConfigFile} --testMode true`;
+    const deployTestModeScript = `${BUILD_SCRIPT} && ${DEPLOY_SCRIPT} --config ${deployConfigFile} --testMode true`;
     await updatePackageScript(basePath, 'deploy-test', deployTestModeScript, fs);
 
     // dependencies

--- a/packages/abap-deploy-config-writer/src/types.ts
+++ b/packages/abap-deploy-config-writer/src/types.ts
@@ -1,4 +1,8 @@
 export interface DeployConfigOptions {
     baseFile?: string; // e.g ui5.yaml
     deployFile?: string; // e.g ui5-deploy.yaml
+    /**
+     * Default is true. If true, the build script will be added to the undeploy script
+     */
+    addBuildToUndeployScript?: boolean;
 }

--- a/packages/abap-deploy-config-writer/test/unit/__snapshots__/index.test.ts.snap
+++ b/packages/abap-deploy-config-writer/test/unit/__snapshots__/index.test.ts.snap
@@ -219,9 +219,9 @@ Object {
         \\"start\\": \\"start script\\",
         \\"build\\": \\"build script\\",
         \\"test\\": \\"test script\\",
-        \\"deploy\\": \\"fiori deploy --config ui5-deploy.yaml\\",
+        \\"deploy\\": \\"npm run build && fiori deploy --config ui5-deploy.yaml\\",
         \\"undeploy\\": \\"fiori undeploy --config ui5-deploy.yaml\\",
-        \\"deploy-test\\": \\"fiori deploy --config ui5-deploy.yaml --testMode true\\"
+        \\"deploy-test\\": \\"npm run build && fiori deploy --config ui5-deploy.yaml --testMode true\\"
     },
     \\"devDependencies\\": {
         \\"rimraf\\": \\"^5.0.5\\"
@@ -345,7 +345,7 @@ Object {
         \\"build\\": \\"build script\\",
         \\"test\\": \\"test script\\",
         \\"deploy\\": \\"npm run build && fiori deploy --config ui5-deploy.yaml\\",
-        \\"undeploy\\": \\"npm run build && fiori undeploy --config ui5-deploy.yaml\\",
+        \\"undeploy\\": \\"fiori undeploy --config ui5-deploy.yaml\\",
         \\"deploy-test\\": \\"npm run build && fiori deploy --config ui5-deploy.yaml --testMode true\\"
     },
     \\"devDependencies\\": {

--- a/packages/abap-deploy-config-writer/test/unit/file.test.ts
+++ b/packages/abap-deploy-config-writer/test/unit/file.test.ts
@@ -1,17 +1,7 @@
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
-import { join } from 'path';
 
-import { FileName, getWebappPath } from '@sap-ux/project-access';
-
-import { addUi5Dependency, isAdpProject } from '../../src/file';
-
-jest.mock('@sap-ux/project-access', () => ({
-    ...jest.requireActual('@sap-ux/project-access'),
-    getWebappPath: jest.fn()
-}));
-
-const mockGetWebappPath = getWebappPath as jest.MockedFunction<typeof getWebappPath>;
+import { addUi5Dependency } from '../../src/file';
 
 describe('File utils', () => {
     test('should return when @ui5/cli version is greater or equal to 3.0.0', () => {
@@ -22,46 +12,5 @@ describe('File utils', () => {
             }
         });
         expect(addUi5Dependency(fs, 'base/path', 'dep')).toBeUndefined();
-    });
-
-    describe('isAdpProject', () => {
-        let mockFs: ReturnType<typeof create>;
-        const mockBasePath = '/test/project';
-        const mockWebappPath = '/test/project/webapp';
-        const mockManifestPath = join(mockWebappPath, FileName.ManifestAppDescrVar);
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-            mockFs = create(createStorage());
-            mockGetWebappPath.mockResolvedValue(mockWebappPath);
-        });
-
-        test('should return true when manifest.appdescr_variant exists in memory', async () => {
-            jest.spyOn(mockFs, 'exists').mockReturnValue(true);
-
-            const result = await isAdpProject(mockFs, mockBasePath);
-
-            expect(result).toBe(true);
-            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
-            expect(mockFs.exists).toHaveBeenCalledWith(mockManifestPath);
-        });
-
-        test('should return false when manifest.appdescr_variant does not exist in memory', async () => {
-            jest.spyOn(mockFs, 'exists').mockReturnValue(false);
-
-            const result = await isAdpProject(mockFs, mockBasePath);
-
-            expect(result).toBe(false);
-            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
-            expect(mockFs.exists).toHaveBeenCalledWith(mockManifestPath);
-        });
-
-        test('should handle getWebappPath errors', async () => {
-            const error = new Error('Failed to get webapp path');
-            mockGetWebappPath.mockRejectedValue(error);
-
-            await expect(isAdpProject(mockFs, mockBasePath)).rejects.toThrow('Failed to get webapp path');
-            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
-        });
     });
 });

--- a/packages/abap-deploy-config-writer/test/unit/file.test.ts
+++ b/packages/abap-deploy-config-writer/test/unit/file.test.ts
@@ -1,18 +1,17 @@
 import { create as createStorage } from 'mem-fs';
 import { create } from 'mem-fs-editor';
 import { join } from 'path';
-import { existsSync } from 'fs';
 
-import { FileName } from '@sap-ux/project-access';
+import { FileName, getWebappPath } from '@sap-ux/project-access';
 
-import { addUi5Dependency, isTsProject } from '../../src/file';
+import { addUi5Dependency, isAdpProject } from '../../src/file';
 
-jest.mock('fs', () => ({
-    ...jest.requireActual('fs'),
-    existsSync: jest.fn()
+jest.mock('@sap-ux/project-access', () => ({
+    ...jest.requireActual('@sap-ux/project-access'),
+    getWebappPath: jest.fn()
 }));
 
-const existsSyncMock = existsSync as jest.Mock;
+const mockGetWebappPath = getWebappPath as jest.MockedFunction<typeof getWebappPath>;
 
 describe('File utils', () => {
     test('should return when @ui5/cli version is greater or equal to 3.0.0', () => {
@@ -25,42 +24,44 @@ describe('File utils', () => {
         expect(addUi5Dependency(fs, 'base/path', 'dep')).toBeUndefined();
     });
 
-    describe('isTsProject', () => {
-        test('should return true when tsconfig.json exists in memory', () => {
-            const fs = create(createStorage());
-            const basePath = '/test/project';
-            const tsconfigPath = join(basePath, FileName.Tsconfig);
+    describe('isAdpProject', () => {
+        let mockFs: ReturnType<typeof create>;
+        const mockBasePath = '/test/project';
+        const mockWebappPath = '/test/project/webapp';
+        const mockManifestPath = join(mockWebappPath, FileName.ManifestAppDescrVar);
 
-            jest.spyOn(fs, 'exists').mockReturnValue(true);
-
-            expect(isTsProject(fs, basePath)).toBe(true);
-            expect(fs.exists).toHaveBeenCalledWith(tsconfigPath);
+        beforeEach(() => {
+            jest.clearAllMocks();
+            mockFs = create(createStorage());
+            mockGetWebappPath.mockResolvedValue(mockWebappPath);
         });
 
-        test('should return true when tsconfig.json exists on disk', () => {
-            const fs = create(createStorage());
-            const basePath = '/test/project';
-            const tsconfigPath = join(basePath, FileName.Tsconfig);
+        test('should return true when manifest.appdescr_variant exists in memory', async () => {
+            jest.spyOn(mockFs, 'exists').mockReturnValue(true);
 
-            jest.spyOn(fs, 'exists').mockReturnValue(false);
-            existsSyncMock.mockReturnValue(true);
+            const result = await isAdpProject(mockFs, mockBasePath);
 
-            expect(isTsProject(fs, basePath)).toBe(true);
-            expect(fs.exists).toHaveBeenCalledWith(tsconfigPath);
-            expect(existsSync).toHaveBeenCalledWith(tsconfigPath);
+            expect(result).toBe(true);
+            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
+            expect(mockFs.exists).toHaveBeenCalledWith(mockManifestPath);
         });
 
-        test('should return false when tsconfig.json does not exist', () => {
-            const fs = create(createStorage());
-            const basePath = '/test/project';
-            const tsconfigPath = join(basePath, FileName.Tsconfig);
+        test('should return false when manifest.appdescr_variant does not exist in memory', async () => {
+            jest.spyOn(mockFs, 'exists').mockReturnValue(false);
 
-            jest.spyOn(fs, 'exists').mockReturnValue(false);
-            existsSyncMock.mockReturnValue(false);
+            const result = await isAdpProject(mockFs, mockBasePath);
 
-            expect(isTsProject(fs, basePath)).toBe(false);
-            expect(fs.exists).toHaveBeenCalledWith(tsconfigPath);
-            expect(existsSync).toHaveBeenCalledWith(tsconfigPath);
+            expect(result).toBe(false);
+            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
+            expect(mockFs.exists).toHaveBeenCalledWith(mockManifestPath);
+        });
+
+        test('should handle getWebappPath errors', async () => {
+            const error = new Error('Failed to get webapp path');
+            mockGetWebappPath.mockRejectedValue(error);
+
+            await expect(isAdpProject(mockFs, mockBasePath)).rejects.toThrow('Failed to get webapp path');
+            expect(mockGetWebappPath).toHaveBeenCalledWith(mockBasePath, mockFs);
         });
     });
 });

--- a/packages/abap-deploy-config-writer/test/unit/index.test.ts
+++ b/packages/abap-deploy-config-writer/test/unit/index.test.ts
@@ -57,6 +57,9 @@ describe('generate', () => {
                 },
                 lrep: 'MOCK_LREP'
             },
+            options: {
+                addBuildToUndeployScript: false
+            },
             isAppStudio: false
         },
         {
@@ -67,6 +70,9 @@ describe('generate', () => {
                     ...config.target,
                     destination: 'MOCK_DESTINATION'
                 }
+            },
+            options: {
+                addBuildToUndeployScript: false
             },
             isAppStudio: false
         },

--- a/packages/create/src/cli/add/deploy-config.ts
+++ b/packages/create/src/cli/add/deploy-config.ts
@@ -149,7 +149,8 @@ async function addDeployConfig(
             logger.debug(`Adding deployment configuration : ${JSON.stringify(config, null, 2)}`);
             const fs = await generateDeployConfig(basePath, config, {
                 baseFile,
-                deployFile
+                deployFile,
+                addBuildToUndeployScript: !isAdp
             });
             await traceChanges(fs);
 


### PR DESCRIPTION
Fix for #3634.
- Adds `build` script for all projects, like it was before.
- Removes `build` script from `undeploy` script from ADP projects only.