### PR TITLE
feat: add fiori skills

### DIFF
--- a/.changeset/fiori-skills-initial.md
+++ b/.changeset/fiori-skills-initial.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-skills": minor
+---
+
+feat(fiori-skills): add new package to install Fiori AI agent skills via npx

--- a/packages/fiori-skills/README.md
+++ b/packages/fiori-skills/README.md
@@ -1,0 +1,63 @@
+# @sap-ux/fiori-skills
+
+Install SAP Fiori AI agent skills to your local skills directory.
+
+## Overview
+
+This package bundles a set of AI agent skills for SAP Fiori development and provides a CLI to copy them into your local skills directory (default: `~/.agents/skills`).
+
+Once installed, the skills are available to any AI agent client that reads from that directory (e.g. Claude Code, Cursor, and other agentskills.io-compatible clients).
+
+## Bundled Skills
+
+| Skill | Description |
+|---|---|
+| `fiori-eslint-setup` | Set up ESLint with `@sap-ux/eslint-plugin-fiori-tools` for a new Fiori or CAP project |
+| `fiori-eslint-migrate` | Migrate a legacy `.eslintrc` config to ESLint 9 flat config format |
+| `fiori-eslint-lint` | Run ESLint on a Fiori project and report or auto-fix issues |
+
+## Usage
+
+### Install skills to the default path (`~/.agents/skills`)
+
+```bash
+npx @sap-ux/fiori-skills
+```
+
+### Install skills to a custom path
+
+```bash
+npx @sap-ux/fiori-skills /path/to/your/skills
+```
+
+### Example output
+
+```
+Installing 3 Fiori skill(s) to: /Users/you/.agents/skills
+
+  installed: fiori-eslint-lint
+  installed: fiori-eslint-migrate
+  installed: fiori-eslint-setup
+
+Done. Skills are ready to use in your AI agent client.
+```
+
+Re-running the command on an existing installation updates the skills in place:
+
+```
+Installing 3 Fiori skill(s) to: /Users/you/.agents/skills
+
+  updated: fiori-eslint-lint
+  updated: fiori-eslint-migrate
+  updated: fiori-eslint-setup
+
+Done. Skills are ready to use in your AI agent client.
+```
+
+## Skill format
+
+Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and a markdown body following the [agentskills.io](https://agentskills.io) format. The frontmatter declares the skill name, description, and compatibility, and the body contains step-by-step instructions the agent follows at runtime.
+
+## License
+
+Apache-2.0

--- a/packages/fiori-skills/eslint.config.js
+++ b/packages/fiori-skills/eslint.config.js
@@ -1,0 +1,15 @@
+const base = require('../../eslint.config.js');
+const { tsParser } = require('typescript-eslint');
+
+module.exports = [
+    ...base,
+    {
+        languageOptions: {
+            parserOptions: {
+                parser: tsParser,
+                tsconfigRootDir: __dirname,
+                project: './tsconfig.eslint.json'
+            }
+        }
+    }
+];

--- a/packages/fiori-skills/jest.config.js
+++ b/packages/fiori-skills/jest.config.js
@@ -1,0 +1,4 @@
+const config = require('../../jest.base');
+// Exclude CLI entry shim from coverage — it is tested via bin invocation, not unit tests
+config.coveragePathIgnorePatterns = ['<rootDir>/src/index.ts'];
+module.exports = config;

--- a/packages/fiori-skills/package.json
+++ b/packages/fiori-skills/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@sap-ux/fiori-skills",
+    "version": "0.1.0",
+    "description": "Install SAP Fiori AI agent skills to your local skills directory",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/SAP/open-ux-tools.git",
+        "directory": "packages/fiori-skills"
+    },
+    "license": "Apache-2.0",
+    "bin": {
+        "fiori-skills": "dist/index.js"
+    },
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "rimraf --glob dist coverage *.tsbuildinfo",
+        "lint": "eslint",
+        "lint:fix": "eslint --fix",
+        "test": "jest --ci --forceExit --detectOpenHandles --colors"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "rimraf": "6.0.1"
+    },
+    "files": [
+        "dist",
+        "skills",
+        "README.md",
+        "package.json"
+    ],
+    "engines": {
+        "node": ">=20.x"
+    }
+}

