### PR TITLE
feat(mcp): Add controller extension and fragment generation

### DIFF
--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -84,6 +84,7 @@
         "@langchain/core": "1.1.8"
     },
     "dependencies": {
+        "@sap-ux/adp-tooling": "workspace:*",
         "@sap-ux/fiori-docs-embeddings": "workspace:*",
         "@sap-ux/store": "workspace:*",
         "@xenova/transformers": "2.17.2",

--- a/packages/fiori-mcp-server/src/constant.ts
+++ b/packages/fiori-mcp-server/src/constant.ts
@@ -3,6 +3,7 @@ export const GENERATE_FIORI_UI_APPLICATION_CAP_ID = 'generate-fiori-ui-applicati
 export const ADD_PAGE = 'add-page';
 export const DELETE_PAGE = 'delete-page';
 export const CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY_ID = 'create-controller-extension';
+export const ADP_CONTROLLER_EXTENSION_FUNCTIONALITY_ID = 'adp-controller-extension';
 export const EXTENSION_FILE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/;
 
 // Telemetry event names

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/details.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/details.ts
@@ -120,11 +120,17 @@ This functionality processes AI-generated controller extensions and fragments fo
 - Writes controller extension files, fragments, and other code files
 - Does NOT write change files (.change) - these are handled separately
 
+CRITICAL WORKFLOW:
+1. The AI (caller) MUST first generate the code following the rules above
+2. Format the code with markdown code blocks, each preceded by "**Path:** fullFilePath" on its own line
+3. Pass the generated code in the "aiResponse" parameter
+4. Without "aiResponse", this tool ONLY validates the project and does NOT create any files
+
 Parameters:
 - prompt: Natural language description of what to create
-- aiResponse (optional): Pre-generated AI response with code blocks
-- viewId (optional): Target view identifier
-- controllerName (optional): Desired controller extension name`,
+- aiResponse: Pre-generated AI response with code blocks
+- controllerName: Desired controller extension name
+- viewId (optional): Target view identifier`,
     parameters: convertToSchema(AdpControllerExtensionSchema)
 };
 

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/details.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/details.ts
@@ -1,0 +1,131 @@
+import type { GetFunctionalityDetailsOutput } from '../../../types';
+import { convertToSchema } from '../../../utils';
+import { AdpControllerExtensionSchema } from './schema';
+import { ADP_CONTROLLER_EXTENSION_FUNCTIONALITY_ID } from '../../../constant';
+
+/**
+ * Knowledge base and rules for ADP controller extension generation
+ * This description guides AI behavior when generating controller extensions
+ */
+const KNOWLEDGE_BASE = `You are a SAPUI5 Adaptation Project expert specializing in controller extensions and xml fragments for adaptation projects.
+
+IMPORTANT RULES:
+1. For controller extensions, always use "sap/ui/core/mvc/ControllerExtension" (NOT "sap/ui/core/mvc/Controller"). Use ControllerExtension.extend() pattern for proper adaptation project architecture.
+2. Assign stable, unique IDs to all controls, elements, subcontrols, items, and sub-items even when they have a key or other identifying attribute. This is crucial for adaptation project functionality.
+3. When providing code, always provide the entire file! Do not omit parts or replace them with an ellipsis. Keep the rest of the file as-is in your reply, only touch the part that needs to be changed.
+4. Immediately before each code block belonging to a file, with no other text in between, write the full path+name of the file in the following format: **Path:** fullFilePath. It is of extreme importance to always provide this format with the word 'Path' before the file path and no other content between this line and the code block.
+
+ADAPTATION PROJECT DETECTION:
+1. Check for the manifest.appdescr_variant file under the webapp folder
+2. If present, this is an adaptation project context
+3. CRITICAL: Read the "layer" property from manifest.appdescr_variant to determine if a customer prefix is needed:
+   - If layer is "CUSTOMER_BASE": Use "customer" prefix in controller extension namespace and fragment event handlers
+   - If layer is anything else: Do NOT use "customer" prefix
+4. Read "id" property from manifest.appdescr_variant and use it as namespace for change files
+5. Use the project root folder name (folder containing webapp) for controller extension namespaces
+6. ALWAYS check the manifest.appdescr_variant file before generating code
+
+CONTROLLER EXTENSION NAMESPACE PATTERN:
+FRAGMENT FILES (XML) - Event Handler References:
+- Standard layer: press=".extension.{project-folder-name}.{controller-extension-name}.{methodName}"
+- CUSTOMER_BASE layer: press=".extension.customer.{project-folder-name}.{controller-extension-name}.{methodName}"
+- Example (standard layer): press=".extension.myapp.ControllerExt.onPressAction"
+- Example (CUSTOMER_BASE layer): press=".extension.customer.myapp.ControllerExt.onPressAction"
+- The ".extension" prefix is ONLY used in fragment XML event handlers
+- The "customer" prefix is ONLY added in fragment XML when layer is CUSTOMER_BASE
+- The {project-folder-name} must be the adaptation project root folder name (the folder above webapp)
+
+CONTROLLER EXTENSION FILES (JS/TS) - File Paths and Namespaces:
+- File path: webapp/changes/coding/{controller-extension-name}.js (NO customer prefix in file path)
+- Namespace in ControllerExtension.extend():
+  * Standard layer: ControllerExtension.extend("{project-folder}.{ControllerExtName}", {...})
+  * CUSTOMER_BASE layer: ControllerExtension.extend("customer.{project-folder}.{ControllerExtName}", {...})
+- Example (standard): ControllerExtension.extend("adapt.blog.ControllerExt", {...})
+- Example (CUSTOMER_BASE): ControllerExtension.extend("customer.adapt.blog.ControllerExt", {...})
+- The "customer" prefix is added to the extend() namespace when layer is CUSTOMER_BASE
+- Do NOT use ".extension" prefix in the controller extension namespace
+- The controller file path does NOT include "customer" - only the namespace in the code does
+
+ID & CONTROL HANDLING:
+- CRITICAL: Do NOT add an id attribute to Dialog controls in controller extension files. Dialogs should be created without an id property.
+- Preserve any provided hints (e.g., <!-- viewName: ... -->, <!-- controlType: ... -->, <!-- targetAggregation: ... -->).
+- Do not remove original comments and align your changes with the given hints.
+- Follow adaptation project naming conventions for IDs
+
+FRAGMENT CONTROL WORKFLOW:
+If the original fragment or change file contains comments such as <!-- targetAggregation: ... --> or <!-- controlType: ... -->, use these as hints for what kind of control or aggregation is expected.
+IMPORTANT: The controlType comment refers to the PARENT control that will contain the fragment content.
+- <!-- controlType --> indicates the type of the parent control (e.g., Toolbar, VBox, etc.)
+- DO NOT add the controlType as a wrapper in your fragment - only provide the inner content
+- Example: If controlType is "Toolbar", provide only the Button/content, not another Toolbar wrapper
+- Keep these comments in the generated code as they are part of the project documentation.
+1. Use <!-- controlType -->, <!-- targetAggregation --> comments to identify the fragment's context.
+2. Provide ONLY the inner content suitable for the parent control (e.g., Button for Toolbar).
+3. Do not wrap the content in the controlType - it's already the parent container.
+4. If the user requests a specific control type, verify it's suitable for the parent container. If not, inform the user why.
+5. Take specific control prompts with priority
+6. Add a stable id to each element in the fragment
+
+CONTROLLER EXTENSION WORKFLOW:
+1. Read manifest.appdescr_variant:
+   - Extract 'id' property (app variant ID) - used for change file namespace
+   - Extract 'layer' property - determines if a customer prefix is needed
+   - CUSTOMER_BASE layer requires "customer" prefix in:
+     * Fragment event handlers: press=".extension.customer.{project}.{Controller}.{method}"
+     * Controller extension namespace: ControllerExtension.extend("customer.{project}.{Controller}", {...})
+
+2. Determine project folder name:
+   - Use the adaptation project root folder name (the folder that contains webapp)
+   - This is used in both fragment event handlers and controller extension namespace
+
+3. Create controller extension file:
+   - File path: webapp/changes/coding/{ControllerExtName}.js (NO customer prefix in path)
+   - Do NOT add .controller to the file name
+   - Use sap.ui.define with "sap/ui/core/mvc/ControllerExtension" (NOT sap/ui/core/mvc/Controller)
+   - Namespace pattern:
+     * Standard layer: return ControllerExtension.extend("{project-folder}.{ControllerExtName}", {...});
+     * CUSTOMER_BASE layer: return ControllerExtension.extend("customer.{project-folder}.{ControllerExtName}", {...});
+   - Example (standard): ControllerExtension.extend("adapt.blog.ControllerExt", {...})
+   - Example (CUSTOMER_BASE): ControllerExtension.extend("customer.adapt.blog.ControllerExt", {...})
+
+4. Create XML fragment file (if needed):
+   - Add stable, unique IDs to ALL controls and sub-elements
+   - Wire event handlers with proper namespace pattern:
+     * Standard layer: press=".extension.{project-folder}.{ControllerExt}.{methodName}"
+     * CUSTOMER_BASE layer: press=".extension.customer.{project-folder}.{ControllerExt}.{methodName}"
+   - The "customer" prefix matches the controller extension namespace
+   - The ".extension" prefix is ONLY used in fragment XML event handlers
+
+5. Do not create duplicate files:
+   - Do not create a new controller extension file if one already exists for the selected view
+
+OUTPUT REQUIREMENTS:
+- Each response must be self-contained and production-ready.
+- Each file must be complete, not partial.
+- Maintain consistent namespaces and controller references.
+- Follow adaptation project structure and conventions.
+- Include comments in code only where useful to explain complex logic.
+- CRITICAL: Assign stable, unique IDs to all controls, elements, subcontrols, items, and sub-items—even when they have a key or an identifying attribute. Verify all elements have IDs before responding.`;
+
+export const ADP_CONTROLLER_EXTENSION_FUNCTIONALITY: GetFunctionalityDetailsOutput = {
+    functionalityId: ADP_CONTROLLER_EXTENSION_FUNCTIONALITY_ID,
+    name: 'Generate ADP Controller Extension with AI',
+    description: `${KNOWLEDGE_BASE}
+
+This functionality processes AI-generated controller extensions and fragments for SAPUI5 Adaptation Projects. It:
+- Validates that the project is an adaptation project (has manifest.appdescr_variant)
+- Reads manifest.appdescr_variant to determine layer and namespace requirements
+- Extracts files from AI response (markdown code blocks with Path markers)
+- Generates proper namespaces based on layer (CUSTOMER_BASE vs standard)
+- Writes controller extension files, fragments, and other code files
+- Does NOT write change files (.change) - these are handled separately
+
+Parameters:
+- prompt: Natural language description of what to create
+- aiResponse (optional): Pre-generated AI response with code blocks
+- viewId (optional): Target view identifier
+- controllerName (optional): Desired controller extension name`,
+    parameters: convertToSchema(AdpControllerExtensionSchema)
+};
+
+export default ADP_CONTROLLER_EXTENSION_FUNCTIONALITY;

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/execute-functionality.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/execute-functionality.ts
@@ -1,0 +1,134 @@
+import type { ExecuteFunctionalityInput, ExecuteFunctionalityOutput } from '../../../types';
+import { promises as FSpromises } from 'node:fs';
+import { join, dirname, relative, isAbsolute, resolve, sep } from 'node:path';
+import { validateWithSchema } from '../../../utils';
+import { logger } from '../../../utils/logger';
+import { AdpControllerExtensionSchema } from './schema';
+import {
+    extractFilesFromResponse,
+    isChangeFile,
+    isAdaptationProject,
+    readManifestVariant,
+    getProjectFolderName
+} from './utils';
+
+/**
+ * Executes the ADP controller extension functionality.
+ * Processes AI-generated controller extensions and fragments for adaptation projects.
+ *
+ * @param input - The input parameters for executing the functionality.
+ * @returns A promise that resolves to the execution output.
+ */
+export default async function executeFunctionality(
+    input: ExecuteFunctionalityInput
+): Promise<ExecuteFunctionalityOutput> {
+    const { parameters, appPath } = input;
+
+    // Validate input parameters
+    const validatedParams = validateWithSchema(AdpControllerExtensionSchema, parameters);
+    const { prompt, aiResponse, viewId: _viewId, controllerName: _controllerName } = validatedParams;
+
+    logger.info(`Executing ADP controller extension functionality for: ${prompt}`);
+
+    // 1. Validate adaptation project
+    if (!isAdaptationProject(appPath)) {
+        throw new Error(
+            'This functionality is only available for adaptation projects. Please ensure manifest.appdescr_variant exists in the webapp folder.'
+        );
+    }
+
+    // 2. Read manifest.appdescr_variant
+    let variant;
+    try {
+        variant = await readManifestVariant(appPath);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to read manifest.appdescr_variant: ${errorMessage}`);
+    }
+
+    const layer = variant.layer ?? '';
+    const variantId = variant.id ?? '';
+    logger.debug(`Manifest variant - layer: ${layer}, id: ${variantId}`);
+
+    // 3. Extract project folder name
+    const projectFolderName = getProjectFolderName(appPath);
+    logger.debug(`Project folder name: ${projectFolderName}`);
+
+    const changes: string[] = [];
+
+    // 4. Process AI response if provided
+    if (aiResponse && typeof aiResponse === 'string') {
+        logger.info('Processing AI response to extract files');
+        const extractedFiles = extractFilesFromResponse(aiResponse);
+        logger.info(`Extracted ${extractedFiles.length} files from AI response`);
+
+        // 5. Filter out change files and write other files
+        for (const file of extractedFiles) {
+            let normalizedPath = file.path.replace(/\\/g, '/');
+
+            // Convert absolute path to relative path if it's within appPath
+            if (isAbsolute(normalizedPath)) {
+                // Resolve both paths to ensure they're properly normalized
+                const resolvedAppPath = resolve(appPath);
+                const resolvedFilePath = resolve(normalizedPath);
+
+                // Check if the file path is within the app path
+                // Use path separator to ensure we match at directory boundaries
+                const appPathWithSep = resolvedAppPath.endsWith(sep) ? resolvedAppPath : resolvedAppPath + sep;
+                if (resolvedFilePath.startsWith(appPathWithSep) || resolvedFilePath === resolvedAppPath) {
+                    // Convert to relative path
+                    normalizedPath = relative(resolvedAppPath, resolvedFilePath);
+                    logger.debug(`Converted absolute path ${resolvedFilePath} to relative: ${normalizedPath}`);
+                } else {
+                    // Absolute path outside appPath - this is an error
+                    logger.error(`File path ${normalizedPath} is outside app path ${appPath}`);
+                    throw new Error(`File path ${normalizedPath} is outside the application path ${appPath}`);
+                }
+            }
+
+            // Skip change files
+            if (isChangeFile(normalizedPath)) {
+                logger.debug(`Skipping change file: ${normalizedPath}`);
+                continue;
+            }
+
+            // Write the file
+            try {
+                const fullPath = join(appPath, normalizedPath);
+                const fileDir = dirname(fullPath);
+
+                // Ensure directory exists
+                await FSpromises.mkdir(fileDir, { recursive: true });
+
+                // Write file
+                await FSpromises.writeFile(fullPath, file.code, 'utf-8');
+                changes.push(`Created ${normalizedPath}`);
+                logger.info(`Created file: ${normalizedPath} at ${fullPath}`);
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                logger.error(`Failed to write file ${normalizedPath}: ${errorMessage}`);
+                throw new Error(`Failed to write file ${normalizedPath}: ${errorMessage}`);
+            }
+        }
+    } else {
+        // If no AI response provided, just validate the project setup
+        logger.info('No AI response provided, validating adaptation project setup only');
+        changes.push('Adaptation project validated successfully');
+    }
+
+    const status = changes.length > 0 ? 'success' : 'skipped';
+    const message =
+        changes.length > 0
+            ? `Successfully processed ${changes.length} file(s) for ADP controller extension`
+            : 'No files were processed. Provide aiResponse parameter with code blocks to generate files.';
+
+    return {
+        functionalityId: input.functionalityId,
+        status,
+        message,
+        parameters: parameters,
+        appPath: appPath,
+        changes,
+        timestamp: new Date().toISOString()
+    };
+}

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/index.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/index.ts
@@ -1,0 +1,13 @@
+import type { FunctionalityHandlers, GetFunctionalityDetailsOutput } from '../../../types';
+
+import details from './details';
+import executeFunctionality from './execute-functionality';
+
+export default {
+    id: details.functionalityId as string,
+    details,
+    handlers: {
+        getFunctionalityDetails: (): Promise<GetFunctionalityDetailsOutput> => Promise.resolve(details),
+        executeFunctionality
+    } as FunctionalityHandlers
+};

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
@@ -16,10 +16,7 @@ export const AdpControllerExtensionSchema: zod.ZodObject<{
         .describe(
             'Optional AI-generated response containing code blocks with Path markers. If not provided, the functionality will only validate the adaptation project.'
         ),
-    viewId: zod
-        .string()
-        .optional()
-        .describe('Optional target view identifier for the controller extension'),
+    viewId: zod.string().optional().describe('Optional target view identifier for the controller extension'),
     controllerName: zod
         .string()
         .optional()

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
@@ -1,0 +1,29 @@
+import * as zod from 'zod';
+
+/**
+ * Schema for ADP controller extension functionality input
+ */
+export const AdpControllerExtensionSchema: zod.ZodObject<{
+    prompt: zod.ZodString;
+    aiResponse?: zod.ZodOptional<zod.ZodString>;
+    viewId?: zod.ZodOptional<zod.ZodString>;
+    controllerName?: zod.ZodOptional<zod.ZodString>;
+}> = zod.object({
+    prompt: zod.string().describe('Natural language prompt describing what controller extension or fragment to create'),
+    aiResponse: zod
+        .string()
+        .optional()
+        .describe(
+            'Optional AI-generated response containing code blocks with Path markers. If not provided, the functionality will only validate the adaptation project.'
+        ),
+    viewId: zod
+        .string()
+        .optional()
+        .describe('Optional target view identifier for the controller extension'),
+    controllerName: zod
+        .string()
+        .optional()
+        .describe('Optional desired controller extension name (without .js/.ts extension)')
+});
+
+export type AdpControllerExtensionInput = zod.infer<typeof AdpControllerExtensionSchema>;

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/schema.ts
@@ -5,25 +5,18 @@ import * as zod from 'zod';
  */
 export const AdpControllerExtensionSchema: zod.ZodObject<{
     prompt: zod.ZodString;
-    aiResponse?: zod.ZodOptional<zod.ZodString>;
+    aiResponse: zod.ZodString;
+    controllerName: zod.ZodString;
     viewId?: zod.ZodOptional<zod.ZodString>;
-    controllerName?: zod.ZodOptional<zod.ZodString>;
 }> = zod.object({
     prompt: zod.string().describe('Natural language prompt describing what controller extension or fragment to create'),
     aiResponse: zod
         .string()
-        .optional()
         .describe(
             'Optional AI-generated response containing code blocks with Path markers. If not provided, the functionality will only validate the adaptation project.'
         ),
-    viewId: zod
-        .string()
-        .optional()
-        .describe('Optional target view identifier for the controller extension'),
-    controllerName: zod
-        .string()
-        .optional()
-        .describe('Optional desired controller extension name (without .js/.ts extension)')
+    viewId: zod.string().optional().describe('Optional target view identifier for the controller extension'),
+    controllerName: zod.string().describe('Optional desired controller extension name (without .js/.ts extension)')
 });
 
 export type AdpControllerExtensionInput = zod.infer<typeof AdpControllerExtensionSchema>;

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/utils.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/utils.ts
@@ -1,0 +1,190 @@
+import { getVariant, type DescriptorVariant, FlexLayer } from '@sap-ux/adp-tooling';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { logger } from '../../../utils/logger';
+
+export interface ExtractedFile {
+    path: string;
+    code: string;
+}
+
+/**
+ * Extract files from AI response containing markdown code blocks with Path markers
+ * @param content - The AI response content with markdown code blocks
+ * @returns Array of extracted files with path and code
+ */
+export function extractFilesFromResponse(content: string): ExtractedFile[] {
+    const codeBlocks: ExtractedFile[] = [];
+    const lines = content.split('\n');
+    let currentPath = '';
+    let inCodeBlock = false;
+    let currentCode = '';
+
+    for (const line of lines) {
+        // Look for **Path:** markers
+        const pathMatch = line.match(/\*\*Path:\*\*\s*(.+)/);
+        if (pathMatch) {
+            currentPath = pathMatch[1].trim();
+            continue;
+        }
+
+        // Look for code block start
+        if (line.match(/^```(\w+)?/) && !inCodeBlock) {
+            inCodeBlock = true;
+            currentCode = '';
+            continue;
+        }
+
+        // Look for code block end
+        if (line.startsWith('```') && inCodeBlock) {
+            inCodeBlock = false;
+            if (currentPath && currentCode.trim()) {
+                codeBlocks.push({
+                    path: currentPath,
+                    code: currentCode.trim()
+                });
+            }
+            currentPath = '';
+            currentCode = '';
+            continue;
+        }
+
+        // Collect code content
+        if (inCodeBlock) {
+            currentCode += line + '\n';
+        }
+    }
+
+    return codeBlocks;
+}
+
+/**
+ * Check if the file path represents a controller extension
+ * @param filePath - The file path to check
+ * @returns True if the file is a controller extension
+ */
+export function isControllerExtensionFile(filePath: string): boolean {
+    const normalizedPath = filePath.toLowerCase();
+
+    // Primary check: files in changes/coding folder (proper adaptation project structure)
+    const isInChangesFolder =
+        normalizedPath.includes('changes/coding') || normalizedPath.includes('changes\\coding');
+    const isJsOrTs = normalizedPath.endsWith('.js') || normalizedPath.endsWith('.ts');
+    const hasControllerKeywords =
+        normalizedPath.includes('controller') ||
+        normalizedPath.includes('extension') ||
+        normalizedPath.includes('ext');
+
+    const isPrimaryMatch = isInChangesFolder && isJsOrTs && hasControllerKeywords;
+
+    // Secondary check: controller files that extend ControllerExtension (even if in wrong location)
+    const isControllerFile = normalizedPath.includes('controller') && isJsOrTs;
+
+    // Enhanced check: look for ControllerExtension pattern in the path
+    const hasExtensionPattern =
+        normalizedPath.includes('controllerext') ||
+        normalizedPath.includes('controller.ext') ||
+        normalizedPath.includes('extension');
+
+    const isSecondaryMatch = isControllerFile && hasExtensionPattern;
+
+    const result = isPrimaryMatch || isSecondaryMatch;
+    logger.debug(
+        `isControllerExtensionFile(${filePath}): primary=${isPrimaryMatch}, secondary=${isSecondaryMatch}, result=${result}`
+    );
+
+    return result;
+}
+
+/**
+ * Check if the file content looks like a controller extension
+ * @param content - The file content to check
+ * @returns True if the content is a controller extension
+ */
+export function isControllerExtensionContent(content: string): boolean {
+    const normalizedContent = content.toLowerCase();
+    const result =
+        normalizedContent.includes('controllerextension') || normalizedContent.includes('controller.extension');
+    logger.debug(`isControllerExtensionContent: result=${result}`);
+    return result;
+}
+
+/**
+ * Check if the file path is a change file
+ * @param filePath - The file path to check
+ * @returns True if the file is a change file
+ */
+export function isChangeFile(filePath: string): boolean {
+    const normalizedPath = filePath.toLowerCase();
+    return normalizedPath.endsWith('.change');
+}
+
+/**
+ * Get project folder name from app path
+ * @param appPath - The application path
+ * @returns The project folder name
+ */
+export function getProjectFolderName(appPath: string): string {
+    const pathParts = appPath.split(/[/\\]/).filter((part) => part.length > 0);
+    // Get the last non-empty part (project folder name)
+    return pathParts[pathParts.length - 1] || '';
+}
+
+/**
+ * Generate controller extension namespace based on layer and project folder
+ * @param projectFolderName - The project folder name
+ * @param controllerExtName - The controller extension name
+ * @param layer - The FlexLayer from manifest.appdescr_variant
+ * @returns The namespace string for ControllerExtension.extend()
+ */
+export function generateControllerExtensionNamespace(
+    projectFolderName: string,
+    controllerExtName: string,
+    layer: string
+): string {
+    const isCustomerBase = layer === FlexLayer.CUSTOMER_BASE;
+    if (isCustomerBase) {
+        return `customer.${projectFolderName}.${controllerExtName}`;
+    }
+    return `${projectFolderName}.${controllerExtName}`;
+}
+
+/**
+ * Generate fragment event handler namespace for XML fragments
+ * @param projectFolderName - The project folder name
+ * @param controllerExtName - The controller extension name
+ * @param methodName - The method name
+ * @param layer - The FlexLayer from manifest.appdescr_variant
+ * @returns The event handler namespace string (e.g., ".extension.project.ControllerExt.methodName")
+ */
+export function generateFragmentEventHandlerNamespace(
+    projectFolderName: string,
+    controllerExtName: string,
+    methodName: string,
+    layer: string
+): string {
+    const isCustomerBase = layer === FlexLayer.CUSTOMER_BASE;
+    if (isCustomerBase) {
+        return `.extension.customer.${projectFolderName}.${controllerExtName}.${methodName}`;
+    }
+    return `.extension.${projectFolderName}.${controllerExtName}.${methodName}`;
+}
+
+/**
+ * Read manifest.appdescr_variant file
+ * @param appPath - The application path
+ * @returns The DescriptorVariant object
+ */
+export async function readManifestVariant(appPath: string): Promise<DescriptorVariant> {
+    return getVariant(appPath);
+}
+
+/**
+ * Check if the project is an adaptation project by checking for manifest.appdescr_variant
+ * @param appPath - The application path
+ * @returns True if it's an adaptation project
+ */
+export function isAdaptationProject(appPath: string): boolean {
+    const manifestVariantPath = join(appPath, 'webapp', 'manifest.appdescr_variant');
+    return existsSync(manifestVariantPath);
+}

