### PR TITLE
chore - fix for lint commit not starting the main build on the PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.ACCESS_PAT }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION

The PR build (pipeline.yml) doesn't start because the commit is made by github-actions[bot] with the --no-verify flag. Looking at [pipeline.yml:6-7], the workflow triggers on pull_request to main branches. However, the commit from the lint workflow has two characteristics that prevent re-triggering:

1. Made by github-actions bot - By default, GitHub Actions workflows don't trigger other workflow runs when using the default GITHUB_TOKEN to prevent infinite loops
2. Commit message "Linting auto fix commit" - from [lint.yml:59]

This is intentional GitHub Actions behavior. When the lint workflow pushes commits using the default credentials, it won't trigger the PR build to avoid circular workflow executions (lint → build → lint → build...). To fix this, the lint workflow would need to use a Personal Access Token (PAT) instead of the default GITHUB_TOKEN when pushing
