### PR TITLE
fix(preview-middleware): implement OVP bridge functions for Add New Card flow

### DIFF
--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -48,7 +48,9 @@ export const enum ApiRoutes {
     FRAGMENT = '/adp/api/fragment',
     CONTROLLER = '/adp/api/controller',
     CODE_EXT = '/adp/api/code_ext',
-    ANNOTATION = '/adp/api/annotation'
+    ANNOTATION = '/adp/api/annotation',
+    OVP_DATASOURCES = '/adp/api/ovp/datasources',
+    OVP_METAMODEL = '/adp/api/ovp/metamodel'
 }
 
 /**
@@ -262,6 +264,9 @@ export class AdpPreview {
             ApiRoutes.ANNOTATION,
             this.routesHandler.handleGetAllAnnotationFilesMappedByDataSource as RequestHandler
         );
+
+        router.get(ApiRoutes.OVP_DATASOURCES, this.routesHandler.handleGetOvpDataSources as RequestHandler);
+        router.get(ApiRoutes.OVP_METAMODEL, this.routesHandler.handleGetOvpMetaModel as RequestHandler);
     }
 
     /**

--- a/packages/adp-tooling/src/preview/routes-handler.ts
+++ b/packages/adp-tooling/src/preview/routes-handler.ts
@@ -392,6 +392,82 @@ export default class RoutesHandler {
     }
 
     /**
+     * Handler for retrieving available OData services from the ABAP V2 catalog.
+     * Used by the OVP "Add New Card" flow to populate the data source selection dropdown.
+     *
+     * @param _req Request
+     * @param res Response
+     * @param next Next Function
+     */
+    public handleGetOvpDataSources = async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (this.isBuildPathMode) {
+                this.sendFilesResponse(res, { dataSources: [] });
+                return;
+            }
+
+            const catalogUrl = '/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/ServiceCollection?$format=json';
+            const response = await this.provider.get(catalogUrl);
+            const parsed = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
+            const results: Record<string, string>[] = parsed?.d?.results ?? [];
+
+            const dataSources = results.map((svc) => ({
+                ServiceUrl: svc.ServiceUrl,
+                Description: svc.Description || svc.TechnicalServiceName,
+                TechnicalServiceName: svc.TechnicalServiceName,
+                TechnicalServiceVersion: svc.TechnicalServiceVersion,
+                MetadataUrl: svc.MetadataUrl
+            }));
+
+            this.sendFilesResponse(res, { dataSources });
+        } catch (e) {
+            this.handleErrorMessage(res, next, e);
+        }
+    };
+
+    /**
+     * Handler for retrieving annotation URLs for a given OData service.
+     * Used by the OVP "Add New Card" flow to construct a metamodel with merged annotations.
+     *
+     * @param req Request (expects `serviceUrl` query parameter)
+     * @param res Response
+     * @param next Next Function
+     */
+    public handleGetOvpMetaModel = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            if (this.isBuildPathMode) {
+                res.status(HttpStatusCodes.BAD_REQUEST).send({ message: 'Not available in build path mode' });
+                return;
+            }
+
+            const serviceUrl = req.query.serviceUrl as string;
+            if (!serviceUrl) {
+                res.status(HttpStatusCodes.BAD_REQUEST).send({ message: 'serviceUrl query parameter is required' });
+                return;
+            }
+
+            let annotationUrls: string[] = [];
+            try {
+                const encodedUrl = encodeURIComponent(serviceUrl);
+                const catalogAnnotUrl =
+                    `/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/ServiceCollection('${encodedUrl}')/Annotations?$format=json`;
+                const annotResponse = await this.provider.get(catalogAnnotUrl);
+                const annotData =
+                    typeof annotResponse.data === 'string' ? JSON.parse(annotResponse.data) : annotResponse.data;
+                annotationUrls = (annotData?.d?.results ?? [])
+                    .map((ann: Record<string, string>) => ann.Url)
+                    .filter(Boolean);
+            } catch {
+                this.logger.warn(`Could not fetch catalog annotations for service: ${serviceUrl}`);
+            }
+
+            this.sendFilesResponse(res, { serviceUrl, annotationUrls });
+        } catch (e) {
+            this.handleErrorMessage(res, next, e);
+        }
+    };
+
+    /**
      * Returns manifest service.
      *
      * @returns Promise<ManifestService>

--- a/packages/preview-middleware-client/src/adp/api-handler.ts
+++ b/packages/preview-middleware-client/src/adp/api-handler.ts
@@ -7,7 +7,9 @@ export const enum ApiEndpoints {
     CONTROLLER = '/adp/api/controller',
     CODE_EXT = '/adp/api/code_ext',
     ANNOTATION_FILE = '/adp/api/annotation',
-    MANIFEST_APP_DESCRIPTOR = '/manifest.appdescr_variant'
+    MANIFEST_APP_DESCRIPTOR = '/manifest.appdescr_variant',
+    OVP_DATASOURCES = '/adp/api/ovp/datasources',
+    OVP_METAMODEL = '/adp/api/ovp/metamodel'
 }
 
 export const enum RequestMethod {

--- a/packages/preview-middleware-client/src/adp/init.ts
+++ b/packages/preview-middleware-client/src/adp/init.ts
@@ -50,7 +50,12 @@ export default async function (rta: RuntimeAuthoring) {
         extPointService.init();
     }
 
-    const applicationType = getApplicationType(rta.getRootControlInstance().getManifest());
+    const manifest = rta.getRootControlInstance().getManifest();
+    if (manifest['sap.ovp']) {
+        (await import('open/ux/preview/client/adp/ovp-bridge')).initOvpBridge();
+    }
+
+    const applicationType = getApplicationType(manifest);
     const quickActionRegistries = await loadDefinitions(applicationType);
 
     await init(rta, quickActionRegistries);

--- a/packages/preview-middleware-client/src/adp/ovp-bridge.ts
+++ b/packages/preview-middleware-client/src/adp/ovp-bridge.ts
@@ -1,0 +1,110 @@
+import log from 'sap/base/Log';
+
+const LOG_PREFIX = 'open.ux.preview.client.adp.ovp-bridge';
+
+interface OvpCatalogEntry {
+    ServiceUrl: string;
+    Description: string;
+    TechnicalServiceName: string;
+    TechnicalServiceVersion: string;
+    MetadataUrl: string;
+}
+
+interface OvpMetaModelResponse {
+    serviceUrl: string;
+    annotationUrls: string[];
+}
+
+interface I18nEntry {
+    key: string;
+    value: string;
+    comment?: string;
+}
+
+declare global {
+    interface Window {
+        writeToI18n: (entries: I18nEntry[]) => Promise<void>;
+        getNewDataSources: (callback: (dataSources: OvpCatalogEntry[]) => void) => void;
+        getMetaModelForNewDataSource: (serviceUrl: string, callback: (metaModel: unknown) => void) => void;
+    }
+}
+
+function getBaseUrl(): string {
+    return document.getElementById('root')?.dataset.openUxPreviewBaseUrl ?? '';
+}
+
+/**
+ * Registers OVP bridge functions on `window` for the sap.ovp "Add New Card" flow.
+ *
+ * The sap.ovp library expects three globals:
+ * - writeToI18n: persists translatable card texts to i18n properties
+ * - getNewDataSources: retrieves available OData services from the ABAP catalog
+ * - getMetaModelForNewDataSource: produces an OData metamodel with merged annotations
+ */
+export function initOvpBridge(): void {
+    const baseUrl = getBaseUrl();
+
+    window.writeToI18n = async function (entries: I18nEntry[]): Promise<void> {
+        const response = await fetch(`${baseUrl}/editor/i18n`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(entries)
+        });
+        if (!response.ok) {
+            const msg = `writeToI18n failed with status ${response.status}`;
+            log.error(msg, LOG_PREFIX);
+            throw new Error(msg);
+        }
+    };
+
+    window.getNewDataSources = function (callback: (dataSources: OvpCatalogEntry[]) => void): void {
+        fetch(`${baseUrl}/adp/api/ovp/datasources`)
+            .then((response) => response.json())
+            .then((data: { dataSources: OvpCatalogEntry[] }) => {
+                callback(data.dataSources);
+            })
+            .catch((error: Error) => {
+                log.error(`getNewDataSources failed: ${error.message}`, LOG_PREFIX);
+                callback([]);
+            });
+    };
+
+    window.getMetaModelForNewDataSource = function (
+        serviceUrl: string,
+        callback: (metaModel: unknown) => void
+    ): void {
+        const params = new URLSearchParams({ serviceUrl });
+        fetch(`${baseUrl}/adp/api/ovp/metamodel?${params.toString()}`)
+            .then((response) => response.json())
+            .then((data: OvpMetaModelResponse) => {
+                sap.ui.require(
+                    ['sap/ui/model/odata/v2/ODataModel'],
+                    (ODataModel: new (config: object) => { getMetaModel: () => { loaded: () => Promise<void> } }) => {
+                        const model = new ODataModel({
+                            serviceUrl: data.serviceUrl,
+                            annotationURI: data.annotationUrls,
+                            json: true,
+                            loadAnnotationsJoined: true,
+                            skipMetadataAnnotationParsing: false
+                        });
+                        model
+                            .getMetaModel()
+                            .loaded()
+                            .then(() => {
+                                callback(model.getMetaModel());
+                            })
+                            .catch((error: Error) => {
+                                log.error(`MetaModel loading failed: ${error.message}`, LOG_PREFIX);
+                                callback(null);
+                            });
+                    }
+                );
+            })
+            .catch((error: Error) => {
+                log.error(`getMetaModelForNewDataSource failed: ${error.message}`, LOG_PREFIX);
+                callback(null);
+            });
+    };
+
+    log.info('OVP bridge functions registered on window', LOG_PREFIX);
+}

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -1178,6 +1178,11 @@ export class FlpSandbox {
         await this.init(manifest, name, adp.resources, adp);
         this.router.use(adp.descriptor.url, adp.proxy.bind(adp));
         this.setupAdpCommonHandlers(adp);
+
+        if (manifest['sap.ovp']) {
+            await this.addStoreI18nKeysRoute();
+            this.logger.info('Registered /editor/i18n route for OVP adaptation project');
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Registers three global `window` functions (`writeToI18n`, `getNewDataSources`, `getMetaModelForNewDataSource`) required by the `sap.ovp` library during ADP initialization when the app is detected as OVP (`manifest['sap.ovp']`)
- Adds server-side API routes (`/adp/api/ovp/datasources`, `/adp/api/ovp/metamodel`) that query the ABAP V2 catalog service for available OData services and annotation URLs
- Ensures the `/editor/i18n` POST route is registered for OVP adaptation projects so translatable card texts can be persisted

Fixes #4404

## Changes

| Package | File | What |
|---------|------|------|
| `@sap-ux/adp-tooling` | `src/preview/adp-preview.ts` | Added `OVP_DATASOURCES` and `OVP_METAMODEL` to `ApiRoutes` enum and registered GET routes in `addApis()` |
| `@sap-ux/adp-tooling` | `src/preview/routes-handler.ts` | Added `handleGetOvpDataSources` (V2 catalog query) and `handleGetOvpMetaModel` (annotation URL lookup) handlers |
| `@sap-ux/preview-middleware` | `src/base/flp.ts` | Conditionally registers `/editor/i18n` route in `initAdp()` when manifest contains `sap.ovp` |
| `@sap-ux/preview-middleware-client` | `src/adp/ovp-bridge.ts` (new) | Client-side bridge module that registers the three `window` globals using `fetch()` to the new server routes |
| `@sap-ux/preview-middleware-client` | `src/adp/init.ts` | Initializes OVP bridge for apps with `manifest['sap.ovp']` |
| `@sap-ux/preview-middleware-client` | `src/adp/api-handler.ts` | Added OVP endpoints to `ApiEndpoints` enum |

## Test plan

- [ ] Create or open an OVP adaptation project
- [ ] Start the Adaptation Editor preview
- [ ] Right-click on an OVP card and select 'Add New Card'
- [ ] In Card Settings dialog, select 'Select New Data Source'
- [ ] Verify the data source dropdown populates with available OData services
- [ ] Select a service and verify entity set options load correctly
- [ ] Save the card and verify translatable texts are written to i18n properties file
- [ ] Verify non-OVP adaptation projects are unaffected