### PR TITLE
chore: add gh actions bot email to ignored users list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -34,7 +34,10 @@
     // Allow Renovate to continue updating PRs after GitHub Actions bot commits
     // This is needed for the update-ui5manifest-version workflow which adds
     // additional changes (test fixtures, changesets) to Renovate PRs
-    gitIgnoredAuthors: ['84985584+kranthie-sap@users.noreply.github.com'],
+    gitIgnoredAuthors: [
+        '84985584+kranthie-sap@users.noreply.github.com',
+        'github-actions[bot]@users.noreply.github.com'
+    ],
 
     ignorePaths: [
         '**/templates/**',


### PR DESCRIPTION
- adds `github-actions[bot]@users.noreply.github.com` back to renovate config for ignored users