--- a/packages/fiori-skills/skills/fiori-eslint-lint/SKILL.md
+++ b/packages/fiori-skills/skills/fiori-eslint-lint/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: fiori-eslint-lint
+description: Run ESLint on a SAP Fiori project and report results or auto-fix issues using @sap-ux/eslint-plugin-fiori-tools. Use when the user asks to lint, check code quality, fix ESLint errors, or run code style checks on a Fiori app.
+compatibility: Requires Node.js and an eslint.config.mjs configured with @sap-ux/eslint-plugin-fiori-tools. If not configured, use the fiori-eslint-setup skill first.
+metadata:
+  author: sap-ux
+  version: "1.0"
+---
+
+# Fiori ESLint Lint & Fix
+
+Run ESLint on a SAP Fiori project to check code quality and optionally auto-fix issues.
+
+## Step 1 — Verify ESLint is configured
+
+Before running lint, check that an ESLint config exists:
+
+```bash
+ls eslint.config.mjs eslint.config.js eslint.config.cjs 2>/dev/null
+```
+
+For CAP projects, check app subfolders:
+```bash
+find . -name "eslint.config.mjs" -not -path "*/node_modules/*" 2>/dev/null
+```
+
+**If no config is found**: Use the `fiori-eslint-setup` skill first to create one, then return here.
+
+## Step 2 — Locate the app to lint
+
+Determine which directory to lint:
+
+- **Standalone Fiori app**: `webapp/` at the project root
+- **CAP project**: Each app under `app/<app-name>/webapp/`
+
+For CAP projects, list available apps:
+```bash
+ls app/ 2>/dev/null
+find app -name "manifest.json" -not -path "*/node_modules/*" 2>/dev/null
+```
+
+If the user specified a particular app or path, use that. Otherwise lint the detected location.
+
+## Step 3 — Run lint (check mode)
+
+Run ESLint to report issues without modifying files:
+
+### Standalone Fiori app:
+```bash
+npx eslint webapp/
+```
+
+### CAP project — specific app:
+```bash
+# Run from the app subfolder (where eslint.config.mjs is)
+cd app/<app-name> && npx eslint webapp/
+```
+
+### CAP project — all apps:
+```bash
+# Find and lint each app that has its own eslint.config.mjs
+find app -name "eslint.config.mjs" -not -path "*/node_modules/*" | while read config; do
+  appdir=$(dirname "$config")
+  echo "=== Linting $appdir ==="
+  (cd "$appdir" && npx eslint webapp/ 2>&1)
+done
+```
+
+### With detailed output format:
+```bash
+# More readable output with file/line references
+npx eslint webapp/ --format stylish
+```
+
+## Step 4 — Interpret the output
+
+ESLint output shows:
+- **Errors** (`error`): Must be fixed — these violate required Fiori coding standards
+- **Warnings** (`warning`): Should be reviewed — best practice suggestions
+
+Example output:
+```
+/path/to/webapp/controller/App.controller.js
+  12:5  error    Local storage must not be used  @sap-ux/fiori-tools/sap-no-localstorage
+  24:1  warning  DOM access is not recommended   @sap-ux/fiori-tools/sap-no-dom-access
+
+✖ 2 problems (1 error, 1 warning)
+  0 errors and 0 warnings potentially fixable with the `--fix` option.
+```
+
+Summarize the results for the user:
+- Total errors and warnings
+- Which files are affected
+- The most common rule violations
+- Whether any issues are auto-fixable
+
+## Step 5 — Auto-fix issues (optional)
+
+Many ESLint rules support automatic fixing. Run with `--fix` to apply safe fixes:
+
+### Standalone:
+```bash
+npx eslint webapp/ --fix
+```
+
+### CAP — specific app:
+```bash
+cd app/<app-name> && npx eslint webapp/ --fix
+```
+
+**IMPORTANT**: The `--fix` flag modifies files in place. Before running:
+1. Confirm with the user that they want auto-fixes applied
+2. Recommend they have a clean git state or backup so fixes can be reviewed/reverted
+
+After fixing, show what changed:
+```bash
+git diff --stat webapp/ 2>/dev/null || echo "(git not available to show diff)"
+```
+
+## Step 6 — Handle unfixable issues
+
+Issues not fixed by `--fix` require manual code changes. For each unfixable error:
+
+1. Read the relevant source file
+2. Identify the problematic code pattern
+3. Suggest or apply the correct Fiori-compliant alternative
+
+### Common Fiori ESLint violations and fixes:
+
+| Rule | Problem | Fix |
+|---|---|---|
+| `sap-no-localstorage` | `localStorage.setItem(...)` | Use `sap.ui.util.Storage` instead |
+| `sap-no-sessionstorage` | `sessionStorage.getItem(...)` | Use `sap.ui.util.Storage` instead |
+| `sap-no-dom-access` | `document.getElementById(...)` | Use UI5 control APIs instead |
+| `sap-no-inner-html-write` | `element.innerHTML = ...` | Avoid; use UI5 controls for rendering |
+| `sap-no-global-variable` | Using undeclared globals | Declare in `globals` config or import |
+| `sap-no-hardcoded-url` | Hardcoded absolute URLs | Use relative paths or manifest datasources |
+| `sap-no-navigator` | `navigator.userAgent` | Avoid browser detection; use UI5 APIs |
+| `sap-flex-enabled` | Missing `flexEnabled: true` in manifest | Add `"flexEnabled": true` to `sap.ui5` section |
+
+## Step 7 — Report summary
+
+After linting (and optional fixing), provide a clear summary:
+
+```
+ESLint Results for webapp/:
+- X errors found (N auto-fixed, M require manual fix)
+- Y warnings found (P auto-fixed, Q require manual fix)
+- Files with issues: [list key files]
+- Most common violations: [top 3 rules]
+```
+
+If everything is clean:
+```
+✅ No ESLint issues found in webapp/
+```
+
+## Tips
+
+- Run `npx eslint webapp/ --fix-dry-run` to preview what auto-fixes would change without applying them
+- Use `npx eslint webapp/ --rule '@sap-ux/fiori-tools/sap-no-localstorage: error'` to check a single rule
+- Add `// eslint-disable-next-line @sap-ux/fiori-tools/<rule-name>` to suppress a specific rule on one line when a violation is intentional and documented
+- The `recommended-for-s4hana` config also lints `manifest.json`, `*.xml`, and `*.cds` files — use `npx eslint .` (not just `webapp/`) to catch annotation issues

