### PR TITLE
feat: Add support for multi param and route navigation intent for the Adaptation Editor

### DIFF
--- a/.changeset/olive-streets-eat.md
+++ b/.changeset/olive-streets-eat.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/preview-middleware': patch
+'@sap-ux/app-config-writer': patch
+---
+
+feat: Add support for multi param and route navigation intent for the Adaptation Editor

--- a/packages/app-config-writer/src/common/package-json.ts
+++ b/packages/app-config-writer/src/common/package-json.ts
@@ -1,4 +1,4 @@
-import type { FlpConfig, MiddlewareConfig as PreviewConfig } from '@sap-ux/preview-middleware';
+import type { Intent, MiddlewareConfig as PreviewConfig } from '@sap-ux/preview-middleware';
 import { join } from 'node:path';
 import type { Editor } from 'mem-fs-editor';
 import { type Package, FileName } from '@sap-ux/project-access';
@@ -39,7 +39,7 @@ export function getScriptsFromPackageJson(fs: Editor, basePath: string): Map<str
  */
 export function extractUrlDetails(script: string): {
     path: string | undefined;
-    intent: FlpConfig['intent'] | undefined;
+    intent: Intent | undefined;
 } {
     //extract the URL from the 'open' command of the script
     let url = / (?:--open|-o|--o) (\S*)/.exec(script)?.[1] ?? undefined;

--- a/packages/app-config-writer/src/common/utils.ts
+++ b/packages/app-config-writer/src/common/utils.ts
@@ -60,9 +60,6 @@ export function getIntentFromPreviewConfig(
     if (!intent) {
         return undefined;
     }
-    if (typeof intent === 'string') {
-        return intent.startsWith('#') ? intent : `#${intent}`;
-    }
     return `#${intent.object}-${intent.action}`;
 }
 

--- a/packages/app-config-writer/src/common/utils.ts
+++ b/packages/app-config-writer/src/common/utils.ts
@@ -57,7 +57,13 @@ export function getIntentFromPreviewConfig(
         return undefined;
     }
     const intent = previewMiddlewareConfig?.flp?.intent;
-    return intent ? `#${intent.object}-${intent.action}` : undefined;
+    if (!intent) {
+        return undefined;
+    }
+    if (typeof intent === 'string') {
+        return intent.startsWith('#') ? intent : `#${intent}`;
+    }
+    return `#${intent.object}-${intent.action}`;
 }
 
 /**

--- a/packages/app-config-writer/test/unit/common/utils.test.ts
+++ b/packages/app-config-writer/test/unit/common/utils.test.ts
@@ -39,4 +39,34 @@ describe('utils', () => {
             expect(await utils.getCLIForPreview(fioriToolsConfig, 'ui5.yaml', fs)).toStrictEqual('fiori run');
         });
     });
+
+    describe('getIntentFromPreviewConfig', () => {
+        test('returns undefined for deprecated fiori-tools config', () => {
+            const config = { component: 'my.component', libs: true };
+            expect(utils.getIntentFromPreviewConfig(config)).toBeUndefined();
+        });
+
+        test('returns undefined when no flp config', () => {
+            expect(utils.getIntentFromPreviewConfig({})).toBeUndefined();
+        });
+
+        test('returns undefined when no intent', () => {
+            expect(utils.getIntentFromPreviewConfig({ flp: {} })).toBeUndefined();
+        });
+
+        test('returns hash from structured intent object', () => {
+            const config = { flp: { intent: { object: 'Order', action: 'manage' } } };
+            expect(utils.getIntentFromPreviewConfig(config)).toBe('#Order-manage');
+        });
+
+        test('returns hash from string intent without leading hash', () => {
+            const config = { flp: { intent: 'Order-manage?year=2024&/display' } };
+            expect(utils.getIntentFromPreviewConfig(config as any)).toBe('#Order-manage?year=2024&/display');
+        });
+
+        test('returns string intent as-is when it already has leading hash', () => {
+            const config = { flp: { intent: '#Order-manage' } };
+            expect(utils.getIntentFromPreviewConfig(config as any)).toBe('#Order-manage');
+        });
+    });
 });

--- a/packages/app-config-writer/test/unit/common/utils.test.ts
+++ b/packages/app-config-writer/test/unit/common/utils.test.ts
@@ -58,15 +58,5 @@ describe('utils', () => {
             const config = { flp: { intent: { object: 'Order', action: 'manage' } } };
             expect(utils.getIntentFromPreviewConfig(config)).toBe('#Order-manage');
         });
-
-        test('returns hash from string intent without leading hash', () => {
-            const config = { flp: { intent: 'Order-manage?year=2024&/display' } };
-            expect(utils.getIntentFromPreviewConfig(config as any)).toBe('#Order-manage?year=2024&/display');
-        });
-
-        test('returns string intent as-is when it already has leading hash', () => {
-            const config = { flp: { intent: '#Order-manage' } };
-            expect(utils.getIntentFromPreviewConfig(config as any)).toBe('#Order-manage');
-        });
     });
 });

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -20,11 +20,11 @@ When this middleware is used together with the `reload-middleware`, then the ord
 | `flp`                   | ---        | optional                                       | ---              | Configuration object for the local SAP Fiori launchpad                                                                                                                                                                                                |
 | `flp.path`              | `string`   | optional                                       | `/test/flp.html` | The mount point of the local SAP Fiori launchpad. In case no file is found at the given path, a virtual endpoint will be instantiated.                                                                                                                |
 | `flp.init`              | `string`   | optional                                       | `undefined`      | UI5 module/script to be executed after the standard initialization                                                                                                                                                                                    |
-| `flp.intent`            | `string` or `object` | optional                              | ---              | Intent for the application. Can be a string (e.g. `"Object-action?param=value&/route"`) or a structured object (see below)                                                                                                                           |
-| `flp.intent.object`     | `string`   | optional                                       | `app`            | Name of the semantic object (when using object format)                                                                                                                                                                                                |
-| `flp.intent.action`     | `string`   | optional                                       | `preview`        | Name of the action (when using object format)                                                                                                                                                                                                         |
-| `flp.intent.params`     | `object`   | optional                                       | `undefined`      | Key-value pairs of intent parameters (when using object format)                                                                                                                                                                                       |
-| `flp.intent.route`      | `string`   | optional                                       | `undefined`      | Inner-app route (when using object format)                                                                                                                                                                                                            |
+| `flp.intent`            | `object`   | optional                                       | ---              | Intent for the application (see below)                                                                                                                                                                                                                |
+| `flp.intent.object`     | `string`   | optional                                       | `app`            | Name of the semantic object                                                                                                                                                                                                                           |
+| `flp.intent.action`     | `string`   | optional                                       | `preview`        | Name of the action                                                                                                                                                                                                                                    |
+| `flp.intent.params`     | `object`   | optional                                       | `undefined`      | Key-value pairs of intent parameters                                                                                                                                                                                                                  |
+| `flp.intent.route`      | `string`   | optional                                       | `undefined`      | Inner-app route                                                                                                                                                                                                                                       |
 | `flp.apps`              | `array`    | optional                                       | `undefined`      | Additional local apps that are available in the local SAP Fiori launchpad                                                                                                                                                                             |
 | `flp.libs`              | `boolean`  | optional                                       | `false`          | Flag to add a generic script fetching the paths of used libraries not available in UI5. To disable it, set it to `false`. If not set, then the project is checked for a `load-reuse-libs` script and, if available, the libraries are fetched as well |
 | `flp.theme`             | `string`   | optional                                       | `(calculated)`   | Name of the UI5 theme to be used (default is `sap_horizon` or the first entry in the sap.ui.supportedThemes list provided in the manifest.json file if `sap_horizon` is not contained in the list)                                                    |
@@ -49,7 +49,7 @@ Array of additional application configurations:
 | ------------------------ |------------|------------------|----------------|-------------------------------------------------------------------------------------------------------------|
 | `target`                 | `string`   | mandatory        | `undefined`    | Target path of the additional application                                                                   |
 | `local` or `componentId` | `string`   | mandatory        | `undefined`    | Either a local path to a folder containing the application or the `componentId` of a remote app is required |
-| `intent`                 | `string` or `object` | optional | ---            | Intent for the application. Can be a string (e.g. `"Object-action?param=value&/route"`) or a structured object |
+| `intent`                 | `object`   | optional         | ---            | Intent for the application                                                                                  |
 | `intent.object`          | `string`   | optional         | `(calculated)` | Name of the semantic object. If not provided, then it will be calculated based on the application ID        |
 | `intent.action`          | `string`   | optional         | `preview`      | Name of the action                                                                                          |
 | `intent.params`          | `object`   | optional         | `undefined`    | Key-value pairs of intent parameters                                                                        |
@@ -105,20 +105,8 @@ server:
 ```
 
 ### [Intent Configuration](#intent-configuration)
-The `flp.intent` can be provided as a string (convenient for copy-pasting from the browser URL bar) or as a structured object (better for tooling).
+The `flp.intent` is a structured object that defines the semantic object, action, and optional parameters and route:
 
-**String format** — copy the intent hash from the FLP URL:
-```Yaml
-server:
-  customMiddleware:
-  - name: preview-middleware
-    afterMiddleware: compression
-    configuration:
-      flp:
-        intent: "SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display"
-```
-
-**Object format** — structured with explicit params and route:
 ```Yaml
 server:
   customMiddleware:
@@ -135,7 +123,7 @@ server:
           route: "/display"
 ```
 
-Both formats produce the same result: `#SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display`
+This produces the hash fragment: `#SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display`
 
 ### [Additional Applications](#additional-applications)
 If you want to test cross application navigation, then you can add additional applications into the local FLP.

--- a/packages/preview-middleware/README.md
+++ b/packages/preview-middleware/README.md
@@ -20,9 +20,11 @@ When this middleware is used together with the `reload-middleware`, then the ord
 | `flp`                   | ---        | optional                                       | ---              | Configuration object for the local SAP Fiori launchpad                                                                                                                                                                                                |
 | `flp.path`              | `string`   | optional                                       | `/test/flp.html` | The mount point of the local SAP Fiori launchpad. In case no file is found at the given path, a virtual endpoint will be instantiated.                                                                                                                |
 | `flp.init`              | `string`   | optional                                       | `undefined`      | UI5 module/script to be executed after the standard initialization                                                                                                                                                                                    |
-| `flp.intent`            | ---        | optional                                       | ---              | Intent object to be used for the application                                                                                                                                                                                                          |
-| `flp.intent.object`     | `string`   | optional                                       | `app`            | Name of the semantic object                                                                                                                                                                                                                           |
-| `flp.intent.action`     | `string`   | optional                                       | `preview`        | Name of the action                                                                                                                                                                                                                                    |
+| `flp.intent`            | `string` or `object` | optional                              | ---              | Intent for the application. Can be a string (e.g. `"Object-action?param=value&/route"`) or a structured object (see below)                                                                                                                           |
+| `flp.intent.object`     | `string`   | optional                                       | `app`            | Name of the semantic object (when using object format)                                                                                                                                                                                                |
+| `flp.intent.action`     | `string`   | optional                                       | `preview`        | Name of the action (when using object format)                                                                                                                                                                                                         |
+| `flp.intent.params`     | `object`   | optional                                       | `undefined`      | Key-value pairs of intent parameters (when using object format)                                                                                                                                                                                       |
+| `flp.intent.route`      | `string`   | optional                                       | `undefined`      | Inner-app route (when using object format)                                                                                                                                                                                                            |
 | `flp.apps`              | `array`    | optional                                       | `undefined`      | Additional local apps that are available in the local SAP Fiori launchpad                                                                                                                                                                             |
 | `flp.libs`              | `boolean`  | optional                                       | `false`          | Flag to add a generic script fetching the paths of used libraries not available in UI5. To disable it, set it to `false`. If not set, then the project is checked for a `load-reuse-libs` script and, if available, the libraries are fetched as well |
 | `flp.theme`             | `string`   | optional                                       | `(calculated)`   | Name of the UI5 theme to be used (default is `sap_horizon` or the first entry in the sap.ui.supportedThemes list provided in the manifest.json file if `sap_horizon` is not contained in the list)                                                    |
@@ -47,9 +49,11 @@ Array of additional application configurations:
 | ------------------------ |------------|------------------|----------------|-------------------------------------------------------------------------------------------------------------|
 | `target`                 | `string`   | mandatory        | `undefined`    | Target path of the additional application                                                                   |
 | `local` or `componentId` | `string`   | mandatory        | `undefined`    | Either a local path to a folder containing the application or the `componentId` of a remote app is required |
-| `intent`                 | ---        | optional         | ---            | Intent object to be used for the application                                                                |
+| `intent`                 | `string` or `object` | optional | ---            | Intent for the application. Can be a string (e.g. `"Object-action?param=value&/route"`) or a structured object |
 | `intent.object`          | `string`   | optional         | `(calculated)` | Name of the semantic object. If not provided, then it will be calculated based on the application ID        |
 | `intent.action`          | `string`   | optional         | `preview`      | Name of the action                                                                                          |
+| `intent.params`          | `object`   | optional         | `undefined`    | Key-value pairs of intent parameters                                                                        |
+| `intent.route`           | `string`   | optional         | `undefined`    | Inner-app route                                                                                             |
 
 ### [`adp.target`](#configuration-option-adptarget)
 | Option        | Value Type | Requirement Type      | Default Value | Description                                                                                                                                      |
@@ -99,6 +103,39 @@ server:
         path: /test/myFLP.html
       debug: true
 ```
+
+### [Intent Configuration](#intent-configuration)
+The `flp.intent` can be provided as a string (convenient for copy-pasting from the browser URL bar) or as a structured object (better for tooling).
+
+**String format** — copy the intent hash from the FLP URL:
+```Yaml
+server:
+  customMiddleware:
+  - name: preview-middleware
+    afterMiddleware: compression
+    configuration:
+      flp:
+        intent: "SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display"
+```
+
+**Object format** — structured with explicit params and route:
+```Yaml
+server:
+  customMiddleware:
+  - name: preview-middleware
+    afterMiddleware: compression
+    configuration:
+      flp:
+        intent:
+          object: SupplierInvoice
+          action: displayFactSheet
+          params:
+            FiscalYear: "2017"
+            SupplierInvoice: "5100000001"
+          route: "/display"
+```
+
+Both formats produce the same result: `#SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display`
 
 ### [Additional Applications](#additional-applications)
 If you want to test cross application navigation, then you can add additional applications into the local FLP.

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -5,7 +5,6 @@ import type {
     DefaultIntent,
     FlpConfig,
     Intent,
-    IntentConfig,
     CompleteTestConfig,
     MiddlewareConfig,
     RtaConfig,
@@ -121,84 +120,17 @@ export const DEFAULT_INTENT = {
 } as Readonly<DefaultIntent>;
 
 /**
- * Parses a query string into a key-value record, splitting only on the first `=` per pair.
+ * Builds the intent hash fragment from an Intent object.
  *
- * @param queryString the raw query string without leading `?` (e.g. "key1=val1&key2=val2")
- */
-function parseParams(queryString: string): Record<string, string> {
-    const params: Record<string, string> = {};
-    for (const pair of queryString.split('&')) {
-        const eqIdx = pair.indexOf('=');
-        const key = eqIdx >= 0 ? pair.slice(0, eqIdx) : pair;
-        const value = eqIdx >= 0 ? pair.slice(eqIdx + 1) : '';
-        if (key) {
-            params[decodeURIComponent(key)] = decodeURIComponent(value);
-        }
-    }
-    return params;
-}
-
-/**
- * Extracts the route and params from the remainder of an intent string (everything after "Object-action").
- *
- * @param remainder the portion of the intent string after the "Object-action" prefix
- * @returns object with optional params and route
- */
-function parseIntentRemainder(remainder: string): { params?: Record<string, string>; route?: string } {
-    const route = /&(\/.*)/.exec(remainder)?.[1];
-    const paramsMatch = /\?([^&]*(?:&(?!\/)[^&]*)*)/.exec(remainder);
-    const params = paramsMatch ? parseParams(paramsMatch[1]) : undefined;
-    return {
-        ...(params && Object.keys(params).length > 0 ? { params } : {}),
-        ...(route ? { route } : {})
-    };
-}
-
-/**
- * Parses an intent string into a structured Intent object.
- *
- * Supported formats:
- *   "Object-action"
- *   "Object-action?param1=value1&param2=value2"
- *   "Object-action?param1=value1&param2=value2&/innerRoute"
- *   "Object-action&/innerRoute"
- *
- * @param intentString the raw intent string (with or without leading #)
- * @returns parsed Intent object
- */
-export function parseIntentString(intentString: string): Intent {
-    const raw = intentString.startsWith('#') ? intentString.slice(1) : intentString;
-
-    const match = /^([^-?&]+)-([^?&]+)/.exec(raw);
-    if (!match) {
-        throw new Error(`Invalid intent format: "${intentString}". Expected "Object-action[?params][&/route]".`);
-    }
-
-    const remainder = raw.slice(match[0].length);
-    return {
-        object: match[1],
-        action: match[2],
-        ...(remainder ? parseIntentRemainder(remainder) : {})
-    };
-}
-
-/**
- * Builds the intent hash fragment from an IntentConfig.
- *
- * @param intentConfig the intent configuration (string or object)
+ * @param intent the structured intent object
  * @returns hash fragment string (without leading #)
  */
