### PR TITLE
feat: update splitter for new ui

### DIFF
--- a/.changeset/yellow-emus-bake.md
+++ b/.changeset/yellow-emus-bake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+UISections/UISplitter: Updated resize splitter UI and set `UISplitterLayoutType.Compact` as the default `splitterLayoutType`.

--- a/packages/ui-components/src/components/UISection/UISections.scss
+++ b/packages/ui-components/src/components/UISection/UISections.scss
@@ -44,9 +44,6 @@
         .sections__item--toggle {
             max-width: calc(100% - #{$splitter-size + 10});
         }
-        > .sections__item:first-child {
-            padding-right: calc($splitter-size / 2);
-        }
     }
     &.sections--vertical {
         // Toggle splitter

--- a/packages/ui-components/src/components/UISection/UISections.scss
+++ b/packages/ui-components/src/components/UISection/UISections.scss
@@ -42,7 +42,7 @@
             }
         }
         .sections__item--toggle {
-            max-width: calc(100% - #{$splitter-size + 10});
+            max-width: calc(100% - #{$splitter-toggle-size + 10});
         }
     }
     &.sections--vertical {
@@ -53,7 +53,7 @@
             }
         }
         .sections__item--toggle {
-            max-height: calc(100% - #{$splitter-size + 10});
+            max-height: calc(100% - #{$splitter-toggle-size + 10});
         }
     }
 }

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -686,7 +686,7 @@ export class UISections extends React.Component<UISectionsProps, UISectionsState
             splitterTitle,
             splitterType = UISplitterType.Resize,
             splitterTabIndex,
-            splitterLayoutType = UISplitterLayoutType.Standard
+            splitterLayoutType = UISplitterLayoutType.Compact
         } = this.props;
         let isSplitterVisible = splitter && index > 0;
         const isSingleSection = this.getVisibleChildrenCount() === 1;

--- a/packages/ui-components/src/components/UISection/UISections.tsx
+++ b/packages/ui-components/src/components/UISection/UISections.tsx
@@ -26,6 +26,11 @@ export interface UISectionsProps {
     splitterTabIndex?: -1 | 0;
     onClose?: () => void;
     splitterTitle?: string;
+    /**
+     * Splitter layout type for resize splitter.
+     *
+     * @default UISplitterLayoutType.Compact
+     */
     splitterLayoutType?: UISplitterLayoutType;
     onResize?: (sizes: Array<UISectionSize | undefined>) => void;
     onToggleFullscreen?: (isFullScreen: boolean) => void;

--- a/packages/ui-components/src/components/UISection/UISplitter.scss
+++ b/packages/ui-components/src/components/UISection/UISplitter.scss
@@ -25,7 +25,7 @@ $splitter-highlight-color: var(--vscode-focusBorder);
         margin: auto;
     }
 
-    // Highligh hover and focus
+    // Highlight hover and focus
     &:after {
         content: '';
         top: 0;
@@ -62,7 +62,7 @@ $splitter-highlight-color: var(--vscode-focusBorder);
             }
         }
 
-        &.splitter--rezize:after {
+        &.splitter--resize:after {
             width: 4px;
         }
     }
@@ -92,7 +92,7 @@ $splitter-highlight-color: var(--vscode-focusBorder);
             }
         }
 
-        &.splitter--rezize:after {
+        &.splitter--resize:after {
             height: 4px;
         }
     }

--- a/packages/ui-components/src/components/UISection/UISplitter.scss
+++ b/packages/ui-components/src/components/UISection/UISplitter.scss
@@ -15,66 +15,22 @@ $splitter-contrast-border: 1px solid var(--vscode-contrastBorder);
 $splitter-hover-contrast-border: 1px dashed var(--vscode-contrastActiveBorder);
 $splitter-focus-border: 1px solid var(--vscode-focusBorder);
 
