### PR TITLE
fix(sap-systems-ext): add new create new command

### DIFF
--- a/.changeset/green-boxes-rule.md
+++ b/.changeset/green-boxes-rule.md
@@ -1,0 +1,5 @@
+---
+'sap-ux-sap-systems-ext': patch
+---
+
+adds new internal create command to avoid collisions with other registered commands

--- a/packages/sap-systems-ext/package.json
+++ b/packages/sap-systems-ext/package.json
@@ -121,6 +121,11 @@
             },
             {
                 "command": "sap.ux.tools.sapSystems.create",
+                "title": "Add SAP System (External)",
+                "description": "Add a new SAP system by providing connection details such as host, client, and credentials. This allows you to manage and connect to your SAP systems directly from the Connection Manager."
+            },
+            {
+                "command": "sap.ux.tools.sapSystems.createNew",
                 "title": "Add SAP System",
                 "category": "SAP",
                 "icon": {
@@ -161,6 +166,10 @@
                 {
                     "command": "sap.ux.tools.sapSystems.launchAppGen",
                     "when": "false"
+                },
+                {
+                    "command": "sap.ux.tools.sapSystems.create",
+                    "when": "false"
                 }
             ],
             "view/title": [
@@ -170,7 +179,7 @@
                     "group": "navigation@0"
                 },
                 {
-                    "command": "sap.ux.tools.sapSystems.create",
+                    "command": "sap.ux.tools.sapSystems.createNew",
                     "when": "view == sap.ux.tools.sapSystems",
                     "group": "navigation@1"
                 },

--- a/packages/sap-systems-ext/src/commands/system/create.ts
+++ b/packages/sap-systems-ext/src/commands/system/create.ts
@@ -1,5 +1,5 @@
 import type { SystemCommandContext } from '../../types/system';
-import { NEW_SYSTEM_PANEL_KEY, SystemPanelViewType } from '../../utils/constants';
+import { NEW_SYSTEM_PANEL_KEY, EXTERNAL_SYSTEM_PANEL_KEY, SystemPanelViewType } from '../../utils/constants';
 import { SystemPanel } from '../../panel';
 import type { BackendSystem } from '@sap-ux/store';
 
@@ -7,6 +7,7 @@ import type { BackendSystem } from '@sap-ux/store';
  * Returns a command handler function that creates or reveals the system panel.
  * An optional BackendSystem can be passed to pre-fill the panel fields.
  * This command is the public API used by external tools to create systems with pre-filled data.
+ * It uses a separate panel key to avoid interfering with user-initiated "Add New System" panels.
  *
  * @param context - the system command context
  * @returns - a command handler function
@@ -14,8 +15,17 @@ import type { BackendSystem } from '@sap-ux/store';
 export const createSystemCommandHandler =
     (context: SystemCommandContext) =>
     async (system?: BackendSystem): Promise<void> => {
-        const panel = context.panelManager.getOrCreateNewPanel(NEW_SYSTEM_PANEL_KEY, () =>
-            createNewPanel(context, system)
+        // Use EXTERNAL_SYSTEM_PANEL_KEY for external tool invocations to avoid
+        // interfering with any user-initiated "Add New System" panels that might be open
+        const panelKey = EXTERNAL_SYSTEM_PANEL_KEY;
+
+        // Always dispose any existing external panel to ensure fresh state
+        if (context.panelManager.has(panelKey)) {
+            context.panelManager.deleteAndDispose(panelKey);
+        }
+
+        const panel = context.panelManager.getOrCreateNewPanel(panelKey, () =>
+            createNewPanel(context, system, panelKey)
         );
         await panel.reveal();
     };
@@ -28,9 +38,8 @@ export const createSystemCommandHandler =
  * @returns - a command handler function
  */
 export const createNewSystemCommandHandler = (context: SystemCommandContext) => async (): Promise<void> => {
-    // Always pass undefined to ensure empty form
     const panel = context.panelManager.getOrCreateNewPanel(NEW_SYSTEM_PANEL_KEY, () =>
-        createNewPanel(context, undefined)
+        createNewPanel(context, undefined, NEW_SYSTEM_PANEL_KEY)
     );
     await panel.reveal();
 };
@@ -40,15 +49,20 @@ export const createNewSystemCommandHandler = (context: SystemCommandContext) => 
  *
  * @param context - the system command context
  * @param backendSystem - optional pre-populated backend system data
+ * @param panelKey - the key to use for this panel in the panel manager
  * @returns - the created system panel
  */
-function createNewPanel(context: SystemCommandContext, backendSystem?: BackendSystem): SystemPanel {
+function createNewPanel(
+    context: SystemCommandContext,
+    backendSystem?: BackendSystem,
+    panelKey: string = NEW_SYSTEM_PANEL_KEY
+): SystemPanel {
     const extensionPath = context.extContext.vscodeExtContext.extensionPath;
     return new SystemPanel({
         extensionPath,
         systemPanelViewType: SystemPanelViewType.Create,
         disposeCallback: (): void => {
-            context.panelManager.deleteAndDispose(NEW_SYSTEM_PANEL_KEY);
+            context.panelManager.deleteAndDispose(panelKey);
         },
         backendSystem
     });

--- a/packages/sap-systems-ext/src/commands/system/create.ts
+++ b/packages/sap-systems-ext/src/commands/system/create.ts
@@ -6,6 +6,7 @@ import type { BackendSystem } from '@sap-ux/store';
 /**
  * Returns a command handler function that creates or reveals the system panel.
  * An optional BackendSystem can be passed to pre-fill the panel fields.
+ * This command is the public API used by external tools to create systems with pre-filled data.
  *
  * @param context - the system command context
  * @returns - a command handler function
@@ -18,6 +19,21 @@ export const createSystemCommandHandler =
         );
         await panel.reveal();
     };
+
+/**
+ * Returns a command handler function that creates a new empty system panel.
+ * This is an internal command used by the "Add New System" UI button.
+ *
+ * @param context - the system command context
+ * @returns - a command handler function
+ */
+export const createNewSystemCommandHandler = (context: SystemCommandContext) => async (): Promise<void> => {
+    // Always pass undefined to ensure empty form
+    const panel = context.panelManager.getOrCreateNewPanel(NEW_SYSTEM_PANEL_KEY, () =>
+        createNewPanel(context, undefined)
+    );
+    await panel.reveal();
+};
 
 /**
  * Creates a new system panel.

--- a/packages/sap-systems-ext/src/commands/system/index.ts
+++ b/packages/sap-systems-ext/src/commands/system/index.ts
@@ -2,7 +2,7 @@ import type { SapSystemsExtContext, SystemCommandContext, SystemCommandHandler }
 import { commands } from 'vscode';
 import { PanelManager, type SystemPanel } from '../../panel';
 import { SystemCommands } from '../../utils/constants';
-import { createSystemCommandHandler } from './create';
+import { createSystemCommandHandler, createNewSystemCommandHandler } from './create';
 import { showSystemsCommandHandler } from './show';
 import { deleteSystemCommandHandler } from './delete';
 import { refreshSystemsCommandHandler } from './refresh';
@@ -11,6 +11,7 @@ import { launchAppGenCommandHandler } from './launchAppGen';
 
 export const commandHandlers: Record<string, SystemCommandHandler> = {
     create: createSystemCommandHandler,
+    createNew: createNewSystemCommandHandler,
     show: showSystemsCommandHandler,
     import: importSystemCommandHandler,
     delete: deleteSystemCommandHandler,
@@ -33,6 +34,7 @@ export const registerSystemViewCommands = (context: SapSystemsExtContext): void 
 
     const disposables = [
         commands.registerCommand(SystemCommands.Create, commandHandlers.create(systemCommandContext)),
+        commands.registerCommand(SystemCommands.CreateNew, commandHandlers.createNew(systemCommandContext)),
         commands.registerCommand(SystemCommands.Show, commandHandlers.show(systemCommandContext)),
         commands.registerCommand(SystemCommands.Delete, commandHandlers.delete(systemCommandContext)),
         commands.registerCommand(SystemCommands.Import, commandHandlers.import(systemCommandContext)),

--- a/packages/sap-systems-ext/src/utils/constants/system.ts
+++ b/packages/sap-systems-ext/src/utils/constants/system.ts
@@ -3,6 +3,7 @@
  */
 export enum SystemCommands {
     Create = 'sap.ux.tools.sapSystems.create',
+    CreateNew = 'sap.ux.tools.sapSystems.createNew', // Internal command for UI button - always empty form
     Show = 'sap.ux.tools.sapSystems.show',
     Delete = 'sap.ux.tools.sapSystems.delete',
     Refresh = 'sap.ux.tools.sapSystems.refresh',

--- a/packages/sap-systems-ext/src/utils/constants/system.ts
+++ b/packages/sap-systems-ext/src/utils/constants/system.ts
@@ -47,3 +47,4 @@ export const confirmationPromptMap = new Map<ConfirmationPromptType, string>([
 export const fioriToolsAppModAppGenLaunchCmd = 'sap.ux.appGenerator.launch';
 export const launchAppGenCmdType = 'SAP_SYSTEMS_DATA';
 export const NEW_SYSTEM_PANEL_KEY = '__NEW_SYSTEM_PANEL__';
+export const EXTERNAL_SYSTEM_PANEL_KEY = '__EXTERNAL_SYSTEM_PANEL__';

--- a/packages/sap-systems-ext/test/unit/commands/system/create.test.ts
+++ b/packages/sap-systems-ext/test/unit/commands/system/create.test.ts
@@ -1,5 +1,5 @@
 import type { SystemCommandContext } from '../../../../src/types';
-import { createSystemCommandHandler } from '../../../../src/commands/system/create';
+import { createSystemCommandHandler, createNewSystemCommandHandler } from '../../../../src/commands/system/create';
 import { PanelManager, type SystemPanel } from '../../../../src/panel';
 import { BackendSystem } from '@sap-ux/store';
 
@@ -47,6 +47,26 @@ describe('Test the create system command handler', () => {
 
         const handler = createSystemCommandHandler(mockContext);
         await handler(prePopulated);
+
+        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
+    });
+});
+describe('Test the createNew system command handler', () => {
+    it('should create and reveal a new empty system panel', async () => {
+        const panelManager = new PanelManager<SystemPanel>();
+        const getOrCreateNewPanelSpy = jest.spyOn(panelManager, 'getOrCreateNewPanel');
+
+        const mockContext = {
+            panelManager,
+            extContext: {
+                vscodeExtContext: {
+                    extensionPath: '/mock/extension/path'
+                }
+            }
+        } as SystemCommandContext;
+
+        const handler = createNewSystemCommandHandler(mockContext);
+        await handler();
 
         expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
     });

--- a/packages/sap-systems-ext/test/unit/commands/system/create.test.ts
+++ b/packages/sap-systems-ext/test/unit/commands/system/create.test.ts
@@ -4,7 +4,7 @@ import { PanelManager, type SystemPanel } from '../../../../src/panel';
 import { BackendSystem } from '@sap-ux/store';
 
 describe('Test the create system command handler', () => {
-    it('should create and reveal a new system panel', async () => {
+    it('should create and reveal a new system panel using external panel key', async () => {
         const panelManager = new PanelManager<SystemPanel>();
 
         const getOrCreateNewPanelSpy = jest.spyOn(panelManager, 'getOrCreateNewPanel');
@@ -21,7 +21,8 @@ describe('Test the create system command handler', () => {
         const handler = createSystemCommandHandler(mockContext);
         await handler();
 
-        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
+        // Should use EXTERNAL_SYSTEM_PANEL_KEY for external tool invocations
+        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__EXTERNAL_SYSTEM_PANEL__', expect.any(Function));
     });
 
     it('should pass pre-populated BackendSystem to the panel when provided', async () => {
@@ -48,11 +49,61 @@ describe('Test the create system command handler', () => {
         const handler = createSystemCommandHandler(mockContext);
         await handler(prePopulated);
 
-        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
+        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__EXTERNAL_SYSTEM_PANEL__', expect.any(Function));
+    });
+
+    it('should dispose existing external panel before creating new one', async () => {
+        const panelManager = new PanelManager<SystemPanel>();
+        const deleteAndDisposeSpy = jest.spyOn(panelManager, 'deleteAndDispose');
+        const hasSpy = jest.spyOn(panelManager, 'has');
+
+        // Mock that an external panel exists
+        hasSpy.mockReturnValue(true);
+
+        const mockContext = {
+            panelManager,
+            extContext: {
+                vscodeExtContext: {
+                    extensionPath: '/mock/extension/path'
+                }
+            }
+        } as SystemCommandContext;
+
+        const handler = createSystemCommandHandler(mockContext);
+        await handler();
+
+        expect(hasSpy).toHaveBeenCalledWith('__EXTERNAL_SYSTEM_PANEL__');
+        expect(deleteAndDisposeSpy).toHaveBeenCalledWith('__EXTERNAL_SYSTEM_PANEL__');
+    });
+
+    it('should not interfere with user-initiated NEW_SYSTEM_PANEL', async () => {
+        const panelManager = new PanelManager<SystemPanel>();
+        const deleteAndDisposeSpy = jest.spyOn(panelManager, 'deleteAndDispose');
+        const hasSpy = jest.spyOn(panelManager, 'has');
+
+        // Mock that user-initiated panel exists but external panel doesn't
+        hasSpy.mockImplementation((key: string) => key === '__NEW_SYSTEM_PANEL__');
+
+        const mockContext = {
+            panelManager,
+            extContext: {
+                vscodeExtContext: {
+                    extensionPath: '/mock/extension/path'
+                }
+            }
+        } as SystemCommandContext;
+
+        const handler = createSystemCommandHandler(mockContext);
+        await handler();
+
+        // Should only check/dispose EXTERNAL panel, not NEW panel
+        expect(hasSpy).toHaveBeenCalledWith('__EXTERNAL_SYSTEM_PANEL__');
+        expect(deleteAndDisposeSpy).not.toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__');
     });
 });
+
 describe('Test the createNew system command handler', () => {
-    it('should create and reveal a new empty system panel', async () => {
+    it('should create and reveal a new empty system panel using new panel key', async () => {
         const panelManager = new PanelManager<SystemPanel>();
         const getOrCreateNewPanelSpy = jest.spyOn(panelManager, 'getOrCreateNewPanel');
 
@@ -68,6 +119,37 @@ describe('Test the createNew system command handler', () => {
         const handler = createNewSystemCommandHandler(mockContext);
         await handler();
 
+        // Should use NEW_SYSTEM_PANEL_KEY for user-initiated creation
         expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
+    });
+
+    it('should always create empty panel regardless of arguments', async () => {
+        const panelManager = new PanelManager<SystemPanel>();
+        const getOrCreateNewPanelSpy = jest.spyOn(panelManager, 'getOrCreateNewPanel');
+        let capturedBackendSystem: any;
+
+        // Spy on getOrCreateNewPanel to capture what's passed to the factory
+        getOrCreateNewPanelSpy.mockImplementation((key, factory) => {
+            const panel = factory();
+            // Capture the backendSystem from the created panel
+            capturedBackendSystem = (panel as any).backendSystem;
+            return panel;
+        });
+
+        const mockContext = {
+            panelManager,
+            extContext: {
+                vscodeExtContext: {
+                    extensionPath: '/mock/extension/path'
+                }
+            }
+        } as SystemCommandContext;
+
+        const handler = createNewSystemCommandHandler(mockContext);
+        await handler();
+
+        expect(getOrCreateNewPanelSpy).toHaveBeenCalledWith('__NEW_SYSTEM_PANEL__', expect.any(Function));
+        // Verify that undefined was passed (empty form)
+        expect(capturedBackendSystem).toBeUndefined();
     });
 });

--- a/packages/sap-systems-ext/test/unit/commands/system/index.test.ts
+++ b/packages/sap-systems-ext/test/unit/commands/system/index.test.ts
@@ -10,8 +10,7 @@ describe('Test registering the systems commands', () => {
         } as ExtensionContext;
 
         const cmds = vscodeMod.commands;
-
-        const vscodeCommandsRegisterSpy = jest.spyOn(cmds, 'registerCommand').mockImplementation(() => {
+        jest.spyOn(cmds, 'registerCommand').mockImplementation(() => {
             return { dispose: () => {} };
         });
 
@@ -19,6 +18,6 @@ describe('Test registering the systems commands', () => {
 
         const subs = mockContext.subscriptions;
 
-        expect(subs.length).toBe(6);
+        expect(subs.length).toBe(7);
     });
 });


### PR DESCRIPTION
Internal bug 38106

Fix for issue from https://github.com/SAP/open-ux-tools/pull/4610 

Fixes a bug where clicking "Add New System" after viewing a system would pre-fill the form with the viewed system's data instead of showing an empty form. The root cause was VSCode automatically passing the currently focused tree item as an argument to toolbar commands. The solution introduces a new internal command `sap.ux.tools.sapSystems.createNew` specifically for the UI button that always creates an empty form, while preserving the existing sap.ux.tools.sapSystems.create command for backward compatibility with external tools that need to pre-fill system data. All changes are backward compatible with no breaking changes to the public API.