### PR TITLE
fix(ui5-info): bump fallback versions

### DIFF
--- a/.changeset/bump-ui5-fallback-versions.md
+++ b/.changeset/bump-ui5-fallback-versions.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-info': patch
+---
+
+fix(ui5-info): bump fallback versions

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/README.md
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/README.md
@@ -12,7 +12,7 @@
 |**Application Title**<br>Project&#39;s &#34;Title&#34;|
 |**Namespace**<br>testnamepsace|
 |**UI5 Theme**<br>sap_horizon|
-|**UI5 Version**<br>1.145.0|
+|**UI5 Version**<br>1.147.0|
 |**Enable TypeScript**<br>False|
 |**Add Eslint configuration**<br>False|
 |**Main Entity**<br>Travel|

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_version": "1.83.1",
+  "_version": "1.84.0",
   "sap.app": {
     "id": "testnamepsace.lropv4noui5version",
     "type": "application",
@@ -55,7 +55,7 @@
   "sap.ui5": {
     "flexEnabled": true,
     "dependencies": {
-      "minUI5Version": "1.145.0",
+      "minUI5Version": "1.147.0",
       "libs": {
         "sap.m": {},
         "sap.ui.core": {},

--- a/packages/ui5-info/src/ui5-version-fallback.ts
+++ b/packages/ui5-info/src/ui5-version-fallback.ts
@@ -8,15 +8,23 @@ export const supportState = {
     skipped: 'Skipped'
 } as const;
 
-// Updated Feb 23, 2026 from https://ui5.sap.com/versionoverview.json
+// Updated Apr-21-2026 from https://ui5.sap.com/versionoverview.json
 export const ui5VersionFallbacks = [
+    {
+        version: '1.147.*',
+        support: supportState.maintenance
+    },
+    {
+        version: '1.146.*',
+        support: supportState.maintenance
+    },
     {
         version: '1.145.*',
         support: supportState.maintenance
     },
     {
         version: '1.144.*',
-        support: supportState.maintenance
+        support: supportState.outOfMaintenance
     },
     {
         version: '1.143.*',
@@ -36,7 +44,7 @@ export const ui5VersionFallbacks = [
     },
     {
         version: '1.139.*',
-        support: supportState.maintenance
+        support: supportState.outOfMaintenance
     },
     {
         version: '1.138.*',

--- a/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
+++ b/packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap
@@ -4993,19 +4993,19 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 [
   {
     "maintained": true,
+    "version": "1.147.0",
+  },
+  {
+    "maintained": true,
+    "version": "1.146.0",
+  },
+  {
+    "maintained": true,
     "version": "1.145.0",
   },
   {
     "maintained": true,
-    "version": "1.144.0",
-  },
-  {
-    "maintained": true,
     "version": "1.142.0",
-  },
-  {
-    "maintained": true,
-    "version": "1.139.0",
   },
   {
     "maintained": true,
@@ -5033,16 +5033,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback for specified min UI5 version, if request fails 1`] = `
 [
   {
+    "version": "1.147.0",
+  },
+  {
+    "version": "1.146.0",
+  },
+  {
     "version": "1.145.0",
   },
   {
-    "version": "1.144.0",
-  },
-  {
     "version": "1.142.0",
-  },
-  {
-    "version": "1.139.0",
   },
   {
     "version": "1.136.0",
@@ -5065,16 +5065,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback if official is not available  1`] = `
 [
   {
+    "version": "1.147.0",
+  },
+  {
+    "version": "1.146.0",
+  },
+  {
     "version": "1.145.0",
   },
   {
-    "version": "1.144.0",
-  },
-  {
     "version": "1.142.0",
-  },
-  {
-    "version": "1.139.0",
   },
   {
     "version": "1.136.0",
@@ -5097,16 +5097,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 versions fallback if snapshot is not available  1`] = `
 [
   {
+    "version": "1.147.0",
+  },
+  {
+    "version": "1.146.0",
+  },
+  {
     "version": "1.145.0",
   },
   {
-    "version": "1.144.0",
-  },
-  {
     "version": "1.142.0",
-  },
-  {
-    "version": "1.139.0",
   },
   {
     "version": "1.136.0",
@@ -5129,16 +5129,16 @@ exports[`getUI5Versions: Handle error cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 versions fallback if official is not available  1`] = `
 [
   {
+    "version": "1.147.0",
+  },
+  {
+    "version": "1.146.0",
+  },
+  {
     "version": "1.145.0",
   },
   {
-    "version": "1.144.0",
-  },
-  {
     "version": "1.142.0",
-  },
-  {
-    "version": "1.139.0",
   },
   {
     "version": "1.136.0",
@@ -5161,16 +5161,16 @@ exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 ver
 exports[`getUI5Versions: Handle fatal cases while getting UI5 versions:  UI5 versions fallback if snapshot is not available  1`] = `
 [
   {
+    "version": "1.147.0",
+  },
+  {
+    "version": "1.146.0",
+  },
+  {
     "version": "1.145.0",
   },
   {
-    "version": "1.144.0",
-  },
-  {
     "version": "1.142.0",
-  },
-  {
-    "version": "1.139.0",
   },
   {
     "version": "1.136.0",

--- a/packages/ui5-info/test/commands.test.ts
+++ b/packages/ui5-info/test/commands.test.ts
@@ -107,16 +107,16 @@ describe('Retrieve NPM UI5 mocking spawn process', () => {
         expect(retrievedUI5Versions).toMatchInlineSnapshot(`
             [
               {
+                "version": "1.147.0",
+              },
+              {
+                "version": "1.146.0",
+              },
+              {
                 "version": "1.145.0",
               },
               {
-                "version": "1.144.0",
-              },
-              {
                 "version": "1.142.0",
-              },
-              {
-                "version": "1.139.0",
               },
               {
                 "version": "1.136.0",


### PR DESCRIPTION
# fix(ui5-info): Bump Fallback UI5 Versions

### Bug Fix

🔧 Updated the UI5 version fallback list in `@sap-ux/ui5-info` to reflect the latest maintenance state as of April 21, 2026. This ensures that when the official UI5 version endpoint is unavailable, the fallback list includes up-to-date versions with accurate support states.

### Changes

* `packages/ui5-info/src/ui5-version-fallback.ts`:
  - Added `1.147.*` and `1.146.*` as new maintenance versions.
  - Updated support state for `1.144.*` from `maintenance` → `out of maintenance`.
  - Updated support state for `1.139.*` from `maintenance` → `out of maintenance`.
  - Updated fallback date comment to `Apr-21-2026`.

* `packages/ui5-info/test/__snapshots__/ui5-version-info.test.ts.snap`: Updated snapshot tests to reflect the new top maintained version (`1.147.0`) across all fallback test scenarios.

* `packages/ui5-info/test/commands.test.ts`: Updated inline snapshots to reflect the updated fallback version list with `1.147.0` as the top maintained version.

* `.changeset/bump-ui5-fallback-versions.md`: Added changeset entry for the patch release of `@sap-ux/ui5-info`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `df4ee977-041d-4093-92c1-cdb4e3521f01`
</details>
