### PR TITLE
chore - update mcp publisher version

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -2,7 +2,7 @@ name: Publish to MCP Registry
 
 env:
     # Releases: https://github.com/modelcontextprotocol/registry/releases
-    DEFAULT_MCP_PUBLISHER_VERSION: 'v1.5.0'
+    DEFAULT_MCP_PUBLISHER_VERSION: 'v1.7.6'
 on:
     # Allow this workflow to be called from other workflows
     workflow_call:


### PR DESCRIPTION
fix 
```
Run ./mcp-publisher login github-oidc
Logging in with github-oidc...
Error: failed to get token: failed to exchange OIDC token: token exchange failed with status 401: {"title":"Unauthorized","status":401,"detail":"Token exchange failed","errors":[{"message":"failed to validate OIDC token: invalid audience: expected https://registry.modelcontextprotocol.io,/ got [mcp-registry]"}]}

Error: Process completed with exit code 1.
```