### PR TITLE
fix(actions): add git commit modifier

### DIFF
--- a/.github/workflows/renovate-pr-automation.yml
+++ b/.github/workflows/renovate-pr-automation.yml
@@ -78,8 +78,8 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add -u || true # Add updated files, but don't fail if no files were changed
-                  git commit -m "chore: update manifest version test fixtures & ui5 version fallbacks"
-                  git push
+                  git commit -m "chore: update manifest version test fixtures & ui5 version fallbacks" --no-verify
+                  git push --no-verify
 
             - name: Create changeset
               uses: mscharley/dependency-changesets-action@v1.2.2


### PR DESCRIPTION
- adds `--no-verify` to commit and push git ops: prevents cases where the npm audit service is down or where a security issue would prevent the commit