### PR TITLE
chore(eslint): disable jsdoc rules in fix mode to prevent incorrect generation in auto fix GH action

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ const pluginJsdoc = require('eslint-plugin-jsdoc');
 const tseslint = require('typescript-eslint');
 const importPlugin = require('eslint-plugin-import');
 const sonarjs = require('eslint-plugin-sonarjs');
+const isFixMode = process.argv.includes('--fix');
 
 const compat = new FlatCompat({
     baseDirectory: __dirname, // optional; default: process.cwd()
@@ -87,7 +88,9 @@ module.exports = [
                     contexts: ['TSMethodSignature']
                 }
             ],
-
+            ...(isFixMode && { // disable in fix mode to avoid generating incorrect JSDoc
+                'jsdoc/require-jsdoc': 'off'
+            }),
             'jsdoc/valid-types': 'error',
             'jsdoc/check-types': 'error',
             'jsdoc/check-param-names': 'error',
@@ -347,6 +350,9 @@ module.exports = [
                     'exemptEmptyFunctions': true
                 }
             ],
+            ...(isFixMode && { // disable in fix mode to avoid generating incorrect JSDoc
+                'jsdoc/require-jsdoc': 'off'
+            }),
             'jsdoc/valid-types': 'off',
             'jsdoc/check-types': 'off',
             'jsdoc/check-tag-names': 'off',


### PR DESCRIPTION
chore(eslint): disable jsdoc rules in fix mode to prevent incorrect generation in auto fix GH action

e.g. avoid auto fix like this https://github.com/SAP/open-ux-tools/pull/3778/changes/e648140faf18b25cee033582d7403588270036f8