### PR TITLE
fix(eslint-plugin-fiori-tools): fix heap OOM on macos Node 20 arm64

### DIFF
--- a/.changeset/eslint-plugin-fiori-tools-oom-fix-v2.md
+++ b/.changeset/eslint-plugin-fiori-tools-oom-fix-v2.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+fix(eslint-plugin-fiori-tools): fix heap OOM on macos Node 20 arm64 by switching to jest coverageProvider v8

--- a/.changeset/eslint-plugin-fiori-tools-oom-fix-v2.md
+++ b/.changeset/eslint-plugin-fiori-tools-oom-fix-v2.md
@@ -1,5 +1,0 @@
----
-"@sap-ux/eslint-plugin-fiori-tools": patch
----
-
-fix(eslint-plugin-fiori-tools): fix heap OOM on macos Node 20 arm64 by switching to jest coverageProvider v8

--- a/packages/eslint-plugin-fiori-tools/jest.config.js
+++ b/packages/eslint-plugin-fiori-tools/jest.config.js
@@ -1,7 +1,6 @@
 const config = require('../../jest.base');
 module.exports = {
     ...config,
-    // Coverage is handled by c8 wrapper for worker thread support
-    collectCoverage: false,
+    coverageProvider: 'v8',
     setupFiles: ['<rootDir>/test/global-setup.ts']
 }

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -20,10 +20,9 @@
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint",
         "lint:fix": "eslint --fix",
-        "test": "c8 --reporter=text --reporter=lcov --exclude='test/**' --exclude='**/*.test.ts'  --include='src/**/*.ts' cross-env NODE_OPTIONS='--experimental-vm-modules' jest --ci --forceExit --detectOpenHandles --colors"
+        "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest --ci --forceExit --detectOpenHandles --colors --maxWorkers=50%"
     },
     "devDependencies": {
-        "c8": "^11.0.0",
         "cross-env": "10.1.0",
         "eslint": "9.39.1",
         "@typescript-eslint/rule-tester": "8.57.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1961,9 +1961,6 @@ importers:
       '@typescript-eslint/rule-tester':
         specifier: 8.57.2
         version: 8.57.2(eslint@9.39.1)(typescript@5.9.3)
-      c8:
-        specifier: ^11.0.0
-        version: 11.0.0
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
@@ -6260,10 +6257,6 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
-
-  '@bcoe/v8-coverage@1.0.2':
-    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
-    engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -11025,16 +11018,6 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-
-  c8@11.0.0:
-    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-    peerDependencies:
-      monocart-coverage-reports: ^2
-    peerDependenciesMeta:
-      monocart-coverage-reports:
-        optional: true
 
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
@@ -17663,10 +17646,6 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  test-exclude@8.0.0:
-    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
-    engines: {node: 20 || >=22}
-
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -20637,8 +20616,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
-
-  '@bcoe/v8-coverage@1.0.2': {}
 
   '@borewit/text-codec@0.2.2':
     optional: true
@@ -26589,20 +26566,6 @@ snapshots:
       run-applescript: 7.1.0
 
   bytes@3.1.2: {}
-
-  c8@11.0.0:
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@istanbuljs/schema': 0.1.3
-      find-up: 5.0.0
-      foreground-child: 3.3.1
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      test-exclude: 8.0.0
-      v8-to-istanbul: 9.3.0
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
 
   cacache@15.3.0:
     dependencies:
@@ -35054,12 +35017,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.5
-
-  test-exclude@8.0.0:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 13.0.6
-      minimatch: 10.2.4
 
   text-decoder@1.2.3:
     dependencies:


### PR DESCRIPTION
## Root cause

The previous fix (#4566) added `--merge-async` to c8, targeting coverage *merge* time. The full stack trace reveals the OOM is one layer deeper — in Node's native `V8CoverageConnection::WriteProfile` at process exit:

```
RunAtExitCallbacks → StartProfilers → takePreciseCoverage → JsonStringifier → OOM
```

c8 runs as a single orchestrator process that accumulates V8 profiler data for **all 71 test files** before serialising it. With `--experimental-vm-modules`, each test file re-instruments every source module, producing ~269 MB of raw coverage data. `JSON.stringify` of this object requires a contiguous string buffer that exhausts the ~2 GB heap on macos arm64 Node 20. `--merge-async` only affects how c8 handles already-written JSON files — the OOM fires before that step.

## Fix

Replace the c8 process-level wrapper with Jest's built-in `coverageProvider: 'v8'`. Jest's own V8 provider collects coverage **per worker process** (one test file each) via `collect-v8-coverage`, keeping per-process memory bounded. The main Jest process aggregates small per-worker reports — the large serialisation never happens in a single process.

Also removes the unused `c8` devDependency and adds `--maxWorkers=50%` (scales to available CPUs rather than hardcoding 2).

`--experimental-vm-modules` is still required — ESLint 9 uses dynamic `import()` internally and fails without it.

## Changes

- `jest.config.js`: remove `collectCoverage: false`, add `coverageProvider: 'v8'`
- `package.json`: drop c8 wrapper, keep `NODE_OPTIONS='--experimental-vm-modules'`, add `--maxWorkers=50%`

## Test plan

- [ ] CI passes on `macos-latest` Node 20.x without OOM
- [ ] 583 tests pass (verified locally)
- [ ] Coverage output unchanged in quality

Closes #4545
