### PR TITLE
chore - Update job timeout in pipeline.yml

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,7 +16,7 @@ jobs:
                 # os: [ubuntu-latest, windows-2025, macos-13, macos-14, macos-14-large, macos-15, macos-latest-large]
                 node-version: [20.x, 22.x]
         runs-on: ${{ matrix.os }}
-        timeout-minutes: 30
+        timeout-minutes: 45
         steps:
             - name: Checkout code repository
               uses: actions/checkout@v4


### PR DESCRIPTION
Increased timeout for job execution from 30 to 45 minutes.

increasing number of jobs are timing out.