### PR TITLE
Revert "fix: run tests on windows (#3823)"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
             fail-fast: false
             matrix:
                 ui5-version: ${{ fromJson(needs.ui5-versions.outputs.ui5_versions) }}
-        runs-on: [ubuntu-latest, windows-2025]
+        runs-on: ubuntu-latest
         needs: ui5-versions
         timeout-minutes: 30
         steps:


### PR DESCRIPTION
This reverts commit cce4b786b81c58510d0580920ecfc17b1568a3ee which prevents integration tests from running and is blocking other PRs.