--- a/packages/fiori-skills/skills/fiori-eslint-migrate/SKILL.md
+++ b/packages/fiori-skills/skills/fiori-eslint-migrate/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: fiori-eslint-migrate
+description: Migrate a SAP Fiori project from legacy ESLint (eslint@8, .eslintrc, eslint-plugin-fiori-custom, or @sap-ux/eslint-plugin-fiori-tools@0.6.x) to ESLint 9+ flat config using @sap-ux/eslint-plugin-fiori-tools@9+. Use when the user has an old .eslintrc file, mentions migration, upgrading ESLint, or sees errors about unsupported ESLint config format.
+compatibility: Requires Node.js with npm, pnpm, or yarn. Project must have an existing ESLint configuration.
+metadata:
+  author: sap-ux
+  version: "1.0"
+---
+
+# Fiori ESLint Migration to ESLint 9 Flat Config
+
+Migrate from legacy ESLint config (`.eslintrc`, `eslintrc.js`, `eslint@8`, `eslint-plugin-fiori-custom`) to ESLint 9+ flat config using `@sap-ux/eslint-plugin-fiori-tools@9+`.
+
+## Step 1 — Detect what needs migrating
+
+Scan the project for legacy ESLint artifacts:
+
+```bash
+# Check for legacy config files
+ls .eslintrc .eslintrc.js .eslintrc.cjs .eslintrc.json .eslintrc.yml .eslintrc.yaml 2>/dev/null
+
+# Check for .eslintignore
+ls .eslintignore 2>/dev/null
+
+# Check current ESLint and plugin versions
+cat package.json | grep -E '"eslint"|"fiori-custom"|"eslint-plugin-fiori"'
+```
+
+For CAP projects, also check each app subfolder:
+```bash
+find . -name ".eslintrc*" -not -path "*/node_modules/*" 2>/dev/null
+find app -name "package.json" -not -path "*/node_modules/*" | xargs grep -l "eslint" 2>/dev/null
+```
+
+## Step 2 — Use the automatic migration tool (recommended)
+
+The `@sap-ux/create` tool can automatically migrate ESLint config. Run this from the app root (the folder containing `webapp/`):
+
+```bash
+npx --yes @sap-ux/create@latest convert eslint-config
+```
+
+For help and options:
+```bash
+npx --yes @sap-ux/create@latest convert eslint-config --help
+```
+
+**What the tool does automatically:**
+1. Creates `eslint.config.mjs` with the flat config format
+2. Migrates ignore patterns from `.eslintignore`
+3. Updates `package.json` to ESLint 9 + `@sap-ux/eslint-plugin-fiori-tools@^9`
+4. Removes the old `.eslintrc*` file
+5. Removes the old `.eslintignore` file
+
+If the automatic tool succeeds, jump to Step 5 to verify.
+
+## Step 3 — Manual migration (if automatic tool fails or custom rules exist)
+
+### 3a. Create eslint.config.mjs
+
+The config file goes at the **app level** (next to `webapp/`):
+
+**Basic migration (was using `plugin:@sap-ux/eslint-plugin-fiori-tools/defaultJS`):**
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    ...fioriTools.configs.recommended
+];
+```
+
+**With custom ignores (migrate from .eslintignore):**
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    {
+        ignores: [
+            'dist',
+            'target',
+            'localService',
+            'backup'
+            // Add any other patterns from your old .eslintignore here
+        ]
+    },
+    ...fioriTools.configs.recommended
+];
+```
+
+**If the project had custom rules on top of the defaults:**
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    ...fioriTools.configs.recommended,
+    {
+        rules: {
+            // Migrate any custom rule overrides here
+            // Old: "fiori-custom/sap-no-localstorage": "error"
+            // New: "@sap-ux/fiori-tools/sap-no-localstorage": "error"
+        }
+    }
+];
+```
+
+### 3b. Migrate rule references in source code
+
+If source files have ESLint disable comments using the old `fiori-custom/` prefix, update them:
+
+```bash
+# Find all references to old rule prefix
+grep -r "fiori-custom/" webapp/ --include="*.js" --include="*.ts" -l 2>/dev/null
+```
+
+Replace `fiori-custom/` with `@sap-ux/fiori-tools/`:
+
+Examples:
+- `// eslint-disable fiori-custom/sap-browser-api-warning` → `// eslint-disable @sap-ux/fiori-tools/sap-browser-api-warning`
+- `// eslint-disable-next-line fiori-custom/sap-no-localstorage` → `// eslint-disable-next-line @sap-ux/fiori-tools/sap-no-localstorage`
+
+### 3c. Delete legacy files
+
+After creating the new config, remove old files:
+```bash
+# Remove old config (adjust filename to match what was found)
+rm -f .eslintrc .eslintrc.js .eslintrc.cjs .eslintrc.json .eslintrc.yml .eslintrc.yaml
+
+# Remove .eslintignore (patterns are now in eslint.config.mjs)
+rm -f .eslintignore
+```
+
+## Step 4 — Update package.json dependencies
+
+Update `eslint` to version 9 and `@sap-ux/eslint-plugin-fiori-tools` to version 9+. Remove `eslint-plugin-fiori-custom` if present.
+
+Detect the package manager:
+```bash
+ls package-lock.json yarn.lock pnpm-lock.yaml 2>/dev/null
+```
+
+**npm:**
+```bash
+npm uninstall eslint-plugin-fiori-custom
+npm install --save-dev eslint@^9 @sap-ux/eslint-plugin-fiori-tools@^9
+```
+
+**pnpm:**
+```bash
+pnpm remove eslint-plugin-fiori-custom
+pnpm add --save-dev eslint@^9 @sap-ux/eslint-plugin-fiori-tools@^9
+```
+
+**yarn:**
+```bash
+yarn remove eslint-plugin-fiori-custom
+yarn add --dev eslint@^9 @sap-ux/eslint-plugin-fiori-tools@^9
+```
+
+**For CAP projects**: Run from the app subfolder if it has its own `package.json`, or from the root if packages are shared.
+
+## Step 5 — Verify the migration
+
+Run ESLint to confirm no configuration errors:
+
+```bash
+# Check config is valid (should print config JSON, not an error)
+npx eslint --print-config webapp/Component.js 2>&1 | head -5
+
+# Run lint on the webapp
+npx eslint webapp/ 2>&1 | head -40
+```
+
+If ESLint reports config errors, common fixes:
+- **"Cannot find module '@sap-ux/eslint-plugin-fiori-tools'"** → Plugin not installed, run install command from Step 4
+- **"FlatConfig is not supported"** → Using ESLint 8, upgrade to ESLint 9
+- **"Unknown rule"** → Old rule prefix still in use, check for remaining `fiori-custom/` references
+
+## What changed between ESLint 8 and 9
+
+| ESLint 8 (legacy) | ESLint 9 (flat config) |
+|---|---|
+| `.eslintrc` / `.eslintrc.js` | `eslint.config.mjs` |
+| `.eslintignore` | `ignores` array in config |
+| `extends: [...]` | Spread `...` configs into array |
+| `plugins: { "fiori-custom": ... }` | Included in `fioriTools.configs.recommended` |
+| `fiori-custom/` rule prefix | `@sap-ux/fiori-tools/` rule prefix |
+| `plugin:@sap-ux/.../defaultJS` | `fioriTools.configs.recommended` |

