### PR TITLE
fix mcp server start-up

### DIFF
--- a/.changeset/tall-rats-poke.md
+++ b/.changeset/tall-rats-poke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+fix "Error [ERR_REQUIRE_ESM]" when starting fiori mcp server e.g. Nodejs 22.8.0

--- a/packages/fiori-mcp-server/src/tools/services/text-embedding.ts
+++ b/packages/fiori-mcp-server/src/tools/services/text-embedding.ts
@@ -1,4 +1,3 @@
-import { pipeline } from '@xenova/transformers';
 /**
  * Text embedding service for converting text queries to vectors.
  */
@@ -19,6 +18,9 @@ export class TextEmbeddingService {
         }
 
         try {
+            // Dynamically import the ES Module
+            const { pipeline } = await import('@xenova/transformers');
+
             // Use the same model as the build process
             this.pipeline = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {
                 quantized: false


### PR DESCRIPTION
fix "Error [ERR_REQUIRE_ESM]" when starting fiori mcp server e.g. Nodejs 22.8.0