--- a/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/utils.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/adp-controller-extension/utils.ts
@@ -10,6 +10,7 @@ export interface ExtractedFile {
 
 /**
  * Extract files from AI response containing markdown code blocks with Path markers
+ *
  * @param content - The AI response content with markdown code blocks
  * @returns Array of extracted files with path and code
  */
@@ -60,6 +61,7 @@ export function extractFilesFromResponse(content: string): ExtractedFile[] {
 
 /**
  * Check if the file path represents a controller extension
+ *
  * @param filePath - The file path to check
  * @returns True if the file is a controller extension
  */
@@ -67,13 +69,10 @@ export function isControllerExtensionFile(filePath: string): boolean {
     const normalizedPath = filePath.toLowerCase();
 
     // Primary check: files in changes/coding folder (proper adaptation project structure)
-    const isInChangesFolder =
-        normalizedPath.includes('changes/coding') || normalizedPath.includes('changes\\coding');
+    const isInChangesFolder = normalizedPath.includes('changes/coding') || normalizedPath.includes('changes\\coding');
     const isJsOrTs = normalizedPath.endsWith('.js') || normalizedPath.endsWith('.ts');
     const hasControllerKeywords =
-        normalizedPath.includes('controller') ||
-        normalizedPath.includes('extension') ||
-        normalizedPath.includes('ext');
+        normalizedPath.includes('controller') || normalizedPath.includes('extension') || normalizedPath.includes('ext');
 
     const isPrimaryMatch = isInChangesFolder && isJsOrTs && hasControllerKeywords;
 
@@ -98,6 +97,7 @@ export function isControllerExtensionFile(filePath: string): boolean {
 
 /**
  * Check if the file content looks like a controller extension
+ *
  * @param content - The file content to check
  * @returns True if the content is a controller extension
  */
@@ -111,6 +111,7 @@ export function isControllerExtensionContent(content: string): boolean {
 
 /**
  * Check if the file path is a change file
+ *
  * @param filePath - The file path to check
  * @returns True if the file is a change file
  */
@@ -121,6 +122,7 @@ export function isChangeFile(filePath: string): boolean {
 
 /**
  * Get project folder name from app path
+ *
  * @param appPath - The application path
  * @returns The project folder name
  */
@@ -132,6 +134,7 @@ export function getProjectFolderName(appPath: string): string {
 
 /**
  * Generate controller extension namespace based on layer and project folder
+ *
  * @param projectFolderName - The project folder name
  * @param controllerExtName - The controller extension name
  * @param layer - The FlexLayer from manifest.appdescr_variant
@@ -151,6 +154,7 @@ export function generateControllerExtensionNamespace(
 
 /**
  * Generate fragment event handler namespace for XML fragments
+ *
  * @param projectFolderName - The project folder name
  * @param controllerExtName - The controller extension name
  * @param methodName - The method name
@@ -172,6 +176,7 @@ export function generateFragmentEventHandlerNamespace(
 
 /**
  * Read manifest.appdescr_variant file
+ *
  * @param appPath - The application path
  * @returns The DescriptorVariant object
  */
@@ -181,6 +186,7 @@ export async function readManifestVariant(appPath: string): Promise<DescriptorVa
 
 /**
  * Check if the project is an adaptation project by checking for manifest.appdescr_variant
+ *
  * @param appPath - The application path
  * @returns True if it's an adaptation project
  */

--- a/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/functionalities/functionalities.ts
@@ -7,6 +7,7 @@ import {
 } from './generate-fiori-ui-application-cap';
 import {
     ADD_PAGE,
+    ADP_CONTROLLER_EXTENSION_FUNCTIONALITY_ID,
     CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY_ID,
     DELETE_PAGE,
     GENERATE_FIORI_UI_APPLICATION_CAP_ID
@@ -14,6 +15,7 @@ import {
 
 import generateFioriUIApplication from './generate-fiori-ui-application';
 import fetchServiceMetadata from './fetch-service-metadata';
+import adpControllerExtension from './adp-controller-extension';
 
 export const FUNCTIONALITIES_DETAILS = [
     ADD_PAGE_FUNCTIONALITY,
@@ -21,7 +23,8 @@ export const FUNCTIONALITIES_DETAILS = [
     DELETE_PAGE_FUNCTIONALITY,
     CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY,
     generateFioriUIApplication.details,
-    fetchServiceMetadata.details
+    fetchServiceMetadata.details,
+    adpControllerExtension.details
 ];
 
 export const FUNCTIONALITIES_HANDLERS: Map<string, FunctionalityHandlers> = new Map([
@@ -30,5 +33,6 @@ export const FUNCTIONALITIES_HANDLERS: Map<string, FunctionalityHandlers> = new 
     [GENERATE_FIORI_UI_APPLICATION_CAP_ID, generateFioriUIApplicationCapHandlers],
     [CREATE_CONTROLLER_EXTENSION_FUNCTIONALITY_ID, createControllerExtensionHandlers],
     [generateFioriUIApplication.id, generateFioriUIApplication.handlers],
-    [fetchServiceMetadata.id, fetchServiceMetadata.handlers]
+    [fetchServiceMetadata.id, fetchServiceMetadata.handlers],
+    [ADP_CONTROLLER_EXTENSION_FUNCTIONALITY_ID, adpControllerExtension.handlers]
 ]);

--- a/packages/fiori-mcp-server/tsconfig.json
+++ b/packages/fiori-mcp-server/tsconfig.json
@@ -11,6 +11,9 @@
   },
   "references": [
     {
+      "path": "../adp-tooling"
+    },
+    {
       "path": "../axios-extension"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2433,6 +2433,9 @@ importers:
       '@lancedb/lancedb':
         specifier: 0.22.0
         version: 0.22.0(apache-arrow@18.1.0)
+      '@sap-ux/adp-tooling':
+        specifier: workspace:*
+        version: link:../adp-tooling
       '@sap-ux/fiori-docs-embeddings':
         specifier: workspace:*
         version: link:../fiori-docs-embeddings


### PR DESCRIPTION
Feat for #4096.
- Adds the logic needed for the model to generate a controller extension and fragment files by taking into account the controlName, viewId, and other information.