### PR TITLE
fix(fpm-writer): `generateCustomField` now includes the `core:require` attribute with the handler file in new fragment files when `eventHandler` is set.

### DIFF
--- a/.changeset/quiet-bats-bathe.md
+++ b/.changeset/quiet-bats-bathe.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fe-fpm-writer': patch
+---
+
+Fix: `generateCustomField` now includes the `core:require` attribute with the handler file in new fragment files when `eventHandler` is set.
+

--- a/packages/fe-fpm-writer/src/field/index.ts
+++ b/packages/fe-fpm-writer/src/field/index.ts
@@ -38,10 +38,7 @@ function enhanceConfig(fs: Editor, data: CustomField, manifestPath: string, mani
     if (config.control) {
         config.content = config.control;
     } else {
-        Object.assign(
-            config,
-            getDefaultFragmentContentData(config.name, config.eventHandler, undefined, undefined, false)
-        );
+        Object.assign(config, getDefaultFragmentContentData(config.name, config.eventHandler));
     }
 
     return config as InternalCustomField;

--- a/packages/fe-fpm-writer/test/unit/__snapshots__/field.test.ts.snap
+++ b/packages/fe-fpm-writer/test/unit/__snapshots__/field.test.ts.snap
@@ -30,7 +30,7 @@ Object {
 
 exports[`CustomField Test property "eventHandler" "eventHandler" is "object" - create new file with custom file and function names 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.DummyOnAction\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/dummyAction'}\\" text=\\"NewCustomField\\" press=\\"handler.DummyOnAction\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -56,7 +56,7 @@ exports[`CustomField Test property "eventHandler" "eventHandler" is "object" - c
 
 exports[`CustomField Test property "eventHandler" "eventHandler" is "object" - create new file with custom function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.DummyOnAction\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomField'}\\" text=\\"NewCustomField\\" press=\\"handler.DummyOnAction\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -82,7 +82,7 @@ exports[`CustomField Test property "eventHandler" "eventHandler" is "object" - c
 
 exports[`CustomField Test property "eventHandler" "eventHandler" is empty "object" - create new file with default function name 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomField'}\\" text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -108,7 +108,7 @@ exports[`CustomField Test property "eventHandler" "eventHandler" is empty "objec
 
 exports[`CustomField Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with absolute position 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.onHandleSecondAction\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomField\\" press=\\"handler.onHandleSecondAction\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -132,7 +132,7 @@ exports[`CustomField Test property "eventHandler" "eventHandler" is object. Appe
 
 exports[`CustomField Test property "eventHandler" "eventHandler" is object. Append new function to existing js file with position as object 1`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.onHandleSecondAction\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/MyExistingAction'}\\" text=\\"NewCustomField\\" press=\\"handler.onHandleSecondAction\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -181,7 +181,7 @@ Object {
 
 exports[`CustomField Typescript - generate with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomField'}\\" text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;
 
@@ -446,7 +446,7 @@ Object {
 
 exports[`CustomField with handler, all properties 2`] = `
 "<core:FragmentDefinition xmlns:core=\\"sap.ui.core\\" xmlns=\\"sap.m\\">
-	<Button text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
+	<Button core:require=\\"{ handler: 'sapux/fe/fpm/writer/test/extensions/custom/NewCustomField'}\\" text=\\"NewCustomField\\" press=\\"handler.onPress\\" />
 </core:FragmentDefinition>"
 `;
 


### PR DESCRIPTION
recent implementation for custom field support was done in PR -> https://github.com/SAP/open-ux-tools/pull/3763

but that logic has a bug when we set `eventHandler: true`, then fragment looks following:
```
<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m">
	<Button text="Dummy2" press="handler.onPress" />
</core:FragmentDefinition>
```

there is missing `core:require`, like:
```
<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m">
	<Button core:require="{ handler: 'javascript/ext/fragment/Dummy2'}" text="Dummy2" press="handler.onPress" />
</core:FragmentDefinition>
```
