### PR TITLE
Fix/apply odata version on prem creds

### DIFF
--- a/.changeset/chilled-peaches-travel.md
+++ b/.changeset/chilled-peaches-travel.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/odata-service-inquirer': patch
+---
+
+Fix for odata version restriction not applied for Abap-on-prem credentials prompts

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -127,7 +127,12 @@ export function getAbapOnPremSystemQuestions(
                 return valRes;
             }
         } as InputQuestion<AbapOnPremAnswers>,
-        ...getCredentialsPrompts<AbapOnPremAnswers>(connectValidator, abapOnPremPromptNamespace, sapClientRef, requiredOdataVersion)
+        ...getCredentialsPrompts<AbapOnPremAnswers>(
+            connectValidator,
+            abapOnPremPromptNamespace,
+            sapClientRef,
+            requiredOdataVersion
+        )
     ];
 
     if (systemNamePromptOptions?.hide !== true) {

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
@@ -3,7 +3,7 @@ import type { ServiceProvider, V2CatalogService, V4CatalogService } from '@sap-u
 import { ODataVersion } from '@sap-ux/axios-extension';
 import type { InputQuestion } from '@sap-ux/inquirer-common';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
-import { BackendSystem } from '@sap-ux/store';
+import type { BackendSystem } from '@sap-ux/store';
 import { initI18nOdataServiceInquirer, t } from '../../../../../src/i18n';
 import type { ConnectionValidator } from '../../../../../src/prompts/connectionValidator';
 import { getAbapOnPremQuestions } from '../../../../../src/prompts/datasources/sap-system/abap-on-prem/questions';


### PR DESCRIPTION
Internal bug ref: 36758

- Pass `requiredOdataVersion` through to credentials prompts when connecting to `Abap-on-Prem` system to restrict catalog requests
- Add tests to cover