### PR TITLE
Increase test timeout from 60s to 120s

### DIFF
--- a/packages/jest-environment-ui5/test/unit/index.test.js
+++ b/packages/jest-environment-ui5/test/unit/index.test.js
@@ -11,7 +11,7 @@ describe('Custom environment', () => {
         expect(failed).toBe(false);
 
         // This is done centrally in the CustomEnvironment constructor but we need to call it here for the test purpose
-    }, 60000);
+    }, 120000);
 
     it('should correctly shim manifest file', () => {
         // Save original window object to restore later


### PR DESCRIPTION
Increased timeout duration for test execution as regularly fails on windows runners

<img width="1141" height="327" alt="Screenshot 2025-11-26 at 18 45 59" src="https://github.com/user-attachments/assets/fd4e32e4-e80f-405d-a77c-ec1b82044898" />
