### PR TITLE
fix: Adjust toolbar border and separator color variables

### DIFF
--- a/.changeset/purple-lies-poke.md
+++ b/.changeset/purple-lies-poke.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Adjust toolbar border and separator color variables

--- a/packages/ui-components/src/components/UIToolbar/UIToolbar.scss
+++ b/packages/ui-components/src/components/UIToolbar/UIToolbar.scss
@@ -10,7 +10,7 @@
     }
 
     &__content {
-        border-bottom: 1px solid var(--vscode-contrastBorder, var(--vscode-editorIndentGuide-background));
+        border-bottom: 1px solid var(--vscode-contrastBorder, var(--vscode-widget-border));
         background-color: var(--vscode-editor-background);
         display: flex;
         flex-wrap: wrap;
@@ -21,7 +21,7 @@
         display: inline-block;
         height: 20px;
         margin: 3px 10px 3px;
-        border-right: 1px solid var(--vscode-contrastBorder, var(--vscode-editorIndentGuide-background));
+        border-right: 1px solid var(--vscode-contrastBorder, var(--vscode-widget-border));
     }
 
     &__column {


### PR DESCRIPTION
Adjust toolbar border and separator color variables to work more smoother with different themes