### PR TITLE
fix(ui5-test-writer): fixes for app info generation

### DIFF
--- a/.changeset/full-dots-punch.md
+++ b/.changeset/full-dots-punch.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-test-writer': patch
+---
+
+app info generation fixes

--- a/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
+++ b/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
@@ -61,7 +61,7 @@ export async function generateOPAFiles(
     const testOutDirPath = join(await getWebappPath(basePath), 'test');
 
     // Access ux-specification to get feature data for OPA test generation
-    const appFeatures = await getAppFeatures(basePath, editor, log, metadata);
+    const appFeatures = await getAppFeatures(basePath, editor, log, metadata, manifest);
     // OPA Journey file
     const startPages = config.pages.filter((page) => page.isStartup).map((page) => page.targetKey);
     const LROP = findLROP(config.pages, manifest);
@@ -318,25 +318,6 @@ function findLROP(
 }
 
 /**
- * Writes page object files for each page configuration.
- *
- * @param pages - the page configurations to write
- * @param rootV4TemplateDirPath - template root directory for v4 templates
- * @param testOutDirPath - output test directory (.../webapp/test)
- * @param editor - a reference to a mem-fs editor
- */
-function writePageObjects(
-    pages: FEV4OPAPageConfig[],
-    rootV4TemplateDirPath: string,
-    testOutDirPath: string,
-    editor: Editor
-): void {
-    pages.forEach((page) => {
-        writePageObject(page, rootV4TemplateDirPath, testOutDirPath, editor);
-    });
-}
-
-/**
  * Writes common test files, page objects, and the first journey file.
  *
  * @param writeContext - shared write context (config, paths, editor, journey params)
@@ -357,7 +338,9 @@ function writeCommonAndPageFiles(writeContext: WriteContext, rootCommonTemplateD
         }
     );
 
-    writePageObjects(config.pages, rootV4TemplateDirPath, testOutDirPath, editor);
+    config.pages.forEach((page) => {
+        writePageObject(page, rootV4TemplateDirPath, testOutDirPath, editor);
+    });
 
     editor.copyTpl(
         join(rootV4TemplateDirPath, 'integration', 'FirstJourney.js'),
@@ -384,14 +367,13 @@ function writeCommonAndPageFiles(writeContext: WriteContext, rootCommonTemplateD
 /**
  * Checks whether a page object file already exists for the given feature name.
  * If it doesn't exist, finds the matching page config and writes the file.
- * Returns the new page's JourneyRunnerPage entry if it was created, or empty array if already present.
  *
  * @param featureName - the feature/page name (equals the manifest targetKey)
  * @param config - the OPA config containing all page configurations
  * @param rootV4TemplateDirPath - template root directory for v4 templates
  * @param testOutDirPath - output test directory (.../webapp/test)
  * @param editor - a reference to a mem-fs editor
- * @returns array with one JourneyRunnerPage if the page was newly created, otherwise empty
+ * @returns JourneyRunnerPage if the page was newly created, undefined otherwise
  */
 function ensurePageExists(
     featureName: string,
@@ -399,17 +381,17 @@ function ensurePageExists(
     rootV4TemplateDirPath: string,
     testOutDirPath: string,
     editor: Editor
-): JourneyRunnerPage[] {
+): JourneyRunnerPage | undefined {
     const pageFilePath = join(testOutDirPath, 'integration', 'pages', `${featureName}.js`);
     if (editor.exists(pageFilePath)) {
-        return [];
+        return undefined;
     }
     const pageConfig = config.pages.find((p) => p.targetKey === featureName);
     if (pageConfig) {
         writePageObject(pageConfig, rootV4TemplateDirPath, testOutDirPath, editor);
-        return [{ targetKey: featureName, appPath: config.appPath }];
+        return { targetKey: featureName, appPath: config.appPath };
     }
-    return [];
+    return undefined;
 }
 
 /**
@@ -446,9 +428,16 @@ function writeJourneyFiles(
             }
         );
         generatedJourneyPages.push(appFeatures.listReport.name);
-        newPages.push(
-            ...ensurePageExists(appFeatures.listReport.name, config, rootV4TemplateDirPath, testOutDirPath, editor)
+        const lrPage = ensurePageExists(
+            appFeatures.listReport.name,
+            config,
+            rootV4TemplateDirPath,
+            testOutDirPath,
+            editor
         );
+        if (lrPage) {
+            newPages.push(lrPage);
+        }
     }
 
     if (appFeatures.objectPages && appFeatures.objectPages.length > 0) {
@@ -468,9 +457,10 @@ function writeJourneyFiles(
                     }
                 );
                 generatedJourneyPages.push(objectPage.name);
-                newPages.push(
-                    ...ensurePageExists(objectPage.name, config, rootV4TemplateDirPath, testOutDirPath, editor)
-                );
+                const opPage = ensurePageExists(objectPage.name, config, rootV4TemplateDirPath, testOutDirPath, editor);
+                if (opPage) {
+                    newPages.push(opPage);
+                }
             }
         });
     }
@@ -489,7 +479,10 @@ function writeJourneyFiles(
             }
         );
         generatedJourneyPages.push(appFeatures.fpm.name);
-        newPages.push(...ensurePageExists(appFeatures.fpm.name, config, rootV4TemplateDirPath, testOutDirPath, editor));
+        const fpmPage = ensurePageExists(appFeatures.fpm.name, config, rootV4TemplateDirPath, testOutDirPath, editor);
+        if (fpmPage) {
+            newPages.push(fpmPage);
+        }
     }
 
     if (newPages.length > 0) {
@@ -560,7 +553,7 @@ export async function generatePageObjectFile(
     pageObjectParameters: { targetKey: string; appID?: string },
     fs?: Editor
 ): Promise<Editor> {
-    const editor = fs || create(createStorage());
+    const editor = fs ?? create(createStorage());
 
     const manifest = readManifest(editor, basePath);
     const { applicationType } = getAppTypeAndHideFilterBarFromManifest(manifest);

--- a/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
+++ b/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
@@ -20,8 +20,10 @@ import { getAppFeatures } from './utils/modelUtils';
 import {
     addIntegrationOldToGitignore,
     addPathsToQUnitJs,
+    addPagesToJourneyRunner,
     hasVirtualOPA5,
-    readHtmlTargetFromQUnitJs
+    readHtmlTargetFromQUnitJs,
+    type JourneyRunnerPage
 } from './utils/opaQUnitUtils';
 
 /**
@@ -316,6 +318,25 @@ function findLROP(
 }
 
 /**
+ * Writes page object files for each page configuration.
+ *
+ * @param pages - the page configurations to write
+ * @param rootV4TemplateDirPath - template root directory for v4 templates
+ * @param testOutDirPath - output test directory (.../webapp/test)
+ * @param editor - a reference to a mem-fs editor
+ */
+function writePageObjects(
+    pages: FEV4OPAPageConfig[],
+    rootV4TemplateDirPath: string,
+    testOutDirPath: string,
+    editor: Editor
+): void {
+    pages.forEach((page) => {
+        writePageObject(page, rootV4TemplateDirPath, testOutDirPath, editor);
+    });
+}
+
+/**
  * Writes common test files, page objects, and the first journey file.
  *
  * @param writeContext - shared write context (config, paths, editor, journey params)
@@ -336,10 +357,7 @@ function writeCommonAndPageFiles(writeContext: WriteContext, rootCommonTemplateD
         }
     );
 
-    // Pages files (one for each page in the app)
-    config.pages.forEach((page) => {
-        writePageObject(page, rootV4TemplateDirPath, testOutDirPath, editor);
-    });
+    writePageObjects(config.pages, rootV4TemplateDirPath, testOutDirPath, editor);
 
     editor.copyTpl(
         join(rootV4TemplateDirPath, 'integration', 'FirstJourney.js'),
@@ -364,6 +382,37 @@ function writeCommonAndPageFiles(writeContext: WriteContext, rootCommonTemplateD
 }
 
 /**
+ * Checks whether a page object file already exists for the given feature name.
+ * If it doesn't exist, finds the matching page config and writes the file.
+ * Returns the new page's JourneyRunnerPage entry if it was created, or empty array if already present.
+ *
+ * @param featureName - the feature/page name (equals the manifest targetKey)
+ * @param config - the OPA config containing all page configurations
+ * @param rootV4TemplateDirPath - template root directory for v4 templates
+ * @param testOutDirPath - output test directory (.../webapp/test)
+ * @param editor - a reference to a mem-fs editor
+ * @returns array with one JourneyRunnerPage if the page was newly created, otherwise empty
+ */
+function ensurePageExists(
+    featureName: string,
+    config: FEV4OPAConfig,
+    rootV4TemplateDirPath: string,
+    testOutDirPath: string,
+    editor: Editor
+): JourneyRunnerPage[] {
+    const pageFilePath = join(testOutDirPath, 'integration', 'pages', `${featureName}.js`);
+    if (editor.exists(pageFilePath)) {
+        return [];
+    }
+    const pageConfig = config.pages.find((p) => p.targetKey === featureName);
+    if (pageConfig) {
+        writePageObject(pageConfig, rootV4TemplateDirPath, testOutDirPath, editor);
+        return [{ targetKey: featureName, appPath: config.appPath }];
+    }
+    return [];
+}
+
+/**
  * Writes journey files for list report, object pages and FPM pages.
  *
  * @param appFeatures - object containing feature data for list report, object pages, and FPM
@@ -381,6 +430,7 @@ function writeJourneyFiles(
 ): void {
     const { config, rootV4TemplateDirPath, testOutDirPath, editor, journeyParams } = writeContext;
     const generatedJourneyPages: string[] = [];
+    const newPages: JourneyRunnerPage[] = [];
 
     if (appFeatures.listReport?.name) {
         editor.copyTpl(
@@ -396,6 +446,9 @@ function writeJourneyFiles(
             }
         );
         generatedJourneyPages.push(appFeatures.listReport.name);
+        newPages.push(
+            ...ensurePageExists(appFeatures.listReport.name, config, rootV4TemplateDirPath, testOutDirPath, editor)
+        );
     }
 
     if (appFeatures.objectPages && appFeatures.objectPages.length > 0) {
@@ -415,6 +468,9 @@ function writeJourneyFiles(
                     }
                 );
                 generatedJourneyPages.push(objectPage.name);
+                newPages.push(
+                    ...ensurePageExists(objectPage.name, config, rootV4TemplateDirPath, testOutDirPath, editor)
+                );
             }
         });
     }
@@ -433,6 +489,11 @@ function writeJourneyFiles(
             }
         );
         generatedJourneyPages.push(appFeatures.fpm.name);
+        newPages.push(...ensurePageExists(appFeatures.fpm.name, config, rootV4TemplateDirPath, testOutDirPath, editor));
+    }
+
+    if (newPages.length > 0) {
+        addPagesToJourneyRunner(newPages, testOutDirPath, editor);
     }
 
     if (!virtualOPA5Configured) {

--- a/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
+++ b/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
@@ -25,6 +25,79 @@ import {
 } from './utils/opaQUnitUtils';
 
 /**
+ * Generate OPA test files for a Fiori elements for OData V4 application.
+ * Note: this can potentially overwrite existing files in the webapp/test folder.
+ *
+ * @param basePath - the absolute target path where the application will be generated
+ * @param opaConfig - parameters for the generation
+ * @param opaConfig.scriptName - the name of the OPA journey file. If not specified, 'FirstJourney' will be used
+ * @param opaConfig.htmlTarget - the name of the html that will be used in OPA journey file. If not specified, 'index.html' will be used
+ * @param opaConfig.appID - the appID. If not specified, will be read from the manifest in sap.app/id
+ * @param metadata - optional metadata for the OPA test generation
+ * @param fs - an optional reference to a mem-fs editor
+ * @param log - optional logger instance
+ * @param standalone - opa test generation run standalone, not during app generation
+ * @returns Reference to a mem-fs-editor
+ */
+export async function generateOPAFiles(
+    basePath: string,
+    opaConfig: { scriptName?: string; appID?: string; htmlTarget?: string },
+    metadata?: string,
+    fs?: Editor,
+    log?: Logger,
+    standalone = false
+): Promise<Editor> {
+    const editor = fs ?? create(createStorage());
+
+    const manifest = readManifest(editor, basePath);
+    const { applicationType, hideFilterBar } = getAppTypeAndHideFilterBarFromManifest(manifest);
+
+    const config = createConfig(manifest, opaConfig, hideFilterBar);
+
+    const rootCommonTemplateDirPath = join(__dirname, '../templates/common');
+    const rootV4TemplateDirPath = join(__dirname, `../templates/${applicationType}`); // Only v4 is supported for the time being
+    const testOutDirPath = join(await getWebappPath(basePath), 'test');
+
+    // Access ux-specification to get feature data for OPA test generation
+    const appFeatures = await getAppFeatures(basePath, editor, log, metadata);
+    // OPA Journey file
+    const startPages = config.pages.filter((page) => page.isStartup).map((page) => page.targetKey);
+    const LROP = findLROP(config.pages, manifest);
+    const journeyParams: JourneyParams = {
+        startPages,
+        startLR: LROP.pageLR?.targetKey,
+        navigatedOP: LROP.pageOP?.targetKey,
+        hideFilterBar: config.hideFilterBar
+    };
+
+    const writeContext: WriteContext = { config, rootV4TemplateDirPath, testOutDirPath, editor, journeyParams };
+
+    if (standalone) {
+        const hasJourneyRunner = existsSync(join(testOutDirPath, 'integration', 'pages', 'JourneyRunner.js'));
+        const virtualOPA5Configured = await hasVirtualOPA5(basePath);
+        if (hasJourneyRunner) {
+            writeJourneyFiles(appFeatures, writeContext, true, true, virtualOPA5Configured);
+        } else {
+            editor.move(join(testOutDirPath, 'integration', '**'), join(testOutDirPath, 'integration_old'));
+
+            await addIntegrationOldToGitignore(basePath, editor);
+            const htmlTarget = readHtmlTargetFromQUnitJs(testOutDirPath, editor) ?? config.htmlTarget;
+            const standaloneConfig = { ...config, htmlTarget };
+            const standaloneWriteContext: WriteContext = { ...writeContext, config: standaloneConfig };
+            if (!virtualOPA5Configured) {
+                writeCommonAndPageFiles(standaloneWriteContext, rootCommonTemplateDirPath);
+            }
+            writeJourneyFiles(appFeatures, standaloneWriteContext, true, hasJourneyRunner, virtualOPA5Configured);
+        }
+    } else {
+        writeCommonAndPageFiles(writeContext, rootCommonTemplateDirPath);
+        writeJourneyFiles(appFeatures, writeContext, false);
+    }
+
+    return editor;
+}
+
+/**
  * Reads the manifest for an app.
  *
  * @param fs - a reference to a mem-fs editor
@@ -408,79 +481,6 @@ function writePageObject(
             globOptions: { dot: true }
         }
     );
-}
-
-/**
- * Generate OPA test files for a Fiori elements for OData V4 application.
- * Note: this can potentially overwrite existing files in the webapp/test folder.
- *
- * @param basePath - the absolute target path where the application will be generated
- * @param opaConfig - parameters for the generation
- * @param opaConfig.scriptName - the name of the OPA journey file. If not specified, 'FirstJourney' will be used
- * @param opaConfig.htmlTarget - the name of the html that will be used in OPA journey file. If not specified, 'index.html' will be used
- * @param opaConfig.appID - the appID. If not specified, will be read from the manifest in sap.app/id
- * @param metadata - optional metadata for the OPA test generation
- * @param fs - an optional reference to a mem-fs editor
- * @param log - optional logger instance
- * @param standalone - opa test generation run standalone, not during app generation
- * @returns Reference to a mem-fs-editor
- */
-export async function generateOPAFiles(
-    basePath: string,
-    opaConfig: { scriptName?: string; appID?: string; htmlTarget?: string },
-    metadata?: string,
-    fs?: Editor,
-    log?: Logger,
-    standalone = false
-): Promise<Editor> {
-    const editor = fs ?? create(createStorage());
-
-    const manifest = readManifest(editor, basePath);
-    const { applicationType, hideFilterBar } = getAppTypeAndHideFilterBarFromManifest(manifest);
-
-    const config = createConfig(manifest, opaConfig, hideFilterBar);
-
-    const rootCommonTemplateDirPath = join(__dirname, '../templates/common');
-    const rootV4TemplateDirPath = join(__dirname, `../templates/${applicationType}`); // Only v4 is supported for the time being
-    const testOutDirPath = join(await getWebappPath(basePath), 'test');
-
-    // Access ux-specification to get feature data for OPA test generation
-    const appFeatures = await getAppFeatures(basePath, editor, log, metadata);
-    // OPA Journey file
-    const startPages = config.pages.filter((page) => page.isStartup).map((page) => page.targetKey);
-    const LROP = findLROP(config.pages, manifest);
-    const journeyParams: JourneyParams = {
-        startPages,
-        startLR: LROP.pageLR?.targetKey,
-        navigatedOP: LROP.pageOP?.targetKey,
-        hideFilterBar: config.hideFilterBar
-    };
-
-    const writeContext: WriteContext = { config, rootV4TemplateDirPath, testOutDirPath, editor, journeyParams };
-
-    if (standalone) {
-        const hasJourneyRunner = existsSync(join(testOutDirPath, 'integration', 'pages', 'JourneyRunner.js'));
-        const virtualOPA5Configured = await hasVirtualOPA5(basePath);
-        if (hasJourneyRunner) {
-            writeJourneyFiles(appFeatures, writeContext, true, true, virtualOPA5Configured);
-        } else {
-            editor.move(join(testOutDirPath, 'integration', '**'), join(testOutDirPath, 'integration_old'));
-
-            await addIntegrationOldToGitignore(basePath, editor);
-            const htmlTarget = readHtmlTargetFromQUnitJs(testOutDirPath, editor) ?? config.htmlTarget;
-            const standaloneConfig = { ...config, htmlTarget };
-            const standaloneWriteContext: WriteContext = { ...writeContext, config: standaloneConfig };
-            if (!virtualOPA5Configured) {
-                writeCommonAndPageFiles(standaloneWriteContext, rootCommonTemplateDirPath);
-            }
-            writeJourneyFiles(appFeatures, standaloneWriteContext, true, true, virtualOPA5Configured);
-        }
-    } else {
-        writeCommonAndPageFiles(writeContext, rootCommonTemplateDirPath);
-        writeJourneyFiles(appFeatures, writeContext, false);
-    }
-
-    return editor;
 }
 
 /**

--- a/packages/ui5-test-writer/src/types.ts
+++ b/packages/ui5-test-writer/src/types.ts
@@ -50,6 +50,13 @@ export type FEV4ManifestTarget = {
                     };
                 };
             };
+            views?: {
+                paths?: Array<{
+                    primary?: unknown[];
+                    secondary?: unknown[];
+                    defaultPath?: string;
+                }>;
+            };
         };
     };
 };

--- a/packages/ui5-test-writer/src/types.ts
+++ b/packages/ui5-test-writer/src/types.ts
@@ -127,6 +127,7 @@ export type ListReportFeatures = {
     filterBarItems?: string[];
     tableColumns?: Record<string, Record<string, string | number | boolean>>;
     toolBarActions?: ActionButtonState[];
+    isALP?: boolean;
 };
 
 export interface ActionButtonState {

--- a/packages/ui5-test-writer/src/utils/listReportUtils.ts
+++ b/packages/ui5-test-writer/src/utils/listReportUtils.ts
@@ -5,6 +5,7 @@ import type {
     ActionButtonState,
     ButtonState,
     ButtonVisibilityResult,
+    FEV4ManifestTarget,
     ListReportFeatures
 } from '../types';
 import {
@@ -18,6 +19,7 @@ import type { ConvertedMetadata, EntitySet } from '@sap-ux/vocabularies-types';
 import { parse } from '@sap-ux/edmx-parser';
 import { convert } from '@sap-ux/annotation-converter';
 import type { PageWithModelV4 } from '@sap/ux-specification/dist/types/src/parser/application';
+import type { Manifest } from '@sap-ux/project-access';
 
 /**
  * Builds a button state object from button visibility result.
@@ -82,19 +84,54 @@ export function safeCheckActionButtonStates(
 }
 
 /**
+ * Returns true when a ListReport manifest target is configured as an Analytical List Page.
+ * ALP targets have a `views.paths` array where at least one entry contains a `primary` array,
+ * indicating the dual-view (chart + table) layout used by ALP.
+ *
+ * @param target - the manifest routing target to inspect
+ * @returns true if the target represents an ALP configuration
+ */
+export function isALPManifestTarget(target: FEV4ManifestTarget): boolean {
+    return (
+        target.options?.settings?.views?.paths?.some(
+            (path) => Array.isArray(path.primary) && path.primary.length > 0
+        ) ?? false
+    );
+}
+
+/**
+ * Returns true if any ListReport target in the manifest is configured as an Analytical List Page.
+ *
+ * @param manifest - the application manifest
+ * @param targetKey - optional specific target key to check; if omitted all ListReport targets are checked
+ * @returns true if the target (or any ListReport target) is an ALP
+ */
+export function isALPFromManifest(manifest: Manifest, targetKey?: string): boolean {
+    const targets = manifest['sap.ui5']?.routing?.targets;
+    if (!targets) {
+        return false;
+    }
+    const keysToCheck = targetKey ? [targetKey] : Object.keys(targets);
+    return keysToCheck.some((key) => {
+        const target = targets[key] as FEV4ManifestTarget;
+        return target?.name === 'sap.fe.templates.ListReport' && isALPManifestTarget(target);
+    });
+}
+
+/**
  * Gets List Report features from the page model using ux-specification.
  *
  * @param listReportPage - the List Report page containing the tree model with feature definitions
  * @param log - optional logger instance
  * @param metadata - optional metadata for the OPA test generation
- * @param isALP - boolean indicating if the page is an Analytical List Page
+ * @param manifest - optional application manifest, used to detect ALP configuration
  * @returns feature data extracted from the List Report page model
  */
 export function getListReportFeatures(
     listReportPage: PageWithModelV4,
     log?: Logger,
     metadata?: string,
-    isALP?: boolean
+    manifest?: Manifest
 ): ListReportFeatures {
     const buttonVisibility =
         metadata && listReportPage.entitySet
@@ -112,7 +149,7 @@ export function getListReportFeatures(
             metadata && listReportPage.entitySet
                 ? safeCheckActionButtonStates(metadata, listReportPage.entitySet, toolbarActions, log)
                 : [],
-        isALP: !!isALP
+        isALP: manifest ? isALPFromManifest(manifest, listReportPage.name) : false
     };
 }
 

--- a/packages/ui5-test-writer/src/utils/listReportUtils.ts
+++ b/packages/ui5-test-writer/src/utils/listReportUtils.ts
@@ -87,12 +87,14 @@ export function safeCheckActionButtonStates(
  * @param listReportPage - the List Report page containing the tree model with feature definitions
  * @param log - optional logger instance
  * @param metadata - optional metadata for the OPA test generation
+ * @param isALP - boolean indicating if the page is an Analytical List Page
  * @returns feature data extracted from the List Report page model
  */
 export function getListReportFeatures(
     listReportPage: PageWithModelV4,
     log?: Logger,
-    metadata?: string
+    metadata?: string,
+    isALP?: boolean
 ): ListReportFeatures {
     const buttonVisibility =
         metadata && listReportPage.entitySet
@@ -109,7 +111,8 @@ export function getListReportFeatures(
         toolBarActions:
             metadata && listReportPage.entitySet
                 ? safeCheckActionButtonStates(metadata, listReportPage.entitySet, toolbarActions, log)
-                : []
+                : [],
+        isALP: !!isALP
     };
 }
 

--- a/packages/ui5-test-writer/src/utils/modelUtils.ts
+++ b/packages/ui5-test-writer/src/utils/modelUtils.ts
@@ -73,6 +73,7 @@ export async function getAppFeatures(
     let listReportPage: PageWithModelV4 | null = null;
     let objectPages: PageWithModelV4[] | null = null;
     let fpmPage: PageWithModelV4 | null = null;
+    let isALP = false;
     let projectMetadata = metadata;
     // Read application model to extract control information needed for test generation
     // specification and readApp might not be available due to specification version, fail gracefully
@@ -92,6 +93,11 @@ export async function getAppFeatures(
         listReportPage = appModel?.applicationModel ? getListReportPage(appModel.applicationModel) : listReportPage;
         objectPages = appModel?.applicationModel ? getObjectPages(appModel.applicationModel) : objectPages;
         fpmPage = appModel?.applicationModel ? getFPMPage(appModel.applicationModel, log) : fpmPage;
+        isALP = appModel?.applicationModel
+            ? Object.values(appModel.applicationModel.pages).some(
+                  (page) => page.pageType === PageTypeV4.AnalyticalListPage
+              )
+            : false;
     } catch (error) {
         log?.warn(
             'Error analyzing project model using specification. No dynamic tests will be generated. Error: ' +
@@ -108,7 +114,7 @@ export async function getAppFeatures(
     // attempt to get individual feature data
     try {
         if (listReportPage) {
-            featureData.listReport = getListReportFeatures(listReportPage, log, projectMetadata);
+            featureData.listReport = getListReportFeatures(listReportPage, log, projectMetadata, isALP);
         }
         if (objectPages) {
             log?.warn('Extracting Object Page features from application model');

--- a/packages/ui5-test-writer/src/utils/modelUtils.ts
+++ b/packages/ui5-test-writer/src/utils/modelUtils.ts
@@ -1,5 +1,6 @@
 import type { Editor } from 'mem-fs-editor';
 import { createApplicationAccess } from '@sap-ux/project-access';
+import type { Manifest } from '@sap-ux/project-access';
 import type { Logger } from '@sap-ux/logger';
 import { PageTypeV4 } from '@sap/ux-specification/dist/types/src/common/page';
 import type { ReadAppResult, Specification } from '@sap/ux-specification/dist/types/src';
@@ -60,20 +61,21 @@ export interface PageWithModelV4WithProperties extends PageWithModelV4 {
  * @param fs - optional mem-fs editor instance
  * @param log - optional logger instance
  * @param metadata - optional metadata for the OPA test generation
+ * @param manifest - optional application manifest, used to detect ALP configuration
  * @returns feature data extracted from the application model
  */
 export async function getAppFeatures(
     basePath: string,
     fs?: Editor,
     log?: Logger,
-    metadata?: string
+    metadata?: string,
+    manifest?: Manifest
 ): Promise<AppFeatures> {
     const featureData: AppFeatures = {};
 
     let listReportPage: PageWithModelV4 | null = null;
     let objectPages: PageWithModelV4[] | null = null;
     let fpmPage: PageWithModelV4 | null = null;
-    let isALP = false;
     let projectMetadata = metadata;
     // Read application model to extract control information needed for test generation
     // specification and readApp might not be available due to specification version, fail gracefully
@@ -93,11 +95,6 @@ export async function getAppFeatures(
         listReportPage = appModel?.applicationModel ? getListReportPage(appModel.applicationModel) : listReportPage;
         objectPages = appModel?.applicationModel ? getObjectPages(appModel.applicationModel) : objectPages;
         fpmPage = appModel?.applicationModel ? getFPMPage(appModel.applicationModel, log) : fpmPage;
-        isALP = appModel?.applicationModel
-            ? Object.values(appModel.applicationModel.pages).some(
-                  (page) => page.pageType === PageTypeV4.AnalyticalListPage
-              )
-            : false;
     } catch (error) {
         log?.warn(
             'Error analyzing project model using specification. No dynamic tests will be generated. Error: ' +
@@ -114,7 +111,7 @@ export async function getAppFeatures(
     // attempt to get individual feature data
     try {
         if (listReportPage) {
-            featureData.listReport = getListReportFeatures(listReportPage, log, projectMetadata, isALP);
+            featureData.listReport = getListReportFeatures(listReportPage, log, projectMetadata, manifest);
         }
         if (objectPages) {
             log?.warn('Extracting Object Page features from application model');

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -211,7 +211,7 @@ export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyR
 
     // 1. Splice into the sap.ui.define([...]) array.
     //    Captures everything between the opening `[` and the closing `]` before `, function`.
-    const defineArrayRegex = /sap\.ui\.define\s*\(\s*\[([\s\S]*?)\]\s*,\s*function/d;
+    const defineArrayRegex = /sap\.ui\.define\s*\(\s*\[([^\]]*)\]\s*,\s*function/d;
     const defineMatch = defineArrayRegex.exec(result);
     if (defineMatch?.indices?.[1]) {
         const [bodyStart, bodyEnd] = defineMatch.indices[1];
@@ -236,7 +236,7 @@ export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyR
 
     // 2. Splice into the function parameter list: `function (JourneyRunner, A, B)`.
     //    Captures everything between `(` and `)` of the function signature.
-    const funcParamRegex = /\]\s*,\s*function\s*\(([\s\S]*?)\)\s*\{/d;
+    const funcParamRegex = /\]\s*,\s*function\s*\(([^)]*)\)\s*\{/d;
     const funcMatch = funcParamRegex.exec(result);
     if (funcMatch?.indices?.[1]) {
         const [, paramEnd] = funcMatch.indices[1];
@@ -246,7 +246,7 @@ export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyR
 
     // 3. Splice into the pages object: `pages: { onTheFoo: Foo, ... }`.
     //    Captures everything between `pages: {` and the closing `}`.
-    const pagesObjectRegex = /pages\s*:\s*\{([\s\S]*?)\}/d;
+    const pagesObjectRegex = /pages\s*:\s*\{([^}]*)\}/d;
     const pagesMatch = pagesObjectRegex.exec(result);
     if (pagesMatch?.indices?.[1]) {
         const [, pagesBodyEnd] = pagesMatch.indices[1];

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -28,6 +28,8 @@ const OPA_QUNIT_FILE = join('integration', 'opaTests.qunit.js');
  */
 const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([^\]]*)\]\s*,\s*function/d;
 
+const MAX_FILE_CONTENT_LENGTH = 10000;
+
 /**
  * Splices new module paths into the sap.ui.require array of the content string.
  * Entries that are already present are skipped. All other content is preserved exactly.
@@ -36,8 +38,6 @@ const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([^\]]*)\]\s*,\s*f
  * @param moduleNames - module paths to add (e.g. ["myApp/test/integration/SomeJourney"])
  * @returns the updated file content, or the original content unchanged if nothing was added
  */
-const MAX_FILE_CONTENT_LENGTH = 100_000;
-
 export function spliceModulesIntoQUnitContent(fileContent: string, moduleNames: string[]): string {
     if (fileContent.length > MAX_FILE_CONTENT_LENGTH) {
         return fileContent;

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -28,11 +28,15 @@ const OPA_QUNIT_FILE = join('integration', 'opaTests.qunit.js');
  */
 const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([^\]]*)\]\s*,\s*function/d;
 
+/** ReDoS mitigation: files larger than this are returned unchanged rather than matched with regex. */
 const MAX_FILE_CONTENT_LENGTH = 10000;
 
 /**
  * Splices new module paths into the sap.ui.require array of the content string.
  * Entries that are already present are skipped. All other content is preserved exactly.
+ *
+ * Note: files exceeding MAX_FILE_CONTENT_LENGTH characters are returned unchanged to prevent
+ * ReDoS on crafted inputs. Valid generated files are well within this limit.
  *
  * @param fileContent - the full content of the opaTests.qunit.js file
  * @param moduleNames - module paths to add (e.g. ["myApp/test/integration/SomeJourney"])
@@ -196,6 +200,9 @@ export interface JourneyRunnerPage {
  *
  * Pages already present (detected by their module path in the define array) are skipped.
  * All other content — formatting, comments, whitespace — is preserved exactly.
+ *
+ * Note: files exceeding MAX_FILE_CONTENT_LENGTH characters are returned unchanged to prevent
+ * ReDoS on crafted inputs. Valid generated files are well within this limit.
  *
  * @param fileContent - the full content of the JourneyRunner.js file
  * @param pages - pages to add

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -170,6 +170,132 @@ export function addPathsToQUnitJs(filePaths: string[], projectPath: string, fs: 
     }
 }
 
+/** Relative path from the test output directory to JourneyRunner.js */
+const JOURNEY_RUNNER_FILE = join('integration', 'pages', 'JourneyRunner.js');
+
+/**
+ * Page entry to splice into an existing JourneyRunner.js.
+ */
+export interface JourneyRunnerPage {
+    /** The page's targetKey, used as both the variable name and `onThe<targetKey>` key */
+    targetKey: string;
+    /** The app module path prefix (e.g. "project1/test/integration/pages") */
+    appPath: string;
+}
+
+/**
+ * Splices new page entries into the three locations of an existing JourneyRunner.js:
+ * - the sap.ui.define dependency array
+ * - the function parameter list
+ * - the pages object literal
+ *
+ * Pages already present (detected by their module path in the define array) are skipped.
+ * All other content — formatting, comments, whitespace — is preserved exactly.
+ *
+ * @param fileContent - the full content of the JourneyRunner.js file
+ * @param pages - pages to add
+ * @returns the updated file content, or the original content unchanged if nothing was added
+ */
+export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyRunnerPage[]): string {
+    // Determine which pages are not yet present by checking the define array
+    const toAdd = pages.filter((page) => {
+        const modulePath = `${page.appPath}/test/integration/pages/${page.targetKey}`;
+        return !fileContent.includes(`"${modulePath}"`);
+    });
+
+    if (toAdd.length === 0) {
+        return fileContent;
+    }
+
+    let result = fileContent;
+
+    // 1. Splice into the sap.ui.define([...]) array.
+    //    Captures everything between the opening `[` and the closing `]` before `, function`.
+    const defineArrayRegex = /sap\.ui\.define\s*\(\s*\[([\s\S]*?)\]\s*,\s*function/d;
+    const defineMatch = defineArrayRegex.exec(result);
+    if (defineMatch?.indices?.[1]) {
+        const [bodyStart, bodyEnd] = defineMatch.indices[1];
+        const arrayBody = result.slice(bodyStart, bodyEnd);
+
+        // Detect indentation from the first existing module entry line
+        const indentMatch = /^([ \t]+)"/m.exec(arrayBody);
+        const indent = indentMatch ? indentMatch[1] : '\t';
+
+        const newEntries = toAdd
+            .map((page) => `${indent}"${page.appPath}/test/integration/pages/${page.targetKey}",`)
+            .join('\n');
+
+        // Ensure the last existing entry ends with a comma before we insert after it.
+        // The trimmed body ends at bodyEnd; look back from there for the last non-whitespace char.
+        const trimmedEnd = result.slice(0, bodyEnd).trimEnd();
+        const needsComma = !trimmedEnd.endsWith(',');
+        const commaFix = needsComma ? ',' : '';
+        const trailingWhitespace = result.slice(trimmedEnd.length, bodyEnd);
+        result =
+            `${trimmedEnd}${commaFix}\n${newEntries}` + `${trailingWhitespace}${result.slice(bodyEnd)}`;
+    }
+
+    // 2. Splice into the function parameter list: `function (JourneyRunner, A, B)`.
+    //    Captures everything between `(` and `)` of the function signature.
+    const funcParamRegex = /\]\s*,\s*function\s*\(([\s\S]*?)\)\s*\{/d;
+    const funcMatch = funcParamRegex.exec(result);
+    if (funcMatch?.indices?.[1]) {
+        const [, paramEnd] = funcMatch.indices[1];
+        const newParams = toAdd.map((page) => `, ${page.targetKey}`).join('');
+        result = `${result.slice(0, paramEnd)}${newParams}${result.slice(paramEnd)}`;
+    }
+
+    // 3. Splice into the pages object: `pages: { onTheFoo: Foo, ... }`.
+    //    Captures everything between `pages: {` and the closing `}`.
+    const pagesObjectRegex = /pages\s*:\s*\{([\s\S]*?)\}/d;
+    const pagesMatch = pagesObjectRegex.exec(result);
+    if (pagesMatch?.indices?.[1]) {
+        const [, pagesBodyEnd] = pagesMatch.indices[1];
+        const pagesBody = result.slice(pagesMatch.indices[1][0], pagesBodyEnd);
+
+        // Detect indentation from the first existing page entry
+        const pageIndentMatch = /^([ \t]+)on/m.exec(pagesBody);
+        const pageIndent = pageIndentMatch ? pageIndentMatch[1] : '\t\t\t';
+
+        const newPageEntries = toAdd
+            .map((page) => `${pageIndent}onThe${page.targetKey}: ${page.targetKey},`)
+            .join('\n');
+
+        // Ensure the last existing entry ends with a comma before we insert after it.
+        const trimmedPagesEnd = result.slice(0, pagesBodyEnd).trimEnd();
+        const needsComma = !trimmedPagesEnd.endsWith(',');
+        const commaFix = needsComma ? ',' : '';
+        const trailingWhitespace = result.slice(trimmedPagesEnd.length, pagesBodyEnd);
+        result =
+            `${trimmedPagesEnd}${commaFix}\n${newPageEntries}` +
+            `${trailingWhitespace}${result.slice(pagesBodyEnd)}`;
+    }
+
+    return result;
+}
+
+/**
+ * Reads JourneyRunner.js from the project, adds new page entries to all three
+ * locations (define array, function params, pages object), and writes the updated
+ * content back. Pages already present are skipped.
+ *
+ * @param pages - pages to add
+ * @param testOutDirPath - path to the test output directory (`.../webapp/test`)
+ * @param fs - mem-fs-editor instance used to read and write the file
+ */
+export function addPagesToJourneyRunner(pages: JourneyRunnerPage[], testOutDirPath: string, fs: Editor): void {
+    try {
+        const filePath = join(testOutDirPath, JOURNEY_RUNNER_FILE);
+        const content = fs.read(filePath);
+        const updated = splicePageIntoJourneyRunner(content, pages);
+        if (updated !== content) {
+            fs.write(filePath, updated);
+        }
+    } catch {
+        // If the file doesn't exist or can't be read, do nothing
+    }
+}
+
 /** Shape of one entry in the `test` array of a `fiori-tools-preview` middleware configuration */
 interface PreviewTestEntry {
     framework?: string;

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -26,7 +26,7 @@ const OPA_QUNIT_FILE = join('integration', 'opaTests.qunit.js');
  * The `d` flag enables `match.indices` so we can read the capture group's
  * exact start/end positions without fragile string searching.
  */
-const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([\s\S]*?)\]\s*,\s*function/d;
+const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([^\]]*)\]\s*,\s*function/d;
 
 /**
  * Splices new module paths into the sap.ui.require array of the content string.
@@ -36,7 +36,12 @@ const SAP_UI_REQUIRE_ARRAY_REGEX = /sap\.ui\.require\s*\(\s*\[([\s\S]*?)\]\s*,\s
  * @param moduleNames - module paths to add (e.g. ["myApp/test/integration/SomeJourney"])
  * @returns the updated file content, or the original content unchanged if nothing was added
  */
+const MAX_FILE_CONTENT_LENGTH = 100_000;
+
 export function spliceModulesIntoQUnitContent(fileContent: string, moduleNames: string[]): string {
+    if (fileContent.length > MAX_FILE_CONTENT_LENGTH) {
+        return fileContent;
+    }
     const match = SAP_UI_REQUIRE_ARRAY_REGEX.exec(fileContent);
     if (!match) {
         return fileContent;
@@ -197,6 +202,9 @@ export interface JourneyRunnerPage {
  * @returns the updated file content, or the original content unchanged if nothing was added
  */
 export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyRunnerPage[]): string {
+    if (fileContent.length > MAX_FILE_CONTENT_LENGTH) {
+        return fileContent;
+    }
     // Determine which pages are not yet present by checking the define array
     const toAdd = pages.filter((page) => {
         const modulePath = `${page.appPath}/test/integration/pages/${page.targetKey}`;

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -79,11 +79,14 @@ export function spliceModulesIntoQUnitContent(fileContent: string, moduleNames: 
         return fileContent;
     }
 
-    const before = fileContent.slice(0, insertPosition);
+    // Ensure the last existing entry ends with a comma before inserting after it.
+    const trimmedBefore = fileContent.slice(0, insertPosition).trimEnd();
+    const needsComma = !trimmedBefore.endsWith(',');
+    const commaFix = needsComma ? ',' : '';
+    const trailingWhitespace = fileContent.slice(trimmedBefore.length, insertPosition);
     const after = fileContent.slice(insertPosition);
 
-    const leadingNewline = arrayBody.endsWith('\n') ? '' : '\n';
-    return `${before}${leadingNewline}${newLines}\n${after}`;
+    return `${trimmedBefore}${commaFix}\n${newLines}\n${trailingWhitespace}${after}`;
 }
 
 /**

--- a/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
+++ b/packages/ui5-test-writer/src/utils/opaQUnitUtils.ts
@@ -231,8 +231,7 @@ export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyR
         const needsComma = !trimmedEnd.endsWith(',');
         const commaFix = needsComma ? ',' : '';
         const trailingWhitespace = result.slice(trimmedEnd.length, bodyEnd);
-        result =
-            `${trimmedEnd}${commaFix}\n${newEntries}` + `${trailingWhitespace}${result.slice(bodyEnd)}`;
+        result = `${trimmedEnd}${commaFix}\n${newEntries}` + `${trailingWhitespace}${result.slice(bodyEnd)}`;
     }
 
     // 2. Splice into the function parameter list: `function (JourneyRunner, A, B)`.
@@ -267,8 +266,7 @@ export function splicePageIntoJourneyRunner(fileContent: string, pages: JourneyR
         const commaFix = needsComma ? ',' : '';
         const trailingWhitespace = result.slice(trimmedPagesEnd.length, pagesBodyEnd);
         result =
-            `${trimmedPagesEnd}${commaFix}\n${newPageEntries}` +
-            `${trailingWhitespace}${result.slice(pagesBodyEnd)}`;
+            `${trimmedPagesEnd}${commaFix}\n${newPageEntries}` + `${trailingWhitespace}${result.slice(pagesBodyEnd)}`;
     }
 
     return result;

--- a/packages/ui5-test-writer/templates/v4/integration/ListReportJourney.js
+++ b/packages/ui5-test-writer/templates/v4/integration/ListReportJourney.js
@@ -41,7 +41,7 @@ sap.ui.define([
 
         opaTest("Check table columns and actions", function (Given, When, Then) {
             <%_ if (toolBarActions && toolBarActions.length > 0) { -%>
-            <%_ if (createButton.visible) { _%>
+            <%_ if (createButton.visible && !isALP) { _%>
             Then.onThe<%- startLR%>.onTable().iCheckCreate({ visible: true });
             // Then.onthe<%- startLR%>.onTable().iPressCreate();
             <%_ } _%>

--- a/packages/ui5-test-writer/templates/v4/integration/ObjectPageJourney.js
+++ b/packages/ui5-test-writer/templates/v4/integration/ObjectPageJourney.js
@@ -60,18 +60,16 @@ sap.ui.define([
         });
 <% } -%>
 
-<% if (bodySections?.length > 0) { -%>
+<% if (bodySections?.length > 0 && !isStandalone) { -%>
         opaTest("Check body sections of the Object Page", function (Given, When, Then) {
 <% if (bodySections?.length > 1) { -%>
             Then.onThe<%- name%>.iCheckNumberOfSections(<%- bodySections.length %>);
 <% } -%>
 <% bodySections.forEach(function(section) { -%>
-<% if (!isStandalone) { -%>
 <% if (bodySections.length > 1) { -%>
             When.onThe<%- name%>.iPressSectionIconTabFilterButton("<%- section.id %>");
 <% } -%>
             Then.onThe<%- name%>.iCheckSection({ section: "<%- section.id %>" });
-<% } -%>
 <% if (section?.subSections?.length > 0) { -%>
 <% section.subSections.forEach(function(subSection) { -%>
             //When.onThe<%- name%>.iGoToSection({ section: "<%- section.id %>", subSection: "<%- subSection.id %>" });

--- a/packages/ui5-test-writer/test/unit/fiori-elements.test.ts
+++ b/packages/ui5-test-writer/test/unit/fiori-elements.test.ts
@@ -401,6 +401,83 @@ describe('ui5-test-writer', () => {
 
                 expect(fs.dump(projectDir)).toMatchSnapshot();
             });
+
+            it('moves integration folder and skips common/page files when OPA5 is configured and no JourneyRunner', async () => {
+                const projectDir = prepareTestFiles('LropVirtualTests');
+                // Return false only for the test output JourneyRunner check (not template paths)
+                existsSyncMock.mockImplementation((p: string) =>
+                    p.includes('test-output') && p.includes('JourneyRunner.js') ? false : realExistsSync(p)
+                );
+
+                fs = await generateOPAFiles(projectDir, {}, metadata, fs, undefined, true);
+
+                const dumped: Record<string, unknown> = fs.dump(projectDir);
+                const paths = Object.keys(dumped);
+                // Journey files should be written
+                expect(paths.some((p) => p.includes('TravelListJourney.js'))).toBe(true);
+                // opaTests.qunit.js and opaTests.qunit.html should NOT be written (virtual OPA5 skips them)
+                expect(paths.every((p) => !p.includes('opaTests.qunit.js'))).toBe(true);
+                expect(paths.every((p) => !p.includes('opaTests.qunit.html'))).toBe(true);
+            });
+        });
+
+        describe('standalone mode without virtual OPA5', () => {
+            let realExistsSync: (path: string) => boolean;
+
+            beforeAll(() => {
+                realExistsSync = jest.requireActual<{ existsSync: (path: string) => boolean }>('node:fs').existsSync;
+            });
+
+            beforeEach(() => {
+                hasVirtualOPA5Mock.mockResolvedValue(false);
+            });
+
+            afterEach(() => {
+                hasVirtualOPA5Mock.mockReset();
+                existsSyncMock.mockImplementation(realExistsSync);
+                const { addPathsToQUnitJs: realAddPaths } = jest.requireActual<{
+                    addPathsToQUnitJs: typeof addPathsToQUnitJsMock;
+                }>('../../src/utils/opaQUnitUtils');
+                addPathsToQUnitJsMock.mockImplementation(realAddPaths);
+            });
+
+            it('moves integration folder and writes common/page/journey files when no JourneyRunner and OPA5 not virtual', async () => {
+                const projectDir = prepareTestFiles('LropVirtualTests');
+                // Return false only for the test output JourneyRunner check (not template paths)
+                existsSyncMock.mockImplementation((p: string) =>
+                    p.includes('test-output') && p.includes('JourneyRunner.js') ? false : realExistsSync(p)
+                );
+
+                fs = await generateOPAFiles(projectDir, {}, metadata, fs, undefined, true);
+
+                const dumped: Record<string, unknown> = fs.dump(projectDir);
+                const paths = Object.keys(dumped);
+                // opaTests.qunit.js should be generated (no virtual OPA5)
+                expect(paths.some((p) => p.includes('opaTests.qunit.js'))).toBe(true);
+                // Journey files should be written
+                expect(paths.some((p) => p.includes('TravelListJourney.js'))).toBe(true);
+                // JourneyRunner.js should be written as part of common files
+                expect(paths.some((p) => p.includes('JourneyRunner.js'))).toBe(true);
+            });
+
+            it('adds journey paths to opaTests.qunit.js when JourneyRunner exists and OPA5 not virtual', async () => {
+                const projectDir = prepareTestFiles('LropVirtualTests');
+                readAppMock.mockResolvedValueOnce(JSON.parse(appModels.V4_MODEL));
+                // Return true only for the test output JourneyRunner check (not template paths)
+                existsSyncMock.mockImplementation((p: string) =>
+                    p.includes('test-output') && p.includes('JourneyRunner.js') ? true : realExistsSync(p)
+                );
+                addPathsToQUnitJsMock.mockImplementation(jest.fn());
+
+                fs = await generateOPAFiles(projectDir, {}, metadata, fs, undefined, true);
+
+                // addPathsToQUnitJs should have been called with journey module paths
+                expect(addPathsToQUnitJsMock).toHaveBeenCalledWith(
+                    expect.arrayContaining([expect.stringContaining('Journey')]),
+                    expect.any(String),
+                    expect.anything()
+                );
+            });
         });
 
         it('generates tests for v4 application with sub object page', async () => {

--- a/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
@@ -10,12 +10,15 @@ import {
     getFilterFieldNames,
     checkActionButtonStates,
     getToolBarActionNames,
-    getToolBarActionItems
+    getToolBarActionItems,
+    isALPManifestTarget,
+    isALPFromManifest
 } from '../../../src/utils/listReportUtils';
-import type { ButtonState } from '../../../src/types';
+import type { ButtonState, FEV4ManifestTarget } from '../../../src/types';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PageWithModelV4 } from '@sap/ux-specification/dist/types/src/parser/application';
+import type { Manifest } from '@sap-ux/project-access';
 
 describe('Test buildButtonState()', () => {
     test('should return visible false when buttonState is undefined', () => {
@@ -1546,5 +1549,178 @@ describe('Test getListReportFeatures()', () => {
         expect(result.deleteButton?.visible).toBeDefined();
 
         expect(Array.isArray(result.toolBarActions)).toBe(true);
+    });
+});
+
+/** ALP manifest target with views.paths containing a primary array */
+const ALP_TARGET: FEV4ManifestTarget = {
+    type: 'Component',
+    name: 'sap.fe.templates.ListReport',
+    options: {
+        settings: {
+            contextPath: '/SalesOrderManage',
+            views: {
+                paths: [
+                    {
+                        primary: [{ annotationPath: 'com.sap.vocabularies.UI.v1.PresentationVariant' }],
+                        secondary: [{ annotationPath: 'com.sap.vocabularies.UI.v1.LineItem' }],
+                        defaultPath: 'both'
+                    }
+                ]
+            }
+        }
+    }
+};
+
+/** Non-ALP ListReport target (no views.paths) */
+const LR_TARGET: FEV4ManifestTarget = {
+    type: 'Component',
+    name: 'sap.fe.templates.ListReport',
+    options: { settings: { contextPath: '/Orders' } }
+};
+
+/** Minimal ALP manifest matching the real alpv4 structure */
+const ALP_MANIFEST: Manifest = {
+    'sap.app': { id: 'alpv4test', type: 'application', applicationVersion: { version: '0.0.1' } },
+    'sap.ui5': {
+        routing: {
+            targets: {
+                SalesOrderManageList: ALP_TARGET as any,
+                SalesOrderManageObjectPage: {
+                    type: 'Component',
+                    name: 'sap.fe.templates.ObjectPage'
+                } as any
+            }
+        }
+    }
+} as unknown as Manifest;
+
+/** Manifest with a standard (non-ALP) ListReport */
+const LR_MANIFEST: Manifest = {
+    'sap.app': { id: 'lrtest', type: 'application', applicationVersion: { version: '0.0.1' } },
+    'sap.ui5': {
+        routing: {
+            targets: {
+                OrdersList: LR_TARGET as any
+            }
+        }
+    }
+} as unknown as Manifest;
+
+describe('isALPManifestTarget()', () => {
+    test('returns true when views.paths contains an entry with a non-empty primary array', () => {
+        expect(isALPManifestTarget(ALP_TARGET)).toBe(true);
+    });
+
+    test('returns false when target has no views configuration', () => {
+        expect(isALPManifestTarget(LR_TARGET)).toBe(false);
+    });
+
+    test('returns false when views.paths is an empty array', () => {
+        const target: FEV4ManifestTarget = {
+            name: 'sap.fe.templates.ListReport',
+            options: { settings: { views: { paths: [] } } }
+        };
+        expect(isALPManifestTarget(target)).toBe(false);
+    });
+
+    test('returns false when views.paths entries have no primary array', () => {
+        const target: FEV4ManifestTarget = {
+            name: 'sap.fe.templates.ListReport',
+            options: {
+                settings: {
+                    views: {
+                        paths: [{ secondary: [{ annotationPath: 'com.sap.vocabularies.UI.v1.LineItem' }] }]
+                    }
+                }
+            }
+        };
+        expect(isALPManifestTarget(target)).toBe(false);
+    });
+
+    test('returns false when primary array is empty', () => {
+        const target: FEV4ManifestTarget = {
+            name: 'sap.fe.templates.ListReport',
+            options: { settings: { views: { paths: [{ primary: [] }] } } }
+        };
+        expect(isALPManifestTarget(target)).toBe(false);
+    });
+
+    test('returns true when one of multiple paths entries has a primary array', () => {
+        const target: FEV4ManifestTarget = {
+            name: 'sap.fe.templates.ListReport',
+            options: {
+                settings: {
+                    views: {
+                        paths: [
+                            { secondary: [{ annotationPath: 'com.sap.vocabularies.UI.v1.LineItem' }] },
+                            { primary: [{ annotationPath: 'com.sap.vocabularies.UI.v1.Chart' }] }
+                        ]
+                    }
+                }
+            }
+        };
+        expect(isALPManifestTarget(target)).toBe(true);
+    });
+});
+
+describe('isALPFromManifest()', () => {
+    test('returns true when the specified target is an ALP ListReport', () => {
+        expect(isALPFromManifest(ALP_MANIFEST, 'SalesOrderManageList')).toBe(true);
+    });
+
+    test('returns false when the specified target is an ObjectPage (not ListReport)', () => {
+        expect(isALPFromManifest(ALP_MANIFEST, 'SalesOrderManageObjectPage')).toBe(false);
+    });
+
+    test('returns true when no targetKey given and at least one ListReport target is ALP', () => {
+        expect(isALPFromManifest(ALP_MANIFEST)).toBe(true);
+    });
+
+    test('returns false when the specified target is a non-ALP ListReport', () => {
+        expect(isALPFromManifest(LR_MANIFEST, 'OrdersList')).toBe(false);
+    });
+
+    test('returns false when no targetKey given and no ListReport targets are ALP', () => {
+        expect(isALPFromManifest(LR_MANIFEST)).toBe(false);
+    });
+
+    test('returns false when manifest has no routing targets', () => {
+        const manifest = { 'sap.app': { id: 'test', type: 'application', applicationVersion: { version: '0.0.1' } } } as unknown as Manifest;
+        expect(isALPFromManifest(manifest)).toBe(false);
+    });
+
+    test('returns false when specified target key does not exist in manifest', () => {
+        expect(isALPFromManifest(ALP_MANIFEST, 'NonExistentTarget')).toBe(false);
+    });
+});
+
+describe('getListReportFeatures() isALP integration', () => {
+    const minimalPage: PageWithModelV4 = {
+        name: 'SalesOrderManageList',
+        model: {
+            root: {
+                aggregations: {
+                    filterBar: { aggregations: {} } as unknown as TreeAggregation,
+                    table: { aggregations: {} } as unknown as TreeAggregation
+                }
+            } as unknown as TreeAggregation
+        } as unknown as TreeModel
+    };
+
+    test('sets isALP true when manifest identifies the page as ALP', () => {
+        const result = getListReportFeatures(minimalPage, undefined, undefined, ALP_MANIFEST);
+        expect(result.isALP).toBe(true);
+    });
+
+    test('sets isALP false when manifest has no ALP configuration for the page', () => {
+        const page: PageWithModelV4 = { ...minimalPage, name: 'OrdersList' };
+        const result = getListReportFeatures(page, undefined, undefined, LR_MANIFEST);
+        expect(result.isALP).toBe(false);
+    });
+
+    test('sets isALP false when no manifest is provided', () => {
+        const result = getListReportFeatures(minimalPage);
+        expect(result.isALP).toBe(false);
     });
 });

--- a/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
@@ -1686,7 +1686,9 @@ describe('isALPFromManifest()', () => {
     });
 
     test('returns false when manifest has no routing targets', () => {
-        const manifest = { 'sap.app': { id: 'test', type: 'application', applicationVersion: { version: '0.0.1' } } } as unknown as Manifest;
+        const manifest = {
+            'sap.app': { id: 'test', type: 'application', applicationVersion: { version: '0.0.1' } }
+        } as unknown as Manifest;
         expect(isALPFromManifest(manifest)).toBe(false);
     });
 

--- a/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
@@ -4,10 +4,17 @@ import {
     spliceModulesIntoQUnitContent,
     splicePageIntoJourneyRunner,
     readHtmlTargetFromQUnitJs,
-    addIntegrationOldToGitignore
+    addIntegrationOldToGitignore,
+    hasVirtualOPA5
 } from '../../../src/utils/opaQUnitUtils';
 import { join } from 'node:path';
 import type { Editor } from 'mem-fs-editor';
+import { getAllUi5YamlFileNames, readUi5Yaml } from '@sap-ux/project-access';
+
+jest.mock('@sap-ux/project-access', () => ({
+    getAllUi5YamlFileNames: jest.fn(),
+    readUi5Yaml: jest.fn()
+}));
 
 /**
  * Matches the actual template output: the last entry has no trailing newline
@@ -477,5 +484,123 @@ describe('addPagesToJourneyRunner()', () => {
             addPagesToJourneyRunner([{ targetKey: 'NewPage', appPath: 'myApp' }], testOutDirPath, fs);
         }).not.toThrow();
         expect(fs.write).not.toHaveBeenCalled();
+    });
+});
+
+describe('MAX_FILE_CONTENT_LENGTH guard', () => {
+    test('spliceModulesIntoQUnitContent returns content unchanged when it exceeds the limit', () => {
+        const oversized = BASE_FILE + ' '.repeat(10_001);
+        const result = spliceModulesIntoQUnitContent(oversized, ['myApp/test/integration/NewJourney']);
+        expect(result).toBe(oversized);
+    });
+
+    test('splicePageIntoJourneyRunner returns content unchanged when it exceeds the limit', () => {
+        const oversized = JOURNEY_RUNNER_FILE + ' '.repeat(10_001);
+        const result = splicePageIntoJourneyRunner(oversized, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+        expect(result).toBe(oversized);
+    });
+
+    test('addPathsToQUnitJs does not write when file content exceeds the limit', () => {
+        const oversized = BASE_FILE + ' '.repeat(10_001);
+        const fs = {
+            read: jest.fn().mockReturnValue(oversized),
+            write: jest.fn()
+        } as unknown as Editor;
+        addPathsToQUnitJs(['myApp/test/integration/NewJourney'], join('/', 'project', 'webapp', 'test'), fs);
+        expect(fs.write).not.toHaveBeenCalled();
+    });
+});
+
+describe('hasVirtualOPA5()', () => {
+    const mockGetAllUi5YamlFileNames = getAllUi5YamlFileNames as jest.MockedFunction<typeof getAllUi5YamlFileNames>;
+    const mockReadUi5Yaml = readUi5Yaml as jest.MockedFunction<typeof readUi5Yaml>;
+    const basePath = join('/', 'project');
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('returns true when a yaml file has a fiori-tools-preview middleware with OPA5 framework', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue({
+                configuration: { test: [{ framework: 'OPA5', path: '/test/opaTests.qunit.html' }] }
+            })
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(true);
+    });
+
+    test('returns false when no yaml file has OPA5 configured', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue({
+                configuration: { test: [{ framework: 'KARMA', path: '/test/karma.html' }] }
+            })
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(false);
+    });
+
+    test('returns false when fiori-tools-preview middleware has no test array', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue({ configuration: {} })
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(false);
+    });
+
+    test('returns false when fiori-tools-preview middleware is not present', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue(undefined)
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(false);
+    });
+
+    test('returns false when no yaml files are found', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue([]);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(false);
+    });
+
+    test('skips yaml files that throw and continues checking remaining files', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5-bad.yaml', 'ui5.yaml']);
+        mockReadUi5Yaml
+            .mockRejectedValueOnce(new Error('Cannot parse'))
+            .mockResolvedValueOnce({
+                findCustomMiddleware: jest.fn().mockReturnValue({
+                    configuration: { test: [{ framework: 'OPA5' }] }
+                })
+            } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(true);
+    });
+
+    test('returns true when OPA5 is in a test array alongside other frameworks', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue({
+                configuration: {
+                    test: [{ framework: 'KARMA' }, { framework: 'OPA5' }, { framework: 'QUnit' }]
+                }
+            })
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(true);
+    });
+
+    test('returns true on the first yaml that has OPA5 without reading further files', async () => {
+        mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5.yaml', 'ui5-mock.yaml']);
+        mockReadUi5Yaml.mockResolvedValue({
+            findCustomMiddleware: jest.fn().mockReturnValue({
+                configuration: { test: [{ framework: 'OPA5' }] }
+            })
+        } as any);
+
+        expect(await hasVirtualOPA5(basePath)).toBe(true);
+        expect(mockReadUi5Yaml).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
@@ -139,6 +139,32 @@ describe('spliceModulesIntoQUnitContent()', () => {
         expect(result).toContain('"myApp/test/integration/NewJourney",');
     });
 
+    test('adds a trailing comma to last existing entry when it is missing (real-world file format)', () => {
+        // Matches the actual generated file: last entry has no trailing comma, no trailing newline before `]`
+        const fileWithNoTrailingComma = `sap.ui.require(
+  [
+    "sap/ui/thirdparty/qunit-2",
+    "sap/ui/qunit/qunit-junit",
+    "sap/ui/qunit/qunit-coverage",
+    'myApp/test/integration/FirstJourney'
+  ], function (QUnit) {
+    "use strict";
+    QUnit.start();
+});
+`;
+        const result = spliceModulesIntoQUnitContent(fileWithNoTrailingComma, ['myApp/test/integration/NewJourney']);
+
+        // Last existing entry must now have a trailing comma
+        expect(result).toContain("'myApp/test/integration/FirstJourney',");
+        // New entry must also have a trailing comma
+        expect(result).toContain('"myApp/test/integration/NewJourney",');
+        // No blank line between the two entries
+        const lines = result.split('\n');
+        const firstJourneyIdx = lines.findIndex((l) => l.includes('FirstJourney'));
+        const newJourneyIdx = lines.findIndex((l) => l.includes('NewJourney'));
+        expect(newJourneyIdx).toBe(firstJourneyIdx + 1);
+    });
+
     test('inserts on its own line when array body has no trailing newline (template format)', () => {
         const result = spliceModulesIntoQUnitContent(TEMPLATE_FILE, ['myApp/test/integration/NewJourney']);
 

--- a/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
@@ -1,6 +1,8 @@
 import {
     addPathsToQUnitJs,
+    addPagesToJourneyRunner,
     spliceModulesIntoQUnitContent,
+    splicePageIntoJourneyRunner,
     readHtmlTargetFromQUnitJs,
     addIntegrationOldToGitignore
 } from '../../../src/utils/opaQUnitUtils';
@@ -306,6 +308,174 @@ describe('addIntegrationOldToGitignore()', () => {
         const fs = makeFsMock(`node_modules/\n${ENTRY}`) as unknown as Editor;
         await addIntegrationOldToGitignore(projectBasePath, fs);
 
+        expect(fs.write).not.toHaveBeenCalled();
+    });
+});
+
+/** Realistic JourneyRunner.js with tab indentation (matching the LropVirtualTests template) */
+const JOURNEY_RUNNER_FILE = `sap.ui.define([
+    "sap/fe/test/JourneyRunner",
+\t"myApp/test/integration/pages/TravelList",
+\t"myApp/test/integration/pages/TravelObjectPage"
+], function (JourneyRunner, TravelList, TravelObjectPage) {
+    'use strict';
+
+    var runner = new JourneyRunner({
+        launchUrl: sap.ui.require.toUrl('myApp') + '/test/flp.html#app-preview',
+        pages: {
+\t\t\tonTheTravelList: TravelList,
+\t\t\tonTheTravelObjectPage: TravelObjectPage
+        },
+        async: true
+    });
+
+    return runner;
+});
+`;
+
+describe('splicePageIntoJourneyRunner()', () => {
+    test('returns file unchanged when all pages already exist', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [
+            { targetKey: 'TravelList', appPath: 'myApp' },
+            { targetKey: 'TravelObjectPage', appPath: 'myApp' }
+        ]);
+
+        expect(result).toBe(JOURNEY_RUNNER_FILE);
+    });
+
+    test('returns file unchanged when pages array is empty', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, []);
+        expect(result).toBe(JOURNEY_RUNNER_FILE);
+    });
+
+    test('adds a new page to all three locations', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        // 1. define array
+        expect(result).toContain('"myApp/test/integration/pages/NewPage",');
+        // 2. function params
+        expect(result).toContain(', NewPage');
+        // 3. pages object
+        expect(result).toContain('onTheNewPage: NewPage,');
+    });
+
+    test('adds a trailing comma to the last existing define entry when missing', () => {
+        // JOURNEY_RUNNER_FILE has TravelObjectPage without a trailing comma in the define array
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        expect(result).toContain('"myApp/test/integration/pages/TravelObjectPage",');
+    });
+
+    test('adds a trailing comma to the last existing pages entry when missing', () => {
+        // JOURNEY_RUNNER_FILE has onTheTravelObjectPage without a trailing comma
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        expect(result).toContain('onTheTravelObjectPage: TravelObjectPage,');
+    });
+
+    test('skips pages already present when adding new ones', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [
+            { targetKey: 'TravelList', appPath: 'myApp' }, // already present
+            { targetKey: 'NewPage', appPath: 'myApp' } // new
+        ]);
+
+        // New page must appear
+        expect(result).toContain('"myApp/test/integration/pages/NewPage",');
+        // Existing page must not be duplicated
+        const count = (result.match(/"myApp\/test\/integration\/pages\/TravelList"/g) ?? []).length;
+        expect(count).toBe(1);
+    });
+
+    test('adds multiple new pages to all three locations', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [
+            { targetKey: 'PageA', appPath: 'myApp' },
+            { targetKey: 'PageB', appPath: 'myApp' }
+        ]);
+
+        expect(result).toContain('"myApp/test/integration/pages/PageA",');
+        expect(result).toContain('"myApp/test/integration/pages/PageB",');
+        expect(result).toContain('onThePageA: PageA,');
+        expect(result).toContain('onThePageB: PageB,');
+        expect(result).toContain(', PageA');
+        expect(result).toContain(', PageB');
+    });
+
+    test('preserves all content outside the patched locations', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        expect(result).toContain("launchUrl: sap.ui.require.toUrl('myApp') + '/test/flp.html#app-preview'");
+        expect(result).toContain("'use strict';");
+        expect(result).toContain('async: true');
+        expect(result).toContain('return runner;');
+    });
+
+    test('new define entries use same indentation as existing entries', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        const lines = result.split('\n');
+        const newDefineLine = lines.find((l) => l.includes('pages/NewPage'));
+        // The first entry in the define array uses 4-space indentation ("sap/fe/test/JourneyRunner")
+        // so new entries inherit the same 4-space indent
+        expect(newDefineLine).toMatch(/^ {4}"/);
+    });
+
+    test('new page object entries use same indentation as existing entries', () => {
+        const result = splicePageIntoJourneyRunner(JOURNEY_RUNNER_FILE, [{ targetKey: 'NewPage', appPath: 'myApp' }]);
+
+        const lines = result.split('\n');
+        const newPageLine = lines.find((l) => l.includes('onTheNewPage'));
+        expect(newPageLine).toMatch(/^\t\t\t/);
+    });
+});
+
+describe('addPagesToJourneyRunner()', () => {
+    const testOutDirPath = join('/', 'project', 'webapp', 'test');
+    const expectedFilePath = join(testOutDirPath, 'integration', 'pages', 'JourneyRunner.js');
+
+    function makeFsMock(content: string): jest.Mocked<Pick<Editor, 'read' | 'write'>> {
+        return {
+            read: jest.fn().mockReturnValue(content),
+            write: jest.fn()
+        };
+    }
+
+    test('reads JourneyRunner.js from the testOutDirPath and writes updated content', () => {
+        const fs = makeFsMock(JOURNEY_RUNNER_FILE) as unknown as Editor;
+        addPagesToJourneyRunner([{ targetKey: 'NewPage', appPath: 'myApp' }], testOutDirPath, fs);
+
+        expect(fs.read).toHaveBeenCalledWith(expectedFilePath);
+        expect(fs.write).toHaveBeenCalledWith(
+            expectedFilePath,
+            expect.stringContaining('"myApp/test/integration/pages/NewPage",')
+        );
+    });
+
+    test('does not write when all pages are already present', () => {
+        const fs = makeFsMock(JOURNEY_RUNNER_FILE) as unknown as Editor;
+        addPagesToJourneyRunner(
+            [
+                { targetKey: 'TravelList', appPath: 'myApp' },
+                { targetKey: 'TravelObjectPage', appPath: 'myApp' }
+            ],
+            testOutDirPath,
+            fs
+        );
+
+        expect(fs.read).toHaveBeenCalledWith(expectedFilePath);
+        expect(fs.write).not.toHaveBeenCalled();
+    });
+
+    test('does not throw when JourneyRunner.js does not exist', () => {
+        const fs = {
+            read: jest.fn().mockImplementation(() => {
+                throw new Error('File not found');
+            }),
+            write: jest.fn()
+        } as unknown as Editor;
+
+        expect(() => {
+            addPagesToJourneyRunner([{ targetKey: 'NewPage', appPath: 'myApp' }], testOutDirPath, fs);
+        }).not.toThrow();
         expect(fs.write).not.toHaveBeenCalled();
     });
 });

--- a/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
@@ -294,6 +294,17 @@ describe('readHtmlTargetFromQUnitJs()', () => {
         expect(readHtmlTargetFromQUnitJs(testPath, fs)).toBe('test/sandbox.html#app-tile');
         expect(fs.read).toHaveBeenCalledWith(opaPath);
     });
+
+    test('returns undefined when fs.read throws', () => {
+        const fs = {
+            exists: jest.fn().mockReturnValue(true),
+            read: jest.fn().mockImplementation(() => {
+                throw new Error('Permission denied');
+            })
+        } as unknown as Editor;
+
+        expect(readHtmlTargetFromQUnitJs(testPath, fs)).toBeUndefined();
+    });
 });
 
 describe('addIntegrationOldToGitignore()', () => {

--- a/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/opaQUnitUtils.test.ts
@@ -568,13 +568,11 @@ describe('hasVirtualOPA5()', () => {
 
     test('skips yaml files that throw and continues checking remaining files', async () => {
         mockGetAllUi5YamlFileNames.mockResolvedValue(['ui5-bad.yaml', 'ui5.yaml']);
-        mockReadUi5Yaml
-            .mockRejectedValueOnce(new Error('Cannot parse'))
-            .mockResolvedValueOnce({
-                findCustomMiddleware: jest.fn().mockReturnValue({
-                    configuration: { test: [{ framework: 'OPA5' }] }
-                })
-            } as any);
+        mockReadUi5Yaml.mockRejectedValueOnce(new Error('Cannot parse')).mockResolvedValueOnce({
+            findCustomMiddleware: jest.fn().mockReturnValue({
+                configuration: { test: [{ framework: 'OPA5' }] }
+            })
+        } as any);
 
         expect(await hasVirtualOPA5(basePath)).toBe(true);
     });


### PR DESCRIPTION
Internal issue 37946

### Fix: App Info Generation Improvements in `ui5-test-writer`

### Bug Fix

🐛 This patch addresses several bugs and gaps in the OPA test generation logic for Fiori Elements apps, particularly around app info generation, ALP (Analytical List Page) detection, and correct handling of page objects and the `JourneyRunner.js` file during standalone upgrades.

### Changes

* `fiori-elements-opa-writer.ts`: Refactored `generateOPAFiles` to be declared earlier in the file and updated it to pass the manifest to `getAppFeatures`. Fixed a bug in the standalone path where `hasJourneyRunner = false` was incorrectly passed as `true` to `writeJourneyFiles`. Added a new `ensurePageExists` helper that creates missing page object files and returns a `JourneyRunnerPage` entry. In `writeJourneyFiles`, newly created page objects are now collected and spliced into `JourneyRunner.js` via `addPagesToJourneyRunner`.

* `types.ts`: Extended `FEV4ManifestTarget` to include the `views.paths` configuration used by Analytical List Pages (ALP). Added `isALP` flag to `ListReportFeatures`.

* `listReportUtils.ts`: Added `isALPManifestTarget` and `isALPFromManifest` utility functions to detect ALP configuration from manifest routing targets. Updated `getListReportFeatures` to accept an optional `manifest` parameter and populate the `isALP` field.

* `modelUtils.ts`: Passed the `manifest` argument through to `getListReportFeatures` so ALP detection works end-to-end.

* `opaQUnitUtils.ts`: Fixed the `SAP_UI_REQUIRE_ARRAY_REGEX` to use a non-backtracking character class (`[^\]]*`) as a ReDoS mitigation. Added `MAX_FILE_CONTENT_LENGTH` guard. Introduced `splicePageIntoJourneyRunner` and `addPagesToJourneyRunner` to update the define array, function parameters, and pages object of an existing `JourneyRunner.js`.

* `ListReportJourney.js` (template): Suppresses the "create button" assertion when the page is an ALP (`!isALP`).

* `ObjectPageJourney.js` (template): Restricts the "Check body sections" test to non-standalone runs (`!isStandalone`), removing a redundant `if (!isStandalone)` guard that was previously nested inside the block.

* `listReportUtils.test.ts`: Added comprehensive unit tests for `isALPManifestTarget`, `isALPFromManifest`, and the `isALP` integration in `getListReportFeatures`.

* `opaQUnitUtils.test.ts`: Added tests for `splicePageIntoJourneyRunner`, `addPagesToJourneyRunner`, `MAX_FILE_CONTENT_LENGTH` guard, and `hasVirtualOPA5`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `fd18a241-98b7-44ae-a907-885c3f6fefa0`
</details>