--- a/packages/fiori-skills/skills/fiori-eslint-setup/SKILL.md
+++ b/packages/fiori-skills/skills/fiori-eslint-setup/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: fiori-eslint-setup
+description: Set up ESLint for a SAP Fiori or CAP project using @sap-ux/eslint-plugin-fiori-tools. Use when a Fiori project is missing an eslint.config.mjs, when the user asks to configure or add ESLint, or when linting has never been set up. Handles standalone Fiori apps and CAP projects where Fiori apps live inside an app/ subfolder.
+compatibility: Requires Node.js with npm, pnpm, or yarn. Designed for SAP Fiori freestyle and Fiori elements projects.
+metadata:
+  author: sap-ux
+  version: "1.0"
+---
+
+# Fiori ESLint Setup
+
+Set up ESLint with `@sap-ux/eslint-plugin-fiori-tools` for a SAP Fiori or CAP project.
+
+## Step 1 — Detect project type and app location
+
+First, determine whether this is:
+- **Standalone Fiori app** — `webapp/manifest.json` exists at the project root
+- **CAP project** — `app/` folder exists containing one or more Fiori apps (each with their own `webapp/manifest.json`)
+
+```bash
+# Check for standalone Fiori app
+ls webapp/manifest.json 2>/dev/null && echo "standalone" || echo "not-standalone"
+
+# Check for CAP project with app folder
+ls app/ 2>/dev/null && echo "cap" || echo "not-cap"
+```
+
+## Step 2 — Determine the correct config location
+
+**IMPORTANT**: The `eslint.config.mjs` must be placed at the **app level**, not the CAP project root.
+
+| Project type | Config location |
+|---|---|
+| Standalone Fiori | `./eslint.config.mjs` (project root) |
+| CAP — single app | `./app/<app-name>/eslint.config.mjs` |
+| CAP — multiple apps | One `eslint.config.mjs` per app: `./app/<app-name>/eslint.config.mjs` |
+
+For CAP projects, list the apps:
+```bash
+ls app/
+```
+
+## Step 3 — Check if config already exists
+
+Before creating anything, check if a config already exists:
+
+```bash
+# Standalone
+ls eslint.config.mjs eslint.config.js .eslintrc .eslintrc.js .eslintrc.json .eslintrc.yml 2>/dev/null
+
+# CAP app level (replace <app-name> with actual app folder name)
+ls app/<app-name>/eslint.config.mjs app/<app-name>/.eslintrc 2>/dev/null
+```
+
+If a config already exists, inform the user and offer to:
+1. Leave it as-is (if it already uses `@sap-ux/eslint-plugin-fiori-tools`)
+2. Use the `fiori-eslint-migrate` skill to migrate it to flat config syntax
+
+## Step 4 — Determine the right configuration
+
+Ask the user (or infer from project context) which config variant to use:
+
+- **`recommended`** — For most Fiori freestyle and Fiori elements projects. Lints JS/TS in `webapp/`.
+- **`recommended-for-s4hana`** — For S/4HANA Fiori elements apps. Adds annotation validation for `manifest.json`, `*.xml`, and `*.cds` files.
+
+Use `recommended-for-s4hana` if you detect any of these signals:
+- Project has CDS files (`*.cds`)
+- `manifest.json` references `sap.fe.templates` or `sap.ovp`
+- User mentions "S/4HANA", "Fiori elements", or "annotations"
+
+## Step 5 — Check if the plugin is installed
+
+```bash
+# Check package.json for the plugin
+cat package.json | grep "eslint-plugin-fiori-tools"
+```
+
+If missing, install it. Choose the package manager the project uses:
+
+```bash
+# Detect package manager
+ls package-lock.json yarn.lock pnpm-lock.yaml 2>/dev/null
+```
+
+Install commands:
+```bash
+# npm
+npm install --save-dev @sap-ux/eslint-plugin-fiori-tools eslint
+
+# pnpm
+pnpm add --save-dev @sap-ux/eslint-plugin-fiori-tools eslint
+
+# yarn
+yarn add --dev @sap-ux/eslint-plugin-fiori-tools eslint
+```
+
+**Note**: For CAP projects, run the install command from the **app subfolder** that has its own `package.json`. If the app shares the root `package.json`, install at the root.
+
+## Step 6 — Create the eslint.config.mjs
+
+Create the config file at the location determined in Step 2.
+
+### Recommended config (standalone Fiori or CAP app):
+
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    ...fioriTools.configs.recommended
+];
+```
+
+### Recommended-for-S/4HANA config:
+
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    ...fioriTools.configs['recommended-for-s4hana']
+];
+```
+
+### With custom ignores (add if needed):
+
+```javascript
+import fioriTools from '@sap-ux/eslint-plugin-fiori-tools';
+
+export default [
+    {
+        ignores: ['dist', 'target', 'localService', 'backup']
+    },
+    ...fioriTools.configs.recommended
+];
+```
+
+## Step 7 — Add a lint script to package.json (optional)
+
+If the project's `package.json` has a `scripts` section but no `lint` script, offer to add one:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  }
+}
+```
+
+For CAP apps where the config is in a subfolder, the script should be run from within that subfolder or use the `--rule-dir` approach.
+
+## Step 8 — Verify the setup
+
+Run ESLint to verify the config works:
+
+```bash
+npx eslint --print-config webapp/Component.js 2>/dev/null | head -20
+```
+
+Or run a quick lint to confirm no config errors:
+
+```bash
+npx eslint webapp/ --max-warnings 9999 2>&1 | head -20
+```
+
+## Important notes
+
+- ESLint 9 requires Node.js >= 18.18.0
+- The plugin expects `webapp/` relative to the config file location
+- Do NOT place the config at the CAP project root if apps have their own `package.json` — ESLint will not resolve the plugin correctly
+- Use `.eslintignore` patterns in the `ignores` array of `eslint.config.mjs` (flat config has no `.eslintignore` support)
+- The `recommended` config already includes ignores for `target/`, `localService/`, `backup/`, and `*.d.ts` files

--- a/packages/fiori-skills/src/index.ts
+++ b/packages/fiori-skills/src/index.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { installSkills } from './install';
+
+const args = process.argv.slice(2);
+const targetPath = args[0];
+
+installSkills(targetPath).catch((error: Error) => {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exit(1);
+});

--- a/packages/fiori-skills/src/install.ts
+++ b/packages/fiori-skills/src/install.ts
@@ -1,0 +1,53 @@
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const DEFAULT_SKILLS_PATH = join(homedir(), '.agents', 'skills');
+const SKILLS_SOURCE_DIR = join(__dirname, '..', 'skills');
+
+/**
+ * Returns the list of skill names bundled with this package.
+ *
+ * @returns Array of skill directory names found in the bundled skills directory.
+ */
+export function getBundledSkills(): string[] {
+    return readdirSync(SKILLS_SOURCE_DIR, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+}
+
+/**
+ * Copies all bundled Fiori skills into the target directory.
+ * Each skill is placed in its own subdirectory named after the skill.
+ *
+ * @param targetPath Optional path to the skills directory. Defaults to ~/.agents/skills.
+ */
+export async function installSkills(targetPath?: string): Promise<void> {
+    const targetDir = resolve(targetPath ?? DEFAULT_SKILLS_PATH);
+
+    if (!existsSync(targetDir)) {
+        mkdirSync(targetDir, { recursive: true });
+    }
+
+    const skills = getBundledSkills();
+
+    if (skills.length === 0) {
+        process.stdout.write('No skills found to install.\n');
+        return;
+    }
+
+    process.stdout.write(`Installing ${skills.length} Fiori skill(s) to: ${targetDir}\n\n`);
+
+    for (const skill of skills) {
+        const sourceSkillDir = join(SKILLS_SOURCE_DIR, skill);
+        const targetSkillDir = join(targetDir, skill);
+
+        const isUpdate = existsSync(targetSkillDir);
+        cpSync(sourceSkillDir, targetSkillDir, { recursive: true });
+
+        const status = isUpdate ? 'updated' : 'installed';
+        process.stdout.write(`  ${status}: ${skill}\n`);
+    }
+
+    process.stdout.write(`\nDone. Skills are ready to use in your AI agent client.\n`);
+}

--- a/packages/fiori-skills/test/install.test.ts
+++ b/packages/fiori-skills/test/install.test.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getBundledSkills, installSkills } from '../src/install';
+
+describe('getBundledSkills', () => {
+    it('returns at least the three Fiori ESLint skills', () => {
+        const skills = getBundledSkills();
+        expect(skills).toContain('fiori-eslint-setup');
+        expect(skills).toContain('fiori-eslint-migrate');
+        expect(skills).toContain('fiori-eslint-lint');
+    });
+});
+
+describe('installSkills', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = join(tmpdir(), `fiori-skills-test-${Date.now()}`);
+    });
+
+    afterEach(() => {
+        if (existsSync(tmpDir)) {
+            rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    it('creates the target directory when it does not exist', async () => {
+        await installSkills(tmpDir);
+        expect(existsSync(tmpDir)).toBe(true);
+    });
+
+    it('copies all bundled skills into the target directory', async () => {
+        await installSkills(tmpDir);
+
+        const bundled = getBundledSkills();
+        const installed = readdirSync(tmpDir);
+
+        for (const skill of bundled) {
+            expect(installed).toContain(skill);
+            expect(existsSync(join(tmpDir, skill, 'SKILL.md'))).toBe(true);
+        }
+    });
+
+    it('overwrites existing skills without error', async () => {
+        // First install
+        await installSkills(tmpDir);
+        // Second install should not throw
+        await expect(installSkills(tmpDir)).resolves.not.toThrow();
+    });
+
+    it('uses the default path (~/.agents/skills) when no argument is given', async () => {
+        // We only verify it resolves — we do not actually write to the home directory in tests
+        const spy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        try {
+            // Pass explicit tmp dir so we don't pollute the real skills dir
+            await installSkills(tmpDir);
+            expect(spy).toHaveBeenCalledWith(expect.stringContaining(tmpDir));
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('creates nested target directory when parent does not exist', async () => {
+        const nestedDir = join(tmpDir, 'deeply', 'nested');
+        await installSkills(nestedDir);
+        expect(existsSync(nestedDir)).toBe(true);
+        mkdirSync(tmpDir, { recursive: true }); // ensure parent exists for cleanup
+    });
+});

--- a/packages/fiori-skills/tsconfig.eslint.json
+++ b/packages/fiori-skills/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["src", "test"]
+}

--- a/packages/fiori-skills/tsconfig.json
+++ b/packages/fiori-skills/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -127,6 +127,9 @@
       "path": "packages/fiori-mcp-server"
     },
     {
+      "path": "packages/fiori-skills"
+    },
+    {
       "path": "packages/fiori-tools-settings"
     },
     {


### PR DESCRIPTION
# Add `@sap-ux/fiori-skills` Package for Installing Fiori AI Agent Skills

### New Feature

✨ Introduces a new `@sap-ux/fiori-skills` package that bundles a set of AI agent skills for SAP Fiori development and provides a CLI to install them into a local skills directory (default: `~/.agents/skills`). Once installed, the skills are available to any AI agent client that reads from that directory (e.g. Claude Code, Cursor, and other [agentskills.io](https://agentskills.io)-compatible clients).

The package can be used directly via `npx @sap-ux/fiori-skills` without a global install.

### Changes

* `packages/fiori-skills/src/install.ts`: Core logic for discovering bundled skills and copying them to the target directory, with support for first-time install and in-place updates.
* `packages/fiori-skills/src/index.ts`: CLI entry point — parses the optional target path argument and invokes `installSkills`.
* `packages/fiori-skills/skills/fiori-eslint-setup/SKILL.md`: Skill for setting up ESLint with `@sap-ux/eslint-plugin-fiori-tools` on new Fiori or CAP projects.
* `packages/fiori-skills/skills/fiori-eslint-migrate/SKILL.md`: Skill for migrating legacy `.eslintrc` configs to ESLint 9 flat config format.
* `packages/fiori-skills/skills/fiori-eslint-lint/SKILL.md`: Skill for running ESLint on a Fiori project and reporting or auto-fixing issues.
* `packages/fiori-skills/package.json`: Package definition with `bin` entry, `files` manifest, and build/test scripts.
* `packages/fiori-skills/README.md`: Documentation covering usage, bundled skills, and skill format.
* `packages/fiori-skills/test/install.test.ts`: Unit tests for `getBundledSkills` and `installSkills`, covering directory creation, skill copying, idempotent updates, and nested paths.
* `packages/fiori-skills/tsconfig.json` / `tsconfig.eslint.json` / `eslint.config.js` / `jest.config.js`: Standard package tooling configuration.
* `tsconfig.json`: Added `packages/fiori-skills` to the root TypeScript project references.
* `.changeset/fiori-skills-initial.md`: Changeset entry marking this as a `minor` release of `@sap-ux/fiori-skills`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `cd0dc8c8-1c38-4c73-9762-7cc7eb346340`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
</details>
