### PR TITLE
feat: Adapt CF projects' structure to work with preview-middleware

### DIFF
--- a/packages/adp-tooling/src/writer/cf.ts
+++ b/packages/adp-tooling/src/writer/cf.ts
@@ -7,7 +7,7 @@ import { adjustMtaYaml } from '../cf';
 import { getApplicationType } from '../source';
 import { fillDescriptorContent } from './manifest';
 import type { CfAdpWriterConfig, Content } from '../types';
-import { getCfVariant, writeCfTemplates } from './project-utils';
+import { getCfVariant, writeCfTemplates, writeUI5YamlCf } from './project-utils';
 import { getI18nDescription, getI18nModels, writeI18nModels } from './i18n';
 
 /**
@@ -53,6 +53,7 @@ export async function generateCf(
     fillDescriptorContent(variant.content as Content[], app.appType, ui5.version, app.i18nModels);
 
     await writeCfTemplates(basePath, variant, fullConfig, fs);
+    await writeUI5YamlCf(fullConfig.project.folder, fullConfig, fs);
 
     return fs;
 }

--- a/packages/adp-tooling/src/writer/options.ts
+++ b/packages/adp-tooling/src/writer/options.ts
@@ -15,7 +15,8 @@ import type {
     CloudApp,
     InternalInboundNavigation,
     CloudCustomTaskConfig,
-    CloudCustomTaskConfigTarget
+    CloudCustomTaskConfigTarget,
+    CfAdpWriterConfig
 } from '../types';
 
 const VSCODE_URL = 'https://REQUIRED_FOR_VSCODE.example';
@@ -345,4 +346,61 @@ export function enhanceManifestChangeContentWithFlpConfig(
         manifestChangeContent.push(addInboundChange);
         manifestChangeContent.push(removeOtherInboundsChange);
     }
+}
+
+/**
+ * Generate custom configuration required for the ui5.yaml.
+ *
+ * @param {UI5Config} ui5Config - Configuration representing the ui5.yaml.
+ * @param {CfAdpWriterConfig} config - Full project configuration.
+ */
+export function enhanceUI5YamlWithCfCustomTask(ui5Config: UI5Config, config: CfAdpWriterConfig): void {
+    const { baseApp, cf, project } = config;
+    ui5Config.addCustomTasks([
+        {
+            name: 'app-variant-bundler-build',
+            beforeTask: 'escapeNonAsciiCharacters',
+            configuration: {
+                module: project.name,
+                appHostId: baseApp.appHostId,
+                appName: baseApp.appName,
+                appVersion: baseApp.appVersion,
+                html5RepoRuntime: cf.html5RepoRuntimeGuid,
+                org: cf.org.GUID,
+                space: cf.space.GUID,
+                sapCloudService: cf.businessSolutionName ?? '',
+                instanceName: cf.businessService
+            }
+        }
+    ]);
+}
+
+/**
+ * Generate custom configuration required for the ui5.yaml.
+ *
+ * @param {UI5Config} ui5Config - Configuration representing the ui5.yaml.
+ */
+export function enhanceUI5YamlWithCfCustomMiddleware(ui5Config: UI5Config): void {
+    const ui5ConfigOptions: Partial<FioriToolsProxyConfigUI5> = {
+        url: 'https://ui5.sap.com'
+    };
+
+    ui5Config.addFioriToolsProxyMiddleware(
+        {
+            ui5: ui5ConfigOptions,
+            backend: []
+        },
+        'compression'
+    );
+    ui5Config.addCustomMiddleware([
+        {
+            name: 'fiori-tools-preview',
+            afterMiddleware: 'fiori-tools-proxy',
+            configuration: {
+                flp: {
+                    theme: 'sap_horizon'
+                }
+            }
+        }
+    ]);
 }

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -8,8 +8,7 @@ import {
     type CustomConfig,
     type TypesConfig,
     type CfAdpWriterConfig,
-    type DescriptorVariant,
-    ApplicationType
+    type DescriptorVariant
 } from '../types';
 import {
     enhanceUI5DeployYaml,
@@ -17,7 +16,9 @@ import {
     hasDeployConfig,
     enhanceUI5YamlWithCustomConfig,
     enhanceUI5YamlWithCustomTask,
-    enhanceUI5YamlWithTranspileMiddleware
+    enhanceUI5YamlWithTranspileMiddleware,
+    enhanceUI5YamlWithCfCustomTask,
+    enhanceUI5YamlWithCfCustomMiddleware
 } from './options';
 
 import type { Package } from '@sap-ux/project-access';
@@ -126,30 +127,6 @@ export function getCfVariant(config: CfAdpWriterConfig): DescriptorVariant {
 }
 
 /**
- * Get the ADP config for the CF project.
- *
- * @param {CfAdpWriterConfig} config - The CF configuration.
- * @returns {Record<string, unknown>} The ADP config for the CF project.
- */
-export function getCfAdpConfig(config: CfAdpWriterConfig): Record<string, unknown> {
-    const { app, project, ui5, cf } = config;
-    const configJson = {
-        componentname: app.namespace,
-        appvariant: project.name,
-        layer: app.layer,
-        isOVPApp: app.appType === ApplicationType.FIORI_ELEMENTS_OVP,
-        isFioriElement: app.appType === ApplicationType.FIORI_ELEMENTS,
-        environment: 'CF',
-        ui5Version: ui5.version,
-        cfApiUrl: cf.url,
-        cfSpace: cf.space.GUID,
-        cfOrganization: cf.org.GUID
-    };
-
-    return configJson;
-}
-
-/**
  * Writes a given project template files within a specified folder in the project directory.
  *
  * @param {string} baseTmplPath - The root path of the templates folder.
@@ -213,6 +190,33 @@ export async function writeUI5Yaml(projectPath: string, data: AdpWriterConfig, f
 }
 
 /**
+ * Writes a ui5.yaml file for CF project within a specified folder in the project directory.
+ *
+ * @param {string} projectPath - The root path of the project.
+ * @param {AdpWriterConfig} data - The data to be populated in the template file.
+ * @param {Editor} fs - The `mem-fs-editor` instance used for file operations.
+ * @returns {void}
+ */
+export async function writeUI5YamlCf(projectPath: string, data: CfAdpWriterConfig, fs: Editor): Promise<void> {
+    try {
+        const ui5ConfigPath = join(projectPath, 'ui5.yaml');
+        const baseUi5ConfigContent = fs.read(ui5ConfigPath);
+        const ui5Config = await UI5Config.newInstance(baseUi5ConfigContent);
+        ui5Config.setConfiguration({ propertiesFileSourceEncoding: 'UTF-8', paths: { webapp: 'dist' } });
+
+        /** Builder task */
+        enhanceUI5YamlWithCfCustomTask(ui5Config, data);
+
+        /** Middlewares */
+        enhanceUI5YamlWithCfCustomMiddleware(ui5Config);
+
+        fs.write(ui5ConfigPath, ui5Config.toString());
+    } catch (e) {
+        throw new Error(`Could not write ui5.yaml file. Reason: ${e.message}`);
+    }
+}
+
+/**
  * Writes a ui5-deploy.yaml file within a specified folder in the project directory.
  *
  * @param {string} projectPath - The root path of the project.
@@ -250,7 +254,7 @@ export async function writeCfTemplates(
     fs: Editor
 ): Promise<void> {
     const baseTmplPath = join(__dirname, '../../templates');
-    const { app, baseApp, cf, project, options } = config;
+    const { app, project, options } = config;
 
     fs.copyTpl(
         join(baseTmplPath, 'project/webapp/manifest.appdescr_variant'),
@@ -263,18 +267,8 @@ export async function writeCfTemplates(
     });
 
     fs.copyTpl(join(baseTmplPath, 'cf/ui5.yaml'), join(project.folder, 'ui5.yaml'), {
-        appHostId: baseApp.appHostId,
-        appName: baseApp.appName,
-        appVersion: baseApp.appVersion,
-        module: project.name,
-        html5RepoRuntime: cf.html5RepoRuntimeGuid,
-        org: cf.org.GUID,
-        space: cf.space.GUID,
-        sapCloudService: cf.businessSolutionName ?? '',
-        instanceName: cf.businessService
+        module: project.name
     });
-
-    fs.writeJSON(join(project.folder, '.adp/config.json'), getCfAdpConfig(config));
 
     fs.copyTpl(join(baseTmplPath, 'cf/i18n/i18n.properties'), join(project.folder, 'webapp/i18n/i18n.properties'), {
         module: project.name,

--- a/packages/adp-tooling/templates/cf/package.json
+++ b/packages/adp-tooling/templates/cf/package.json
@@ -4,6 +4,7 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
+		"start": "fiori run --open /test/flp.html#app-preview",
 		"build": "npm run clean && ui5 build --include-task=generateCachebusterInfo && npm run zip",
 		"zip": "cd dist && npx bestzip ../<%= module %>.zip *",
 		"clean": "npx rimraf <%= module %>.zip dist",
@@ -22,7 +23,8 @@
 	"devDependencies": {
 		"@sap/ui5-builder-webide-extension": "1.0.x",
 		"@sapui5/ts-types": "^1.85.1",
-		"@ui5/cli": "^3.0.0",
+		"@sap/ux-ui5-tooling": "1",
+		"@ui5/cli": "^4.0.16",
 		"@ui5/task-adaptation": "^1.0.x",
 		"bestzip": "2.1.4",
 		"rimraf": "3.0.2"

--- a/packages/adp-tooling/templates/cf/ui5.yaml
+++ b/packages/adp-tooling/templates/cf/ui5.yaml
@@ -3,17 +3,3 @@ specVersion: "2.2"
 type: application
 metadata:
   name: <%= module %>
-builder:
-  customTasks:
-    - name: app-variant-bundler-build
-      beforeTask: escapeNonAsciiCharacters
-      configuration:
-        appHostId: <%= appHostId %>
-        appName: <%= appName %>
-        appVersion: <%= appVersion %>
-        moduleName: <%= module %>
-        org: <%= org %>
-        space: <%= space %>
-        html5RepoRuntime: <%= html5RepoRuntime %>
-        sapCloudService: <%= sapCloudService %>
-        serviceInstanceName: <%= instanceName %>


### PR DESCRIPTION
Feat for #3699.
- Removes `.adp/config.json`.
- Adds `fiori-preview` and `fiori-proxy` middleware.
- Adds `start` script for starting the preview in a new tab.