### PR TITLE
chore: update pipeline config to publish extensions as draft

### DIFF
--- a/.changeset/bold-games-joke.md
+++ b/.changeset/bold-games-joke.md
@@ -1,0 +1,5 @@
+---
+'sap-ux-sap-systems-ext': patch
+---
+
+change to draft release for extensions

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -239,7 +239,7 @@ jobs:
                   tag_name: ${{ env.EXT_PKG }}@${{ env.EXT_VERSION }}
                   name: ${{ env.EXT_PKG }} v${{ env.EXT_VERSION }}
                   body: 'Extension release: ${{ env.EXT_PKG }} v${{ env.EXT_VERSION }}'
-                  draft: false
+                  draft: true
                   prerelease: false
                   generate_release_notes: true
                   files: ${{ env.EXT_DIR }}/*.vsix


### PR DESCRIPTION
Extensions published will be draft until they have been tested and can be flagged for publish to the market place 