-export function buildIntentHash(intentConfig: IntentConfig): string {
-    if (typeof intentConfig === 'string') {
-        return intentConfig.startsWith('#') ? intentConfig.slice(1) : intentConfig;
-    }
+export function buildIntentHash(intent: Intent): string {
+    let hash = `${intent.object}-${intent.action}`;
 
-    let hash = `${intentConfig.object}-${intentConfig.action}`;
+    const params = intent.params;
+    const route = intent.route;
 
-    const params = intentConfig.params;
-    const route = intentConfig.route;
-
-    // URLSearchParams encodes spaces as '+' (form-urlencoded), but FLP hash fragments require '%20' (percent-encoding).
     if (params && Object.keys(params).length > 0) {
         const paramString = Object.entries(params)
             .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
@@ -212,19 +144,6 @@ export function buildIntentHash(intentConfig: IntentConfig): string {
     }
 
     return hash;
-}
-
-/**
- * Resolves an IntentConfig (string or object from ui5.yaml) into a normalized Intent object.
- *
- * @param input the intent configuration from ui5.yaml
- * @returns normalized Intent object
- */
-export function resolveIntent(input: IntentConfig): Intent {
-    if (typeof input === 'string') {
-        return parseIntentString(input);
-    }
-    return input;
 }
 
 /**
@@ -296,7 +215,7 @@ function getUI5Libs(manifest: Partial<Manifest>): string {
 export function getFlpConfigWithDefaults(config: Partial<FlpConfig> = {}): FlpConfig {
     const flpConfig = {
         path: config.path ?? DEFAULT_PATH,
-        intent: config.intent ? resolveIntent(config.intent) : DEFAULT_INTENT,
+        intent: config.intent ?? DEFAULT_INTENT,
         apps: config.apps ?? [],
         libs: config.libs,
         theme: config.theme,
@@ -418,20 +337,18 @@ export async function addApp(
  * Get the application name based on the manifest and app configuration.
  *
  * @param manifest - The application manifest.
- * @param intentConfig - The app intent configuration (string or object).
+ * @param intent - The app intent configuration.
  * @returns The application name.
  */
-export function getAppName(manifest: Partial<Manifest>, intentConfig?: IntentConfig): string {
+export function getAppName(manifest: Partial<Manifest>, intent?: Intent): string {
     const id = manifest['sap.app']?.id ?? '';
 
-    const intent: Intent = intentConfig
-        ? resolveIntent(intentConfig)
-        : {
-              object: id.replace(/\./g, ''),
-              action: 'preview'
-          };
+    const resolved: Intent = intent ?? {
+        object: id.replace(/\./g, ''),
+        action: 'preview'
+    };
 
-    return `${intent.object}-${intent.action}`;
+    return `${resolved.object}-${resolved.action}`;
 }
 
 /**

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -122,6 +122,8 @@ export const DEFAULT_INTENT = {
 
 /**
  * Parses a query string into a key-value record, splitting only on the first `=` per pair.
+ *
+ * @param queryString
  */
 function parseParams(queryString: string): Record<string, string> {
     const params: Record<string, string> = {};
@@ -138,6 +140,8 @@ function parseParams(queryString: string): Record<string, string> {
 
 /**
  * Extracts the route and params from the remainder of an intent string (everything after "Object-action").
+ *
+ * @param remainder
  */
 function parseIntentRemainder(remainder: string): { params?: Record<string, string>; route?: string } {
     const route = /&(\/.*)/.exec(remainder)?.[1];

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -5,6 +5,7 @@ import type {
     DefaultIntent,
     FlpConfig,
     Intent,
+    IntentConfig,
     CompleteTestConfig,
     MiddlewareConfig,
     RtaConfig,
@@ -120,6 +121,105 @@ export const DEFAULT_INTENT = {
 } as Readonly<DefaultIntent>;
 
 /**
+ * Parses an intent string into a structured Intent object.
+ *
+ * Supported formats:
+ *   "Object-action"
+ *   "Object-action?param1=value1&param2=value2"
+ *   "Object-action?param1=value1&param2=value2&/innerRoute"
+ *   "Object-action&/innerRoute"
+ *
+ * @param intentString the raw intent string (with or without leading #)
+ * @returns parsed Intent object
+ */
+export function parseIntentString(intentString: string): Intent {
+    const raw = intentString.startsWith('#') ? intentString.slice(1) : intentString;
+
+    const intentPattern = /^([^-?&]+)-([^?&]+)/;
+    const match = raw.match(intentPattern);
+    if (!match) {
+        throw new Error(`Invalid intent format: "${intentString}". Expected "Object-action[?params][&/route]".`);
+    }
+
+    const object = match[1];
+    const action = match[2];
+    const remainder = raw.slice(match[0].length);
+
+    let params: Record<string, string> | undefined;
+    let route: string | undefined;
+
+    if (remainder) {
+        const routeMatch = remainder.match(/&(\/.*)/);
+        if (routeMatch) {
+            route = routeMatch[1];
+        }
+
+        const paramsMatch = remainder.match(/\?([^&]*(?:&(?!\/)[^&]*)*)/);
+        if (paramsMatch) {
+            params = {};
+            const paramPairs = paramsMatch[1].split('&');
+            for (const pair of paramPairs) {
+                const [key, value] = pair.split('=');
+                if (key) {
+                    params[decodeURIComponent(key)] = decodeURIComponent(value ?? '');
+                }
+            }
+        }
+    }
+
+    return {
+        object,
+        action,
+        ...(params && Object.keys(params).length > 0 ? { params } : {}),
+        ...(route ? { route } : {})
+    };
+}
+
+/**
+ * Builds the intent hash fragment from an IntentConfig.
+ *
+ * @param intentConfig the intent configuration (string or object)
+ * @returns hash fragment string (without leading #)
+ */
+export function buildIntentHash(intentConfig: IntentConfig): string {
+    if (typeof intentConfig === 'string') {
+        return intentConfig.startsWith('#') ? intentConfig.slice(1) : intentConfig;
+    }
+
+    let hash = `${intentConfig.object}-${intentConfig.action}`;
+
+    const params = intentConfig.params;
+    const route = intentConfig.route;
+
+    if (params && Object.keys(params).length > 0) {
+        const paramString = Object.entries(params)
+            .map(([key, value]) => `${key}=${value}`)
+            .join('&');
+        hash += `?${paramString}`;
+    }
+
+    if (route) {
+        const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+        hash += `&${normalizedRoute}`;
+    }
+
+    return hash;
+}
+
+/**
+ * Resolves an IntentConfig (string or object from ui5.yaml) into a normalized Intent object.
+ *
+ * @param input the intent configuration from ui5.yaml
+ * @returns normalized Intent object
+ */
+export function resolveIntent(input: IntentConfig): Intent {
+    if (typeof input === 'string') {
+        return parseIntentString(input);
+    }
+    return input;
+}
+
+/**
  * SAPUI5 delivered namespaces from https://ui5.sap.com/#/api/sap
  */
 const UI5_LIBS = [
@@ -188,7 +288,7 @@ function getUI5Libs(manifest: Partial<Manifest>): string {
 export function getFlpConfigWithDefaults(config: Partial<FlpConfig> = {}): FlpConfig {
     const flpConfig = {
         path: config.path ?? DEFAULT_PATH,
-        intent: config.intent ?? DEFAULT_INTENT,
+        intent: config.intent ? resolveIntent(config.intent) : DEFAULT_INTENT,
         apps: config.apps ?? [],
         libs: config.libs,
         theme: config.theme,
@@ -310,18 +410,20 @@ export async function addApp(
  * Get the application name based on the manifest and app configuration.
  *
  * @param manifest - The application manifest.
- * @param intent - The app configuration.
+ * @param intentConfig - The app intent configuration (string or object).
  * @returns The application name.
  */
-export function getAppName(manifest: Partial<Manifest>, intent?: Intent): string {
+export function getAppName(manifest: Partial<Manifest>, intentConfig?: IntentConfig): string {
     const id = manifest['sap.app']?.id ?? '';
 
-    intent ??= {
-        object: id.replace(/\./g, ''),
-        action: 'preview'
-    };
+    const intent: Intent = intentConfig
+        ? resolveIntent(intentConfig)
+        : {
+              object: id.replace(/\./g, ''),
+              action: 'preview'
+          };
 
-    return `${intent?.object}-${intent?.action}`;
+    return `${intent.object}-${intent.action}`;
 }
 
 /**
@@ -462,7 +564,7 @@ export function getPreviewPaths(config: MiddlewareConfig, logger: ToolsLogger = 
     sanitizeConfig(config, logger);
     // add flp preview url
     const flpConfig = getFlpConfigWithDefaults(config.flp);
-    urls.push({ path: `${flpConfig.path}#${flpConfig.intent.object}-${flpConfig.intent.action}`, type: 'preview' });
+    urls.push({ path: `${flpConfig.path}#${buildIntentHash(flpConfig.intent)}`, type: 'preview' });
     // add editor urls
     if (config.editors) {
         config.editors.rta?.endpoints.forEach((endpoint) => {

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -193,6 +193,7 @@ export function buildIntentHash(intentConfig: IntentConfig): string {
     const params = intentConfig.params;
     const route = intentConfig.route;
 
+    // URLSearchParams encodes spaces as '+' (form-urlencoded), but FLP hash fragments require '%20' (percent-encoding).
     if (params && Object.keys(params).length > 0) {
         const paramString = Object.entries(params)
             .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -159,9 +159,11 @@ export function parseIntentString(intentString: string): Intent {
             params = {};
             const paramPairs = paramsMatch[1].split('&');
             for (const pair of paramPairs) {
-                const [key, value] = pair.split('=');
+                const eqIdx = pair.indexOf('=');
+                const key = eqIdx >= 0 ? pair.slice(0, eqIdx) : pair;
+                const value = eqIdx >= 0 ? pair.slice(eqIdx + 1) : '';
                 if (key) {
-                    params[decodeURIComponent(key)] = decodeURIComponent(value ?? '');
+                    params[decodeURIComponent(key)] = decodeURIComponent(value);
                 }
             }
         }
@@ -193,7 +195,7 @@ export function buildIntentHash(intentConfig: IntentConfig): string {
 
     if (params && Object.keys(params).length > 0) {
         const paramString = Object.entries(params)
-            .map(([key, value]) => `${key}=${value}`)
+            .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
             .join('&');
         hash += `?${paramString}`;
     }

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -121,6 +121,35 @@ export const DEFAULT_INTENT = {
 } as Readonly<DefaultIntent>;
 
 /**
+ * Parses a query string into a key-value record, splitting only on the first `=` per pair.
+ */
+function parseParams(queryString: string): Record<string, string> {
+    const params: Record<string, string> = {};
+    for (const pair of queryString.split('&')) {
+        const eqIdx = pair.indexOf('=');
+        const key = eqIdx >= 0 ? pair.slice(0, eqIdx) : pair;
+        const value = eqIdx >= 0 ? pair.slice(eqIdx + 1) : '';
+        if (key) {
+            params[decodeURIComponent(key)] = decodeURIComponent(value);
+        }
+    }
+    return params;
+}
+
+/**
+ * Extracts the route and params from the remainder of an intent string (everything after "Object-action").
+ */
+function parseIntentRemainder(remainder: string): { params?: Record<string, string>; route?: string } {
+    const route = /&(\/.*)/.exec(remainder)?.[1];
+    const paramsMatch = /\?([^&]*(?:&(?!\/)[^&]*)*)/.exec(remainder);
+    const params = paramsMatch ? parseParams(paramsMatch[1]) : undefined;
+    return {
+        ...(params && Object.keys(params).length > 0 ? { params } : {}),
+        ...(route ? { route } : {})
+    };
+}
+
+/**
  * Parses an intent string into a structured Intent object.
  *
  * Supported formats:
@@ -135,45 +164,16 @@ export const DEFAULT_INTENT = {
 export function parseIntentString(intentString: string): Intent {
     const raw = intentString.startsWith('#') ? intentString.slice(1) : intentString;
 
-    const intentPattern = /^([^-?&]+)-([^?&]+)/;
-    const match = raw.match(intentPattern);
+    const match = /^([^-?&]+)-([^?&]+)/.exec(raw);
     if (!match) {
         throw new Error(`Invalid intent format: "${intentString}". Expected "Object-action[?params][&/route]".`);
     }
 
-    const object = match[1];
-    const action = match[2];
     const remainder = raw.slice(match[0].length);
-
-    let params: Record<string, string> | undefined;
-    let route: string | undefined;
-
-    if (remainder) {
-        const routeMatch = remainder.match(/&(\/.*)/);
-        if (routeMatch) {
-            route = routeMatch[1];
-        }
-
-        const paramsMatch = remainder.match(/\?([^&]*(?:&(?!\/)[^&]*)*)/);
-        if (paramsMatch) {
-            params = {};
-            const paramPairs = paramsMatch[1].split('&');
-            for (const pair of paramPairs) {
-                const eqIdx = pair.indexOf('=');
-                const key = eqIdx >= 0 ? pair.slice(0, eqIdx) : pair;
-                const value = eqIdx >= 0 ? pair.slice(eqIdx + 1) : '';
-                if (key) {
-                    params[decodeURIComponent(key)] = decodeURIComponent(value);
-                }
-            }
-        }
-    }
-
     return {
-        object,
-        action,
-        ...(params && Object.keys(params).length > 0 ? { params } : {}),
-        ...(route ? { route } : {})
+        object: match[1],
+        action: match[2],
+        ...(remainder ? parseIntentRemainder(remainder) : {})
     };
 }
 

--- a/packages/preview-middleware/src/base/config.ts
+++ b/packages/preview-middleware/src/base/config.ts
@@ -123,7 +123,7 @@ export const DEFAULT_INTENT = {
 /**
  * Parses a query string into a key-value record, splitting only on the first `=` per pair.
  *
- * @param queryString
+ * @param queryString the raw query string without leading `?` (e.g. "key1=val1&key2=val2")
  */
 function parseParams(queryString: string): Record<string, string> {
     const params: Record<string, string> = {};
@@ -141,7 +141,8 @@ function parseParams(queryString: string): Record<string, string> {
 /**
  * Extracts the route and params from the remainder of an intent string (everything after "Object-action").
  *
- * @param remainder
+ * @param remainder the portion of the intent string after the "Object-action" prefix
+ * @returns object with optional params and route
  */
 function parseIntentRemainder(remainder: string): { params?: Record<string, string>; route?: string } {
     const route = /&(\/.*)/.exec(remainder)?.[1];

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -58,7 +58,8 @@ import {
     getAppName,
     sanitizeRtaConfig,
     CARD_GENERATOR_DEFAULT,
-    remapResourcesForPath
+    remapResourcesForPath,
+    buildIntentHash
 } from './config';
 import { generateCdm } from './cdm';
 import { readFileSync } from 'node:fs';
@@ -378,7 +379,7 @@ export class FlpSandbox {
         previewUrl: string
     ): Promise<void> {
         const scenario = rta.options?.scenario;
-        let templatePreviewUrl = `${previewUrl}?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#${this.flpConfig.intent.object}-${this.flpConfig.intent.action}`;
+        let templatePreviewUrl = `${previewUrl}?sap-ui-xx-viewCache=false&fiori-tools-rta-mode=forAdaptation&sap-ui-rta-skip-flex-validation=true&sap-ui-xx-condense-changes=true#${buildIntentHash(this.flpConfig.intent)}`;
         if (scenario === 'ADAPTATION_PROJECT') {
             templatePreviewUrl = templatePreviewUrl.replace('?', `?sap-ui-layer=${rta.layer}&`);
         }
@@ -695,13 +696,13 @@ export class FlpSandbox {
                 manifest = {
                     'sap.app': {
                         id: app.componentId,
-                        title: app.intent ? `${app.intent.object}-${app.intent.action}` : app.componentId
+                        title: app.intent ? buildIntentHash(app.intent) : app.componentId
                     }
                 } as Manifest;
             }
             if (manifest) {
                 await addApp(this.templateConfig, manifest, app, this.logger);
-                this.logger.info(`Adding additional intent: ${app.intent?.object}-${app.intent?.action}`);
+                this.logger.info(`Adding additional intent: ${app.intent ? buildIntentHash(app.intent) : 'none'}`);
             } else {
                 this.logger.info(
                     `Invalid application config for route ${app.target} because neither componentId nor local folder provided.`

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -701,6 +701,8 @@ export class FlpSandbox {
 
     /**
      * Resolves a manifest for an additional app from either its local folder or componentId.
+     *
+     * @param app
      */
     private async resolveAppManifest(app: FlpConfig['apps'][number]): Promise<Manifest | undefined> {
         if (app.local) {

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -59,8 +59,7 @@ import {
     sanitizeRtaConfig,
     CARD_GENERATOR_DEFAULT,
     remapResourcesForPath,
-    buildIntentHash,
-    resolveIntent
+    buildIntentHash
 } from './config';
 import { generateCdm } from './cdm';
 import { readFileSync } from 'node:fs';
@@ -712,11 +711,10 @@ export class FlpSandbox {
             return JSON.parse(readFileSync(join(webappPath, 'manifest.json'), 'utf-8')) as Manifest;
         }
         if (app.componentId) {
-            const resolved = app.intent ? resolveIntent(app.intent) : undefined;
             return {
                 'sap.app': {
                     id: app.componentId,
-                    title: resolved ? `${resolved.object}-${resolved.action}` : app.componentId
+                    title: app.intent ? `${app.intent.object}-${app.intent.action}` : app.componentId
                 }
             } as Manifest;
         }

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -59,7 +59,8 @@ import {
     sanitizeRtaConfig,
     CARD_GENERATOR_DEFAULT,
     remapResourcesForPath,
-    buildIntentHash
+    buildIntentHash,
+    resolveIntent
 } from './config';
 import { generateCdm } from './cdm';
 import { readFileSync } from 'node:fs';
@@ -693,10 +694,11 @@ export class FlpSandbox {
                 this.router.use(app.target, serveStatic(webappPath));
                 this.logger.info(`Serving additional application at ${app.target} from ${app.local}`);
             } else if (app.componentId) {
+                const resolved = app.intent ? resolveIntent(app.intent) : undefined;
                 manifest = {
                     'sap.app': {
                         id: app.componentId,
-                        title: app.intent ? buildIntentHash(app.intent) : app.componentId
+                        title: resolved ? `${resolved.object}-${resolved.action}` : app.componentId
                     }
                 } as Manifest;
             }

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -687,21 +687,7 @@ export class FlpSandbox {
      */
     private async addRoutesForAdditionalApps(): Promise<void> {
         for (const app of this.flpConfig.apps) {
-            let manifest: Manifest | undefined;
-            if (app.local) {
-                const webappPath = await getWebappPath(app.local, this.fs);
-                manifest = JSON.parse(readFileSync(join(webappPath, 'manifest.json'), 'utf-8')) as Manifest | undefined;
-                this.router.use(app.target, serveStatic(webappPath));
-                this.logger.info(`Serving additional application at ${app.target} from ${app.local}`);
-            } else if (app.componentId) {
-                const resolved = app.intent ? resolveIntent(app.intent) : undefined;
-                manifest = {
-                    'sap.app': {
-                        id: app.componentId,
-                        title: resolved ? `${resolved.object}-${resolved.action}` : app.componentId
-                    }
-                } as Manifest;
-            }
+            const manifest = await this.resolveAppManifest(app);
             if (manifest) {
                 await addApp(this.templateConfig, manifest, app, this.logger);
                 this.logger.info(`Adding additional intent: ${app.intent ? buildIntentHash(app.intent) : 'none'}`);
@@ -711,6 +697,28 @@ export class FlpSandbox {
                 );
             }
         }
+    }
+
+    /**
+     * Resolves a manifest for an additional app from either its local folder or componentId.
+     */
+    private async resolveAppManifest(app: FlpConfig['apps'][number]): Promise<Manifest | undefined> {
+        if (app.local) {
+            const webappPath = await getWebappPath(app.local, this.fs);
+            this.router.use(app.target, serveStatic(webappPath));
+            this.logger.info(`Serving additional application at ${app.target} from ${app.local}`);
+            return JSON.parse(readFileSync(join(webappPath, 'manifest.json'), 'utf-8')) as Manifest;
+        }
+        if (app.componentId) {
+            const resolved = app.intent ? resolveIntent(app.intent) : undefined;
+            return {
+                'sap.app': {
+                    id: app.componentId,
+                    title: resolved ? `${resolved.object}-${resolved.action}` : app.componentId
+                }
+            } as Manifest;
+        }
+        return undefined;
     }
 
     /**

--- a/packages/preview-middleware/src/index.ts
+++ b/packages/preview-middleware/src/index.ts
@@ -9,6 +9,8 @@ export {
 } from './base';
 export {
     FlpConfig,
+    Intent,
+    IntentConfig,
     RtaConfig,
     TestConfig,
     MiddlewareConfig,

--- a/packages/preview-middleware/src/index.ts
+++ b/packages/preview-middleware/src/index.ts
@@ -10,7 +10,6 @@ export {
 export {
     FlpConfig,
     Intent,
-    IntentConfig,
     RtaConfig,
     TestConfig,
     MiddlewareConfig,

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -12,13 +12,6 @@ export interface Intent {
 }
 
 /**
- * Intent configuration as provided in ui5.yaml.
- * Either a full intent string (e.g. "Object-action?p1=v1&/route")
- * or a structured Intent object.
- */
-export type IntentConfig = string | Intent;
-
-/**
  * Configuration for additional applications
  */
 export interface App {
@@ -31,7 +24,7 @@ export interface App {
      * Optional component id if it differs from the manifest (e.g. for adaptation projects)
      */
     componentId?: string;
-    intent?: IntentConfig;
+    intent?: Intent;
 }
 
 export interface RtaEditor {
@@ -60,7 +53,7 @@ interface InternalRtaConfig {
  */
 export interface FlpConfig {
     path: string;
-    intent: IntentConfig;
+    intent: Intent;
     /**
      * Optional: if set to true then a locate-reuse-libs script will be attached to the html
      */

--- a/packages/preview-middleware/src/types/index.ts
+++ b/packages/preview-middleware/src/types/index.ts
@@ -2,12 +2,21 @@ import type { AdpPreviewConfig } from '@sap-ux/adp-tooling';
 import type { UI5FlexLayer } from '@sap-ux/project-access';
 
 /**
- * Intent object consisting of an object and an action.
+ * Intent object consisting of an object, action, and optional parameters/route.
  */
 export interface Intent {
     object: string;
     action: string;
+    params?: Record<string, string>;
+    route?: string;
 }
+
+/**
+ * Intent configuration as provided in ui5.yaml.
+ * Either a full intent string (e.g. "Object-action?p1=v1&/route")
+ * or a structured Intent object.
+ */
+export type IntentConfig = string | Intent;
 
 /**
  * Configuration for additional applications
@@ -22,7 +31,7 @@ export interface App {
      * Optional component id if it differs from the manifest (e.g. for adaptation projects)
      */
     componentId?: string;
-    intent?: Intent;
+    intent?: IntentConfig;
 }
 
 export interface RtaEditor {
@@ -51,7 +60,7 @@ interface InternalRtaConfig {
  */
 export interface FlpConfig {
     path: string;
-    intent: Intent;
+    intent: IntentConfig;
     /**
      * Optional: if set to true then a locate-reuse-libs script will be attached to the html
      */

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -123,11 +123,7 @@ describe('config', () => {
             } as MiddlewareConfig;
             const previews = getPreviewPaths(config);
             expect(previews).toHaveLength(5);
-            expect(
-                previews.find(
-                    ({ path }) => path === `${config?.flp?.path}#myapp-myaction`
-                )
-            ).toBeDefined();
+            expect(previews.find(({ path }) => path === `${config?.flp?.path}#myapp-myaction`)).toBeDefined();
             expect(previews.find(({ path }) => path === config?.editors?.rta?.endpoints[0]?.path)).toBeDefined();
             expect(previews.find(({ path }) => path === config?.editors?.rta?.endpoints[1]?.path)).toBeDefined();
             expect(consoleSpyError).toHaveBeenCalledWith(
@@ -179,9 +175,7 @@ describe('config', () => {
                 }
             } as unknown as MiddlewareConfig;
             const paths = getPreviewPaths(config);
-            expect(paths[0].path).toBe(
-                '/test/flp.html#SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
-            );
+            expect(paths[0].path).toBe('/test/flp.html#SupplierInvoice-displayFactSheet?FiscalYear=2017&/display');
         });
     });
 
@@ -405,9 +399,7 @@ describe('config', () => {
 
         test('intent with params', () => {
             expect(
-                parseIntentString(
-                    'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001'
-                )
+                parseIntentString('SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001')
             ).toEqual({
                 object: 'SupplierInvoice',
                 action: 'displayFactSheet',

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -8,9 +8,7 @@ import {
     getFlpConfigWithDefaults,
     getPreviewPaths,
     remapResourcesForPath,
-    parseIntentString,
-    buildIntentHash,
-    resolveIntent
+    buildIntentHash
 } from '../../../src/base/config';
 import { mergeTestConfigDefaults } from '../../../src/base/test';
 import type { MiddlewareConfig } from '../../../src';
@@ -36,17 +34,6 @@ describe('config', () => {
             const intent = { object: 'myapp', action: 'myaction' };
             const flpConfig = getFlpConfigWithDefaults({ path, intent });
             expect(flpConfig).toMatchObject({ path, intent });
-        });
-        test('resolves string intent from yaml', () => {
-            const flpConfig = getFlpConfigWithDefaults({
-                intent: 'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
-            });
-            expect(flpConfig.intent).toEqual({
-                object: 'SupplierInvoice',
-                action: 'displayFactSheet',
-                params: { FiscalYear: '2017' },
-                route: '/display'
-            });
         });
         test('resolves structured intent with params from yaml', () => {
             const flpConfig = getFlpConfigWithDefaults({
@@ -168,10 +155,15 @@ describe('config', () => {
             });
         });
 
-        test('preview path includes intent params and route from string config', () => {
+        test('preview path includes intent params and route', () => {
             const config = {
                 flp: {
-                    intent: 'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
+                    intent: {
+                        object: 'SupplierInvoice',
+                        action: 'displayFactSheet',
+                        params: { FiscalYear: '2017' },
+                        route: '/display'
+                    }
                 }
             } as unknown as MiddlewareConfig;
             const paths = getPreviewPaths(config);
@@ -389,67 +381,6 @@ describe('config', () => {
         });
     });
 
-    describe('parseIntentString', () => {
-        test('simple intent', () => {
-            expect(parseIntentString('app-preview')).toEqual({
-                object: 'app',
-                action: 'preview'
-            });
-        });
-
-        test('intent with params', () => {
-            expect(
-                parseIntentString('SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001')
-            ).toEqual({
-                object: 'SupplierInvoice',
-                action: 'displayFactSheet',
-                params: { FiscalYear: '2017', SupplierInvoice: '5100000001' }
-            });
-        });
-
-        test('param value containing equals sign is preserved', () => {
-            expect(parseIntentString('App-action?filter=price=100')).toEqual({
-                object: 'App',
-                action: 'action',
-                params: { filter: 'price=100' }
-            });
-        });
-
-        test('intent with route only', () => {
-            expect(parseIntentString('SupplierInvoice-create&/create/isSharedDraft=false')).toEqual({
-                object: 'SupplierInvoice',
-                action: 'create',
-                route: '/create/isSharedDraft=false'
-            });
-        });
-
-        test('intent with params and route', () => {
-            expect(
-                parseIntentString(
-                    'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display'
-                )
-            ).toEqual({
-                object: 'SupplierInvoice',
-                action: 'displayFactSheet',
-                params: { FiscalYear: '2017', SupplierInvoice: '5100000001' },
-                route: '/display'
-            });
-        });
-
-        test('strips leading #', () => {
-            expect(parseIntentString('#app-preview')).toEqual({
-                object: 'app',
-                action: 'preview'
-            });
-        });
-
-        test('throws on invalid format', () => {
-            expect(() => parseIntentString('invalid')).toThrow(
-                'Invalid intent format: "invalid". Expected "Object-action[?params][&/route]".'
-            );
-        });
-    });
-
     describe('buildIntentHash', () => {
         test('basic intent without params', () => {
             expect(buildIntentHash({ object: 'app', action: 'preview' })).toBe('app-preview');
@@ -500,45 +431,6 @@ describe('config', () => {
             expect(buildIntentHash({ object: 'App', action: 'view', params: { filter: 'a&b=c' } })).toBe(
                 'App-view?filter=a%26b%3Dc'
             );
-        });
-
-        test('string passthrough without leading hash', () => {
-            expect(buildIntentHash('SupplierInvoice-displayFactSheet?FiscalYear=2017&/display')).toBe(
-                'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
-            );
-        });
-
-        test('string passthrough strips leading hash', () => {
-            expect(buildIntentHash('#app-preview')).toBe('app-preview');
-        });
-    });
-
-    describe('resolveIntent', () => {
-        test('passes through object as-is', () => {
-            const intent = { object: 'app', action: 'preview' };
-            expect(resolveIntent(intent)).toEqual(intent);
-        });
-
-        test('parses string into object', () => {
-            expect(resolveIntent('SupplierInvoice-displayFactSheet?FiscalYear=2017&/display')).toEqual({
-                object: 'SupplierInvoice',
-                action: 'displayFactSheet',
-                params: { FiscalYear: '2017' },
-                route: '/display'
-            });
-        });
-    });
-
-    describe('roundtrip: parse → build', () => {
-        const cases = [
-            'app-preview',
-            'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001',
-            'SupplierInvoice-create&/create/isSharedDraft=false',
-            'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display'
-        ];
-
-        test.each(cases)('roundtrip: %s', (input) => {
-            expect(buildIntentHash(parseIntentString(input))).toBe(input);
         });
     });
 });

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -7,7 +7,10 @@ import {
     generatePreviewFiles,
     getFlpConfigWithDefaults,
     getPreviewPaths,
-    remapResourcesForPath
+    remapResourcesForPath,
+    parseIntentString,
+    buildIntentHash,
+    resolveIntent
 } from '../../../src/base/config';
 import { mergeTestConfigDefaults } from '../../../src/base/test';
 import type { MiddlewareConfig } from '../../../src';
@@ -33,6 +36,27 @@ describe('config', () => {
             const intent = { object: 'myapp', action: 'myaction' };
             const flpConfig = getFlpConfigWithDefaults({ path, intent });
             expect(flpConfig).toMatchObject({ path, intent });
+        });
+        test('resolves string intent from yaml', () => {
+            const flpConfig = getFlpConfigWithDefaults({
+                intent: 'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
+            });
+            expect(flpConfig.intent).toEqual({
+                object: 'SupplierInvoice',
+                action: 'displayFactSheet',
+                params: { FiscalYear: '2017' },
+                route: '/display'
+            });
+        });
+        test('resolves structured intent with params from yaml', () => {
+            const flpConfig = getFlpConfigWithDefaults({
+                intent: { object: 'app', action: 'manage', params: { id: '123' } }
+            });
+            expect(flpConfig.intent).toEqual({
+                object: 'app',
+                action: 'manage',
+                params: { id: '123' }
+            });
         });
     });
 
@@ -101,8 +125,7 @@ describe('config', () => {
             expect(previews).toHaveLength(5);
             expect(
                 previews.find(
-                    ({ path }) =>
-                        path === `${config?.flp?.path}#${config?.flp?.intent?.object}-${config?.flp?.intent?.action}`
+                    ({ path }) => path === `${config?.flp?.path}#myapp-myaction`
                 )
             ).toBeDefined();
             expect(previews.find(({ path }) => path === config?.editors?.rta?.endpoints[0]?.path)).toBeDefined();
@@ -147,6 +170,18 @@ describe('config', () => {
             previews.forEach(({ path }) => {
                 expect(path.startsWith('/')).toBe(true);
             });
+        });
+
+        test('preview path includes intent params and route from string config', () => {
+            const config = {
+                flp: {
+                    intent: 'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
+                }
+            } as unknown as MiddlewareConfig;
+            const paths = getPreviewPaths(config);
+            expect(paths[0].path).toBe(
+                '/test/flp.html#SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
+            );
         });
     });
 
@@ -357,6 +392,147 @@ describe('config', () => {
             expect(config.basePath).toBe('.');
             // posix.join('.', 'preview', 'client') normalises to 'preview/client' (no leading './')
             expect(config.ui5.resources['open.ux.preview.client']).toBe('preview/client');
+        });
+    });
+
+    describe('parseIntentString', () => {
+        test('simple intent', () => {
+            expect(parseIntentString('app-preview')).toEqual({
+                object: 'app',
+                action: 'preview'
+            });
+        });
+
+        test('intent with params', () => {
+            expect(
+                parseIntentString(
+                    'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001'
+                )
+            ).toEqual({
+                object: 'SupplierInvoice',
+                action: 'displayFactSheet',
+                params: { FiscalYear: '2017', SupplierInvoice: '5100000001' }
+            });
+        });
+
+        test('intent with route only', () => {
+            expect(parseIntentString('SupplierInvoice-create&/create/isSharedDraft=false')).toEqual({
+                object: 'SupplierInvoice',
+                action: 'create',
+                route: '/create/isSharedDraft=false'
+            });
+        });
+
+        test('intent with params and route', () => {
+            expect(
+                parseIntentString(
+                    'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display'
+                )
+            ).toEqual({
+                object: 'SupplierInvoice',
+                action: 'displayFactSheet',
+                params: { FiscalYear: '2017', SupplierInvoice: '5100000001' },
+                route: '/display'
+            });
+        });
+
+        test('strips leading #', () => {
+            expect(parseIntentString('#app-preview')).toEqual({
+                object: 'app',
+                action: 'preview'
+            });
+        });
+
+        test('throws on invalid format', () => {
+            expect(() => parseIntentString('invalid')).toThrow(
+                'Invalid intent format: "invalid". Expected "Object-action[?params][&/route]".'
+            );
+        });
+    });
+
+    describe('buildIntentHash', () => {
+        test('basic intent without params', () => {
+            expect(buildIntentHash({ object: 'app', action: 'preview' })).toBe('app-preview');
+        });
+
+        test('intent with params', () => {
+            expect(
+                buildIntentHash({
+                    object: 'SupplierInvoice',
+                    action: 'displayFactSheet',
+                    params: { FiscalYear: '2017', SupplierInvoice: '5100000001' }
+                })
+            ).toBe('SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001');
+        });
+
+        test('intent with route only', () => {
+            expect(
+                buildIntentHash({
+                    object: 'SupplierInvoice',
+                    action: 'create',
+                    route: '/create/isSharedDraft=false'
+                })
+            ).toBe('SupplierInvoice-create&/create/isSharedDraft=false');
+        });
+
+        test('intent with params and route', () => {
+            expect(
+                buildIntentHash({
+                    object: 'SupplierInvoice',
+                    action: 'displayFactSheet',
+                    params: { FiscalYear: '2017', SupplierInvoice: '5100000001' },
+                    route: '/display'
+                })
+            ).toBe('SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display');
+        });
+
+        test('normalizes route without leading slash', () => {
+            expect(buildIntentHash({ object: 'app', action: 'preview', route: 'display' })).toBe(
+                'app-preview&/display'
+            );
+        });
+
+        test('empty params object is ignored', () => {
+            expect(buildIntentHash({ object: 'app', action: 'preview', params: {} })).toBe('app-preview');
+        });
+
+        test('string passthrough without leading hash', () => {
+            expect(buildIntentHash('SupplierInvoice-displayFactSheet?FiscalYear=2017&/display')).toBe(
+                'SupplierInvoice-displayFactSheet?FiscalYear=2017&/display'
+            );
+        });
+
+        test('string passthrough strips leading hash', () => {
+            expect(buildIntentHash('#app-preview')).toBe('app-preview');
+        });
+    });
+
+    describe('resolveIntent', () => {
+        test('passes through object as-is', () => {
+            const intent = { object: 'app', action: 'preview' };
+            expect(resolveIntent(intent)).toEqual(intent);
+        });
+
+        test('parses string into object', () => {
+            expect(resolveIntent('SupplierInvoice-displayFactSheet?FiscalYear=2017&/display')).toEqual({
+                object: 'SupplierInvoice',
+                action: 'displayFactSheet',
+                params: { FiscalYear: '2017' },
+                route: '/display'
+            });
+        });
+    });
+
+    describe('roundtrip: parse → build', () => {
+        const cases = [
+            'app-preview',
+            'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001',
+            'SupplierInvoice-create&/create/isSharedDraft=false',
+            'SupplierInvoice-displayFactSheet?FiscalYear=2017&SupplierInvoice=5100000001&/display'
+        ];
+
+        test.each(cases)('roundtrip: %s', (input) => {
+            expect(buildIntentHash(parseIntentString(input))).toBe(input);
         });
     });
 });

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -407,6 +407,14 @@ describe('config', () => {
             });
         });
 
+        test('param value containing equals sign is preserved', () => {
+            expect(parseIntentString('App-action?filter=price=100')).toEqual({
+                object: 'App',
+                action: 'action',
+                params: { filter: 'price=100' }
+            });
+        });
+
         test('intent with route only', () => {
             expect(parseIntentString('SupplierInvoice-create&/create/isSharedDraft=false')).toEqual({
                 object: 'SupplierInvoice',
@@ -486,6 +494,12 @@ describe('config', () => {
 
         test('empty params object is ignored', () => {
             expect(buildIntentHash({ object: 'app', action: 'preview', params: {} })).toBe('app-preview');
+        });
+
+        test('encodes special characters in param values', () => {
+            expect(
+                buildIntentHash({ object: 'App', action: 'view', params: { filter: 'a&b=c' } })
+            ).toBe('App-view?filter=a%26b%3Dc');
         });
 
         test('string passthrough without leading hash', () => {

--- a/packages/preview-middleware/test/unit/base/config.test.ts
+++ b/packages/preview-middleware/test/unit/base/config.test.ts
@@ -497,9 +497,9 @@ describe('config', () => {
         });
 
         test('encodes special characters in param values', () => {
-            expect(
-                buildIntentHash({ object: 'App', action: 'view', params: { filter: 'a&b=c' } })
-            ).toBe('App-view?filter=a%26b%3Dc');
+            expect(buildIntentHash({ object: 'App', action: 'view', params: { filter: 'a&b=c' } })).toBe(
+                'App-view?filter=a%26b%3Dc'
+            );
         });
 
         test('string passthrough without leading hash', () => {


### PR DESCRIPTION
Feat for #4624.
- Add support for string-based intent configuration in `ui5.yaml` (e.g. intent: "**Object-action?param=value&/route**") alongside the existing structured object format
- Extend the `Intent` type with optional params and route fields for full cross-app navigation support
- Export Intent and `IntentConfig` types from the public API
- Fix `@sap-ux/app-config-writer` consumer to handle the new `IntentConfig` union type