+$splitter-grip-color: var(--vscode-widget-border);
+$splitter-highlight-color: var(--vscode-focusBorder);
+
 .splitter {
-    background-color: var(--vscode-panelSection-border);
     position: absolute;
     outline: none;
 
-    &--horizontal {
-        top: 0;
-        bottom: 0;
-        cursor: ew-resize;
-
-        &:after {
-            @include splitter-border($splitter-contrast-border, true);
-        }
+    // Grip
+    &__grip {
+        position: absolute;
+        margin: auto;
+        background-color: $splitter-grip-color;
+        z-index: -1;
     }
 
-    &--vertical {
-        cursor: ns-resize;
-        left: 0;
-        right: 0;
-
-        &:after {
-            @include splitter-border($splitter-contrast-border, false);
-        }
-    }
-
-    &--compact {
-        background: var(--vscode-editorWidget-border);
-        &.splitter--vertical {
-            .splitter__grip {
-                height: 3px;
-            }
-        }
-        &.splitter--horizontal {
-            .splitter__grip {
-                width: 12px;
-                svg {
-                    transform-origin: 5px 7px;
-                }
-            }
-        }
-    }
-
-    &--toggle {
-        cursor: pointer;
-
-        .splitter__grip {
-            height: 12px;
-        }
-    }
-
-    &--resize {
-        &.splitter--horizontal {
-            cursor: ew-resize;
-        }
-
-        &.splitter--vertical {
-            cursor: ns-resize;
-        }
-    }
-
+    // Highligh hover and focus
     &:after {
         content: '';
         top: 0;
@@ -82,16 +38,65 @@ $splitter-focus-border: 1px solid var(--vscode-focusBorder);
         right: 0;
         bottom: 0;
         position: absolute;
+        z-index: 1;
+        margin: auto;
     }
 
-    // Grip
-    &__grip {
-        position: absolute;
-        height: 16px;
-        top: 50%;
-        transform: translateY(-50%);
+    &--horizontal {
+        top: 0;
+        bottom: 0;
+        cursor: col-resize;
+
+        .splitter__grip {
+            height: 100%;
+            width: 1px;
+            left: 0;
+            right: 0;
+        }
+
+        &:after {
+            width: 4px;
+        }
+    }
+
+    &--vertical {
+        cursor: row-resize;
         left: 0;
         right: 0;
+
+        .splitter__grip {
+            width: 100%;
+            height: 1px;
+            top: 0;
+            bottom: 0;
+        }
+
+        &:after {
+            height: 4px;
+        }
+    }
+
+    &--toggle {
+        cursor: pointer;
+
+        .splitter__grip {
+            position: absolute;
+            height: 16px;
+            top: 50%;
+            transform: translateY(-50%);
+            left: 0;
+            right: 0;
+        }
+    }
+
+    &--resize {
+        &.splitter--horizontal {
+            cursor: col-resize;
+        }
+
+        &.splitter--vertical {
+            cursor: row-resize;
+        }
     }
 
     & + .section {
@@ -111,32 +116,20 @@ $splitter-focus-border: 1px solid var(--vscode-focusBorder);
 
     // Splitter focus style
     &:hover {
-        .splitter__grip svg path {
-            fill: var(--vscode-button-foreground);
+        &:after {
+            // animation: fadeInAnimation 0.07s ease-in 0.3s forwards;
+            background-color: $splitter-highlight-color;
+            transition: background-color 0.07s ease-in 0.3s;
         }
-        background-color: var(--vscode-focusBorder);
     }
     &--horizontal {
-        &:hover:after {
-            @include splitter-border($splitter-hover-contrast-border, true);
-        }
-
-        &:focus:after {
-            @include splitter-border($splitter-focus-border, true);
-        }
     }
 
     &--vertical {
-        &:hover:after {
-            @include splitter-border($splitter-hover-contrast-border, false);
-        }
-
-        &:focus:after {
-            @include splitter-border($splitter-focus-border, false);
-        }
     }
 
     // Hide with animation for delay
+    // ToDo???
     &--hidden {
         animation: 0.5s delayedFadeOut;
         animation-fill-mode: forwards;
@@ -151,31 +144,9 @@ $splitter-focus-border: 1px solid var(--vscode-focusBorder);
         }
     }
 
-    // Rotate icon
-    &--toggle {
-        &.splitter--horizontal {
-            .splitter__grip {
-                svg {
-                    transform: rotate(180deg);
-                }
-            }
-        }
-        &.splitter--vertical {
-            .splitter__grip {
-                svg {
-                    transform: rotate(270deg);
-                }
-            }
-        }
-    }
-    &--resize {
-        &.splitter--standard.splitter--vertical,
-        &.splitter--compact.splitter--horizontal {
-            .splitter__grip {
-                svg {
-                    transform: rotate(90deg);
-                }
-            }
+    &--active {
+        &:after {
+            background-color: $splitter-highlight-color;
         }
     }
 }
@@ -190,23 +161,18 @@ $splitter-focus-border: 1px solid var(--vscode-focusBorder);
     background: transparent;
 
     &--horizontal {
-        cursor: ew-resize;
+        cursor: col-resize;
     }
 
     &--vertical {
-        cursor: ns-resize;
+        cursor: row-resize;
     }
 }
 
-.sections__item--hidden .splitter--toggle {
-    &.splitter--horizontal {
-        .splitter__grip svg {
-            transform: rotate(0) translateX(-1px);
-        }
-    }
-    &.splitter--vertical {
-        .splitter__grip svg {
-            transform: rotate(90deg) translateX(-1px);
+.ms-Fabric--isFocusVisible .splitter {
+    &:focus {
+        &:after {
+            background-color: $splitter-highlight-color;
         }
     }
 }

--- a/packages/ui-components/src/components/UISection/UISplitter.scss
+++ b/packages/ui-components/src/components/UISection/UISplitter.scss
@@ -11,10 +11,7 @@
     }
 }
 
-$splitter-contrast-border: 1px solid var(--vscode-contrastBorder);
-$splitter-hover-contrast-border: 1px dashed var(--vscode-contrastActiveBorder);
 $splitter-focus-border: 1px solid var(--vscode-focusBorder);
-
 $splitter-grip-color: var(--vscode-widget-border);
 $splitter-highlight-color: var(--vscode-focusBorder);
 
@@ -26,8 +23,6 @@ $splitter-highlight-color: var(--vscode-focusBorder);
     &__grip {
         position: absolute;
         margin: auto;
-        background-color: $splitter-grip-color;
-        z-index: -1;
     }
 
     // Highligh hover and focus
@@ -49,12 +44,25 @@ $splitter-highlight-color: var(--vscode-focusBorder);
 
         .splitter__grip {
             height: 100%;
-            width: 1px;
+            width: $splitter-resize-size;
             left: 0;
             right: 0;
         }
+        &.splitter--compact {
+            .splitter__grip {
+                width: $splitter-resize-compact-size;
+            }
+        }
+        &.splitter--toggle {
+            .splitter__grip {
+                width: 100%;
+                svg {
+                    transform: rotate(180deg);
+                }
+            }
+        }
 
-        &:after {
+        &.splitter--rezize:after {
             width: 4px;
         }
     }
@@ -66,30 +74,49 @@ $splitter-highlight-color: var(--vscode-focusBorder);
 
         .splitter__grip {
             width: 100%;
-            height: 1px;
+            height: $splitter-resize-size;
             top: 0;
             bottom: 0;
         }
+        &.splitter--compact {
+            .splitter__grip {
+                height: $splitter-resize-compact-size;
+            }
+        }
+        &.splitter--toggle {
+            .splitter__grip {
+                height: 100%;
+                svg {
+                    transform: rotate(270deg);
+                }
+            }
+        }
 
-        &:after {
+        &.splitter--rezize:after {
             height: 4px;
         }
     }
 
     &--toggle {
         cursor: pointer;
+        background-color: $splitter-grip-color;
 
         .splitter__grip {
+            width: 100%;
             position: absolute;
             height: 16px;
             top: 50%;
             transform: translateY(-50%);
             left: 0;
             right: 0;
+            z-index: 0;
         }
     }
 
     &--resize {
+        .splitter__grip {
+            background-color: $splitter-grip-color;
+        }
         &.splitter--horizontal {
             cursor: col-resize;
         }
@@ -102,34 +129,28 @@ $splitter-highlight-color: var(--vscode-focusBorder);
     & + .section {
         .section__header__title,
         .section__body {
-            padding-left: calc($splitter-size / 2);
-        }
-    }
-
-    &--toggle + .section {
-        .section__header__title,
-        .section__body {
-            padding: 0;
-            margin: 0;
+            padding-left: calc($splitter-toggle-size / 2);
         }
     }
 
     // Splitter focus style
     &:hover {
-        &:after {
-            // animation: fadeInAnimation 0.07s ease-in 0.3s forwards;
-            background-color: $splitter-highlight-color;
-            transition: background-color 0.07s ease-in 0.3s;
+        &.splitter--resize {
+            &:after {
+                // animation: fadeInAnimation 0.07s ease-in 0.3s forwards;
+                background-color: $splitter-highlight-color;
+                transition: background-color 0.07s ease-in 0.3s;
+            }
         }
-    }
-    &--horizontal {
-    }
-
-    &--vertical {
+        &.splitter--toggle {
+            background-color: $splitter-highlight-color;
+            svg path {
+                fill: var(--vscode-button-foreground);
+            }
+        }
     }
 
     // Hide with animation for delay
-    // ToDo???
     &--hidden {
         animation: 0.5s delayedFadeOut;
         animation-fill-mode: forwards;
@@ -171,8 +192,22 @@ $splitter-highlight-color: var(--vscode-focusBorder);
 
 .ms-Fabric--isFocusVisible .splitter {
     &:focus {
-        &:after {
-            background-color: $splitter-highlight-color;
+        &.splitter--resize {
+            &:after {
+                background-color: $splitter-highlight-color;
+            }
+        }
+        &.splitter--toggle {
+            &.splitter--horizontal {
+                &:after {
+                    @include splitter-border($splitter-focus-border, true);
+                }
+            }
+            &.splitter--vertical {
+                &:after {
+                    @include splitter-border($splitter-focus-border, false);
+                }
+            }
         }
     }
 }

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -51,8 +51,9 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
         y: 0
     };
     private readonly rootRef: React.RefObject<HTMLDivElement>;
-    private readonly size = 4;
+    private readonly size = 8;
     private readonly compactSize = 4;
+    private readonly toggleSize = 14;
     private animationFrame?: number;
     /**
      *
@@ -254,8 +255,11 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
     render(): React.ReactElement {
         const { type, vertical, hidden, title, splitterLayoutType } = this.props;
         const tabIndex = this.props.splitterTabIndex ?? 0;
-        const size = splitterLayoutType === UISplitterLayoutType.Standard ? this.size : this.compactSize;
-        const splitterOffset = type === UISplitterType.Toggle ? -size : -size / 2;
+        let size = splitterLayoutType === UISplitterLayoutType.Standard ? this.size : this.compactSize;
+        if (type === UISplitterType.Toggle) {
+            size = this.toggleSize;
+        }
+        const splitterOffset = -size / 2;
         const role = type === UISplitterType.Toggle ? 'button' : 'separator';
         const orientation = vertical ? 'horizontal' : 'vertical';
         let ariaPressed: boolean | undefined;

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -150,13 +150,17 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
             document.body.removeEventListener('mousemove', this.doMousemoveResize);
             this.splitterOverlay.remove();
         }
-        if (start && this.props.onResizeStart) {
-            this.props.onResizeStart();
+        if (start) {
+            if (this.props.onResizeStart) {
+                this.props.onResizeStart();
+            }
             this.setState({
                 active: true
             });
-        } else if (!start && this.props.onResizeEnd) {
-            this.props.onResizeEnd();
+        } else {
+            if (this.props.onResizeEnd) {
+                this.props.onResizeEnd();
+            }
             requestAnimationFrame(() => {
                 this.setState({
                     active: false

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -282,7 +282,7 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
                 }
                 onClick={type === UISplitterType.Toggle ? (): void => this.toggleSplitter() : undefined}
                 className={this.getClassNames()}>
-                <div className="splitter__grip">{this.getIcon(type, splitterLayoutType)}</div>
+                <div className="splitter__grip">{this.getIcon(type)}</div>
             </div>
         );
     }

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -177,16 +177,12 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
     }
 
     /**
-     * Gets icon.
+     * Returns the icon component for the given splitter type.
      *
-     * @param type
-     * @param splitterLayoutType
-     * @returns {string}
+     * @param type - The splitter type.
+     * @returns The corresponding icon element, or an empty fragment if no icon is defined.
      */
-    private getIcon(
-        type: UISplitterType,
-        splitterLayoutType: UISplitterLayoutType = UISplitterLayoutType.Standard
-    ): React.ReactElement {
+    private getIcon(type: UISplitterType): React.ReactElement {
         let icon: UiIcons | undefined;
         if (type === UISplitterType.Toggle) {
             icon = UiIcons.ArrowLeft;

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -37,18 +37,22 @@ interface PointPosition {
     y: number;
 }
 
+export interface UISplitterState {
+    active?: boolean;
+}
+
 /**
  *
  */
-export class UISplitter extends React.Component<UISplitterProps> {
+export class UISplitter extends React.Component<UISplitterProps, UISplitterState> {
     private readonly splitterOverlay: HTMLDivElement;
     private readonly mousedownPosition: PointPosition = {
         x: 0,
         y: 0
     };
     private readonly rootRef: React.RefObject<HTMLDivElement>;
-    private readonly size = 14;
-    private readonly compactSize = 8;
+    private readonly size = 4;
+    private readonly compactSize = 4;
     private animationFrame?: number;
     /**
      *
@@ -56,6 +60,9 @@ export class UISplitter extends React.Component<UISplitterProps> {
      */
     constructor(props: UISplitterProps) {
         super(props);
+        this.state = {
+            active: false
+        };
         this.rootRef = React.createRef();
         this.stopMousemoveResize = this.stopMousemoveResize.bind(this);
         this.doMousemoveResize = this.doMousemoveResize.bind(this);
@@ -144,8 +151,18 @@ export class UISplitter extends React.Component<UISplitterProps> {
         }
         if (start && this.props.onResizeStart) {
             this.props.onResizeStart();
+            this.setState({
+                active: true
+            });
         } else if (!start && this.props.onResizeEnd) {
             this.props.onResizeEnd();
+            // setTimeout(() => {
+            window.requestAnimationFrame(() => {
+                this.setState({
+                    active: false
+                });
+            });
+            // }, 0);
         }
     }
 
@@ -168,14 +185,12 @@ export class UISplitter extends React.Component<UISplitterProps> {
     private getIcon(
         type: UISplitterType,
         splitterLayoutType: UISplitterLayoutType = UISplitterLayoutType.Standard
-    ): string {
+    ): React.ReactElement {
+        let icon: UiIcons | undefined;
         if (type === UISplitterType.Toggle) {
-            return UiIcons.ArrowLeft;
-        } else if (splitterLayoutType === UISplitterLayoutType.Compact) {
-            return UiIcons.Grabber;
-        } else {
-            return UiIcons.VerticalGrip;
+            icon = UiIcons.ArrowLeft;
         }
+        return icon ? <UIIcon iconName={icon} /> : <></>;
     }
 
     /**
@@ -217,6 +232,7 @@ export class UISplitter extends React.Component<UISplitterProps> {
      */
     getClassNames(): string {
         const { type, vertical, hidden, splitterLayoutType } = this.props;
+        const { active } = this.state;
         let classNames = `splitter splitter--${type}`;
         // vertical or horizontal
         classNames += ` ${vertical ? 'splitter--vertical' : 'splitter--horizontal'}`;
@@ -226,6 +242,9 @@ export class UISplitter extends React.Component<UISplitterProps> {
         classNames += ` ${
             splitterLayoutType === UISplitterLayoutType.Standard ? 'splitter--standard' : 'splitter--compact'
         }`;
+        if (active && type === UISplitterType.Resize) {
+            classNames += ' splitter--active';
+        }
         return classNames;
     }
 
@@ -263,9 +282,7 @@ export class UISplitter extends React.Component<UISplitterProps> {
                 }
                 onClick={type === UISplitterType.Toggle ? (): void => this.toggleSplitter() : undefined}
                 className={this.getClassNames()}>
-                <div className="splitter__grip">
-                    <UIIcon iconName={this.getIcon(type, splitterLayoutType)} />
-                </div>
+                <div className="splitter__grip">{this.getIcon(type, splitterLayoutType)}</div>
             </div>
         );
     }

--- a/packages/ui-components/src/components/UISection/UISplitter.tsx
+++ b/packages/ui-components/src/components/UISection/UISplitter.tsx
@@ -157,13 +157,11 @@ export class UISplitter extends React.Component<UISplitterProps, UISplitterState
             });
         } else if (!start && this.props.onResizeEnd) {
             this.props.onResizeEnd();
-            // setTimeout(() => {
-            window.requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
                 this.setState({
                     active: false
                 });
             });
-            // }, 0);
         }
     }
 

--- a/packages/ui-components/src/components/UISection/_variables.scss
+++ b/packages/ui-components/src/components/UISection/_variables.scss
@@ -1,1 +1,4 @@
-$splitter-size: 14px;
+$splitter-toggle-size: 14px;
+$splitter-resize-compact-size: 1px;
+$splitter-resize-size: 2px;
+

--- a/packages/ui-components/stories/UISections.story.tsx
+++ b/packages/ui-components/stories/UISections.story.tsx
@@ -91,7 +91,13 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
         propertyChange(id, option?.key);
     };
     const sectionElements = [
-        <UISections.Section key="first" height="100%" cleanPadding={true} hidden={!leftSectionVisible} data-test="test">
+        <UISections.Section
+            key="first"
+            height="100%"
+            cleanPadding={true}
+            hidden={!leftSectionVisible}
+            data-test="test"
+            title="First">
             <div>
                 {text}
                 {text}
@@ -101,7 +107,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
     ];
     if (props.threeSections) {
         sectionElements.push(
-            <UISections.Section key="second" height="100%" cleanPadding={true}>
+            <UISections.Section key="second" height="100%" cleanPadding={true} title="Third">
                 <div>
                     {text}
                     {text}
@@ -111,7 +117,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
         );
     }
     sectionElements.push(
-        <UISections.Section key="last" height="100%" cleanPadding={true} hidden={!rightSectionVisible}>
+        <UISections.Section key="last" height="100%" cleanPadding={true} hidden={!rightSectionVisible} title="Second">
             <div>
                 {text}
                 {text}

--- a/packages/ui-components/stories/UISections.story.tsx
+++ b/packages/ui-components/stories/UISections.story.tsx
@@ -54,7 +54,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
         splitterTabIndex: 0,
         minSectionSize: props.threeSections ? [100, 100, 100] : [300, 300],
         animation: true,
-        splitterLayoutType: UISplitterLayoutType.Standard,
+        splitterLayoutType: UISplitterLayoutType.Compact,
         sizesAsPercents: false,
         sizes: props.threeSections ? [firstSectionSize, undefined, 200] : [firstSectionSize, undefined]
     });
@@ -91,13 +91,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
         propertyChange(id, option?.key);
     };
     const sectionElements = [
-        <UISections.Section
-            key="first"
-            height="100%"
-            cleanPadding={true}
-            hidden={!leftSectionVisible}
-            data-test="test"
-            title="First">
+        <UISections.Section key="first" height="100%" cleanPadding={true} hidden={!leftSectionVisible} data-test="test">
             <div>
                 {text}
                 {text}
@@ -107,7 +101,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
     ];
     if (props.threeSections) {
         sectionElements.push(
-            <UISections.Section key="second" height="100%" cleanPadding={true} title="Third">
+            <UISections.Section key="second" height="100%" cleanPadding={true}>
                 <div>
                     {text}
                     {text}
@@ -117,7 +111,7 @@ function SectionsExample(props: SectionsExampleProps): JSX.Element {
         );
     }
     sectionElements.push(
-        <UISections.Section key="last" height="100%" cleanPadding={true} hidden={!rightSectionVisible} title="Second">
+        <UISections.Section key="last" height="100%" cleanPadding={true} hidden={!rightSectionVisible}>
             <div>
                 {text}
                 {text}

--- a/packages/ui-components/test/unit/components/UISections.test.tsx
+++ b/packages/ui-components/test/unit/components/UISections.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Enzyme from 'enzyme';
 import { UISections } from '../../../src/components/UISection/UISections';
 import { UISectionLayout } from '../../../src/components/UISection/UISection';
-import { UISplitterType } from '../../../src/components/UISection/UISplitter';
+import { UISplitterLayoutType, UISplitterType } from '../../../src/components/UISection/UISplitter';
 import type { UISectionsProps, UISectionsState } from '../../../src/components/UISection/UISections';
 import { mockResizeObserver, mockDomEventListener } from '../../utils/utils';
 import { initIcons } from '../../../src/components/Icons';
@@ -135,6 +135,34 @@ describe('<Sections />', () => {
         });
         const dom: HTMLElement = wrapper.getDOMNode();
         expect(dom.style.height).toEqual(height);
+    });
+
+    describe('Test "splitterLayoutType" property', () => {
+        const testCases = [
+            {
+                name: 'Default value',
+                splitterLayoutType: undefined,
+                isCompact: true
+            },
+            {
+                name: 'splitterLayoutType = Compact',
+                splitterLayoutType: UISplitterLayoutType.Compact,
+                isCompact: true
+            },
+            {
+                name: 'splitterLayoutType = Standard',
+                splitterLayoutType: UISplitterLayoutType.Standard,
+                isCompact: false
+            }
+        ];
+        test.each(testCases)('$name', ({ splitterLayoutType, isCompact }) => {
+            wrapper.setProps({
+                splitter: true,
+                splitterLayoutType
+            });
+            expect(wrapper.find('.splitter--compact').length).toEqual(isCompact ? 1 : 0);
+            expect(wrapper.find('.splitter--standard').length).toEqual(isCompact ? 0 : 1);
+        });
     });
 
     it('Test "hidden" section', () => {

--- a/packages/ui-components/test/unit/components/UISplitter.test.tsx
+++ b/packages/ui-components/test/unit/components/UISplitter.test.tsx
@@ -62,12 +62,19 @@ describe('<Splitter />', () => {
                     vertical={orientation}
                 />
             );
+            // Check if there no 'splitter--active' before resizing
+            expect(resizeWrapper.find('.splitter--active').length).toEqual(0);
             resizeWrapper
                 .find('.splitter')
                 .simulate('mousedown', { clientX: mouseStartCoordinate, button: 0, clientY: mouseStartCoordinate });
             simulateMouseEvent('mousemove', mouseMoveCoordinate1, mouseMoveCoordinate1);
             simulateMouseEvent('mousemove', mouseMoveCoordinate2, mouseMoveCoordinate2);
+            // Check if there is 'splitter--active' during resize
+            expect(resizeWrapper.find('.splitter--active').length).toEqual(1);
             simulateMouseEvent('mouseup', mouseMoveCoordinate2, mouseMoveCoordinate2);
+            // Check if there no 'splitter--active' after resizing
+            resizeWrapper.update();
+            expect(resizeWrapper.find('.splitter--active').length).toEqual(0);
             // Another 'simulateMouseEvent' with 'mousemove' to detect is removeEventListener called
             simulateMouseEvent('mousemove', 300, 300);
             expect(onResizeStart).toHaveBeenCalledTimes(1);

--- a/packages/ui-components/test/unit/components/UISplitter.test.tsx
+++ b/packages/ui-components/test/unit/components/UISplitter.test.tsx
@@ -204,7 +204,7 @@ describe('<Splitter />', () => {
                 expect: {
                     standard: true,
                     horizontal: true,
-                    icon: UiIcons.VerticalGrip
+                    icon: undefined
                 }
             },
             {
@@ -214,7 +214,7 @@ describe('<Splitter />', () => {
                 expect: {
                     standard: true,
                     vertical: true,
-                    icon: UiIcons.VerticalGrip
+                    icon: undefined
                 }
             },
             {
@@ -224,7 +224,7 @@ describe('<Splitter />', () => {
                 expect: {
                     compact: true,
                     horizontal: true,
-                    icon: UiIcons.Grabber
+                    icon: undefined
                 }
             },
             {
@@ -234,7 +234,7 @@ describe('<Splitter />', () => {
                 expect: {
                     compact: true,
                     vertical: true,
-                    icon: UiIcons.Grabber
+                    icon: undefined
                 }
             }
         ];
@@ -252,9 +252,12 @@ describe('<Splitter />', () => {
                 expect(wrapper.find('.splitter--vertical').length).toEqual(testCase.expect.vertical ? 1 : 0);
                 expect(wrapper.find('.splitter--horizontal').length).toEqual(testCase.expect.horizontal ? 1 : 0);
 
-                const icon = wrapper.find('UIIcon');
                 expect(wrapper.find('.splitter__grip').length).toEqual(1);
-                expect(icon.prop('iconName')).toEqual(testCase.expect.icon);
+                const icon = wrapper.find('UIIcon');
+                expect(icon.length).toEqual(testCase.expect.icon ? 1 : 0);
+                if (testCase.expect.icon) {
+                    expect(icon.prop('iconName')).toEqual(testCase.expect.icon);
+                }
             });
         }
     });


### PR DESCRIPTION
update splitter for new ui:
1. New ui for resize splitter:
<img width="1091" height="686" alt="image" src="https://github.com/user-attachments/assets/9ad86565-2f1e-46b2-8bb0-0071e1fde0ba" />

2. to keep backward compatibility - `toggle` splitter still can be set, but ui is not changed for it(only for resize splitter);
3. default `splitterLayoutType` now is `UISplitterLayoutType.Compact`
