### PR TITLE
fix: prompts examples fails because of full fpm writer import in browser

### DIFF
--- a/examples/ui-prompting-examples/src/utils/types.ts
+++ b/examples/ui-prompting-examples/src/utils/types.ts
@@ -7,9 +7,9 @@ import {
     type RichTextEditorPromptsAnswer,
     type SupportedGeneratorAnswers,
     type Answers,
-    type CodeSnippet,
-    PromptsType
+    type CodeSnippet
 } from '@sap-ux/fe-fpm-writer';
+import { PromptsType } from '@sap-ux/fe-fpm-writer/dist/prompts/types';
 import type { AddonActions } from '../addons/types';
 import type { DynamicChoices, TranslationProperties } from '@sap-ux/ui-prompting';
 import type { I18nBundle } from '@sap-ux/i18n';


### PR DESCRIPTION
Issue after https://github.com/SAP/open-ux-tools/pull/3082

In `examples/ui-prompting-examples/src/utils/types.ts` we just export enum for storybook webapp usage -> https://github.com/SAP/open-ux-tools/blob/d0460a82b3dcc8db98e4c7bf4adfd17c494c683a/examples/ui-prompting-examples/src/utils/types.ts#L51
Problem happens if we import enum from whole `fpm-writer`:

<img width="1272" height="681" alt="image" src="https://github.com/user-attachments/assets/ef6f627c-e6cb-47be-8823-afbf9d3addb2" />

Alternative could be to duplicate enum