### PR TITLE
fix(jest-environment-ui5): sonar issue (no that)

### DIFF
--- a/packages/jest-environment-ui5/src/index.js
+++ b/packages/jest-environment-ui5/src/index.js
@@ -166,7 +166,7 @@ class UI5DOMEnvironment extends JSDOMEnvironment {
                 };
                 resolve();
             },
-            function() {
+            function () {
                 resolve();
             }
         );


### PR DESCRIPTION
Do not assign `this` to `that`.

https://sonarcloud.io/project/issues?impactSeverities=HIGH&issueStatuses=OPEN%2CCONFIRMED&id=SAP_open-ux-tools&open=AZlxb4eUbI3s_xdeJz4k