### PR TITLE
fix(cds-odata-annotation-converter): missing dependency

### DIFF
--- a/.changeset/moody-waves-yell.md
+++ b/.changeset/moody-waves-yell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/cds-odata-annotation-converter': patch
+---
+
+fix: missing dependency

--- a/.eslintrc
+++ b/.eslintrc
@@ -180,7 +180,7 @@
         "valid-typeof": "error",
         "accessor-pairs": "error",
         "block-scoped-var": "warn",
-        "consistent-return": "warn",
+        "consistent-return": "off",
         "curly": ["error", "all"],
         "default-case": "warn",
         "no-alert": "error",
@@ -279,7 +279,7 @@
         "import/no-extraneous-dependencies": [
             "error",
             {
-                "devDependencies": true,
+                "devDependencies": false,
                 "optionalDependencies": true,
                 "peerDependencies": true,
                 "bundledDependencies": false

--- a/packages/cds-odata-annotation-converter/package.json
+++ b/packages/cds-odata-annotation-converter/package.json
@@ -33,13 +33,13 @@
     "dependencies": {
         "@sap-ux/cds-annotation-parser": "workspace:*",
         "@sap-ux/odata-annotation-core": "workspace:*",
+        "@sap-ux/odata-annotation-core-types": "workspace:*",
         "@sap-ux/odata-vocabularies": "workspace:*",
         "@sap/ux-cds-compiler-facade": "1.19.0",
         "i18next": "25.3.0",
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "@sap-ux/odata-annotation-core-types": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "npm-run-all2": "6.2.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1084,6 +1084,9 @@ importers:
       '@sap-ux/odata-annotation-core':
         specifier: workspace:*
         version: link:../odata-annotation-core
+      '@sap-ux/odata-annotation-core-types':
+        specifier: workspace:*
+        version: link:../odata-annotation-core-types
       '@sap-ux/odata-vocabularies':
         specifier: workspace:*
         version: link:../odata-vocabularies
@@ -1097,9 +1100,6 @@ importers:
         specifier: 25.3.0
         version: 25.3.0(typescript@5.9.3)
     devDependencies:
-      '@sap-ux/odata-annotation-core-types':
-        specifier: workspace:*
-        version: link:../odata-annotation-core-types
       '@sap-ux/project-access':
         specifier: workspace:*
         version: link:../project-access


### PR DESCRIPTION
`@sap-ux/odata-annotation-core-types` was wrongly added as a devDependency, but used in code as a real dependecy.

Also enable lint rule to check for such cases.