### PR TITLE
fix(eslint-plugin-fiori-tools): resolve heap OOM on macos Node 20 arm64 (#4545)

### DIFF
--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -20,7 +20,7 @@
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint",
         "lint:fix": "eslint --fix",
-        "test": "c8 --reporter=text --reporter=lcov --exclude='test/**' --exclude='**/*.test.ts'  --include='src/**/*.ts' cross-env NODE_OPTIONS='--experimental-vm-modules' jest --ci --forceExit --detectOpenHandles --colors"
+        "test": "c8 --reporter=text --reporter=lcov --merge-async --exclude='test/**' --exclude='**/*.test.ts'  --include='src/**/*.ts' cross-env NODE_OPTIONS='--experimental-vm-modules' jest --ci --forceExit --detectOpenHandles --colors --maxWorkers=2"
     },
     "devDependencies": {
         "c8": "^11.0.0",


### PR DESCRIPTION
# Fix Heap OOM Crash on macOS Node 20 arm64 for `eslint-plugin-fiori-tools`

### Bug Fix

🐛 Resolves a fatal heap out-of-memory crash occurring on `macos-latest` with Node 20.x (arm64) after the `eslint-plugin-fiori-tools` test suite completes. All tests passed successfully, but the process crashed during teardown due to excessive V8 coverage data being loaded into memory simultaneously.

**Root Cause:** `--experimental-vm-modules` causes Jest to create a new `vm.Module` context per test file, causing V8's coverage engine to re-instrument every module for each test file. With 72 test files, this produces ~128K coverage records across 38 JSON files totalling ~269 MB — with one file alone at 175 MB. Without `--merge-async`, `c8` loads all files at once, creating a ~2 GB heap spike that exceeds Node 20's default heap limit on macOS arm64.

### Changes

* `packages/eslint-plugin-fiori-tools/package.json`: Updated the `test` script with two mitigations:
  - Added `--merge-async` to `c8` so V8 coverage files are merged incrementally rather than all at once, avoiding the memory spike during teardown.
  - Added `--maxWorkers=2` to Jest to cap the number of parallel worker processes, reducing the volume of duplicate V8 script contexts.

### GitHub Issues

* [#4545](https://github.com/SAP/open-ux-tools/issues/4545): BUG - Out of memory crash on Node 20 arm64 after test suite completes

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- GithubContextProvider: [https://github.com/SAP/open-ux-tools/issues/4545](https://github.com/SAP/open-ux-tools/issues/4545)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.edited`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `a4d8d726-7926-4d82-85e6-9398be58a169`
</details>
