### PR TITLE
fix(infra): remove --frozen-lockfile from install for ui5 manifest

### DIFF
--- a/.github/workflows/renovate-pr-automation.yml
+++ b/.github/workflows/renovate-pr-automation.yml
@@ -58,7 +58,7 @@ jobs:
                   cache: 'pnpm'
 
             - name: Install pnpm modules
-              run: pnpm install --frozen-lockfile
+              run: pnpm install
 
             - name: Build project
               run: pnpm build


### PR DESCRIPTION
- allows workflow to update the lockerfile if renovate fails to do so for manifest schenario