### PR TITLE
fix(ci): add statuses: write permission to restore SonarCloud PR decoration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       actions: read # Required to download artifacts
       pull-requests: write # Required for PR decoration comments
+      statuses: write # Required for SonarCloud to post quality gate commit status
     steps:
       - name: 'Checkout project'
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds `statuses: write` permission to the `sonar` job in `sonar.yml`

## Root Cause

PR #4571 introduced an explicit `permissions` block to the sonar workflow. By GitHub's design, explicitly declaring permissions locks the `GITHUB_TOKEN` to *only* what is declared — dropping everything else, including `statuses: write`.

SonarCloud's GitHub App posts quality gate results as a **commit status** using `statuses: write`. Without it, the scan completes and results appear on sonarcloud.io, but nothing is posted back to the PR on GitHub.

Before #4571, the job had no `permissions` block so it inherited the repo defaults (which include `statuses: write`) — this is why decoration was working on Apr 14 (e.g. #4551) but broke after #4571 merged.

## Test plan

- [ ] Verify SonarCloud posts a quality gate comment/status on a PR after this merges