### PR TITLE
feat(fiori-mcp-server): add Claude Code plugin metadata

### DIFF
--- a/packages/fiori-mcp-server/.claude-plugin/plugin.json
+++ b/packages/fiori-mcp-server/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "sap-fiori",
+  "version": "0.6.41",
+  "description": "SAP Fiori MCP server. Generate and adapt SAP Fiori elements applications with AI coding assistants. Supports List Report, Object Page, and Flexible Column layouts.",
+  "author": {
+    "name": "SAP SE"
+  },
+  "homepage": "https://github.com/SAP/open-ux-tools",
+  "repository": "https://github.com/SAP/open-ux-tools",
+  "license": "Apache-2.0",
+  "keywords": ["sap", "fiori", "ui5", "mcp"]
+}

--- a/packages/fiori-mcp-server/.mcp.json
+++ b/packages/fiori-mcp-server/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "fiori-mcp": {
+    "command": "npx",
+    "args": ["--yes", "@sap-ux/fiori-mcp-server@latest", "fiori-mcp"]
+  }
+}


### PR DESCRIPTION
Adding `.claude-plugin/plugin.json` and `.mcp.json` to `packages/fiori-mcp-server/` to enable listing on the [Claude Code plugin directory](https://claude.com/plugins).

Once merged, Claude Code users can discover and install the Fiori MCP server via `claude plugin install sap-fiori`.

- Two new files, no changes to existing code
- Both files validated with `claude plugin validate` and MCP `tools/list` (all 5 tools respond)
- The CAP MCP server ([cap-js/mcp-server](https://github.com/cap-js/mcp-server/tree/main/.claude-plugin)) already has equivalent files