### PR TITLE
fix: add user kranthie-sap to renovate's ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,7 +35,7 @@
     // Allow Renovate to continue updating PRs after GitHub Actions bot commits
     // This is needed for the update-ui5manifest-version workflow which adds
     // additional changes (test fixtures, changesets) to Renovate PRs
-    gitIgnoredAuthors: ['github-actions[bot]@users.noreply.github.com'],
+    gitIgnoredAuthors: ['github-actions[bot]@users.noreply.github.com', kranthie-sap],
 
     ignorePaths: [
         '**/templates/**',


### PR DESCRIPTION
- Adds user: `kranthie-sap` to the renovate's ignore, so it does not block the PR from auto rebasing