### PR TITLE
Adds new package odata-download-sub-generator

### DIFF
--- a/packages/abap-deploy-config-sub-generator/CHANGELOG.md
+++ b/packages/abap-deploy-config-sub-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sap-ux/abap-deploy-config-sub-generator
 
+## 0.2.28
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+
 ## 0.2.27
 
 ### Patch Changes

--- a/packages/abap-deploy-config-sub-generator/package.json
+++ b/packages/abap-deploy-config-sub-generator/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/SAP/open-ux-tools.git",
         "directory": "packages/abap-deploy-config-sub-generator"
     },
-    "version": "0.2.27",
+    "version": "0.2.28",
     "license": "Apache-2.0",
     "main": "generators/app/index.js",
     "scripts": {

--- a/packages/adp-flp-config-sub-generator/CHANGELOG.md
+++ b/packages/adp-flp-config-sub-generator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @sap-ux/adp-flp-config-sub-generator
 
+## 0.1.203
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+    - @sap-ux/flp-config-inquirer@0.4.150
+
 ## 0.1.202
 
 ### Patch Changes

--- a/packages/adp-flp-config-sub-generator/package.json
+++ b/packages/adp-flp-config-sub-generator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/adp-flp-config-sub-generator",
     "description": "Generator for adding FLP configuration to an Adaptation Project",
-    "version": "0.1.202",
+    "version": "0.1.203",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/adp-tooling/CHANGELOG.md
+++ b/packages/adp-tooling/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sap-ux/adp-tooling
 
+## 0.18.91
+
+### Patch Changes
+
+- 53af342: feat: Create service keys
+
 ## 0.18.90
 
 ### Patch Changes

--- a/packages/adp-tooling/package.json
+++ b/packages/adp-tooling/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Aadp-tooling"
     },
-    "version": "0.18.90",
+    "version": "0.18.91",
     "license": "Apache-2.0",
     "author": "@SAP/ux-tools-team",
     "main": "dist/index.js",

--- a/packages/adp-tooling/src/cf/app/html5-repo.ts
+++ b/packages/adp-tooling/src/cf/app/html5-repo.ts
@@ -5,7 +5,7 @@ import type { ToolsLogger } from '@sap-ux/logger';
 import type { Manifest } from '@sap-ux/project-access';
 
 import { t } from '../../i18n';
-import { getServiceNameByTags, getServiceInstanceKeys, createServiceInstance } from '../services/api';
+import { getServiceNameByTags, getOrCreateServiceInstanceKeys, createServiceInstance } from '../services/api';
 import type { HTML5Content, ServiceInfo, Uaa, CfAppParams } from '../../types';
 
 const HTML5_APPS_REPO_RUNTIME = 'html5-apps-repo-runtime';
