### PR TITLE
fix(odata-service-inquirer): Existing system validation

### DIFF
--- a/.changeset/fair-icons-check.md
+++ b/.changeset/fair-icons-check.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for existing system url/client validation shown in wrong prompt (abap-on-prem)

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -9,7 +9,7 @@ import {
     type ServiceSelectionPromptOptions,
     type SystemNamePromptOptions
 } from '../../../../types';
-import { PromptState } from '../../../../utils';
+import { isBackendSystemKeyExisting, PromptState } from '../../../../utils';
 import { ConnectionValidator } from '../../../connectionValidator';
 import { BasicCredentialsPromptNames, getCredentialsPrompts } from '../credentials/questions';
 import { getSystemUrlQuestion, getUserSystemNameQuestion } from '../shared-prompts/shared-prompts';
@@ -80,7 +80,13 @@ export function getAbapOnPremSystemQuestions(
     const sapClientRef: { sapClient: string | undefined; isValid: boolean } = { sapClient: undefined, isValid: true };
 
     const questions: Question<AbapOnPremAnswers>[] = [
-        getSystemUrlQuestion<AbapOnPremAnswers>(connectValidator, abapOnPremPromptNamespace, requiredOdataVersion),
+        getSystemUrlQuestion<AbapOnPremAnswers>(
+            connectValidator,
+            abapOnPremPromptNamespace,
+            requiredOdataVersion,
+            undefined,
+            false
+        ),
         {
             type: 'input',
             name: abapOnPremPromptNames.sapClient,
@@ -88,11 +94,24 @@ export function getAbapOnPremSystemQuestions(
             guiOptions: {
                 breadcrumb: t('prompts.sapClient.breadcrumb')
             },
-            validate: (client) => {
+            validate: (client, prevAnswers: AbapOnPremAnswers) => {
                 const valRes = validateClient(client);
                 if (valRes === true) {
                     sapClientRef.sapClient = client;
                     sapClientRef.isValid = true;
+                    // If we also have a system url, warn about existing stored system overwrite
+                    if (prevAnswers?.[systemUrlPromptName]) {
+                        const existingBackend = isBackendSystemKeyExisting(
+                            PromptState.backendSystemsCache,
+                            prevAnswers[systemUrlPromptName],
+                            client
+                        );
+                        if (existingBackend) {
+                            return t('prompts.validationMessages.backendSystemExistsWarning', {
+                                backendName: existingBackend.name
+                            });
+                        }
+                    }
                     return true;
                 }
                 sapClientRef.sapClient = undefined;

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
@@ -48,13 +48,15 @@ function systemAuthTypeToAuthenticationType(
  * @param promptNamespace The namespace for the prompt, used to identify the prompt instance and namespaced answers.
  * @param requiredOdataVersion The required OData version for the system connection, only catalogs supporting the specifc odata version will be used.
  * @param cachedConnectedSystem An existing connection may be passed which will prevent reauthentication
+ * @param showExistingSystemWarning if the url exists in secure store a validation message will be returned
  * @returns the system url prompt
  */
 export function getSystemUrlQuestion<T extends Answers>(
     connectValidator: ConnectionValidator,
     promptNamespace?: string,
     requiredOdataVersion?: OdataVersion,
-    cachedConnectedSystem?: ConnectedSystem
+    cachedConnectedSystem?: ConnectedSystem,
+    showExistingSystemWarning = true
 ): InputQuestion<T> {
     const promptName = `${promptNamespace ? promptNamespace + ':' : ''}${newSystemPromptNames.newSystemUrl}`;
     const newSystemUrlQuestion = {
@@ -76,7 +78,7 @@ export function getSystemUrlQuestion<T extends Answers>(
                 cachedConnectedSystem.backendSystem?.authenticationType === 'reentranceTicket'
             ) {
                 connectValidator.setConnectedSystem(cachedConnectedSystem);
-            } else {
+            } else if (showExistingSystemWarning) {
                 const existingBackend = isBackendSystemKeyExisting(PromptState.backendSystemsCache, url);
                 if (existingBackend) {
                     // Not a cached connection so re-validate as new backend system entry

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
@@ -6,6 +6,7 @@ import { getAbapOnPremQuestions } from '../../../../../src/prompts/datasources/s
 import { newSystemPromptNames } from '../../../../../src/prompts/datasources/sap-system/new-system/types';
 import { promptNames } from '../../../../../src/types';
 import { PromptState } from '../../../../../src/utils';
+import * as utils from '../../../../../src/utils';
 import type { InputQuestion } from '@sap-ux/inquirer-common';
 import { Severity } from '@sap-devx/yeoman-ui-types';
 
@@ -207,30 +208,31 @@ describe('questions', () => {
         expect(await (userSystemNamePrompt?.when as Function)({ [systemUrlPromptName]: systemUrl })).toBe(true);
     });
 
-    test('Should check if an existing backend system configuration exists and show validation error (VSCode)', async () => {
+    test('Should not show an existing system validation error (since it is shown with client prompt)', async () => {
+        const isBackendSystemKeyExistingSpy = jest.spyOn(utils, 'isBackendSystemKeyExisting');
         const systemUrl = 'http://some.abap.system:1234';
         const systemUrlPromptName = `abapOnPrem:${newSystemPromptNames.newSystemUrl}`;
         const newSystemQuestions = getAbapOnPremQuestions();
         const systemUrlQuestion = newSystemQuestions.find((question) => question.name === systemUrlPromptName);
-        PromptState.backendSystemsCache = [
-            {
-                name: 'System1234',
-                url: systemUrl,
-                systemType: 'OnPrem'
-            }
-        ];
-
-        expect(await (systemUrlQuestion?.validate as Function)(systemUrl)).toEqual(
-            t('prompts.validationMessages.backendSystemExistsWarning', { backendName: 'System1234' })
-        );
+        expect(await (systemUrlQuestion?.validate as Function)('')).toBe(true);
+        expect(isBackendSystemKeyExistingSpy).not.toHaveBeenCalled();
     });
 
     test('Should validate sap-client input', () => {
+        jest.spyOn(utils, 'isBackendSystemKeyExisting').mockReturnValue({
+            name: 'System1234',
+            url: 'http://some.system.hos'
+        });
         const newSystemQuestions = getAbapOnPremQuestions();
         const sapClientPrompt = newSystemQuestions.find((question) => question.name === `sapClient`);
         expect((sapClientPrompt?.validate as Function)('')).toBe(true);
         expect((sapClientPrompt?.validate as Function)('123')).toBe(true);
         expect((sapClientPrompt?.validate as Function)('123x')).toEqual(expect.any(String));
+
+        // Should show an existing system warning for client prompt when abap on prem url provided for an existing system (non-BAS)
+        expect(
+            (sapClientPrompt?.validate as Function)('123', { 'abapOnPrem:newSystemUrl': 'http://some.system.host' })
+        ).toEqual(t('prompts.validationMessages.backendSystemExistsWarning', { backendName: 'System1234' }));
     });
 
     test('Should show `NODE_TLD_REJECT_UNAUTHORIZED` warning if set when bypassing certificate errors', async () => {

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/cf-abap/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/cf-abap/questions.test.ts
@@ -8,6 +8,7 @@ import * as cfTools from '@sap/cf-tools';
 import { PromptState } from '../../../../../src/utils/prompt-state';
 import LoggerHelper from '../../../../../src/prompts/logger-helper';
 import { initI18nOdataServiceInquirer } from '../../../../../src/i18n';
+import * as utils from '../../../../../src/utils';
 
 const serviceProviderMock = {} as Partial<ServiceProvider>;
 
@@ -118,6 +119,7 @@ describe('tests cf abap service dicovery prompts for BAS', () => {
         const getCredsSpy = jest.spyOn(cfTools, 'apiGetInstanceCredentials');
         const createDestSpy = jest.spyOn(btpUtils, 'createOAuth2UserTokenExchangeDest');
         const validateDestSpy = jest.spyOn(connectionValidatorMock, 'validateDestination');
+        const existingBackendSpy = jest.spyOn(utils, 'isBackendSystemKeyExisting');
         const questions = getCfAbapBASQuestions();
         const cfDiscoQuestion = questions.find((question) => question.name === `cfAbapBas:cloudFoundryAbapSystem`);
         expect(
@@ -137,6 +139,7 @@ describe('tests cf abap service dicovery prompts for BAS', () => {
         );
         expect(validateDestSpy).toHaveBeenCalledWith(createdDestinationMock, undefined, undefined);
         expect(PromptState.odataService.connectedSystem?.destination).toEqual(createdDestinationMock);
+        expect(existingBackendSpy).not.toHaveBeenCalled();
     });
 
     test('test getCfAbapBASQuestions validate() will throw an exception if the user is missing privileges on CF', async () => {


### PR DESCRIPTION
Fix for: https://github.com/SAP/open-ux-tools/issues/3750

- Only show existing system validation with client prompt in on prem usage 
- Show existing system validation with system url prompt for cloud system urls
- Adds tests to cover