### PR TITLE
fix(generator-adp): Change endpoint used for checking user authentication

### DIFF
--- a/.changeset/pink-buckets-sort.md
+++ b/.changeset/pink-buckets-sort.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/generator-adp": patch
+---
+
+fix(generator-adp): Change endpoint used for checking user authentication

--- a/packages/generator-adp/src/base/questions/credentials.ts
+++ b/packages/generator-adp/src/base/questions/credentials.ts
@@ -93,8 +93,8 @@ function getPasswordPrompt(abapTarget: AbapTarget, logger: ToolsLogger): Passwor
 
 /**
  * Helper function which asserts whether a client is authenticated on an ABAP system or throws.
- * Since we do not have a dedicated api call to detect if a client is authenticated we use the
- * {@link LayeredRepositoryService.getSystemInfo} call which is a protected one.
+ * Uses {@link LayeredRepositoryService.getCsrfToken} which is available on all ABAP system versions
+ * and returns 401 when credentials are invalid.
  *
  * @param {ClientCredentials} credentials - Object containing client credentials to a specific ABAP system.
  * @param {ToolsLogger} logger - The logger instance.
@@ -104,5 +104,5 @@ function getPasswordPrompt(abapTarget: AbapTarget, logger: ToolsLogger): Passwor
 async function assertAuthenticated(credentials: ClientCredentials, logger: ToolsLogger): Promise<void> {
     const abapProvider = await getConfiguredProvider(credentials, logger);
     const layeredRepositoryService = abapProvider.getLayeredRepository();
-    await layeredRepositoryService.getSystemInfo();
+    await layeredRepositoryService.getCsrfToken();
 }

--- a/packages/generator-adp/src/base/questions/credentials.ts
+++ b/packages/generator-adp/src/base/questions/credentials.ts
@@ -92,9 +92,8 @@ function getPasswordPrompt(abapTarget: AbapTarget, logger: ToolsLogger): Passwor
 }
 
 /**
- * Helper function which asserts whether a client is authenticated on an ABAP system or throws.
- * Uses {@link LayeredRepositoryService.getCsrfToken} which is available on all ABAP system versions
- * and returns 401 when credentials are invalid.
+ * Since we do not have a dedicated api call to detect if a client is authenticated we use the
+ * {@link LayeredRepositoryService.getCsrfToken} call which is a protected one.
  *
  * @param {ClientCredentials} credentials - Object containing client credentials to a specific ABAP system.
  * @param {ToolsLogger} logger - The logger instance.

--- a/packages/generator-adp/test/unit/base/questions/credentials.test.ts
+++ b/packages/generator-adp/test/unit/base/questions/credentials.test.ts
@@ -110,14 +110,14 @@ describe('Credentials Prompts', () => {
 
     describe('Password Prompt', () => {
         let passwordPrompt: any;
-        let mockGetSystemInfo: jest.Mock;
+        let mockGetCsrfToken: jest.Mock;
 
         beforeEach(() => {
             const result = getCredentialsPrompts(mockAbapTarget, mockLogger);
             passwordPrompt = result[1];
-            mockGetSystemInfo = jest.fn();
+            mockGetCsrfToken = jest.fn();
             mockGetConfiguredProvider.mockResolvedValue({
-                getLayeredRepository: () => ({ getSystemInfo: mockGetSystemInfo })
+                getLayeredRepository: () => ({ getCsrfToken: mockGetCsrfToken })
             } as unknown as AbapServiceProvider);
         });
 
@@ -139,7 +139,7 @@ describe('Credentials Prompts', () => {
             mockIsAppStudio.mockReturnValue(false);
             mockAbapTarget.url = 'some-system';
             mockValidateEmptyString.mockReturnValue(true);
-            mockGetSystemInfo.mockResolvedValue({});
+            mockGetCsrfToken.mockResolvedValue({});
 
             const prompts = getCredentialsPrompts(mockAbapTarget, mockLogger);
             const passwordPrompt = prompts[1];
@@ -159,7 +159,7 @@ describe('Credentials Prompts', () => {
                 },
                 mockLogger
             );
-            expect(mockGetSystemInfo).toHaveBeenCalled();
+            expect(mockGetCsrfToken).toHaveBeenCalled();
             expect(result).toBe(true);
         });
 
@@ -167,7 +167,7 @@ describe('Credentials Prompts', () => {
             mockIsAppStudio.mockReturnValue(true);
             mockAbapTarget.destination = 'SYS_010';
             mockValidateEmptyString.mockReturnValue(true);
-            mockGetSystemInfo.mockResolvedValue({});
+            mockGetCsrfToken.mockResolvedValue({});
 
             const prompts = getCredentialsPrompts(mockAbapTarget, mockLogger);
             const passwordPrompt = prompts[1];
@@ -187,7 +187,7 @@ describe('Credentials Prompts', () => {
                 },
                 mockLogger
             );
-            expect(mockGetSystemInfo).toHaveBeenCalled();
+            expect(mockGetCsrfToken).toHaveBeenCalled();
             expect(result).toBe(true);
         });
 
@@ -230,7 +230,7 @@ describe('Credentials Prompts', () => {
                     statusText: 'Unauthorized'
                 }
             };
-            mockGetSystemInfo.mockRejectedValue(mockError);
+            mockGetCsrfToken.mockRejectedValue(mockError);
 
             const prompts = getCredentialsPrompts(mockAbapTarget, mockLogger);
             const passwordPrompt = prompts[1];


### PR DESCRIPTION
#4583

* Changed LREP endpoint used for authentication validation from `System Info` endpoint to `Get CSRF Token` endpoint.