@@ -66,7 +66,7 @@ export async function downloadZip(token: string, appHostId: string, uri: string)
  */
 export async function getHtml5RepoCredentials(spaceGuid: string, logger: ToolsLogger): Promise<ServiceInfo> {
     try {
-        let serviceInfo = await getServiceInstanceKeys(
+        let serviceInfo = await getOrCreateServiceInstanceKeys(
             {
                 spaceGuids: [spaceGuid],
                 planNames: ['app-runtime'],
@@ -79,7 +79,7 @@ export async function getHtml5RepoCredentials(spaceGuid: string, logger: ToolsLo
             await createServiceInstance('app-runtime', HTML5_APPS_REPO_RUNTIME, serviceName, {
                 logger
             });
-            serviceInfo = await getServiceInstanceKeys({ names: [HTML5_APPS_REPO_RUNTIME] }, logger);
+            serviceInfo = await getOrCreateServiceInstanceKeys({ names: [HTML5_APPS_REPO_RUNTIME] }, logger);
             if (!serviceInfo?.serviceKeys?.length) {
                 logger.debug(t('error.noUaaCredentialsFoundForHtml5Repo'));
                 throw new Error(t('error.cannotFindHtml5RepoRuntime'));

--- a/packages/adp-tooling/src/cf/project/yaml.ts
+++ b/packages/adp-tooling/src/cf/project/yaml.ts
@@ -34,6 +34,7 @@ interface AdjustMtaYamlParams {
     businessSolutionName: string;
     businessService: string;
     serviceKeys?: ServiceKeys[];
+    spaceGuid: string;
 }
 
 /**
@@ -445,7 +446,8 @@ export async function adjustMtaYaml(
         appRouterType,
         businessSolutionName,
         businessService,
-        serviceKeys
+        serviceKeys,
+        spaceGuid
     }: AdjustMtaYamlParams,
     memFs: Editor,
     timestamp: string,
@@ -489,7 +491,7 @@ export async function adjustMtaYaml(
     adjustMtaYamlOwnModule(yamlContent, adpProjectName);
     // should go last since it sorts the modules (workaround, should be removed after fixed in deployment module)
     adjustMtaYamlFlpModule(yamlContent, mtaProjectName, businessService);
-    await createServices(yamlContent, initialServices, timestamp, templatePathOverwrite, logger);
+    await createServices(yamlContent, initialServices, timestamp, spaceGuid, templatePathOverwrite, logger);
 
     const updatedYamlContent = yaml.dump(yamlContent, {
         lineWidth: -1 // Disable line wrapping to keep URLs on single lines

--- a/packages/adp-tooling/src/cf/services/api.ts
+++ b/packages/adp-tooling/src/cf/services/api.ts
@@ -54,7 +54,7 @@ export async function getBusinessServiceInfo(
     config: CfConfig,
     logger: ToolsLogger
 ): Promise<ServiceInfo | null> {
-    const serviceKeys = await getServiceInstanceKeys(
+    const serviceKeys = await getOrCreateServiceInstanceKeys(
         {
             spaceGuids: [config.space.GUID],
             names: [businessService]
@@ -204,7 +204,7 @@ export async function createServiceInstance(
             `Creating service instance '${serviceInstanceName}' of service '${serviceName}' with '${plan}' plan`
         );
 
-        const commandParameters: string[] = ['create-service', serviceName, plan, serviceInstanceName];
+        const commandParameters: string[] = ['create-service', serviceName, plan, serviceInstanceName, '--wait'];
 
         if (xsSecurityProjectName) {
             let xsSecurity = null;
@@ -223,7 +223,11 @@ export async function createServiceInstance(
             commandParameters.push('-c', JSON.stringify(xsSecurity));
         }
 
-        await Cli.execute(commandParameters);
+        const result = await Cli.execute(commandParameters);
+        if (result && result.exitCode !== 0) {
+            logger?.error(`Service creation failed: ${result.stderr || 'Unknown error'}`);
+            throw new Error(`Service creation failed with code ${result.exitCode}: ${result.stderr || ''}`);
+        }
         logger?.log(`Service instance '${serviceInstanceName}' created successfully`);
     } catch (e) {
         logger?.error(e);
@@ -254,6 +258,7 @@ export async function getServiceNameByTags(spaceGuid: string, tags: string[]): P
  * @param {MtaYaml} yamlContent - The YAML content.
  * @param {string[]} initialServices - The initial services.
  * @param {string} timestamp - The timestamp.
+ * @param {string} spaceGuid - The space GUID.
  * @param {string} [templatePathOverwrite] - The template path overwrite.
  * @param {ToolsLogger} logger - The logger.
  * @returns {Promise<void>} The promise.
@@ -262,6 +267,7 @@ export async function createServices(
     yamlContent: MtaYaml,
     initialServices: string[],
     timestamp: string,
+    spaceGuid: string,
     templatePathOverwrite?: string,
     logger?: ToolsLogger
 ): Promise<void> {
@@ -291,6 +297,13 @@ export async function createServices(
                     }
                 );
             }
+            await getOrCreateServiceInstanceKeys(
+                {
+                    spaceGuids: [spaceGuid],
+                    names: [resource.parameters?.['service-name'] ?? '']
+                },
+                logger
+            );
         }
     }
 }
@@ -302,7 +315,7 @@ export async function createServices(
  * @param {ToolsLogger} logger - The logger.
  * @returns {Promise<ServiceInfo | null>} The service instance keys.
  */
-export async function getServiceInstanceKeys(
+export async function getOrCreateServiceInstanceKeys(
     serviceInstanceQuery: GetServiceInstanceParams,
     logger?: ToolsLogger
 ): Promise<ServiceInfo | null> {

--- a/packages/adp-tooling/src/cf/services/cli.ts
+++ b/packages/adp-tooling/src/cf/services/cli.ts
@@ -55,7 +55,7 @@ export async function getServiceKeys(serviceInstanceGuid: string): Promise<Servi
  */
 export async function createServiceKey(serviceInstanceName: string, serviceKeyName: string): Promise<void> {
     try {
-        const cliResult = await Cli.execute(['create-service-key', serviceInstanceName, serviceKeyName], ENV);
+        const cliResult = await Cli.execute(['create-service-key', serviceInstanceName, serviceKeyName, '--wait'], ENV);
         if (cliResult.exitCode !== 0) {
             throw new Error(cliResult.stderr);
         }

--- a/packages/adp-tooling/src/types.ts
+++ b/packages/adp-tooling/src/types.ts
@@ -1104,6 +1104,10 @@ export interface CfAdpWriterConfig {
          * Business service instance keys.
          */
         serviceInfo?: ServiceInfo | null;
+        /**
+         * GUID of the BTP space.
+         */
+        spaceGuid: string;
     };
     project: {
         name: string;
@@ -1144,6 +1148,7 @@ export interface CreateCfConfigParams {
     packageJson: Package;
     toolsId: string;
     serviceInfo?: ServiceInfo | null;
+    spaceGuid: string;
 }
 
 export const AppRouterType = {

--- a/packages/adp-tooling/src/writer/cf.ts
+++ b/packages/adp-tooling/src/writer/cf.ts
@@ -9,7 +9,7 @@ import { readUi5Yaml } from '@sap-ux/project-access';
 import {
     adjustMtaYaml,
     getAppHostIds,
-    getServiceInstanceKeys,
+    getOrCreateServiceInstanceKeys,
     addServeStaticMiddleware,
     addBackendProxyMiddleware,
     getCfUi5AppInfo,
@@ -54,7 +54,8 @@ export async function generateCf(
             appRouterType: cf.approuter,
             businessSolutionName: cf.businessSolutionName ?? '',
             businessService: cf.businessService,
-            serviceKeys: cf.serviceInfo?.serviceKeys
+            serviceKeys: cf.serviceInfo?.serviceKeys,
+            spaceGuid: cf.space.GUID
         },
         fs,
         timestamp,
@@ -140,15 +141,18 @@ export async function generateCfConfig(
 
     const ui5Config = await readUi5Yaml(basePath, yamlPath);
 
-    const bundlerTask = ui5Config.findCustomTask<{ serviceInstanceName?: string }>('app-variant-bundler-build');
+    const bundlerTask = ui5Config.findCustomTask<{ space?: string; serviceInstanceName?: string }>(
+        'app-variant-bundler-build'
+    );
     const serviceInstanceName = bundlerTask?.configuration?.serviceInstanceName;
     if (!serviceInstanceName) {
         throw new Error('No serviceInstanceName found in app-variant-bundler-build configuration');
     }
 
-    const serviceInfo = await getServiceInstanceKeys(
+    const serviceInfo = await getOrCreateServiceInstanceKeys(
         {
-            names: [serviceInstanceName]
+            names: [serviceInstanceName],
+            spaceGuids: [bundlerTask?.configuration?.space ?? '']
         },
         logger
     );

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -2,13 +2,7 @@ import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import type { Editor } from 'mem-fs-editor';
 
-import {
-    type CloudApp,
-    type AdpWriterConfig,
-    type TypesConfig,
-    type CfAdpWriterConfig,
-    type DescriptorVariant
-} from '../types';
+import type { CloudApp, AdpWriterConfig, TypesConfig, CfAdpWriterConfig, DescriptorVariant } from '../types';
 import {
     enhanceUI5DeployYaml,
     enhanceUI5Yaml,

--- a/packages/adp-tooling/src/writer/writer-config.ts
+++ b/packages/adp-tooling/src/writer/writer-config.ts
@@ -233,7 +233,8 @@ export function getCfConfig(params: CreateCfConfigParams): CfAdpWriterConfig {
             serviceInstanceGuid: params.serviceInstanceGuid,
             backendUrls: params.backendUrls,
             oauthPaths: params.oauthPaths,
-            serviceInfo: params.serviceInfo
+            serviceInfo: params.serviceInfo,
+            spaceGuid: params.spaceGuid
         },
         project: {
             name: params.attributeAnswers.projectName,

--- a/packages/adp-tooling/test/unit/cf/project/yaml.test.ts
+++ b/packages/adp-tooling/test/unit/cf/project/yaml.test.ts
@@ -324,6 +324,7 @@ describe('YAML Project Functions', () => {
                     projectPath,
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.STANDALONE,
+                    spaceGuid,
                     businessSolutionName,
                     businessService
                 },
@@ -358,6 +359,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,
@@ -396,6 +398,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: null as unknown as AppRouterType,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,
@@ -432,6 +435,7 @@ describe('YAML Project Functions', () => {
                         adpProjectName: 'test-adp-project',
                         appRouterType: AppRouterType.STANDALONE,
                         businessSolutionName,
+                        spaceGuid,
                         businessService
                     },
                     mockMemFs,
@@ -481,6 +485,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,
@@ -533,6 +538,7 @@ describe('YAML Project Functions', () => {
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
                     businessService,
+                    spaceGuid,
                     serviceKeys: mockServiceKeys as unknown as ServiceKeys[]
                 },
                 mockMemFs,
@@ -581,6 +587,7 @@ describe('YAML Project Functions', () => {
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
                     businessService,
+                    spaceGuid,
                     serviceKeys: mockServiceKeys as unknown as ServiceKeys[]
                 },
                 mockMemFs,
@@ -631,6 +638,7 @@ describe('YAML Project Functions', () => {
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
                     businessService,
+                    spaceGuid,
                     serviceKeys: mockServiceKeys as unknown as ServiceKeys[]
                 },
                 mockMemFs,
@@ -673,6 +681,7 @@ describe('YAML Project Functions', () => {
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
                     businessService,
+                    spaceGuid,
                     serviceKeys: mockServiceKeys
                 },
                 mockMemFs,
@@ -732,6 +741,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,
@@ -792,6 +802,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,
@@ -852,6 +863,7 @@ describe('YAML Project Functions', () => {
                     adpProjectName: 'test-adp-project',
                     appRouterType: AppRouterType.MANAGED,
                     businessSolutionName,
+                    spaceGuid,
                     businessService
                 },
                 mockMemFs,

--- a/packages/adp-tooling/test/unit/cf/services/api.test.ts
+++ b/packages/adp-tooling/test/unit/cf/services/api.test.ts
@@ -13,7 +13,7 @@ import {
     createServiceInstance,
     getServiceNameByTags,
     createServices,
-    getServiceInstanceKeys
+    getOrCreateServiceInstanceKeys
 } from '../../../../src/cf/services/api';
 import { initI18n, t } from '../../../../src/i18n';
 import { isLoggedInCf } from '../../../../src/cf/core/auth';
@@ -405,7 +405,8 @@ describe('CF Services API', () => {
                 'create-service',
                 serviceName,
                 plan,
-                serviceInstanceName
+                serviceInstanceName,
+                '--wait'
             ]);
         });
 
@@ -428,6 +429,7 @@ describe('CF Services API', () => {
                 'xsuaa',
                 plan,
                 serviceInstanceName,
+                '--wait',
                 '-c',
                 JSON.stringify({ xsappname: 'test-project' })
             ]);
@@ -444,6 +446,25 @@ describe('CF Services API', () => {
                     error: 'Service creation failed'
                 })
             );
+        });
+
+        test('should handle non-zero exit code from CLI', async () => {
+            mockCFToolsCliExecute.mockResolvedValue({
+                exitCode: 1,
+                stdout: '',
+                stderr: 'Service already exists'
+            });
+
+            await expect(
+                createServiceInstance(plan, serviceInstanceName, serviceName, { logger: mockLogger })
+            ).rejects.toThrow(
+                t('error.failedToCreateServiceInstance', {
+                    serviceInstanceName: serviceInstanceName,
+                    error: 'Service creation failed with code 1: Service already exists'
+                })
+            );
+
+            expect(mockLogger.error).toHaveBeenCalledWith('Service creation failed: Service already exists');
         });
 
         test('should handle xs-security.json parsing failure', async () => {
@@ -505,6 +526,31 @@ describe('CF Services API', () => {
     });
 
     describe('createServices', () => {
+        const mockCfApiResponse = {
+            resources: [
+                {
+                    name: 'test-xsuaa-service',
+                    guid: 'test-guid'
+                }
+            ]
+        };
+
+        const mockServiceKeysResponse = [
+            {
+                credentials: {
+                    clientid: 'test-client-id',
+                    clientsecret: 'test-client-secret',
+                    url: 'test-url',
+                    uaa: {
+                        clientid: 'test-uaa-clientid',
+                        clientsecret: 'test-uaa-clientsecret',
+                        url: 'test-uaa-url'
+                    },
+                    uri: 'test-uri',
+                    endpoints: {}
+                }
+            }
+        ];
         test('should create all required services', async () => {
             const yamlContent: MtaYaml = {
                 '_schema-version': '3.2.0',
@@ -533,7 +579,10 @@ describe('CF Services API', () => {
                 stderr: ''
             });
 
-            await createServices(yamlContent, initialServices, '1234567890', 'test-space-guid', mockLogger);
+            mockRequestCfApi.mockResolvedValue(mockCfApiResponse);
+            mockGetServiceKeys.mockResolvedValue(mockServiceKeysResponse);
+
+            await createServices(yamlContent, initialServices, '1234567890', 'test-space-guid', undefined, mockLogger);
 
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(
                 expect.arrayContaining([
@@ -545,6 +594,9 @@ describe('CF Services API', () => {
                     expect.any(String)
                 ])
             );
+
+            expect(mockRequestCfApi).toHaveBeenCalledWith(expect.stringContaining('service_instances'));
+            expect(mockGetServiceKeys).toHaveBeenCalledWith('test-guid');
         });
 
         test('should create non-xsuaa service without security file path', async () => {
@@ -567,7 +619,6 @@ describe('CF Services API', () => {
                 ]
             };
             const initialServices = ['portal'];
-            const spaceGuid = 'test-space-guid';
 
             mockGetProjectNameForXsSecurity.mockReturnValue('test-project-1234567890');
             mockCFToolsCliExecute.mockResolvedValue({
@@ -576,7 +627,10 @@ describe('CF Services API', () => {
                 stderr: ''
             });
 
-            await createServices(yamlContent, initialServices, '1234567890', undefined, mockLogger);
+            mockRequestCfApi.mockResolvedValue(mockCfApiResponse);
+            mockGetServiceKeys.mockResolvedValue(mockServiceKeysResponse);
+
+            await createServices(yamlContent, initialServices, '1234567890', 'test-space-guid', undefined, mockLogger);
 
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(
                 expect.arrayContaining(['create-service', 'destination', 'lite', 'test-destination-service'])
@@ -584,10 +638,12 @@ describe('CF Services API', () => {
 
             // Verify that the call does NOT include the -c flag (no security file path)
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(expect.not.arrayContaining(['-c']));
+            expect(mockRequestCfApi).toHaveBeenCalledWith(expect.stringContaining('service_instances'));
+            expect(mockGetServiceKeys).toHaveBeenCalledWith('test-guid');
         });
     });
 
-    describe('getServiceInstanceKeys', () => {
+    describe('getOrCreateServiceInstanceKeys', () => {
         test('should return service keys when service instance is found', async () => {
             const serviceInstanceQuery = {
                 spaceGuids: ['test-space-guid'],
@@ -626,7 +682,7 @@ describe('CF Services API', () => {
             });
             mockGetServiceKeys.mockResolvedValue(mockServiceKeys.serviceKeys);
 
-            const result = await getServiceInstanceKeys(serviceInstanceQuery, mockLogger);
+            const result = await getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger);
 
             expect(result).toEqual(mockServiceKeys);
             expect(mockLogger.log).toHaveBeenCalledWith("Use 'test-service' HTML5 Repo instance");
@@ -640,7 +696,7 @@ describe('CF Services API', () => {
 
             mockRequestCfApi.mockResolvedValue({ resources: [] });
 
-            const result = await getServiceInstanceKeys(serviceInstanceQuery, mockLogger);
+            const result = await getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger);
 
             expect(result).toBeNull();
         });
@@ -653,7 +709,7 @@ describe('CF Services API', () => {
 
             mockRequestCfApi.mockRejectedValue(new Error('Service query failed'));
 
-            await expect(getServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
+            await expect(getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
                 t('error.failedToGetServiceInstanceKeys', {
                     error: t('error.failedToGetServiceInstance', {
                         error: 'Service query failed',
@@ -673,7 +729,7 @@ describe('CF Services API', () => {
                 resources: 'not-an-array'
             });
 
-            await expect(getServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
+            await expect(getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
                 t('error.failedToGetServiceInstanceKeys', {
                     error: t('error.failedToGetServiceInstance', {
                         error: t('error.noValidJsonForServiceInstance'),
@@ -715,7 +771,7 @@ describe('CF Services API', () => {
                 }
             ]);
 
-            const result = await getServiceInstanceKeys(serviceInstanceQuery, mockLogger);
+            const result = await getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger);
 
             expect(result).toEqual({
                 serviceKeys: [
@@ -765,7 +821,7 @@ describe('CF Services API', () => {
 
             mockCreateServiceKey.mockRejectedValue(new Error('Failed to create service key'));
 
-            await expect(getServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
+            await expect(getOrCreateServiceInstanceKeys(serviceInstanceQuery, mockLogger)).rejects.toThrow(
                 t('error.failedToGetServiceInstanceKeys', {
                     error: t('error.failedToGetOrCreateServiceKeys', {
                         serviceInstanceName: 'test-service',

--- a/packages/adp-tooling/test/unit/cf/services/cli.test.ts
+++ b/packages/adp-tooling/test/unit/cf/services/cli.test.ts
@@ -162,7 +162,7 @@ describe('CF Services CLI', () => {
             await createServiceKey(serviceInstanceName, serviceKeyName);
 
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(
-                ['create-service-key', serviceInstanceName, serviceKeyName],
+                ['create-service-key', serviceInstanceName, serviceKeyName, '--wait'],
                 { env: { 'CF_COLOR': 'false' } }
             );
         });
@@ -182,7 +182,7 @@ describe('CF Services CLI', () => {
                 })
             );
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(
-                ['create-service-key', serviceInstanceName, serviceKeyName],
+                ['create-service-key', serviceInstanceName, serviceKeyName, '--wait'],
                 { env: { 'CF_COLOR': 'false' } }
             );
         });
@@ -195,7 +195,7 @@ describe('CF Services CLI', () => {
                 t('error.createServiceKeyFailed', { serviceInstanceName, error: error.message })
             );
             expect(mockCFToolsCliExecute).toHaveBeenCalledWith(
-                ['create-service-key', serviceInstanceName, serviceKeyName],
+                ['create-service-key', serviceInstanceName, serviceKeyName, '--wait'],
                 { env: { 'CF_COLOR': 'false' } }
             );
         });

--- a/packages/adp-tooling/test/unit/writer/cf.test.ts
+++ b/packages/adp-tooling/test/unit/writer/cf.test.ts
@@ -11,7 +11,7 @@ import { generateCf, writeUi5AppInfo, generateCfConfig } from '../../../src/writ
 import { AppRouterType, FlexLayer, type CfAdpWriterConfig, type CfUi5AppInfo, type CfConfig } from '../../../src/types';
 import {
     getAppHostIds,
-    getServiceInstanceKeys,
+    getOrCreateServiceInstanceKeys,
     addServeStaticMiddleware,
     addBackendProxyMiddleware,
     getCfUi5AppInfo,
@@ -26,7 +26,9 @@ jest.mock('../../../src/base/project-builder');
 jest.mock('@sap-ux/project-access');
 
 const mockGetAppHostIds = getAppHostIds as jest.MockedFunction<typeof getAppHostIds>;
-const mockGetServiceInstanceKeys = getServiceInstanceKeys as jest.MockedFunction<typeof getServiceInstanceKeys>;
+const mockGetOrCreateServiceInstanceKeys = getOrCreateServiceInstanceKeys as jest.MockedFunction<
+    typeof getOrCreateServiceInstanceKeys
+>;
 const mockAddServeStaticMiddleware = addServeStaticMiddleware as jest.MockedFunction<typeof addServeStaticMiddleware>;
 const mockAddBackendProxyMiddleware = addBackendProxyMiddleware as jest.MockedFunction<
     typeof addBackendProxyMiddleware
@@ -87,7 +89,8 @@ const config: CfAdpWriterConfig = {
         serviceInfo: {
             serviceKeys: mockServiceKeys,
             serviceInstance: { guid: 'service-guid', name: 'service-name' }
-        }
+        },
+        spaceGuid: 'space-guid'
     },
     project: {
         name: 'test-cf-project',
@@ -259,7 +262,7 @@ describe('CF Writer', () => {
 
         beforeEach(() => {
             mockReadUi5Yaml.mockResolvedValue(mockUi5Config as any);
-            mockGetServiceInstanceKeys.mockResolvedValue({
+            mockGetOrCreateServiceInstanceKeys.mockResolvedValue({
                 serviceKeys: mockServiceKeys,
                 serviceInstance: { guid: 'service-guid', name: 'service-name' }
             });
@@ -280,12 +283,15 @@ describe('CF Writer', () => {
             mkdirSync(projectDir, { recursive: true });
 
             mockUi5Config.findCustomTask.mockReturnValue({
-                configuration: { serviceInstanceName: 'test-service' }
+                configuration: { serviceInstanceName: 'test-service', space: 'space-guid' }
             });
 
             const fs = await generateCfConfig(projectDir, 'ui5.yaml', mockCfConfig, mockLogger);
 
-            expect(mockGetServiceInstanceKeys).toHaveBeenCalledWith({ names: ['test-service'] }, mockLogger);
+            expect(mockGetOrCreateServiceInstanceKeys).toHaveBeenCalledWith(
+                { names: ['test-service'], spaceGuids: ['space-guid'] },
+                mockLogger
+            );
             expect(mockGetAppHostIds).toHaveBeenCalledWith(mockServiceKeys);
             expect(mockGetBaseAppId).toHaveBeenCalledWith(projectDir);
             expect(mockGetCfUi5AppInfo).toHaveBeenCalledWith('test-app-id', ['host-123'], mockCfConfig, mockLogger);
@@ -316,10 +322,10 @@ describe('CF Writer', () => {
             mkdirSync(projectDir, { recursive: true });
 
             mockUi5Config.findCustomTask.mockReturnValue({
-                configuration: { serviceInstanceName: 'test-service' }
+                configuration: { serviceInstanceName: 'test-service', space: 'space-guid' }
             });
 
-            mockGetServiceInstanceKeys.mockResolvedValue(null);
+            mockGetOrCreateServiceInstanceKeys.mockResolvedValue(null);
 
             await expect(generateCfConfig(projectDir, 'ui5.yaml', mockCfConfig, mockLogger)).rejects.toThrow(
                 'No service keys found for service instance: test-service'

--- a/packages/adp-tooling/test/unit/writer/project-utils.test.ts
+++ b/packages/adp-tooling/test/unit/writer/project-utils.test.ts
@@ -73,7 +73,8 @@ const cfData = {
         serviceInfo: {
             serviceKeys: mockServiceKeys,
             serviceInstance: { guid: 'service-guid', name: 'service-name' }
-        }
+        },
+        spaceGuid: 'space-guid'
     },
     project: {
         name: 'my-test-cf-project',

--- a/packages/adp-tooling/test/unit/writer/writer-config.test.ts
+++ b/packages/adp-tooling/test/unit/writer/writer-config.test.ts
@@ -184,7 +184,8 @@ describe('getCfConfig', () => {
         serviceInfo: {
             serviceKeys: mockServiceKeys,
             serviceInstance: { guid: 'service-guid', name: 'service-name' }
-        }
+        },
+        spaceGuid: 'space-guid'
     };
 
     test('should create CF config with managed approuter', () => {

--- a/packages/backend-proxy-middleware-cf/CHANGELOG.md
+++ b/packages/backend-proxy-middleware-cf/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sap-ux/backend-proxy-middleware-cf
 
+## 0.0.81
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+
 ## 0.0.80
 
 ### Patch Changes

--- a/packages/backend-proxy-middleware-cf/package.json
+++ b/packages/backend-proxy-middleware-cf/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Abackend-proxy-middleware-cf"
     },
-    "version": "0.0.80",
+    "version": "0.0.81",
     "license": "Apache-2.0",
     "author": "@SAP/ux-tools-team",
     "main": "dist/index.js",

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @sap-ux/create
 
+## 0.15.37
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+    - @sap-ux/flp-config-inquirer@0.4.150
+    - @sap-ux/preview-middleware@0.23.153
+    - @sap-ux/app-config-writer@0.6.120
+
 ## 0.15.36
 
 ### Patch Changes

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/create",
     "description": "SAP Fiori tools module to add or remove features",
-    "version": "0.15.36",
+    "version": "0.15.37",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/deploy-config-sub-generator/CHANGELOG.md
+++ b/packages/deploy-config-sub-generator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sap-ux/deploy-config-sub-generator
 
+## 0.5.110
+
+### Patch Changes
+
+- @sap-ux/abap-deploy-config-sub-generator@0.2.28
+
 ## 0.5.109
 
 ### Patch Changes

--- a/packages/deploy-config-sub-generator/package.json
+++ b/packages/deploy-config-sub-generator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/deploy-config-sub-generator",
     "description": "Main generator for configuring ABAP or Cloud Foundry deployment configuration",
-    "version": "0.5.109",
+    "version": "0.5.110",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/eslint-plugin-fiori-tools/CHANGELOG.md
+++ b/packages/eslint-plugin-fiori-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sap-ux/eslint-plugin-fiori-tools
 
+## 9.8.0
+
+### Minor Changes
+
+- af65902: Add table personalization rule that checks that all table customization settings are available in OData V4 applications.
+
 ## 9.7.8
 
 ### Patch Changes

--- a/packages/eslint-plugin-fiori-tools/README.md
+++ b/packages/eslint-plugin-fiori-tools/README.md
@@ -163,4 +163,5 @@ export default [
 | [sap-width-including-column-header](docs/rules/sap-width-including-column-header.md) | Ensures that small tables (less than six columns) have the `widthIncludingColumnHeader` property set to `true` for better calculation of column width. | | ✅ |
 | [sap-state-preservation-mode](docs/rules/sap-state-preservation-mode.md) | Ensures Valid `statePreservationMode` Configuration in SAP Fiori Elements | | ✅ |
 | [sap-table-column-vertical-alignment](docs/rules/sap-table-column-vertical-alignment.md) | Ensures `tableColumnVerticalAlignment` Configuration for Responsive Type Tables in SAP Fiori Elements applications | | ✅ |
+| [sap-table-personalization](docs/rules/sap-table-personalization.md) | Ensures that all table `personalization` options are enabled in the OData V4 applications. | | ✅ |
 </div>

--- a/packages/eslint-plugin-fiori-tools/docs/rules/sap-table-personalization.md
+++ b/packages/eslint-plugin-fiori-tools/docs/rules/sap-table-personalization.md
@@ -1,0 +1,108 @@
+# Require `personalization` Property in OData V4 Tables is Enabled in the `manifest.json` File (`sap-table-personalization`)
+
+## Rule Details
+
+Ensures that all table `personalization` options are enabled on the OData V4 application pages. Table personalization is provided by default for all tables.
+
+Restriction: grouping is available for Analytical tables in applications with minUI5 version starting from 1.108 and Responsive tables in applications with minUI5 version starting from 1.120.
+
+### Why Was This Rule Introduced?
+
+Users should see all table personalization options that are available: adding or removing columns, filtering, sorting, and grouping.
+
+### Warning Message
+
+The following patterns are considered warnings:
+
+### Incorrect `personalization` Values
+
+```json
+{
+  "tableSettings": {
+    "personalization": false
+  }
+}
+```
+
+Setting `personalization` property to false disables every table personalization setting, so it is the same as defining all  `personalization` properties to `false`:
+
+```json
+{
+  "tableSettings": {
+    "personalization": {
+      "column" : false,
+      "sort" : false,
+      "filter" : false, 
+      "group": false
+    }
+  }
+}
+```
+
+If the value "object" is used, omitting a setting is treated as `false`.
+
+```json
+{
+  "tableSettings": {
+    "personalization": {}
+  }
+}
+```
+
+If you don't define all properties as `true`, all properties omitted will be switched off, like `filter` and `group` are also `false` in this example:
+
+```json
+{
+  "tableSettings": {
+    "personalization": {
+      "column": true,
+      "sort": false
+    }
+  }
+}
+```
+
+
+
+The following patterns are considered correct:
+
+### Correct `personalization` definition
+
+```json
+{
+  "tableSettings": {
+    "personalization": true
+  }
+}
+```
+
+The `personalization` property is correctly set to `true`, every table setting is enabled.
+
+```json
+{
+  "tableSettings": {
+    "personalization": {
+      "column" : true,
+      "sort" : true,
+      "filter" : true, 
+      "group": true
+    }
+  }
+}
+```
+
+Every table `personalization` property is correctly set to `true`.
+Omitting table personalization from the `manifest.json` table settings is also correct, because all personalization settings are provided by default for all tables.
+
+## How to Fix
+
+To fix the warning, ensure that either the `personalization` property is set to `true` or not defined in the table settings.
+You can use the quick fix provided by the plugin, it sets `personalization` property to `true`.
+
+## Bug Report
+
+If you encounter an issue with this rule, please open a [GitHub issue](https://github.com/SAP/open-ux-tools/issues).
+
+## Further Reading
+
+- [UI5 UI Adaptation Documentation](https://ui5.sap.com/sdk/#/topic/3e2b4d212b66481a829ccef1dc0ca16b)

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/eslint-plugin-fiori-tools",
-    "version": "9.7.8",
+    "version": "9.8.0",
     "description": "Custom linting plugin for Fiori tools apps",
     "repository": {
         "type": "git",

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -273,6 +273,7 @@ export const configs: Record<string, Linter.Config[]> = {
                 '@sap-ux/fiori-tools/sap-enable-paste': 'warn',
                 '@sap-ux/fiori-tools/sap-creation-mode-for-table': 'warn',
                 '@sap-ux/fiori-tools/sap-state-preservation-mode': 'warn',
+                '@sap-ux/fiori-tools/sap-table-personalization': 'warn',
                 '@sap-ux/fiori-tools/sap-table-column-vertical-alignment': 'warn'
             }
         }

--- a/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
+++ b/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
@@ -1,5 +1,6 @@
 import type { Manifest } from '@sap-ux/project-access';
 import type { AnnotationReference } from '../project-context/parser';
+import type { SourceLocation } from '@eslint/core';
 export const WIDTH_INCLUDING_COLUMN_HEADER_RULE_TYPE = 'sap-width-including-column-header';
 export const ANCHOR_BAR_VISIBLE = 'sap-anchor-bar-visible';
 export const FLEX_ENABLED = 'sap-flex-enabled';
@@ -8,6 +9,7 @@ export const ENABLE_EXPORT = 'sap-enable-export';
 export const ENABLE_PASTE = 'sap-enable-paste';
 export const CREATION_MODE_FOR_TABLE = 'sap-creation-mode-for-table';
 export const STATE_PRESERVATION_MODE = 'sap-state-preservation-mode';
+export const TABLE_PERSONALIZATION = 'sap-table-personalization';
 export const TABLE_COLUMN_VERTICAL_ALIGNMENT = 'sap-table-column-vertical-alignment';
 
 export interface WidthIncludingColumnHeaderDiagnostic {
@@ -29,6 +31,7 @@ export interface ManifestPropertyDiagnosticData {
     uri: string;
     object: Manifest;
     propertyPath: string[];
+    loc?: SourceLocation;
 }
 
 export interface FlexEnabled {
@@ -84,6 +87,24 @@ export interface StatePreservationMode {
     value?: string;
 }
 
+export type PersonalizationProperty = 'column' | 'filter' | 'sort' | 'group';
+export type PersonalizationMessageId =
+    | 'sap-table-personalization'
+    | 'sap-table-personalization-column'
+    | 'sap-table-personalization-filter'
+    | 'sap-table-personalization-sort'
+    | 'sap-table-personalization-group'
+    | 'sap-table-missing-personalization-properties';
+
+export interface TablePersonalization {
+    type: typeof TABLE_PERSONALIZATION;
+    messageId: PersonalizationMessageId;
+    property?: PersonalizationProperty;
+    undefinedProperties?: PersonalizationProperty[];
+    pageName: string;
+    manifest: ManifestPropertyDiagnosticData;
+}
+
 export interface TableColumnVerticalAlignment {
     type: typeof TABLE_COLUMN_VERTICAL_ALIGNMENT;
     manifest: ManifestPropertyDiagnosticData;
@@ -98,4 +119,5 @@ export type Diagnostic =
     | EnableExport
     | EnablePaste
     | StatePreservationMode
+    | TablePersonalization
     | TableColumnVerticalAlignment;

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
@@ -55,6 +55,7 @@ export interface TableSettings {
     disableCopyToClipboard: boolean;
     enableExport: boolean;
     enablePaste: boolean;
+    personalization: boolean | { column?: boolean; filter?: boolean; sort?: boolean; group?: boolean };
 }
 
 export type OrphanTable = ConfigurationBase<'orphan-table', TableSettings>;
@@ -153,6 +154,18 @@ function createTable(configurationKey: string, pathToPage: string[], table?: Tab
                     'name'
                 ],
                 values: getCreationModeValues()
+            },
+            personalization: {
+                configurationPath: [
+                    ...pathToPage,
+                    'options',
+                    'settings',
+                    'controlConfiguration',
+                    configurationKey,
+                    'tableSettings',
+                    'personalization'
+                ],
+                values: [true, false, {}]
             }
         }
     };
@@ -278,6 +291,14 @@ interface TableConfiguration {
         creationMode?: {
             name?: string;
         };
+        personalization?:
+            | boolean
+            | {
+                  column?: boolean;
+                  filter?: boolean;
+                  sort?: boolean;
+                  group?: boolean;
+              };
     };
 }
 
@@ -367,6 +388,8 @@ function linkListReportTable(
                 const creationModeValue = controlConfiguration.tableSettings?.creationMode?.name;
                 tableControl.configuration.creationMode.valueInFile = creationModeValue;
                 tableControl.configuration.creationMode.values = getCreationModeValues(tableType);
+                const personalization = controlConfiguration.tableSettings?.personalization;
+                tableControl.configuration.personalization.valueInFile = personalization;
             }
         } else {
             // no annotation definition found for this table, but configuration exists
@@ -460,6 +483,8 @@ function linkObjectPageSections(
             const creationModeValue = controlConfiguration.tableSettings?.creationMode?.name;
             tableControl.configuration.creationMode.valueInFile = creationModeValue;
             tableControl.configuration.creationMode.values = getCreationModeValues(tableType);
+            const personalization = controlConfiguration.tableSettings?.personalization;
+            tableControl.configuration.personalization.valueInFile = personalization;
         } else {
             // no annotation definition found for this section, but configuration exists
             const orphanedSection: OrphanSection = {

--- a/packages/eslint-plugin-fiori-tools/src/rules/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/index.ts
@@ -9,6 +9,7 @@ import {
     ENABLE_EXPORT,
     ENABLE_PASTE,
     STATE_PRESERVATION_MODE,
+    TABLE_PERSONALIZATION,
     TABLE_COLUMN_VERTICAL_ALIGNMENT
 } from '../language/diagnostics';
 
@@ -70,6 +71,7 @@ import statePreservationMode from './sap-state-preservation-mode';
 import copyToClipboard from './sap-copy-to-clipboard';
 import enableExport from './sap-enable-export';
 import enablePaste from './sap-enable-paste';
+import tablePersonalization from './sap-table-personalization';
 import tableColumnVerticalAlignment from './sap-table-column-vertical-alignment';
 
 import type { Rule } from 'eslint';
@@ -131,5 +133,6 @@ export const rules: Record<string, Rule.RuleModule | FioriRuleDefinition | Fiori
     [ENABLE_PASTE]: enablePaste,
     [CREATION_MODE_FOR_TABLE]: creationModeForTable,
     [STATE_PRESERVATION_MODE]: statePreservationMode,
+    [TABLE_PERSONALIZATION]: tablePersonalization,
     [TABLE_COLUMN_VERTICAL_ALIGNMENT]: tableColumnVerticalAlignment
 };

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-table-personalization.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-table-personalization.ts
@@ -1,0 +1,207 @@
+import type { FioriRuleDefinition } from '../types';
+import {
+    type PersonalizationMessageId,
+    type PersonalizationProperty,
+    TABLE_PERSONALIZATION,
+    type TablePersonalization
+} from '../language/diagnostics';
+import { createFioriRule } from '../language/rule-factory';
+import type { MemberNode } from '@humanwhocodes/momoa';
+import { createJsonFixer } from '../language/rule-fixer';
+import type { FeV4PageType, Table } from '../project-context/linker/fe-v4';
+import type { ParsedApp } from '../project-context/parser';
+import { isLowerThanMinimalUi5Version } from '../utils/version';
+
+const PersonalizationProperties = ['column', 'filter', 'group', 'sort'];
+
+const TABLE_PERSONALIZATION_COLUMN = 'sap-table-personalization-column';
+const TABLE_PERSONALIZATION_FILTER = 'sap-table-personalization-filter';
+const TABLE_PERSONALIZATION_SORT = 'sap-table-personalization-sort';
+const TABLE_PERSONALIZATION_GROUP = 'sap-table-personalization-group';
+const MISSING_PERSONALIZATION_PROPERTIES = 'sap-table-missing-personalization-properties';
+
+const MessageIdByProperty: {
+    [key: string]: PersonalizationMessageId;
+} = {
+    ['']: TABLE_PERSONALIZATION,
+    column: TABLE_PERSONALIZATION_COLUMN,
+    filter: TABLE_PERSONALIZATION_FILTER,
+    sort: TABLE_PERSONALIZATION_SORT,
+    group: TABLE_PERSONALIZATION_GROUP
+};
+
+const rule: FioriRuleDefinition = createFioriRule({
+    ruleId: TABLE_PERSONALIZATION,
+    meta: {
+        type: 'suggestion',
+        docs: {
+            recommended: true,
+            description:
+                'You can use table personalization to modify the settings of a table. By default, the table personalization provides options for adding or removing columns, filtering, sorting, and grouping.',
+            url: 'https://github.com/SAP/open-ux-tools/blob/main/packages/eslint-plugin-fiori-tools/docs/rules/sap-table-personalization.md'
+        },
+        messages: {
+            [TABLE_PERSONALIZATION]:
+                'Table personalization should be enabled. Currently every table personalization setting is disabled.',
+            [TABLE_PERSONALIZATION_COLUMN]: 'Adding or removing table columns should be enabled.',
+            [TABLE_PERSONALIZATION_FILTER]: 'Table data filtering should be enabled.',
+            [TABLE_PERSONALIZATION_SORT]: 'Table data sorting should be enabled.',
+            [TABLE_PERSONALIZATION_GROUP]:
+                'Table data grouping should be enabled for analytical and responsive type tables.',
+            [MISSING_PERSONALIZATION_PROPERTIES]:
+                'In case of using an object, omitting a setting is treated as false. {{undefinedPropertiesString}}.'
+        },
+        fixable: 'code'
+    },
+
+    check(context) {
+        const problems: TablePersonalization[] = [];
+
+        for (const [appKey, app] of Object.entries(context.sourceCode.projectContext.linkedModel.apps)) {
+            if (app.type !== 'fe-v4') {
+                continue;
+            }
+            const parsedApp = context.sourceCode.projectContext.index.apps[appKey];
+            const parsedService = context.sourceCode.projectContext.getIndexedServiceForMainService(parsedApp);
+            if (!parsedService) {
+                continue;
+            }
+
+            for (const page of app.pages) {
+                for (const table of page.lookup['table'] ?? []) {
+                    const tableProblems = checkPersonalizationValue(table, page, parsedApp);
+                    problems.push(...tableProblems);
+                }
+            }
+        }
+        return problems;
+    },
+    createJsonVisitorHandler: (context, diagnostic, deepestPathResult) => {
+        return function report(node: MemberNode): void {
+            diagnostic.manifest.loc = node.loc;
+            let undefinedPropertiesString = '';
+            let messageId = MessageIdByProperty[diagnostic.property ?? ''];
+            if (diagnostic.undefinedProperties?.length) {
+                undefinedPropertiesString = `Currently ${diagnostic.undefinedProperties.join(', ')} ${diagnostic.undefinedProperties.length === 1 ? 'is disabled' : 'are disabled'}`;
+                messageId = MISSING_PERSONALIZATION_PROPERTIES;
+            }
+            return context.report({
+                node,
+                data: {
+                    undefinedPropertiesString
+                },
+                messageId,
+                fix: createJsonFixer({
+                    context,
+                    deepestPathResult,
+                    node,
+                    operation: 'update',
+                    value: true,
+                    fixParent: !!diagnostic.property
+                })
+            });
+        };
+    }
+});
+
+/**
+ * Determines whether the property value should be checked.
+ * Property 'group' has table type and min UI5 version limitations.
+ *
+ * @param table - OData V4 table.
+ * @param parsedApp - Parsed application.
+ * @param propertyName - Property name.
+ * @returns true if property has to be enabled.
+ */
+function shouldCheckProperty(table: Table, parsedApp: ParsedApp, propertyName: PersonalizationProperty): boolean {
+    if (propertyName !== 'group') {
+        return true;
+    }
+    const minUI5Version = parsedApp.manifest.minUI5Version;
+    const tableType = table.configuration.tableType.valueInFile;
+    const checkGroupForAnalyticalTable =
+        tableType === 'AnalyticalTable' &&
+        minUI5Version &&
+        !isLowerThanMinimalUi5Version(minUI5Version, { major: 1, minor: 108 });
+    const checkGroupForResponsiveTable =
+        tableType === 'ResponsiveTable' &&
+        minUI5Version &&
+        !isLowerThanMinimalUi5Version(minUI5Version, { major: 1, minor: 120 });
+    if (checkGroupForAnalyticalTable || checkGroupForResponsiveTable) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Checks table personalization boolean of object value.
+ *
+ * @param table - OData V4 table.
+ * @param page - OData V4 page.
+ * @param parsedApp - Parsed application.
+ * @returns TablePersonalization issues collected for all properties
+ */
+function checkPersonalizationValue(table: Table, page: FeV4PageType, parsedApp: ParsedApp): TablePersonalization[] {
+    const problems: TablePersonalization[] = [];
+
+    const personalization = table.configuration.personalization.valueInFile;
+    // Check if boolean value
+    if (personalization === true || personalization === undefined) {
+        // Every table personalization setting is enabled
+        return [];
+    }
+    if (personalization === false) {
+        // Every table personalization setting is disabled
+        return [
+            {
+                type: TABLE_PERSONALIZATION,
+                pageName: page.targetName,
+                messageId: MessageIdByProperty[''],
+                manifest: {
+                    uri: parsedApp.manifest.manifestUri,
+                    object: parsedApp.manifestObject,
+                    propertyPath: table.configuration.personalization.configurationPath
+                }
+            }
+        ];
+    }
+    const undefinedProperties: PersonalizationProperty[] = [];
+    // Check personalization object properties
+    for (const key of PersonalizationProperties) {
+        const property = key as PersonalizationProperty;
+        const propertyValue = personalization[property];
+        if (shouldCheckProperty(table, parsedApp, property)) {
+            if (propertyValue === false) {
+                problems.push({
+                    type: TABLE_PERSONALIZATION,
+                    pageName: page.targetName,
+                    property,
+                    messageId: MessageIdByProperty[property],
+                    manifest: {
+                        uri: parsedApp.manifest.manifestUri,
+                        object: parsedApp.manifestObject,
+                        propertyPath: [...table.configuration.personalization.configurationPath, property]
+                    }
+                });
+            } else if (propertyValue === undefined) {
+                undefinedProperties.push(property);
+            }
+        }
+    }
+    if (undefinedProperties.length) {
+        problems.push({
+            type: TABLE_PERSONALIZATION,
+            pageName: page.targetName,
+            undefinedProperties,
+            messageId: MISSING_PERSONALIZATION_PROPERTIES,
+            manifest: {
+                uri: parsedApp.manifest.manifestUri,
+                object: parsedApp.manifestObject,
+                propertyPath: table.configuration.personalization.configurationPath
+            }
+        });
+    }
+    return problems;
+}
+
+export default rule;

--- a/packages/eslint-plugin-fiori-tools/test/language/__snapshots__/rule-fixer.test.ts.snap
+++ b/packages/eslint-plugin-fiori-tools/test/language/__snapshots__/rule-fixer.test.ts.snap
@@ -55,6 +55,19 @@ Array [
 ]
 `;
 
+exports[`createJsonFixer DELETE operation should delete parent object value if fixParent = true 1`] = `
+Array [
+  Object {
+    "range": Array [
+      0,
+      4,
+    ],
+    "text": "",
+    "type": "remove",
+  },
+]
+`;
+
 exports[`createJsonFixer DELETE operation should replace a single property in an object node 1`] = `
 Array [
   Object {
@@ -194,6 +207,20 @@ Array [
 ]
 `;
 
+exports[`createJsonFixer INSERT operation should insert value on a parent node - fixParent = true 1`] = `
+Array [
+  Object {
+    "range": Array [
+      401,
+      401,
+    ],
+    "text": "
+  \\"newProp\\": false",
+    "type": "insert",
+  },
+]
+`;
+
 exports[`createJsonFixer Operation inference should infer DELETE when no missingSegments and value is undefined 1`] = `
 Array [
   Object {
@@ -284,6 +311,19 @@ Array [
   \\"enabled\\": true,
   \\"count\\": 5
 }",
+    "type": "replace",
+  },
+]
+`;
+
+exports[`createJsonFixer UPDATE operation should update the value for a parent node - fixParent = true 1`] = `
+Array [
+  Object {
+    "range": Array [
+      0,
+      3,
+    ],
+    "text": "false",
     "type": "replace",
   },
 ]

--- a/packages/eslint-plugin-fiori-tools/test/language/rule-fixer.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/language/rule-fixer.test.ts
@@ -202,6 +202,45 @@ describe('createJsonFixer', () => {
             expect(fixer.replaceTextRange).toHaveBeenCalled();
             expect(result).toMatchSnapshot();
         });
+
+        it('should update the value for a parent node - fixParent = true', () => {
+            const sourceText = `{"parent": {"old": true}}`;
+            const { node, ast } = createNodeFromJson(sourceText, ['parent', 'old']);
+            const mockContextWithText = {
+                sourceCode: {
+                    getParent: jest
+                        .fn()
+                        .mockReturnValueOnce({
+                            name: 'parent',
+                            type: 'Object',
+                            members: [{ name: 'old', type: 'Member', value: { range: [1, 2] } }]
+                        })
+                        .mockReturnValueOnce({ name: 'parent', type: 'Member', value: { range: [0, 3] } }),
+                    text: sourceText,
+                    ast: { body: ast.body }
+                },
+                report: jest.fn()
+            } as unknown as JSONRuleContext<string, unknown[]>;
+
+            const deepestPathResult: DeepestExistingPathResult = {
+                validatedPath: ['parent', 'old'],
+                missingSegments: []
+            };
+
+            const fixer = createMockFixer();
+            const fixerFn = createJsonFixer({
+                context: mockContextWithText,
+                node,
+                deepestPathResult,
+                value: false,
+                fixParent: true
+            });
+
+            const result = fixerFn!(fixer);
+
+            expect(fixer.replaceTextRange).toHaveBeenCalled();
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe('INSERT operation', () => {
@@ -322,6 +361,46 @@ describe('createJsonFixer', () => {
 
             expect(result).toEqual([]);
             expect(fixer.insertTextBeforeRange).not.toHaveBeenCalled();
+        });
+
+        it('should insert value on a parent node - fixParent = true', () => {
+            const sourceText = `{"parent": {"old": true}}`;
+            const { node, ast } = createNodeFromJson(sourceText, ['parent', 'old']);
+            const mockContextWithText = {
+                sourceCode: {
+                    getParent: jest
+                        .fn()
+                        .mockReturnValueOnce({ name: 'parent', type: 'Object', members: [{}] })
+                        .mockReturnValueOnce({
+                            name: { loc: { start: { column: 1 } } },
+                            type: 'Member',
+                            value: { type: 'Object', range: [2, 3], loc: { start: { offset: 400 } }, members: [] }
+                        }),
+                    text: sourceText,
+                    ast: { body: ast.body }
+                },
+                report: jest.fn()
+            } as unknown as JSONRuleContext<string, unknown[]>;
+
+            const deepestPathResult: DeepestExistingPathResult = {
+                validatedPath: ['parent', 'old'],
+                missingSegments: ['newProp']
+            };
+
+            const fixer = createMockFixer();
+            const fixerFn = createJsonFixer({
+                context: mockContextWithText,
+                node,
+                deepestPathResult,
+                value: false,
+                operation: 'insert',
+                fixParent: true
+            });
+
+            const result = fixerFn!(fixer);
+
+            expect(fixer.insertTextBeforeRange).toHaveBeenCalled();
+            expect(result).toMatchSnapshot();
         });
     });
 
@@ -488,6 +567,45 @@ describe('createJsonFixer', () => {
             const result = fixerFn!(fixer);
 
             expect(result).toEqual([]);
+        });
+
+        it('should delete parent object value if fixParent = true', () => {
+            const sourceText = `{"parent": {"old": true}}`;
+            const { node, ast } = createNodeFromJson(sourceText, ['parent', 'old']);
+            const mockContextWithText = {
+                sourceCode: {
+                    getParent: jest
+                        .fn()
+                        .mockReturnValueOnce({ name: 'parent', type: 'Object', members: [{}] })
+                        .mockReturnValueOnce({
+                            name: { loc: { start: { offset: 3 } } },
+                            type: 'Member',
+                            value: { loc: { end: { offset: 4 } } }
+                        }),
+                    text: sourceText,
+                    ast: { body: ast.body }
+                },
+                report: jest.fn()
+            } as unknown as JSONRuleContext<string, unknown[]>;
+
+            const deepestPathResult: DeepestExistingPathResult = {
+                validatedPath: ['parent', 'old'],
+                missingSegments: []
+            };
+
+            const fixer = createMockFixer();
+            const fixerFn = createJsonFixer({
+                context: mockContextWithText,
+                node,
+                deepestPathResult,
+                operation: 'delete',
+                fixParent: true
+            });
+
+            const result = fixerFn!(fixer);
+
+            expect(fixer.removeRange).toHaveBeenCalled();
+            expect(result).toMatchSnapshot();
         });
     });
 

--- a/packages/eslint-plugin-fiori-tools/test/project-context/linker/__snapshots__/fe-v4.test.ts.snap
+++ b/packages/eslint-plugin-fiori-tools/test/project-context/linker/__snapshots__/fe-v4.test.ts.snap
@@ -184,6 +184,25 @@ Object {
       false,
     ],
   },
+  "personalization": Object {
+    "configurationPath": Array [
+      "sap.ui5",
+      "routing",
+      "targets",
+      "IncidentsList",
+      "options",
+      "settings",
+      "controlConfiguration",
+      "@com.sap.vocabularies.UI.v1.LineItem",
+      "tableSettings",
+      "personalization",
+    ],
+    "values": Array [
+      true,
+      false,
+      Object {},
+    ],
+  },
   "tableType": Object {
     "configurationPath": Array [
       "sap.ui5",

--- a/packages/eslint-plugin-fiori-tools/test/rules/sap-table-personalization.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/rules/sap-table-personalization.test.ts
@@ -1,0 +1,1016 @@
+import { RuleTester } from 'eslint';
+import tablePersonalizationRule from '../../src/rules/sap-table-personalization';
+import { meta, languages } from '../../src/index';
+import {
+    getAnnotationsAsXmlCode,
+    getManifestAsCode,
+    setup,
+    V4_ANNOTATIONS,
+    V4_ANNOTATIONS_PATH,
+    V4_FACETS_ANNOTATIONS,
+    V4_MANIFEST,
+    V4_MANIFEST_PATH
+} from '../test-helper';
+
+const ruleTester = new RuleTester({
+    plugins: { ['@sap-ux/eslint-plugin-fiori-tools']: { ...meta, languages } },
+    language: '@sap-ux/eslint-plugin-fiori-tools/fiori'
+});
+
+const FACETSV4 = {
+    filename: V4_ANNOTATIONS_PATH,
+    code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_FACETS_ANNOTATIONS)
+};
+
+const TEST_NAME = 'sap-table-personalization';
+const { createValidTest, createInvalidTest } = setup(TEST_NAME);
+
+ruleTester.run(TEST_NAME, tablePersonalizationRule, {
+    valid: [
+        createValidTest(
+            {
+                name: 'V4 - table personalization missing',
+                filename: V4_MANIFEST_PATH,
+                code: JSON.stringify(V4_MANIFEST, undefined, 2)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page table - personalization is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - object page table - personalization is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsObjectPage',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            'incidentFlow/@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - AnalyticalTable + minUI5=1.108 - group is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.108.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'AnalyticalTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: true,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - ResponsiveTable + minUI5=1.120=exact boundary - group is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.120.0'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: true,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - ResponsiveTable + minUI5=1.122 - group is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.122.5'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: true,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - GridTable - group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.110.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'GridTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: false,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - AnalyticalTable + minUI5=1.100 - group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.100.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'AnalyticalTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: false,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - AnalyticalTable + minUI5=1.108= exact boundary - group is true',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.108.0'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'AnalyticalTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: true,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createValidTest(
+            {
+                name: 'V4 - list report page - ResponsiveTable + minUI5=1.119 - group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.107.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: false,
+                            sort: true
+                        }
+                    }
+                ])
+            },
+            [FACETSV4]
+        )
+    ],
+
+    invalid: [
+        createInvalidTest(
+            {
+                name: 'V4 - list report page table - personalization is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: false
+                    }
+                ]),
+                errors: [
+                    {
+                        messageId: 'sap-table-personalization',
+                        line: 127,
+                        column: 21
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - object page table - personalization is {} - all properties disabled, group not checked',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsObjectPage',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            'incidentFlow/@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {}
+                    }
+                ]),
+                errors: [
+                    {
+                        messageId: 'sap-table-missing-personalization-properties',
+                        line: 145,
+                        column: 21
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsObjectPage',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            'incidentFlow/@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - Analytical table - all personalization properties are false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.109.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'AnalyticalTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: false,
+                            filter: false,
+                            group: false,
+                            sort: false
+                        }
+                    }
+                ]),
+                errors: [
+                    {
+                        messageId: 'sap-table-personalization-column',
+                        line: 128,
+                        column: 23
+                    },
+                    {
+                        messageId: 'sap-table-personalization-filter',
+                        line: 129,
+                        column: 23
+                    },
+                    {
+                        messageId: 'sap-table-personalization-group',
+                        line: 130,
+                        column: 23
+                    },
+                    {
+                        messageId: 'sap-table-personalization-sort',
+                        line: 131,
+                        column: 23
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.109.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'AnalyticalTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - Responsive table - group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            filter: true,
+                            group: false,
+                            sort: true
+                        }
+                    }
+                ]),
+                errors: [
+                    {
+                        messageId: 'sap-table-personalization-group',
+                        line: 130,
+                        column: 23
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - empty object, group is checked, group is undefined',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {}
+                    }
+                ]),
+                errors: [
+                    {
+                        line: 127,
+                        column: 21,
+                        message:
+                            'In case of using an object, omitting a setting is treated as false. Currently column, filter, group, sort are disabled.'
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - undefined settings, group is not checked, group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            group: false,
+                            filter: false
+                        }
+                    }
+                ]),
+                errors: [
+                    {
+                        line: 127,
+                        column: 21,
+                        message:
+                            'In case of using an object, omitting a setting is treated as false. Currently column, sort are disabled.'
+                    },
+                    {
+                        line: 129,
+                        column: 23,
+                        message: 'Table data filtering should be enabled.'
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - single undefined property, group is not checked',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            group: false,
+                            filter: false,
+                            sort: true
+                        }
+                    }
+                ]),
+                errors: [
+                    {
+                        line: 127,
+                        column: 21,
+                        message:
+                            'In case of using an object, omitting a setting is treated as false. Currently column is disabled.'
+                    },
+                    {
+                        line: 129,
+                        column: 23,
+                        message: 'Table data filtering should be enabled.'
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4 - list report page - undefined settings, group is checked, group is false',
+                filename: V4_MANIFEST_PATH,
+                code: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: {
+                            column: true,
+                            group: false
+                        }
+                    }
+                ]),
+                errors: [
+                    {
+                        line: 127,
+                        column: 21,
+                        message:
+                            'In case of using an object, omitting a setting is treated as false. Currently filter, sort are disabled.'
+                    },
+                    {
+                        line: 129,
+                        column: 23,
+                        message: 'Table data grouping should be enabled for analytical and responsive type tables.'
+                    }
+                ],
+                output: getManifestAsCode(V4_MANIFEST, [
+                    {
+                        path: ['sap.ui5', 'dependencies', 'minUI5Version'],
+                        value: '1.121.1'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'type'
+                        ],
+                        value: 'ResponsiveTable'
+                    },
+                    {
+                        path: [
+                            'sap.ui5',
+                            'routing',
+                            'targets',
+                            'IncidentsList',
+                            'options',
+                            'settings',
+                            'controlConfiguration',
+                            '@com.sap.vocabularies.UI.v1.LineItem',
+                            'tableSettings',
+                            'personalization'
+                        ],
+                        value: true
+                    }
+                ])
+            },
+            [FACETSV4]
+        )
+    ]
+});

--- a/packages/fiori-mcp-server/CHANGELOG.md
+++ b/packages/fiori-mcp-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sap-ux/fiori-mcp-server
 
+## 0.6.42
+
+### Patch Changes
+
+- 681f169: fix: MCP server title
+
 ## 0.6.41
 
 ### Patch Changes

--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/fiori-mcp-server",
     "description": "SAP Fiori - Model Context Protocol (MCP) server",
-    "version": "0.6.41",
+    "version": "0.6.42",
     "keywords": [
         "SAP Fiori tools",
         "SAP Fiori elements",

--- a/packages/fiori-mcp-server/src/server.ts
+++ b/packages/fiori-mcp-server/src/server.ts
@@ -63,7 +63,7 @@ export class FioriFunctionalityServer {
                         mimeType: 'image/png'
                     }
                 ],
-                title: 'SAP Fiori MCP Server'
+                title: 'MCP Server for SAP Fiori'
             },
             {
                 capabilities: {

--- a/packages/flp-config-inquirer/CHANGELOG.md
+++ b/packages/flp-config-inquirer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sap-ux/flp-config-inquirer
 
+## 0.4.150
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+
 ## 0.4.149
 
 ### Patch Changes

--- a/packages/flp-config-inquirer/package.json
+++ b/packages/flp-config-inquirer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/flp-config-inquirer",
     "description": "Prompts module that can prompt users for inputs required for FLP configuration",
-    "version": "0.4.149",
+    "version": "0.4.150",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/flp-config-sub-generator/CHANGELOG.md
+++ b/packages/flp-config-sub-generator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sap-ux/flp-config-sub-generator
 
+## 0.3.158
+
+### Patch Changes
+
+- @sap-ux/flp-config-inquirer@0.4.150
+- @sap-ux/app-config-writer@0.6.120
+
 ## 0.3.157
 
 ### Patch Changes

--- a/packages/flp-config-sub-generator/package.json
+++ b/packages/flp-config-sub-generator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sap-ux/flp-config-sub-generator",
     "description": "Generator for creating Fiori Launcpad configuration",
-    "version": "0.3.157",
+    "version": "0.3.158",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/generator-adp/CHANGELOG.md
+++ b/packages/generator-adp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @sap-ux/generator-adp
 
+## 0.9.28
+
+### Patch Changes
+
+- 53af342: feat: Create service keys
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+
 ## 0.9.27
 
 ### Patch Changes

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -3,7 +3,7 @@
     "displayName": "SAPUI5 Adaptation Project",
     "homepage": "https://help.sap.com/viewer/584e0bcbfd4a4aff91c815cefa0bce2d/Cloud/en-US/ada9567b767941aba8d49fdb4fdedea7.html",
     "description": "Adaptation project allows you to create an app variant for an existing SAP Fiori elements-based or SAPUI5 freestyle application, without changing the original application.",
-    "version": "0.9.27",
+    "version": "0.9.28",
     "repository": {
         "type": "git",
         "url": "https://github.com/SAP/open-ux-tools.git",

--- a/packages/generator-adp/src/app/index.ts
+++ b/packages/generator-adp/src/app/index.ts
@@ -25,7 +25,7 @@ import {
     loadApps,
     loadCfConfig,
     storeCredentials,
-    getServiceInstanceKeys
+    getOrCreateServiceInstanceKeys
 } from '@sap-ux/adp-tooling';
 import {
     getDefaultTargetFolder,
@@ -639,7 +639,7 @@ export default class extends Generator {
         const backendUrls = this.cfPrompter.backendUrls;
         const oauthPaths = this.cfPrompter.oauthPaths;
 
-        const serviceInfo = await getServiceInstanceKeys(
+        const serviceInfo = await getOrCreateServiceInstanceKeys(
             {
                 names: [this.cfServicesAnswers.businessService ?? '']
             },
@@ -660,7 +660,8 @@ export default class extends Generator {
             publicVersions,
             packageJson: getPackageInfo(),
             toolsId: this.toolsId,
-            serviceInfo
+            serviceInfo,
+            spaceGuid: this.cfConfig.space.GUID
         });
 
         if (config.options) {

--- a/packages/preview-middleware/CHANGELOG.md
+++ b/packages/preview-middleware/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sap-ux/preview-middleware
 
+## 0.23.153
+
+### Patch Changes
+
+- Updated dependencies [53af342]
+    - @sap-ux/adp-tooling@0.18.91
+
 ## 0.23.152
 
 ### Patch Changes

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -9,7 +9,7 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Apreview-middleware"
     },
-    "version": "0.23.152",
+    "version": "0.23.153",
     "license": "Apache-2.0",
     "author": "@SAP/ux-tools-team",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Introduces a new Yeoman generator package (`@sap-ux/odata-download-generator`) that downloads OData entity data from backend services for use with the mock data server.

## Features
- Downloads entity data based on Fiori Elements application configuration
- Automatically detects related entities from navigation properties  
- Supports value help and code list data downloads
- Filters data using semantic keys with range support (e.g., `1-10`, `A,B,C`)
- Writes JSON files compatible with the UI5 mock data server
- Updates local metadata files from the remote service

## Changes
- Added new `packages/odata-download-sub-generator` package
- Interactive prompts for application, system, entity, and filter selection
- Comprehensive test coverage for generator, prompts, and OData query building
- Updated `sonar-project.properties` and root `tsconfig.json` to include new package

## Test Plan
- [x] Unit tests pass (`pnpm test`)
- [x] Lint checks pass (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
