### PR TITLE
fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

### DIFF
--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -3,6 +3,8 @@
 "@sap-ux/odata-service-inquirer": minor
 "@sap-ux/fiori-elements-writer": patch
 "@sap-ux/fiori-app-sub-generator": patch
+"@sap-ux/fiori-generator-shared": patch
+"sap-ux-sap-systems-ext-webapp": patch
 ---
 
 fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -4,7 +4,7 @@
 "@sap-ux/fiori-elements-writer": patch
 "@sap-ux/fiori-app-sub-generator": patch
 "@sap-ux/fiori-generator-shared": patch
-"sap-ux-sap-systems-ext-webapp": patch
+"@sap-ux/sap-systems-ext-webapp": patch
 ---
 
 fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -2,6 +2,7 @@
 "@sap-ux/odata-service-writer": minor
 "@sap-ux/odata-service-inquirer": minor
 "@sap-ux/fiori-elements-writer": patch
+"@sap-ux/fiori-app-sub-generator": patch
 ---
 
 fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -1,6 +1,7 @@
 ---
 "@sap-ux/odata-service-writer": minor
 "@sap-ux/odata-service-inquirer": minor
+"@sap-ux/fiori-elements-writer": patch
 ---
 
 fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -3,10 +3,4 @@
 "@sap-ux/odata-service-inquirer": minor
 ---
 
-fix(odata-service-writer, odata-service-inquirer): dynamically detect OData version 4.01 from service metadata
-
-Previously, `odataVersion: "4.01"` was written into manifest.json for all OData V4 apps when minUI5Version >= 1.144, regardless of whether the backend service actually supported OData 4.01. This caused cache buster token generation failures in ABAP appIndex and deployment issues in WorkZone.
-
-- Adds `OdataVersion.v401 = '4.01'` to the `OdataVersion` enum in `odata-service-writer`
-- Fixes `parseOdataVersion` in `odata-service-inquirer` to correctly detect `4.01` from the metadata document version attribute instead of truncating via `Number.parseInt`
-- Updates `manifest.ts` to write `odataVersion: "4.01"` only when the service metadata declares 4.01 **and** minUI5Version >= 1.144; plain OData V4 services always write `"4.0"`
+fix(odata-service-writer, odata-service-inquirer): dynamically detect OData 4.01 from service metadata

--- a/.changeset/fix-dynamic-odata-version-detection.md
+++ b/.changeset/fix-dynamic-odata-version-detection.md
@@ -1,0 +1,12 @@
+---
+"@sap-ux/odata-service-writer": minor
+"@sap-ux/odata-service-inquirer": minor
+---
+
+fix(odata-service-writer, odata-service-inquirer): dynamically detect OData version 4.01 from service metadata
+
+Previously, `odataVersion: "4.01"` was written into manifest.json for all OData V4 apps when minUI5Version >= 1.144, regardless of whether the backend service actually supported OData 4.01. This caused cache buster token generation failures in ABAP appIndex and deployment issues in WorkZone.
+
+- Adds `OdataVersion.v401 = '4.01'` to the `OdataVersion` enum in `odata-service-writer`
+- Fixes `parseOdataVersion` in `odata-service-inquirer` to correctly detect `4.01` from the metadata document version attribute instead of truncating via `Number.parseInt`
+- Updates `manifest.ts` to write `odataVersion: "4.01"` only when the service metadata declares 4.01 **and** minUI5Version >= 1.144; plain OData V4 services always write `"4.0"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,7 @@ chore(package-name): upgrade i18next 25.8.18 → 25.8.20
 ```
 
 **Changeset message conventions:**
+- Keep the message to a **single concise line** — no bullet points, no extended descriptions, no background context
 - Use conventional commit prefixes: `fix`, `feat`, `chore`, etc.
 - For dependency-only upgrades: `chore(package-name): upgrade <dep> <old> → <new>`
 - For multiple dep upgrades: `chore(package-name): upgrade runtime dependencies (<dep1> <ver>, <dep2> <ver>)`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ From [CONTRIBUTING.md](CONTRIBUTING.md):
 3. **Code review** - Wait for approval before merging
 4. **Don't resolve conversations** - Let reviewers mark as resolved
 5. **AI-generated code** - Follow [SAP's GenAI guidelines](https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md)
+6. **Document deviations** - If a change cannot adhere to a guideline in this AGENTS.md (e.g. a breaking refactor is out of scope), document the deviation and the reason in the PR description
 
 ## Package Management
 
@@ -744,6 +745,7 @@ Before submitting changes, verify:
 - [ ] Commit messages follow Conventional Commits
 - [ ] PR is focused on one issue
 - [ ] Documentation updated if needed
+- [ ] Any deviations from this AGENTS.md spec are documented in the PR description
 
 ---
 

--- a/packages/fiori-app-sub-generator/src/types/external.ts
+++ b/packages/fiori-app-sub-generator/src/types/external.ts
@@ -22,27 +22,27 @@ type FloorplanAttributesType = {
 
 export const FloorplanAttributes: FloorplanAttributesType = {
     [FloorplanFE.FE_LROP]: {
-        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.ListReportObjectPage
     },
     [FloorplanFE.FE_ALP]: {
-        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.AnalyticalListPage
     },
     [FloorplanFE.FE_WORKLIST]: {
-        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.Worklist
     },
     [FloorplanFE.FE_FEOP]: {
-        supportedODataVersion: [OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.FormEntryObjectPage
     },
     [FloorplanFE.FE_OVP]: {
-        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.OverviewPage
     },
     [FloorplanFE.FE_FPM]: {
-        supportedODataVersion: [OdataVersion.v4],
+        supportedODataVersion: [OdataVersion.v4, OdataVersion.v401],
         templateType: FETemplateType.FlexibleProgrammingModel
     },
     [FloorplanFF.FF_SIMPLE]: {

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -103,7 +103,7 @@ export function getMinSupportedUI5Version(
         const templateType = FloorplanAttributes[floorplan].templateType as FETemplateType;
         minUI5Version = TemplateTypeAttributes[templateType].minimumUi5Version[version];
     }
-    return minUI5Version ?? (version !== OdataVersion.v2 ? minSupportedUi5VersionV4 : minSupportedUi5Version);
+    return minUI5Version ?? (version === OdataVersion.v2 ? minSupportedUi5Version : minSupportedUi5VersionV4);
 }
 
 /**

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -103,7 +103,7 @@ export function getMinSupportedUI5Version(
         const templateType = FloorplanAttributes[floorplan].templateType as FETemplateType;
         minUI5Version = TemplateTypeAttributes[templateType].minimumUi5Version[version];
     }
-    return minUI5Version ?? (version === OdataVersion.v4 ? minSupportedUi5VersionV4 : minSupportedUi5Version);
+    return minUI5Version ?? (version !== OdataVersion.v2 ? minSupportedUi5VersionV4 : minSupportedUi5Version);
 }
 
 /**

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -39,6 +39,9 @@ import { getBackendSystemType } from '@sap-ux/store';
 export function getODataVersion(edmx: string): OdataVersion {
     try {
         const convertedMetadata = convert(parse(edmx));
+        if (convertedMetadata.version === '4.01') {
+            return OdataVersion.v401;
+        }
         return convertedMetadata.version.startsWith('4') ? OdataVersion.v4 : OdataVersion.v2;
     } catch (error) {
         throw Error(t('error.appConfigUnparseableEdmx'));
@@ -77,7 +80,9 @@ export function buildSapClientParam(sapClient: string): string {
  */
 export function getRequiredOdataVersion(floorplan: Floorplan): OdataVersion | undefined {
     const supportedVers = FloorplanAttributes[floorplan].supportedODataVersion;
-    return supportedVers.length === 1 ? supportedVers[0] : undefined;
+    // Collapse v401 to v4 — they are the same family for version requirement purposes
+    const baseVers = [...new Set(supportedVers.map((v) => (v === OdataVersion.v401 ? OdataVersion.v4 : v)))];
+    return baseVers.length === 1 ? baseVers[0] : undefined;
 }
 
 /**

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
@@ -31,7 +31,7 @@
             "annotation"
           ],
           "localUri": "localService/mainService/metadata.xml",
-          "odataVersion": "4.01"
+          "odataVersion": "4.0"
         }
       }
     }

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
@@ -390,7 +390,7 @@ describe('Test transform state', () => {
         });
     });
 
-    test('Should resolve minUI5Version for OdataVersion.v401 the same as v4', async () => {
+    test('Should resolve minUI5Version for OdataVersion.v401', async () => {
         const state: State = {
             project: {
                 name: 'TestProject1',
@@ -413,7 +413,7 @@ describe('Test transform state', () => {
         expect(result).toMatchObject({
             ui5: {
                 version: undefined,
-                minUI5Version: '1.84.0'
+                minUI5Version: '1.144.0'
             }
         });
     });

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/transforms.test.ts
@@ -1,5 +1,5 @@
 import type { ServiceProvider } from '@sap-ux/axios-extension';
-import { DatasourceType, type EntityRelatedAnswers } from '@sap-ux/odata-service-inquirer';
+import { DatasourceType, OdataVersion, type EntityRelatedAnswers } from '@sap-ux/odata-service-inquirer';
 import type { BackendSystem } from '@sap-ux/store';
 import { AuthenticationType } from '@sap-ux/store';
 import { transformState } from '../../../src/fiori-app-generator/transforms';
@@ -386,6 +386,34 @@ describe('Test transform state', () => {
                 localVersion: undefined,
                 minUI5Version: '1.84.0',
                 frameworkUrl: 'https://ui5.sap.com'
+            }
+        });
+    });
+
+    test('Should resolve minUI5Version for OdataVersion.v401 the same as v4', async () => {
+        const state: State = {
+            project: {
+                name: 'TestProject1',
+                description: 'An SAP Fiori application.',
+                title: 'App Title',
+                skipAnnotations: false,
+                namespace: 'namespace1',
+                targetFolder: ''
+            } as Project,
+            service: { ...baseState.service, version: OdataVersion.v401 },
+            floorplan: FloorplanFE.FE_LROP,
+            entityRelatedConfig: {
+                mainEntity: {
+                    entitySetName: 'SEPMRA_C_PD_Product',
+                    entitySetType: 'SEPMRA_C_PD_ProductType'
+                }
+            }
+        };
+        const result = await transformState<FioriElementsApp<unknown>>(state);
+        expect(result).toMatchObject({
+            ui5: {
+                version: undefined,
+                minUI5Version: '1.84.0'
             }
         });
     });

--- a/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
@@ -127,7 +127,7 @@ describe('Test utils', () => {
 
     test('getMinSupportedUI5Version - LROP v401', () => {
         const minVerson = getMinSupportedUI5Version(OdataVersion.v401, FloorplanFE.FE_LROP);
-        expect(minVerson).toBe('1.84.0');
+        expect(minVerson).toBe('1.144.0');
     });
 
     test('getMinSupportedUI5Version - form entry', () => {

--- a/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
@@ -125,6 +125,11 @@ describe('Test utils', () => {
         expect(minVerson).toBe('1.84.0');
     });
 
+    test('getMinSupportedUI5Version - LROP v401', () => {
+        const minVerson = getMinSupportedUI5Version(OdataVersion.v401, FloorplanFE.FE_LROP);
+        expect(minVerson).toBe('1.84.0');
+    });
+
     test('getMinSupportedUI5Version - form entry', () => {
         const minVerson = getMinSupportedUI5Version(OdataVersion.v4, FloorplanFE.FE_FEOP);
         expect(minVerson).toBe('1.90.0');
@@ -371,6 +376,43 @@ describe('Test utils', () => {
                 projectRoot: projectPath,
                 debugOptions: expectedDebugOptions,
                 startFile: 'test/flp.html'
+            };
+            expect(createLaunchConfig).toHaveBeenCalledWith(projectPath, expectedFioriOptions, editor, {});
+            expect(writeApplicationInfoSettings).toHaveBeenCalledWith(projectPath);
+        });
+
+        it('should generate correct launch config for OData v401', async () => {
+            isAppStudioMock.mockReturnValue(false);
+            await generateLaunchConfig(
+                {
+                    targetFolder: mockProject.targetFolder,
+                    projectName: mockProject.name,
+                    flpAppId: mockProject.flpAppId,
+                    sapClientParam: buildSapClientParam('001'),
+                    odataVersion: OdataVersion.v401,
+                    datasourceType: 'odataServiceUrl' as DatasourceType
+                },
+                editor,
+                mockVsCode,
+                {} as Logger
+            );
+
+            const expectedDebugOptions: DebugOptions = {
+                vscode: mockVsCode,
+                addStartCmd: true,
+                sapClientParam: 'sap-client=001',
+                flpAppId: mockProject.flpAppId,
+                flpSandboxAvailable: true,
+                isAppStudio: false,
+                odataVersion: '4.0',
+                writeToAppOnly: false
+            };
+
+            const expectedFioriOptions: FioriOptions = {
+                name: mockProject.name,
+                projectRoot: projectPath,
+                debugOptions: expectedDebugOptions,
+                startFile: undefined
             };
             expect(createLaunchConfig).toHaveBeenCalledWith(projectPath, expectedFioriOptions, editor, {});
             expect(writeApplicationInfoSettings).toHaveBeenCalledWith(projectPath);

--- a/packages/fiori-elements-writer/src/data/defaults.ts
+++ b/packages/fiori-elements-writer/src/data/defaults.ts
@@ -56,7 +56,7 @@ export function setDefaultTemplateSettings<T extends {}>(template: Template<T>, 
             tableType: alpSettings.tableType ?? TableType.ANALYTICAL // Overrides the UI5 default: ''
         });
 
-        if (odataVersion === OdataVersion.v4) {
+        if (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401) {
             const alpV4Settings: ALPSettingsV4 = template.settings as unknown as ALPSettingsV4;
             Object.assign(templateSettings, {
                 selectionMode: alpV4Settings.selectionMode ?? TableSelectionMode.NONE
@@ -151,7 +151,7 @@ export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<
     setFioriAppDefaults(feApp.app, feApp.template.type, feApp.service.version);
 
     const customUi5Libs =
-        feApp.service.version === OdataVersion.v4 && feApp.service.metadata
+        (feApp.service.version === OdataVersion.v4 || feApp.service.version === OdataVersion.v401) && feApp.service.metadata
             ? getAnnotationV4Libs(feApp.service.metadata)
             : [];
 

--- a/packages/fiori-elements-writer/src/data/defaults.ts
+++ b/packages/fiori-elements-writer/src/data/defaults.ts
@@ -151,7 +151,8 @@ export function setAppDefaults<T>(feApp: FioriElementsApp<T>): FioriElementsApp<
     setFioriAppDefaults(feApp.app, feApp.template.type, feApp.service.version);
 
     const customUi5Libs =
-        (feApp.service.version === OdataVersion.v4 || feApp.service.version === OdataVersion.v401) && feApp.service.metadata
+        (feApp.service.version === OdataVersion.v4 || feApp.service.version === OdataVersion.v401) &&
+        feApp.service.metadata
             ? getAnnotationV4Libs(feApp.service.metadata)
             : [];
 

--- a/packages/fiori-elements-writer/src/data/manifestSettings.ts
+++ b/packages/fiori-elements-writer/src/data/manifestSettings.ts
@@ -73,11 +73,12 @@ export function extendManifestJson<T>(
     };
 
     // Manifest paths to be extended
+    const templateVersion = feApp.service.version === OdataVersion.v401 ? OdataVersion.v4 : feApp.service.version;
     const extendTemplatePaths = [
         join(rootTemplatesPath, 'common', 'extend', 'webapp'),
         join(rootTemplatesPath, templatePath, 'extend', 'webapp'),
-        join(rootTemplatesPath, `v${feApp.service.version}`, templatePath, 'extend', 'webapp'),
-        join(rootTemplatesPath, `v${feApp.service.version}`, 'common', 'extend', 'webapp')
+        join(rootTemplatesPath, `v${templateVersion}`, templatePath, 'extend', 'webapp'),
+        join(rootTemplatesPath, `v${templateVersion}`, 'common', 'extend', 'webapp')
     ];
     const manifestPath = join(targetPath, 'webapp', 'manifest.json');
 

--- a/packages/fiori-elements-writer/src/data/manifestSettings.ts
+++ b/packages/fiori-elements-writer/src/data/manifestSettings.ts
@@ -27,7 +27,7 @@ export function extendManifestJson<T>(
     let templatePath = feApp.template.type;
     // FEOP and ALP v4 are variants of LROP and so we use the same template and settings
     if (
-        feApp.service.version === OdataVersion.v4 &&
+        (feApp.service.version === OdataVersion.v4 || feApp.service.version === OdataVersion.v401) &&
         (
             [
                 TemplateType.FormEntryObjectPage,

--- a/packages/fiori-elements-writer/src/data/templateAttributes.ts
+++ b/packages/fiori-elements-writer/src/data/templateAttributes.ts
@@ -32,7 +32,8 @@ const commonUi5Libs: FrameworkLibs = {
         'sap.ui.generic.app',
         'sap.suite.ui.generic.template'
     ],
-    [OdataVersion.v4]: ['sap.m', 'sap.fe.templates']
+    [OdataVersion.v4]: ['sap.m', 'sap.fe.templates'],
+    [OdataVersion.v401]: ['sap.m', 'sap.fe.templates']
 };
 
 type TemplateLibsEntry = {
@@ -95,6 +96,38 @@ const templateLibs: TemplateLibs = {
         [TemplateType.FlexibleProgrammingModel]: {
             baseComponent: appComponentLibFioriElements,
             ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.fe.core', 'sap.ushell'],
+            manifestLibs: ['sap.m', 'sap.fe.core']
+        }
+    },
+    [OdataVersion.v401]: {
+        [TemplateType.ListReportObjectPage]: {
+            baseComponent: appComponentLibFioriElements,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
+            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
+        },
+        [TemplateType.FormEntryObjectPage]: {
+            baseComponent: appComponentLibFioriElements,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
+            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
+        },
+        [TemplateType.AnalyticalListPage]: {
+            baseComponent: appComponentLibFioriElements,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
+            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
+        },
+        [TemplateType.Worklist]: {
+            baseComponent: appComponentLibFioriElements,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
+            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
+        },
+        [TemplateType.OverviewPage]: {
+            baseComponent: appComponentLibOVP,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell', 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout'],
+            manifestLibs: [...commonUi5Libs[OdataVersion.v401], 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout']
+        },
+        [TemplateType.FlexibleProgrammingModel]: {
+            baseComponent: appComponentLibFioriElements,
+            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.fe.core', 'sap.ushell'],
             manifestLibs: ['sap.m', 'sap.fe.core']
         }
     }

--- a/packages/fiori-elements-writer/src/data/templateAttributes.ts
+++ b/packages/fiori-elements-writer/src/data/templateAttributes.ts
@@ -23,6 +23,8 @@ const appComponentLibFioriElements = 'sap/fe/core/AppComponent';
 
 type FrameworkLibs = Record<OdataVersion, string[]>;
 
+const v4CommonLibs = ['sap.m', 'sap.fe.templates'];
+
 const commonUi5Libs: FrameworkLibs = {
     [OdataVersion.v2]: [
         'sap.m',
@@ -33,8 +35,8 @@ const commonUi5Libs: FrameworkLibs = {
         'sap.ui.generic.app',
         'sap.suite.ui.generic.template'
     ],
-    [OdataVersion.v4]: ['sap.m', 'sap.fe.templates'],
-    [OdataVersion.v401]: ['sap.m', 'sap.fe.templates']
+    [OdataVersion.v4]: v4CommonLibs,
+    [OdataVersion.v401]: v4CommonLibs
 };
 
 type TemplateLibsEntry = {
@@ -47,6 +49,39 @@ type TemplateLibs = {
     [V in OdataVersion]: {
         [T in TemplateType]?: TemplateLibsEntry;
     };
+};
+
+const v4TemplateLibs: { [T in TemplateType]?: TemplateLibsEntry } = {
+    [TemplateType.ListReportObjectPage]: {
+        baseComponent: appComponentLibFioriElements,
+        ui5Libs: [...v4CommonLibs, 'sap.ushell'],
+        manifestLibs: [...v4CommonLibs]
+    },
+    [TemplateType.FormEntryObjectPage]: {
+        baseComponent: appComponentLibFioriElements,
+        ui5Libs: [...v4CommonLibs, 'sap.ushell'],
+        manifestLibs: [...v4CommonLibs]
+    },
+    [TemplateType.AnalyticalListPage]: {
+        baseComponent: appComponentLibFioriElements,
+        ui5Libs: [...v4CommonLibs, 'sap.ushell'],
+        manifestLibs: [...v4CommonLibs]
+    },
+    [TemplateType.Worklist]: {
+        baseComponent: appComponentLibFioriElements,
+        ui5Libs: [...v4CommonLibs, 'sap.ushell'],
+        manifestLibs: [...v4CommonLibs]
+    },
+    [TemplateType.OverviewPage]: {
+        baseComponent: appComponentLibOVP,
+        ui5Libs: [...v4CommonLibs, 'sap.ushell', 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout'],
+        manifestLibs: [...v4CommonLibs, 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout']
+    },
+    [TemplateType.FlexibleProgrammingModel]: {
+        baseComponent: appComponentLibFioriElements,
+        ui5Libs: [...v4CommonLibs, 'sap.fe.core', 'sap.ushell'],
+        manifestLibs: ['sap.m', 'sap.fe.core']
+    }
 };
 
 const templateLibs: TemplateLibs = {
@@ -68,70 +103,8 @@ const templateLibs: TemplateLibs = {
             ui5Libs: [...commonUi5Libs[OdataVersion.v2], 'sap.collaboration']
         }
     },
-    [OdataVersion.v4]: {
-        [TemplateType.ListReportObjectPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v4]]
-        },
-        [TemplateType.FormEntryObjectPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v4]]
-        },
-        [TemplateType.AnalyticalListPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v4]]
-        },
-        [TemplateType.Worklist]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v4]]
-        },
-        [TemplateType.OverviewPage]: {
-            baseComponent: appComponentLibOVP,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.ushell', 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v4], 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout']
-        },
-        [TemplateType.FlexibleProgrammingModel]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v4], 'sap.fe.core', 'sap.ushell'],
-            manifestLibs: ['sap.m', 'sap.fe.core']
-        }
-    },
-    [OdataVersion.v401]: {
-        [TemplateType.ListReportObjectPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
-        },
-        [TemplateType.FormEntryObjectPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
-        },
-        [TemplateType.AnalyticalListPage]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
-        },
-        [TemplateType.Worklist]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v401]]
-        },
-        [TemplateType.OverviewPage]: {
-            baseComponent: appComponentLibOVP,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.ushell', 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout'],
-            manifestLibs: [...commonUi5Libs[OdataVersion.v401], 'sap.ovp', 'sap.ui.rta', 'sap.ui.layout']
-        },
-        [TemplateType.FlexibleProgrammingModel]: {
-            baseComponent: appComponentLibFioriElements,
-            ui5Libs: [...commonUi5Libs[OdataVersion.v401], 'sap.fe.core', 'sap.ushell'],
-            manifestLibs: ['sap.m', 'sap.fe.core']
-        }
-    }
+    [OdataVersion.v4]: v4TemplateLibs,
+    [OdataVersion.v401]: v4TemplateLibs
 };
 
 /**

--- a/packages/fiori-elements-writer/src/data/templateAttributes.ts
+++ b/packages/fiori-elements-writer/src/data/templateAttributes.ts
@@ -3,6 +3,7 @@ import { OdataVersion, TemplateType } from '../types';
 // first version with SAP Fiori 3 theme
 export const minSupportedUI5Version = '1.65.0';
 export const minSupportedUI5VersionV4 = '1.84.0';
+const minSupportedUI5VersionV401 = '1.144.0';
 
 export const changesPreviewToVersion = '1.78.0';
 
@@ -185,52 +186,61 @@ type TemplateAttributes = {
 
 export const TemplateTypeAttributes: TemplateAttributes = {
     [TemplateType.Worklist]: {
-        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
             [OdataVersion.v2]: minSupportedUI5Version,
-            [OdataVersion.v4]: '1.99.0'
+            [OdataVersion.v4]: '1.99.0',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         },
         annotationGenerationSupport: {
-            [OdataVersion.v4]: true
+            [OdataVersion.v4]: true,
+            [OdataVersion.v401]: true
         }
     },
     [TemplateType.ListReportObjectPage]: {
-        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
             [OdataVersion.v2]: minSupportedUI5Version,
-            [OdataVersion.v4]: '1.84.0'
+            [OdataVersion.v4]: '1.84.0',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         },
         annotationGenerationSupport: {
-            [OdataVersion.v4]: true
+            [OdataVersion.v4]: true,
+            [OdataVersion.v401]: true
         }
     },
     [TemplateType.AnalyticalListPage]: {
-        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
             [OdataVersion.v2]: minSupportedUI5Version,
-            [OdataVersion.v4]: '1.90.0'
+            [OdataVersion.v4]: '1.90.0',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         }
     },
     [TemplateType.OverviewPage]: {
-        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v2, OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
             [OdataVersion.v2]: minSupportedUI5Version,
-            [OdataVersion.v4]: '1.96.8'
+            [OdataVersion.v4]: '1.96.8',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         }
     },
     [TemplateType.FormEntryObjectPage]: {
-        supportedODataVersions: [OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
-            [OdataVersion.v4]: '1.90.0'
+            [OdataVersion.v4]: '1.90.0',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         },
         annotationGenerationSupport: {
-            [OdataVersion.v4]: true
+            [OdataVersion.v4]: true,
+            [OdataVersion.v401]: true
         }
     },
     [TemplateType.FlexibleProgrammingModel]: {
-        supportedODataVersions: [OdataVersion.v4],
+        supportedODataVersions: [OdataVersion.v4, OdataVersion.v401],
         minimumUi5Version: {
-            [OdataVersion.v4]: '1.94.0'
+            [OdataVersion.v4]: '1.94.0',
+            [OdataVersion.v401]: minSupportedUI5VersionV401
         }
     }
 };

--- a/packages/fiori-elements-writer/src/index.ts
+++ b/packages/fiori-elements-writer/src/index.ts
@@ -92,7 +92,7 @@ function getOpaConfig(
  */
 function shouldAddTest(service: Partial<OdataService>, addTests?: boolean): boolean {
     return (
-        !!addTests && service?.version === OdataVersion.v4 && (!!service?.metadata || service?.type === ServiceType.CDS)
+        !!addTests && (service?.version === OdataVersion.v4 || service?.version === OdataVersion.v401) && (!!service?.metadata || service?.type === ServiceType.CDS)
     );
 }
 

--- a/packages/fiori-elements-writer/src/index.ts
+++ b/packages/fiori-elements-writer/src/index.ts
@@ -92,7 +92,9 @@ function getOpaConfig(
  */
 function shouldAddTest(service: Partial<OdataService>, addTests?: boolean): boolean {
     return (
-        !!addTests && (service?.version === OdataVersion.v4 || service?.version === OdataVersion.v401) && (!!service?.metadata || service?.type === ServiceType.CDS)
+        !!addTests &&
+        (service?.version === OdataVersion.v4 || service?.version === OdataVersion.v401) &&
+        (!!service?.metadata || service?.type === ServiceType.CDS)
     );
 }
 
@@ -208,7 +210,8 @@ async function generate<T extends {}>(
         await generateFpmConfig(feApp, basePath, fs);
     } else {
         // Copy odata version specific common templates and version specific, floorplan specific templates
-        const templateVersionPath = join(rootTemplatesPath, `v${feApp.service?.version}`);
+        const templateVersion = feApp.service?.version === OdataVersion.v401 ? OdataVersion.v4 : feApp.service?.version;
+        const templateVersionPath = join(rootTemplatesPath, `v${templateVersion}`);
         [join(templateVersionPath, 'common', 'add'), join(templateVersionPath, feApp.template.type, 'add')].forEach(
             (templatePath) => {
                 fs!.copyTpl(

--- a/packages/fiori-elements-writer/test/unit/defaults.test.ts
+++ b/packages/fiori-elements-writer/test/unit/defaults.test.ts
@@ -35,6 +35,16 @@ describe('Defaults', () => {
             }
         `);
 
+        expect(setDefaultTemplateSettings(cloneDeep(template), OdataVersion.v401)).toMatchInlineSnapshot(`
+            Object {
+              "entityConfig": Object {
+                "mainEntityName": "",
+              },
+              "selectionMode": "None",
+              "tableType": "AnalyticalTable",
+            }
+        `);
+
         expect(setDefaultTemplateSettings(cloneDeep(template), OdataVersion.v2)).toMatchInlineSnapshot(`
             Object {
               "autoHide": undefined,

--- a/packages/fiori-elements-writer/test/unit/validate.test.ts
+++ b/packages/fiori-elements-writer/test/unit/validate.test.ts
@@ -154,6 +154,69 @@ describe('Validate', () => {
         );
     });
 
+    test('Valid app config with OData v401 for ListReportObjectPage', () => {
+        const feApp: FioriElementsApp<LROPSettings> = {
+            ...Object.assign(
+                feBaseConfig('felrop1'),
+                { ui5: { version: '1.144.0', minUI5Version: '1.144.0' } },
+                {
+                    template: { type: TemplateType.ListReportObjectPage, settings: {} },
+                    service: { version: OdataVersion.v401 }
+                }
+            )
+        } as FioriElementsApp<LROPSettings>;
+
+        expect(() => validateApp(feApp)).not.toThrow();
+    });
+
+    test('Valid app config with OData v401 for FormEntryObjectPage', () => {
+        const feApp: FioriElementsApp<LROPSettings> = {
+            ...Object.assign(
+                feBaseConfig('fefeop1'),
+                { ui5: { version: '1.144.0', minUI5Version: '1.144.0' } },
+                {
+                    template: { type: TemplateType.FormEntryObjectPage, settings: {} },
+                    service: { version: OdataVersion.v401 }
+                }
+            )
+        } as FioriElementsApp<LROPSettings>;
+
+        expect(() => validateApp(feApp)).not.toThrow();
+    });
+
+    test('Invalid ui5 version for OData v401 template', () => {
+        const feApp: FioriElementsApp<LROPSettings> = {
+            ...Object.assign(
+                feBaseConfig('felrop1'),
+                {
+                    ui5: {
+                        version: '1.100.0',
+                        minUI5Version: '1.100.0'
+                    }
+                },
+                {
+                    template: {
+                        type: TemplateType.ListReportObjectPage,
+                        settings: {}
+                    },
+                    service: {
+                        version: OdataVersion.v401
+                    }
+                }
+            )
+        } as FioriElementsApp<LROPSettings>;
+
+        expect(() => validateApp(feApp)).toThrow(
+            t('error.unsupportedUI5Version', {
+                versionProperty: 'version',
+                ui5Version: feApp.ui5?.version,
+                templateType: feApp.template.type,
+                minRequiredUI5Version:
+                    TemplateTypeAttributes[TemplateType.ListReportObjectPage].minimumUi5Version[OdataVersion.v401]
+            })
+        );
+    });
+
     test('Missing required property', () => {
         // Missing property: `FioriElementsApp.service`
         const feApp: FioriElementsApp<ALPSettings> = {

--- a/packages/fiori-elements-writer/test/unit/writeAnnotations.test.ts
+++ b/packages/fiori-elements-writer/test/unit/writeAnnotations.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { writeAnnotations } from '../../src/writeAnnotations';
-import { TemplateType } from '../../src/types';
+import { OdataVersion, TemplateType } from '../../src/types';
 import { generateAnnotations } from '@sap-ux/annotation-generator';
 import type { Editor } from 'mem-fs-editor';
 import { applyBaseConfigToFEApp } from '../common';
@@ -56,6 +56,31 @@ describe('writeAnnotations', () => {
     it('should call generateAnnotations with correct parameters for non-CAP service', async () => {
         const appInfo = applyBaseConfigToFEApp('test', TemplateType.ListReportObjectPage);
         appInfo.appOptions.addAnnotations = true;
+        delete appInfo.service.capService;
+
+        await writeAnnotations('test', appInfo, fs);
+
+        expect(generateAnnotations).toHaveBeenCalledWith(
+            fs,
+            {
+                serviceName: 'mainService',
+                appName: 'test',
+                project: join('test')
+            },
+            {
+                entitySetName: 'Travel',
+                annotationFilePath: join('webapp', 'annotations', 'annotation.xml'),
+                addFacets: true,
+                addLineItems: true,
+                addValueHelps: false
+            }
+        );
+    });
+
+    it('should call generateAnnotations for OData v401 service', async () => {
+        const appInfo = applyBaseConfigToFEApp('test', TemplateType.ListReportObjectPage);
+        appInfo.appOptions.addAnnotations = true;
+        appInfo.service.version = OdataVersion.v401;
         delete appInfo.service.capService;
 
         await writeAnnotations('test', appInfo, fs);

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -22,7 +22,7 @@ import type { Answers, ListChoiceOptions, Question } from 'inquirer';
 import { t } from '../../../../i18n';
 import type { OdataServicePromptOptions, ServiceSelectionPromptOptions } from '../../../../types';
 import { promptNames } from '../../../../types';
-import { areArraysEquivalent, getDefaultChoiceIndex, getPromptHostEnvironment, PromptState } from '../../../../utils';
+import { areArraysEquivalent, convertODataVersionType, getDefaultChoiceIndex, getPromptHostEnvironment, PromptState } from '../../../../utils';
 import type { ConnectionValidator } from '../../../connectionValidator';
 import LoggerHelper from '../../../logger-helper';
 import { errorHandler } from '../../../prompt-helpers';
@@ -257,8 +257,9 @@ async function createServiceChoicesFromCatalog(
     serviceFilter?: string[]
 ): Promise<ListChoiceOptions<ServiceAnswer>[]> {
     let catalogs: CatalogService[] = [];
-    if (requiredOdataVersion && availableCatalogs[requiredOdataVersion]) {
-        catalogs.push(availableCatalogs[requiredOdataVersion] as CatalogService);
+    const catalogVersion = convertODataVersionType(requiredOdataVersion);
+    if (catalogVersion && availableCatalogs[catalogVersion]) {
+        catalogs.push(availableCatalogs[catalogVersion] as CatalogService);
     } else {
         catalogs = Object.values(availableCatalogs).filter((cat): cat is CatalogService => cat !== undefined);
     }

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -22,7 +22,13 @@ import type { Answers, ListChoiceOptions, Question } from 'inquirer';
 import { t } from '../../../../i18n';
 import type { OdataServicePromptOptions, ServiceSelectionPromptOptions } from '../../../../types';
 import { promptNames } from '../../../../types';
-import { areArraysEquivalent, convertODataVersionType, getDefaultChoiceIndex, getPromptHostEnvironment, PromptState } from '../../../../utils';
+import {
+    areArraysEquivalent,
+    convertODataVersionType,
+    getDefaultChoiceIndex,
+    getPromptHostEnvironment,
+    PromptState
+} from '../../../../utils';
 import type { ConnectionValidator } from '../../../connectionValidator';
 import LoggerHelper from '../../../logger-helper';
 import { errorHandler } from '../../../prompt-helpers';

--- a/packages/odata-service-inquirer/src/prompts/edmx/alp-questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/alp-questions.ts
@@ -89,8 +89,8 @@ export function getAnalyticListPageQuestions(
 
     // Layout prompts
     if (!hideTableLayoutPrompts) {
-        // v4 specific options
-        if (odataVersion === OdataVersion.v4) {
+        // v4/v401 specific options
+        if (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401) {
             alpQuestions.push({
                 when: (prevAnswers: EntitySelectionAnswers) => {
                     return !!prevAnswers.mainEntity;

--- a/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
@@ -1,5 +1,3 @@
-import { convert } from '@sap-ux/annotation-converter';
-import { parse } from '@sap-ux/edmx-parser';
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { ConvertedMetadata, EntitySet, NavigationProperty } from '@sap-ux/vocabularies-types';
 import type { ListChoiceOptions } from 'inquirer';
@@ -8,6 +6,7 @@ import LoggerHelper from '../logger-helper';
 import type { TableType, TemplateType } from '@sap-ux/fiori-elements-writer';
 import { filterAggregateTransformations, findEntitySetByName, shouldUseAnalyticalTable } from '@sap-ux/inquirer-common';
 import { getTableCapabilitiesByEntitySet } from '@sap-ux/project-access';
+import { parseOdataVersion } from '../../utils';
 
 export type EntityAnswer = {
     entitySetName: string;
@@ -113,20 +112,16 @@ export function getEntityChoices(
     let convertedMetadata: ConvertedMetadata | undefined;
     let odataVersion: OdataVersion | undefined;
     try {
-        convertedMetadata = convert(parse(edmx));
-        const parsedOdataVersion = Number.parseInt(convertedMetadata?.version, 10);
-        if (Number.isNaN(parsedOdataVersion)) {
-            LoggerHelper.logger.error(t('errors.unparseableOdataVersion'));
-            throw new Error(t('errors.unparseableOdataVersion'));
-        }
-        // Note that odata version > `4` e.g. `4.1`, is not currently supported by `@sap-ux/edmx-converter`
-        odataVersion = parsedOdataVersion === 4 ? OdataVersion.v4 : OdataVersion.v2;
+        ({ convertedMetadata, odataVersion } = parseOdataVersion(edmx));
         let entitySets: EntitySet[] = [];
 
         if (entitySetFilter === 'filterDraftEnabled') {
             entitySets = filterDraftEnabledEntities(convertedMetadata.entitySets) ?? [];
-        } else if (entitySetFilter === 'filterAggregateTransformationsOnly' && odataVersion === OdataVersion.v4) {
-            // Only for v4 odata version, if a v2 metadata is passed, this will be ignored
+        } else if (
+            entitySetFilter === 'filterAggregateTransformationsOnly' &&
+            (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401)
+        ) {
+            // Only for v4/v401 odata version, if a v2 metadata is passed, this will be ignored
             entitySets = filterAggregateTransformations(convertedMetadata.entitySets);
         } else {
             entitySets = convertedMetadata.entitySets;
@@ -200,7 +195,7 @@ export function getNavigationEntityChoices(
     const mainEntitySet = findEntitySetByName(metadata, mainEntityName);
 
     let navProps: NavigationProperty[] = [];
-    if (odataVersion === OdataVersion.v4) {
+    if (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401) {
         navProps = mainEntitySet?.entityType.navigationProperties.filter((navProp) => navProp.isCollection) ?? [];
     } else {
         navProps = mainEntitySet?.entityType.navigationProperties ?? [];

--- a/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/entity-helper.ts
@@ -255,8 +255,8 @@ export function getDefaultTableType(
         return 'AnalyticalTable';
     }
 
-    // Handle OData v4 specific logic
-    if (odataVersion === OdataVersion.v4 && entitySet) {
+    // Handle OData v4/v401 specific logic
+    if ((odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401) && entitySet) {
         const canUseAnalytical = templateType === 'lrop' || templateType === 'worklist' || templateType === 'alp';
         const { hasRecursiveHierarchyForEntitySet: hasHierarchy, hasAggregateTransformations: hasAnalyticalData } =
             getTableCapabilitiesByEntitySet(entitySet);

--- a/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/edmx/questions.ts
@@ -52,7 +52,7 @@ function validateEntityChoices(
     if (entityChoiceOptions.length === 0) {
         if (templateType === 'feop' && isCapService) {
             validationMsg = t('prompts.mainEntitySelection.noDraftEnabledEntitiesError');
-        } else if (templateType === 'alp' && odataVersion === OdataVersion.v4) {
+        } else if (templateType === 'alp' && (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401)) {
             validationMsg = t('prompts.mainEntitySelection.noEntitiesAlpV4Error');
         } else {
             validationMsg = t('prompts.mainEntitySelection.noEntitiesError');
@@ -362,7 +362,8 @@ function getTableLayoutQuestions(
 
         tableLayoutQuestions.push({
             when: (prevAnswers: TableConfigAnswers) =>
-                prevAnswers?.tableType === 'TreeTable' && odataVersion === OdataVersion.v4,
+                prevAnswers?.tableType === 'TreeTable' &&
+                (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401),
             type: 'input',
             name: EntityPromptNames.hierarchyQualifier,
             message: t('prompts.hierarchyQualifier.message'),
@@ -444,7 +445,10 @@ function getAddAnnotationQuestions(
         return annotationQuestions;
     }
 
-    if ((templateType === 'lrop' || templateType === 'worklist') && odataVersion === OdataVersion.v4) {
+    if (
+        (templateType === 'lrop' || templateType === 'worklist') &&
+        (odataVersion === OdataVersion.v4 || odataVersion === OdataVersion.v401)
+    ) {
         annotationQuestions.push({
             type: 'confirm',
             name: EntityPromptNames.addLineItemAnnotations,

--- a/packages/odata-service-inquirer/src/prompts/validators.ts
+++ b/packages/odata-service-inquirer/src/prompts/validators.ts
@@ -1,5 +1,5 @@
 import { t } from '../i18n';
-import type { OdataVersion } from '@sap-ux/odata-service-writer';
+import { OdataVersion } from '@sap-ux/odata-service-writer';
 import LoggerHelper from './logger-helper';
 import { parseOdataVersion } from '../utils';
 import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
@@ -21,6 +21,10 @@ export function validateODataVersion(
         const { convertedMetadata, odataVersion } = parseOdataVersion(edmx);
 
         if (requiredVersion && requiredVersion !== odataVersion) {
+            // v401 is backwards compatible with v4 — a v4 requirement is satisfied by a v401 service
+            if (requiredVersion === OdataVersion.v4 && odataVersion === OdataVersion.v401) {
+                return { version: odataVersion, convertedMetadata };
+            }
             const odataErrorMsg = t('prompts.validationMessages.odataVersionMismatch', {
                 providedOdataVersion: odataVersion,
                 requiredOdataVersion: requiredVersion

--- a/packages/odata-service-inquirer/src/utils/index.ts
+++ b/packages/odata-service-inquirer/src/utils/index.ts
@@ -48,7 +48,7 @@ export function parseOdataVersion(metadata: string): {
             throw new Error(t('errors.unparseableOdataVersion'));
         }
         let odataVersion: OdataVersion;
-        if (rawVersion.startsWith('4.01')) {
+        if (rawVersion === '4.01') {
             odataVersion = OdataVersion.v401;
         } else if (rawVersion.startsWith('4')) {
             odataVersion = OdataVersion.v4;

--- a/packages/odata-service-inquirer/src/utils/index.ts
+++ b/packages/odata-service-inquirer/src/utils/index.ts
@@ -41,14 +41,17 @@ export function parseOdataVersion(metadata: string): {
 } {
     try {
         const convertedMetadata = convert(parse(metadata));
-        const parsedOdataVersion = Number.parseInt(convertedMetadata?.version, 10);
+        const rawVersion = convertedMetadata?.version;
 
-        if (Number.isNaN(parsedOdataVersion)) {
+        if (!rawVersion || Number.isNaN(Number.parseInt(rawVersion, 10))) {
             LoggerHelper.logger.error(t('errors.unparseableOdataVersion'));
             throw new Error(t('errors.unparseableOdataVersion'));
         }
-        // Note that odata version > `4` e.g. `4.1`, is not currently supported by `@sap-ux/edmx-converter`
-        const odataVersion = parsedOdataVersion === 4 ? OdataVersion.v4 : OdataVersion.v2;
+        const odataVersion = rawVersion.startsWith('4.01')
+            ? OdataVersion.v401
+            : rawVersion.startsWith('4')
+              ? OdataVersion.v4
+              : OdataVersion.v2;
         return {
             odataVersion,
             convertedMetadata

--- a/packages/odata-service-inquirer/src/utils/index.ts
+++ b/packages/odata-service-inquirer/src/utils/index.ts
@@ -43,15 +43,18 @@ export function parseOdataVersion(metadata: string): {
         const convertedMetadata = convert(parse(metadata));
         const rawVersion = convertedMetadata?.version;
 
-        if (!rawVersion || Number.isNaN(Number.parseInt(rawVersion, 10))) {
+        if (!rawVersion || !/^[14]/.test(rawVersion)) {
             LoggerHelper.logger.error(t('errors.unparseableOdataVersion'));
             throw new Error(t('errors.unparseableOdataVersion'));
         }
-        const odataVersion = rawVersion.startsWith('4.01')
-            ? OdataVersion.v401
-            : rawVersion.startsWith('4')
-              ? OdataVersion.v4
-              : OdataVersion.v2;
+        let odataVersion: OdataVersion;
+        if (rawVersion.startsWith('4.01')) {
+            odataVersion = OdataVersion.v401;
+        } else if (rawVersion.startsWith('4')) {
+            odataVersion = OdataVersion.v4;
+        } else {
+            odataVersion = OdataVersion.v2;
+        }
         return {
             odataVersion,
             convertedMetadata

--- a/packages/odata-service-inquirer/test/unit/prompts/edmx/entity-helper.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/edmx/entity-helper.test.ts
@@ -18,6 +18,7 @@ describe('Test entity helper functions', () => {
     let metadataV2WithDraftRoot: string;
     let metadataV4WithHierarchyRecursiveHierarchy: string;
     let metadataV4WithHierarchyAndCompleteAnalyticalTransformations: string;
+    let metadataV401: string;
 
     beforeAll(async () => {
         metadataV4WithAggregateTransforms = await readFile(
@@ -42,6 +43,7 @@ describe('Test entity helper functions', () => {
             join(__dirname, '../test-data/metadataV4WithHierarchyAndCompleteAnalyticalTransformations.xml'),
             'utf8'
         );
+        metadataV401 = await readFile(join(__dirname, '../../utils/fixtures/metadata_v401.xml'), 'utf8');
     });
 
     describe('Test getNavigationEntityOptions', () => {
@@ -205,6 +207,12 @@ describe('Test entity helper functions', () => {
             expect(typeNameChoices[0].name).toEqual('I_Currency');
             expect(typeNameChoices[0].value.entitySetName).toEqual('I_Currency');
             expect(typeNameChoices[0].value.entitySetType).toEqual('SEPMRA_PROD_MAN.I_CurrencyType');
+        });
+
+        test('should detect OData v401 and return entity choices', () => {
+            const entityOptions = getEntityChoices(metadataV401);
+            expect(entityOptions.odataVersion).toEqual(OdataVersion.v401);
+            expect(entityOptions.choices.length).toBeGreaterThan(0);
         });
 
         test('should set mainEntityParameterName for a single valid parameterised main entity', async () => {

--- a/packages/odata-service-inquirer/test/unit/prompts/validators.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/validators.test.ts
@@ -1,6 +1,8 @@
 import { OdataVersion } from '@sap-ux/odata-service-writer';
 import { validateODataVersion } from '../../../src/prompts/validators';
 import { initI18nOdataServiceInquirer } from '../../../src/i18n';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const validMetadataV2 =
     '<?xml version="1.0" encoding="utf-8"?><edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">' +
@@ -9,8 +11,11 @@ const validMetadataV4 =
     '<?xml version="1.0" encoding="utf-8"?><edmx:Edmx Version="4.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">' +
     '<edmx:DataServices m:DataServiceVersion="4.0"></edmx:DataServices></edmx:Edmx>';
 describe('prompt validators', () => {
+    let validMetadataV401: string;
+
     beforeAll(async () => {
         await initI18nOdataServiceInquirer();
+        validMetadataV401 = await readFile(join(__dirname, '../utils/fixtures/metadata_v401.xml'), 'utf8');
     });
 
     describe('validateODataVersion', () => {
@@ -30,6 +35,29 @@ describe('prompt validators', () => {
         it('should return metadata odata version', () => {
             expect(validateODataVersion(validMetadataV2)).toMatchObject({ version: OdataVersion.v2 });
             expect(validateODataVersion(validMetadataV4)).toMatchObject({ version: OdataVersion.v4 });
+        });
+
+        it('should accept v401 metadata when no required version is specified', () => {
+            expect(validateODataVersion(validMetadataV401)).toMatchObject({ version: OdataVersion.v401 });
+        });
+
+        it('should accept v401 metadata when required version is v401', () => {
+            expect(validateODataVersion(validMetadataV401, OdataVersion.v401)).toMatchObject({
+                version: OdataVersion.v401
+            });
+        });
+
+        it('should accept v401 metadata when required version is v4 (backwards compatible)', () => {
+            expect(validateODataVersion(validMetadataV401, OdataVersion.v4)).toMatchObject({
+                version: OdataVersion.v401
+            });
+        });
+
+        it('should reject v401 metadata when required version is v2', () => {
+            expect(validateODataVersion(validMetadataV401, OdataVersion.v2)).toMatchObject({
+                validationMsg:
+                    'The template you have chosen supports V2 OData services only. The provided version is V4.01.'
+            });
         });
     });
 });

--- a/packages/odata-service-inquirer/test/unit/utils/fixtures/metadata_v401.xml
+++ b/packages/odata-service-inquirer/test/unit/utils/fixtures/metadata_v401.xml
@@ -1,0 +1,4670 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.01" xmlns="http://docs.oasis-open.org/odata/ns/edm" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_COMMUNICATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="Communication" Namespace="com.sap.vocabularies.Communication.v1"/>
+        <edmx:Include Alias="SAP__communication" Namespace="com.sap.vocabularies.Communication.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_PERSONALDATA',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="PersonalData" Namespace="com.sap.vocabularies.PersonalData.v1"/>
+        <edmx:Include Alias="SAP__personalData" Namespace="com.sap.vocabularies.PersonalData.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_ANALYTICS',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="Analytics" Namespace="com.sap.vocabularies.Analytics.v1"/>
+        <edmx:Include Alias="SAP__analytics" Namespace="com.sap.vocabularies.Analytics.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_AGGREGATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__aggregation" Namespace="Org.OData.Aggregation.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_AUTHORIZATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__authorization" Namespace="Org.OData.Authorization.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CAPABILITIES',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__capabilities" Namespace="Org.OData.Capabilities.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CODELIST',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__CodeList" Namespace="com.sap.vocabularies.CodeList.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_COMMON',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__common" Namespace="com.sap.vocabularies.Common.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_CORE',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__core" Namespace="Org.OData.Core.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_HIERARCHY',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__hierarchy" Namespace="com.sap.vocabularies.Hierarchy.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_HTML5',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__HTML5" Namespace="com.sap.vocabularies.HTML5.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_MEASURES',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__measures" Namespace="Org.OData.Measures.V1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_ODM',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__ODM" Namespace="com.sap.vocabularies.ODM.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_PDF',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__PDF" Namespace="com.sap.vocabularies.PDF.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_SESSION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__session" Namespace="com.sap.vocabularies.Session.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_SUPPORT',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__support" Namespace="com.sap.vocabularies.Support.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_UI',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__UI" Namespace="com.sap.vocabularies.UI.v1"/>
+    </edmx:Reference>
+    <edmx:Reference Uri="/sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Vocabularies(TechnicalName='%2FIWBEP%2FVOC_VALIDATION',Version='0001',SAP__Origin='LOCAL')/$value">
+        <edmx:Include Alias="SAP__validation" Namespace="Org.OData.Validation.V1"/>
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema Alias="SAP__self" Namespace="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001">
+            <Annotation String="1.0.0" Term="SAP__core.SchemaVersion"/>
+            <EntityType Name="Root_V2Type">
+                <Key>
+                    <PropertyRef Name="root"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="root" Nullable="false" Type="Edm.Guid"/>
+                <Property MaxLength="1024" Name="description" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="6" Name="accp" Nullable="false" Type="Edm.String"/>
+                <Property Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Property Name="curr_16_2" Nullable="false" Precision="16" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="datn" Type="Edm.Date"/>
+                <Property Name="dats" Type="Edm.Date"/>
+                <Property Name="dec_16_5" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Property Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Property Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Property Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Property Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Property Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Property MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Property Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="raw_16" Type="Edm.Guid"/>
+                <Property Name="string" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestampl" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property MaxLength="3" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Property Name="uuid_raw16" Type="Edm.Guid"/>
+                <Property Name="uuid_char32" Type="Edm.Guid"/>
+                <Property Name="uuid_char22" Type="Edm.Guid"/>
+                <Property Name="uuid_char26" Type="Edm.Guid"/>
+                <Property MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Property Name="utclong" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="HasDraftEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="DraftEntityCreationDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="DraftEntityLastChangeDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="HasActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="IsActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="__OperationControl" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2OperationControl"/>
+                <Property Name="SAP__Messages" Nullable="false" Type="Collection(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.SAP__Message)"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.I_DraftAdministrativeDataType"/>
+                <NavigationProperty Name="SiblingEntity" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </EntityType>
+            <EntityType Name="Root_V1Type">
+                <Key>
+                    <PropertyRef Name="root"/>
+                    <PropertyRef Name="IsActiveEntity"/>
+                </Key>
+                <Property Name="root" Nullable="false" Type="Edm.Guid"/>
+                <Property MaxLength="1024" Name="description" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="6" Name="accp" Nullable="false" Type="Edm.String"/>
+                <Property Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Property Name="curr_16_2" Nullable="false" Precision="16" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="datn" Type="Edm.Date"/>
+                <Property Name="dats" Type="Edm.Date"/>
+                <Property Name="dec_16_5" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Property Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df16_dec_10" Nullable="false" Precision="10" Type="Edm.Decimal"/>
+                <Property Name="df16_raw" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df16_scl" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df16_scl_int" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="df34_dec_10" Nullable="false" Precision="10" Type="Edm.Decimal"/>
+                <Property Name="df34_raw" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df34_scl" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df34_scl_int" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Property Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Property Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Property Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Property Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Property MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Property Name="prec" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="raw_16" Type="Edm.Guid"/>
+                <Property Name="string" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestampl" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property MaxLength="3" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Property Name="uuid_raw16" Type="Edm.Guid"/>
+                <Property Name="uuid_char32" Type="Edm.Guid"/>
+                <Property Name="uuid_char22" Type="Edm.Guid"/>
+                <Property Name="uuid_char26" Type="Edm.Guid"/>
+                <Property MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Property Name="utclong" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="lchr_int" Nullable="false" Type="Edm.Int32"/>
+                <Property MaxLength="256" Name="lchr" Nullable="false" Type="Edm.String"/>
+                <Property Name="HasDraftEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="DraftEntityCreationDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="DraftEntityLastChangeDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="HasActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="IsActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="__OperationControl" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1OperationControl"/>
+                <Property Name="SAP__Messages" Nullable="false" Type="Collection(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.SAP__Message)"/>
+                <NavigationProperty Name="DraftAdministrativeData" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.I_DraftAdministrativeDataType"/>
+                <NavigationProperty Name="SiblingEntity" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </EntityType>
+            <EntityType Name="I_DraftAdministrativeDataType">
+                <Key>
+                    <PropertyRef Name="DraftUUID"/>
+                    <PropertyRef Name="DraftEntityType"/>
+                </Key>
+                <Property Name="DraftUUID" Nullable="false" Type="Edm.Guid"/>
+                <Property MaxLength="30" Name="DraftEntityType" Nullable="false" Type="Edm.String"/>
+                <Property Name="CreationDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property MaxLength="12" Name="CreatedByUser" Nullable="false" Type="Edm.String"/>
+                <Property Name="LastChangeDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property MaxLength="12" Name="LastChangedByUser" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="1" Name="DraftAccessType" Nullable="false" Type="Edm.String"/>
+                <Property Name="ProcessingStartDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property MaxLength="12" Name="InProcessByUser" Nullable="false" Type="Edm.String"/>
+                <Property Name="DraftIsKeptByUser" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="EnqueueStartDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="DraftIsCreatedByMe" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="DraftIsLastChangedByMe" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="DraftIsProcessedByMe" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="80" Name="CreatedByUserDescription" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="80" Name="LastChangedByUserDescription" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="80" Name="InProcessByUserDescription" Nullable="false" Type="Edm.String"/>
+            </EntityType>
+            <ComplexType Name="Root_V2OperationControl">
+                <Property Name="Edit" Nullable="false" Type="Edm.Boolean"/>
+            </ComplexType>
+            <ComplexType Name="Root_V1OperationControl">
+                <Property Name="Edit" Nullable="false" Type="Edm.Boolean"/>
+            </ComplexType>
+            <ComplexType Name="xDMOxTEST_C_DTE_Root_V2_O401">
+                <Property MaxLength="6" Name="accp" Nullable="false" Type="Edm.String"/>
+                <Property Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Property Name="curr_16_2" Nullable="false" Precision="16" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="datn" Type="Edm.Date"/>
+                <Property Name="dats" Type="Edm.Date"/>
+                <Property Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="dec_16_5" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Property MaxLength="1024" Name="description" Nullable="false" Type="Edm.String"/>
+                <Property Name="DraftEntityCreationDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="DraftEntityLastChangeDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Property Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Property Name="HasActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="HasDraftEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Property Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Property Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="IsActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Property Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="raw_16" Type="Edm.Guid"/>
+                <Property Name="root" Type="Edm.Guid"/>
+                <Property MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Property Name="string" Nullable="false" Type="Edm.String"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestampl" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property MaxLength="3" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Property Name="utclong" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="uuid_char22" Type="Edm.Guid"/>
+                <Property Name="uuid_char26" Type="Edm.Guid"/>
+                <Property Name="uuid_char32" Type="Edm.Guid"/>
+                <Property MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Property Name="uuid_raw16" Type="Edm.Guid"/>
+            </ComplexType>
+            <ComplexType Name="xDMOxTEST_C_DTE_Root_V1_O401">
+                <Property MaxLength="6" Name="accp" Nullable="false" Type="Edm.String"/>
+                <Property Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Property Name="curr_16_2" Nullable="false" Precision="16" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Property Name="datn" Type="Edm.Date"/>
+                <Property Name="dats" Type="Edm.Date"/>
+                <Property Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="dec_16_5" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Property MaxLength="1024" Name="description" Nullable="false" Type="Edm.String"/>
+                <Property Name="df16_dec_10" Nullable="false" Precision="10" Type="Edm.Decimal"/>
+                <Property Name="df16_raw" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df16_scl" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df16_scl_int" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="df34_dec_10" Nullable="false" Precision="10" Type="Edm.Decimal"/>
+                <Property Name="df34_raw" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df34_scl" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Property Name="df34_scl_int" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="DraftEntityCreationDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="DraftEntityLastChangeDateTime" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Property Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Property Name="HasActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="HasDraftEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Property Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Property Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Property Name="IsActiveEntity" Nullable="false" Type="Edm.Boolean"/>
+                <Property MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Property MaxLength="256" Name="lchr" Nullable="false" Type="Edm.String"/>
+                <Property Name="lchr_int" Nullable="false" Type="Edm.Int32"/>
+                <Property MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Property Name="prec" Nullable="false" Type="Edm.Int16"/>
+                <Property Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Property Name="raw_16" Type="Edm.Guid"/>
+                <Property Name="root" Type="Edm.Guid"/>
+                <Property MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Property Name="string" Nullable="false" Type="Edm.String"/>
+                <Property Name="timestamp" Type="Edm.DateTimeOffset"/>
+                <Property Name="timestampl" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Property MaxLength="3" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Property Name="utclong" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Property Name="uuid_char22" Type="Edm.Guid"/>
+                <Property Name="uuid_char26" Type="Edm.Guid"/>
+                <Property Name="uuid_char32" Type="Edm.Guid"/>
+                <Property MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Property Name="uuid_raw16" Type="Edm.Guid"/>
+            </ComplexType>
+            <ComplexType Name="SAP__Message">
+                <Property Name="code" Nullable="false" Type="Edm.String"/>
+                <Property Name="message" Nullable="false" Type="Edm.String"/>
+                <Property Name="target" Type="Edm.String"/>
+                <Property Name="additionalTargets" Nullable="false" Type="Collection(Edm.String)"/>
+                <Property Name="transition" Nullable="false" Type="Edm.Boolean"/>
+                <Property Name="numericSeverity" Nullable="false" Type="Edm.Byte"/>
+                <Property Name="longtextUrl" Type="Edm.String"/>
+            </ComplexType>
+            <Action IsBound="true" Name="v2_o401_msg_short_duration_h">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_dec_16_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_boolean">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="Discard">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_unit_3">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_tims">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_raw_16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_numc_4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df34_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_timn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_datn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_lchr">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_accp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_char_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_duration_h">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="v2_o401_param_self">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_int1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_decfloat16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_char_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_dats">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df16_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df34_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_sstring">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_string">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_lang">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_timestampl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="Resume">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df34_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_duration_s">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_unit_3">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_param_structure">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.xDMOxTEST_C_DTE_Root_V2_O401"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_uuid_char36">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df34_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df16_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_decfloat16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_duration_h">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_timestamp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_int8">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_duration_d">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_dec_2_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_clnt">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_timestampl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_duration_h">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_boolean">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df16_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_tims">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_fltp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_duration_m">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df16_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df16_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_raw_16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_timestamp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_curr_2_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df34_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_curr_16_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_unit_3">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="Discard">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df34_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_quan">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_char_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_decfloat16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df34_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_datn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_decfloat34">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_sstring">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df16_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_int4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_tims">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_fltp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_uuid_char22">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_raw_16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_utclong">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_int1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_uuid_char32">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_int4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_uuid_char22">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_dats">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_utclong">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_lchr">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df16_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_duration_m">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_cuky">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_int8">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_uuid_char36">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_clnt">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_timestamp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df16_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_accp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_string">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_int4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_clnt">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_uuid_char36">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_lchr">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_timn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_int2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_uuid_char26">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_lang">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_curr_2_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_decfloat34">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_accp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_utclong">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_uuid_char22">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_param_null">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_prec">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_dec_16_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_utclong">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_quan">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_uuid_raw16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_numc_4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_accp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_sstring">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_lchr">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_quan">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_timn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_duration_d">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_duration_d">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_curr_16_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_tims">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_uuid_char22">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_curr_16_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_boolean">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_duration_m">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_int2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_curr_2_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_sstring">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df16_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_uuid_char26">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_lang">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_curr_16_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_uuid_char26">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_boolean">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_timn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="Prepare">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_duration_s">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_char_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df16_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_duration_s">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_cuky">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_unit_3">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df34_dec_10">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="v1_o401_param_self">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_param_null">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_uuid_char32">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_char_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_numc_4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_timestampl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_prec">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_fltp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_param_structure">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+                <Parameter Name="boolean" Nullable="false" Type="Edm.Boolean"/>
+                <Parameter MaxLength="1" Name="char_1" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="char_5" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="3" Name="clnt" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="5" Name="cuky" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="curr_2_2" Nullable="false" Precision="2" Scale="variable" Type="Edm.Decimal"/>
+                <Parameter Name="datn" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dats" Nullable="true" Type="Edm.Date"/>
+                <Parameter Name="dec_2_1" Nullable="false" Precision="2" Scale="1" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat16" Nullable="false" Precision="16" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="decfloat34" Nullable="false" Precision="34" Scale="floating" Type="Edm.Decimal"/>
+                <Parameter Name="duration_s" Nullable="false" Precision="31" Scale="12" Type="Edm.Decimal"/>
+                <Parameter Name="duration_m" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_h" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="duration_d" Nullable="false" Type="Edm.Int64"/>
+                <Parameter Name="fltp" Nullable="false" Type="Edm.Double"/>
+                <Parameter Name="int1" Nullable="false" Type="Edm.Byte"/>
+                <Parameter Name="int2" Nullable="false" Type="Edm.Int16"/>
+                <Parameter Name="int4" Nullable="false" Type="Edm.Int32"/>
+                <Parameter Name="int8" Nullable="false" Type="Edm.Int64"/>
+                <Parameter MaxLength="2" Name="lang" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="4" Name="numc_4" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="quan" Nullable="false" Precision="16" Scale="5" Type="Edm.Decimal"/>
+                <Parameter Name="raw_16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="string" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="1333" Name="sstring" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="timestamp" Nullable="true" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timestampl" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <Parameter Name="timn" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter Name="tims" Nullable="false" Type="Edm.TimeOfDay"/>
+                <Parameter MaxLength="2" Name="unit_3" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="uuid_raw16" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char32" Nullable="true" Type="Edm.Guid"/>
+                <Parameter Name="uuid_char22" Nullable="true" Type="Edm.Guid"/>
+                <Parameter MaxLength="26" Name="uuid_char26" Nullable="false" Type="Edm.String"/>
+                <Parameter MaxLength="36" Name="uuid_char36" Nullable="false" Type="Edm.String"/>
+                <Parameter Name="utclong" Nullable="true" Precision="7" Type="Edm.DateTimeOffset"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.xDMOxTEST_C_DTE_Root_V1_O401"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_uuid_char32">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_df34_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df16_raw">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_uuid_raw16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_decfloat34">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_fltp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df16_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_int8">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_decfloat16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_timestampl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_int1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_duration_s">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_uuid_raw16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_quan">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="Prepare">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_df34_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_dec_16_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_int2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_curr_2_2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_timestamp">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_duration_m">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_df34_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_dec_2_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_df34_scl">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_dec_2_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_uuid_char26">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_string">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_clnt">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_char_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_uuid_char32">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_int2">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_int1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_dats">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="Edit">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+                <Parameter Name="PreserveChanges" Nullable="false" Type="Edm.Boolean"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="Activate">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_dec_2_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="Activate">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action EntitySetPath="_it" IsBound="true" Name="Edit">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+                <Parameter Name="PreserveChanges" Nullable="false" Type="Edm.Boolean"/>
+                <ReturnType Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_datn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="Resume">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_dec_16_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_lang">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_string">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_long_decfloat34">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_raw_16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_uuid_char36">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_cuky">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_dats">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_int4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_cuky">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_char_1">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_duration_d">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_char_5">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_datn">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_short_int8">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <Action IsBound="true" Name="v2_o401_msg_short_numc_4">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type"/>
+            </Action>
+            <Action IsBound="true" Name="v1_o401_msg_long_uuid_raw16">
+                <Parameter Name="_it" Nullable="false" Type="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type"/>
+            </Action>
+            <EntityContainer Name="Container">
+                <EntitySet EntityType="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.I_DraftAdministrativeDataType" Name="I_DraftAdministrativeData"/>
+                <EntitySet EntityType="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type" Name="Root_V1">
+                    <NavigationPropertyBinding Path="DraftAdministrativeData" Target="I_DraftAdministrativeData"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="Root_V1"/>
+                </EntitySet>
+                <EntitySet EntityType="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V2Type" Name="Root_V2">
+                    <NavigationPropertyBinding Path="DraftAdministrativeData" Target="I_DraftAdministrativeData"/>
+                    <NavigationPropertyBinding Path="SiblingEntity" Target="Root_V2"/>
+                </EntitySet>
+            </EntityContainer>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/accp">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/boolean">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Label"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Currency" Term="SAP__common.Label"/>
+                <Annotation String="Crcy" Term="SAP__common.Heading"/>
+                <Annotation String="Currency Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=WAERS_CURC" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/curr_16_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/HasActiveEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Has active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/HasDraftEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Has Draft" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has draft document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/IsActiveEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Is active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Is active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/numc_4">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/quan">
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/unit_3">
+                <Annotation Term="SAP__common.IsUnit"/>
+                <Annotation String="Internal UoM" Term="SAP__common.Label"/>
+                <Annotation String="MU" Term="SAP__common.Heading"/>
+                <Annotation String="Unit of Measurement" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=MSEHI" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/accp">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation String="ACCP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Crcy" Term="SAP__common.Heading"/>
+                <Annotation String="Currency Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=WAERS_CURC" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/curr_16_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_16_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/dec_16_5">
+                <Annotation String="DEC_16_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/description">
+                <Annotation String="DESCRIPTION" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df16_dec_10">
+                <Annotation String="DF16_DEC_10" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df16_raw">
+                <Annotation String="DF16_RAW" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df16_scl">
+                <Annotation String="DF16_SCL" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df16_scl_int">
+                <Annotation String="DF16_SCL_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df34_dec_10">
+                <Annotation String="DF34_DEC_10" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df34_raw">
+                <Annotation String="DF34_RAW" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df34_scl">
+                <Annotation String="DF34_SCL" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/df34_scl_int">
+                <Annotation String="DF34_SCL_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/HasActiveEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Has active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/HasDraftEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Has Draft" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has draft document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/IsActiveEntity">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Is active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Is active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+                <Annotation String="L" Term="SAP__common.Heading"/>
+                <Annotation String="Language Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=LANGU" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/lchr">
+                <Annotation String="LCHR" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/lchr_int">
+                <Annotation String="LCHR_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/numc_4">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/prec">
+                <Annotation String="PREC" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/quan">
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/root">
+                <Annotation String="ROOT" Term="SAP__common.Label"/>
+                <Annotation String="UUID" Term="SAP__common.Heading"/>
+                <Annotation String="16 Byte UUID in 16 Bytes (Raw Format)" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/unit_3">
+                <Annotation Term="SAP__common.IsUnit"/>
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation String="MU" Term="SAP__common.Heading"/>
+                <Annotation String="Unit of Measurement" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=MSEHI" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/root">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation String="UUID" Term="SAP__common.Label"/>
+                <Annotation String="16 Byte UUID in 16 Bytes (Raw Format)" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/accp">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Currency" Term="SAP__common.Label"/>
+                <Annotation String="Crcy" Term="SAP__common.Heading"/>
+                <Annotation String="Currency Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=WAERS_CURC" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/curr_16_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/numc_4">
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/quan">
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/unit_3">
+                <Annotation Term="SAP__common.IsUnit"/>
+                <Annotation String="Internal UoM" Term="SAP__common.Label"/>
+                <Annotation String="MU" Term="SAP__common.Heading"/>
+                <Annotation String="Unit of Measurement" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=MSEHI" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/HasDraftEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Has Draft" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has draft document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/DraftEntityCreationDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Created On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/DraftEntityLastChangeDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Last Changed On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/HasActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Has active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/IsActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Is active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Is active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/__OperationControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/Root_V2">
+                <Annotation Term="SAP__capabilities.NavigationRestrictions">
+                    <Record>
+                        <PropertyValue Property="RestrictedProperties">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue NavigationPropertyPath="SiblingEntity" Property="NavigationProperty"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Bool="false" Property="Insertable"/>
+                                        </Record>
+                                    </PropertyValue>
+                                    <PropertyValue Property="DeepUpdateSupport">
+                                        <Record>
+                                            <PropertyValue Bool="false" Property="Supported"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__common.DraftRoot">
+                    <Record>
+                        <PropertyValue Property="DiscardAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Discard"/>
+                        <PropertyValue Property="PreparationAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Prepare"/>
+                        <PropertyValue Property="ActivationAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Activate"/>
+                        <PropertyValue Property="EditAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Edit"/>
+                        <PropertyValue Property="ResumeAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Resume"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Searchable"/>
+                        <PropertyValue EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group " Property="UnsupportedExpressions"/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Filterable"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="description"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="string"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="sstring"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityCreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityLastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="NonFilterableProperties">
+                            <Collection>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SortRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonSortableProperties">
+                            <Collection>
+                                <PropertyPath>description</PropertyPath>
+                                <PropertyPath>string</PropertyPath>
+                                <PropertyPath>sstring</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="DeltaUpdateSupported"/>
+                        <PropertyValue Property="NonUpdatableNavigationProperties">
+                            <Collection>
+                                <PropertyPath>DraftAdministrativeData</PropertyPath>
+                                <PropertyPath>SiblingEntity</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Bool="true" Property="SelectSupported"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeepUpdateSupport">
+                    <Record>
+                        <PropertyValue Bool="true" Property="ContentIDSupported"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_self(SAP__self.Root_V2Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_structure(SAP__self.Root_V2Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v2_o401_param_null(SAP__self.Root_V2Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.Root_V2Type)/PreserveChanges">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="TRUE" Term="SAP__common.Label"/>
+                <Annotation String="Data element for domain BOOLE: TRUE (='X') and FALSE (=' ')" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.Root_V2Type)">
+                <Annotation Path="_it/__OperationControl/Edit" Term="SAP__core.OperationAvailable"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type">
+                <Annotation String="Data Type Exposure: V2 O401 C Root" Term="SAP__common.Label"/>
+                <Annotation Path="SAP__Messages" Term="SAP__common.Messages"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container">
+                <Annotation Term="SAP__CodeList.CurrencyCodes">
+                    <Record>
+                        <PropertyValue Property="Url" String="../../../../default/iwbep/common/0001/$metadata"/>
+                        <PropertyValue Property="CollectionPath" String="Currencies"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__CodeList.UnitsOfMeasure">
+                    <Record>
+                        <PropertyValue Property="Url" String="../../../../default/iwbep/common/0001/$metadata"/>
+                        <PropertyValue Property="CollectionPath" String="UnitsOfMeasure"/>
+                    </Record>
+                </Annotation>
+                <Annotation Bool="true" Term="SAP__common.ApplyMultiUnitBehaviorForSortingAndFiltering"/>
+                <Annotation Term="SAP__capabilities.FilterFunctions">
+                    <Collection>
+                        <String>eq</String>
+                        <String>ne</String>
+                        <String>gt</String>
+                        <String>ge</String>
+                        <String>lt</String>
+                        <String>le</String>
+                        <String>and</String>
+                        <String>or</String>
+                        <String>contains</String>
+                        <String>startswith</String>
+                        <String>endswith</String>
+                        <String>any</String>
+                        <String>all</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__support.TechnicalInfoLinks">
+                    <Record>
+                        <PropertyValue Property="Url" String="../../../../default/iwbep/common/0001/$metadata"/>
+                        <PropertyValue Property="FunctionImport" String="GetTechnicalInfoLinks"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SupportedFormats">
+                    <Collection>
+                        <String>application/json</String>
+                        <String>application/pdf</String>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__PDF.Features">
+                    <Record>
+                        <PropertyValue Property="DocumentDescriptionReference" String="../../../../default/iwbep/common/0001/$metadata"/>
+                        <PropertyValue Property="DocumentDescriptionCollection" String="MyDocumentDescriptions"/>
+                        <PropertyValue Bool="true" Property="ArchiveFormat"/>
+                        <PropertyValue Bool="true" Property="Border"/>
+                        <PropertyValue Bool="true" Property="CoverPage"/>
+                        <PropertyValue Bool="true" Property="FitToPage"/>
+                        <PropertyValue Bool="true" Property="FontName"/>
+                        <PropertyValue Bool="true" Property="FontSize"/>
+                        <PropertyValue Bool="true" Property="HeaderFooter"/>
+                        <PropertyValue Bool="true" Property="IANATimezoneFormat"/>
+                        <PropertyValue Bool="true" Property="Margin"/>
+                        <PropertyValue Bool="true" Property="Padding"/>
+                        <PropertyValue Int="20000" Property="ResultSizeDefault"/>
+                        <PropertyValue Int="20000" Property="ResultSizeMaximum"/>
+                        <PropertyValue Bool="true" Property="Signature"/>
+                        <PropertyValue Bool="true" Property="TextDirectionLayout"/>
+                        <PropertyValue Bool="true" Property="Treeview"/>
+                        <PropertyValue Bool="true" Property="UploadToFileShare"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.KeyAsSegmentSupported"/>
+                <Annotation Term="SAP__capabilities.AsynchronousRequestsSupported"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/root">
+                <Annotation String="ROOT" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation String="UUID" Term="SAP__common.Heading"/>
+                <Annotation String="16 Byte UUID in 16 Bytes (Raw Format)" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/description">
+                <Annotation String="DESCRIPTION" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/accp">
+                <Annotation String="ACCP" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.accp'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.boolean'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.char_1'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.char_5'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.clnt'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_currencystdvh/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.cuky'/$metadata</String>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.cuky'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Crcy" Term="SAP__common.Heading"/>
+                <Annotation String="Currency Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=WAERS_CURC" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/curr_16_2">
+                <Annotation String="CURR_16_2" Term="SAP__common.Label"/>
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.curr_16_2'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/curr_2_2">
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.curr_2_2'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.datn'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.dats'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/dec_16_5">
+                <Annotation String="DEC_16_5" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.dec_16_5'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.dec_2_1'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.decfloat16'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.decfloat34'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df16_dec_10">
+                <Annotation String="DF16_DEC_10" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df16_dec_10'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df16_raw">
+                <Annotation String="DF16_RAW" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df16_raw'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df16_scl">
+                <Annotation String="DF16_SCL" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df16_scl'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df16_scl_int">
+                <Annotation String="DF16_SCL_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df34_dec_10">
+                <Annotation String="DF34_DEC_10" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df34_dec_10'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df34_raw">
+                <Annotation String="DF34_RAW" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df34_raw'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df34_scl">
+                <Annotation String="DF34_SCL" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.df34_scl'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/df34_scl_int">
+                <Annotation String="DF34_SCL_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.duration_s'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.duration_m'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.duration_h'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.duration_d'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.fltp'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.int1'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.int2'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.int4'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.int8'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_language/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.lang'/$metadata</String>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.lang'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="L" Term="SAP__common.Heading"/>
+                <Annotation String="Language Key" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=LANGU" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.numc_4'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/prec">
+                <Annotation String="PREC" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.prec'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.quan'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.raw_16'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.string'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.sstring'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.timestamp'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.timestampl'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.timn'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.tims'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/unit_3">
+                <Annotation Term="SAP__common.IsUnit"/>
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_unitofmeasurestdvh/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.unit_3'/$metadata</String>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.unit_3'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="MU" Term="SAP__common.Heading"/>
+                <Annotation String="Unit of Measurement" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=MSEHI" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.uuid_raw16'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.uuid_char32'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.uuid_char22'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.uuid_char26'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.uuid_char36'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.utclong'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/lchr_int">
+                <Annotation String="LCHR_INT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/lchr">
+                <Annotation String="LCHR" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/dmo/test_vh_dte_root_v1_o401/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-*dmo*test_c_dte_root_v1_o401.lchr'/$metadata</String>
+                    </Collection>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/HasDraftEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Has Draft" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has draft document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/DraftEntityCreationDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Created On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/DraftEntityLastChangeDateTime">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Last Changed On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/HasActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Has active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Has active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/IsActiveEntity">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Is active" Term="SAP__common.Label"/>
+                <Annotation String="Draft - Indicator - Is active document" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type/__OperationControl">
+                <Annotation Term="SAP__core.Computed"/>
+                <Annotation Term="SAP__UI.HiddenFilter"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/Root_V1">
+                <Annotation Term="SAP__capabilities.NavigationRestrictions">
+                    <Record>
+                        <PropertyValue Property="RestrictedProperties">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue NavigationPropertyPath="SiblingEntity" Property="NavigationProperty"/>
+                                    <PropertyValue Property="InsertRestrictions">
+                                        <Record>
+                                            <PropertyValue Bool="false" Property="Insertable"/>
+                                        </Record>
+                                    </PropertyValue>
+                                    <PropertyValue Property="DeepUpdateSupport">
+                                        <Record>
+                                            <PropertyValue Bool="false" Property="Supported"/>
+                                        </Record>
+                                    </PropertyValue>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__common.DraftRoot">
+                    <Record>
+                        <PropertyValue Property="DiscardAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Discard"/>
+                        <PropertyValue Property="ResumeAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Resume"/>
+                        <PropertyValue Property="PreparationAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Prepare"/>
+                        <PropertyValue Property="EditAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Edit"/>
+                        <PropertyValue Property="ActivationAction" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Activate"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Searchable"/>
+                        <PropertyValue EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group " Property="UnsupportedExpressions"/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Filterable"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="description"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="string"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="sstring"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SearchExpression"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityCreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="DraftEntityLastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="NonFilterableProperties">
+                            <Collection>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.SortRestrictions">
+                    <Record>
+                        <PropertyValue Property="NonSortableProperties">
+                            <Collection>
+                                <PropertyPath>description</PropertyPath>
+                                <PropertyPath>string</PropertyPath>
+                                <PropertyPath>sstring</PropertyPath>
+                                <PropertyPath>__OperationControl</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="DeltaUpdateSupported"/>
+                        <PropertyValue Property="NonUpdatableNavigationProperties">
+                            <Collection>
+                                <PropertyPath>DraftAdministrativeData</PropertyPath>
+                                <PropertyPath>SiblingEntity</PropertyPath>
+                            </Collection>
+                        </PropertyValue>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Bool="true" Property="SelectSupported"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeepUpdateSupport">
+                    <Record>
+                        <PropertyValue Bool="true" Property="ContentIDSupported"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_null(SAP__self.Root_V1Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_self(SAP__self.Root_V1Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/boolean">
+                <Annotation String="BOOLEAN" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="Truth Value" Term="SAP__common.Heading"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/char_1">
+                <Annotation String="CHAR_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/char_5">
+                <Annotation String="CHAR_5" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/clnt">
+                <Annotation String="CLNT" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/cuky">
+                <Annotation Term="SAP__common.IsCurrency"/>
+                <Annotation String="CUKY" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/curr_2_2">
+                <Annotation Path="cuky" Term="SAP__measures.ISOCurrency"/>
+                <Annotation String="CURR_2_2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/datn">
+                <Annotation String="DATN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/dats">
+                <Annotation String="DATS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/dec_2_1">
+                <Annotation String="DEC_2_1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/decfloat16">
+                <Annotation String="DECFLOAT16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/decfloat34">
+                <Annotation String="DECFLOAT34" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/duration_s">
+                <Annotation String="DURATION_S" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/duration_m">
+                <Annotation String="DURATION_M" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/duration_h">
+                <Annotation String="DURATION_H" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/duration_d">
+                <Annotation String="DURATION_D" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/fltp">
+                <Annotation String="FLTP" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/int1">
+                <Annotation String="INT1" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/int2">
+                <Annotation String="INT2" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/int4">
+                <Annotation String="INT4" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/int8">
+                <Annotation String="INT8" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/lang">
+                <Annotation String="LANG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/numc_4">
+                <Annotation String="NUMC_4" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsDigitSequence"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/quan">
+                <Annotation String="QUAN" Term="SAP__common.Label"/>
+                <Annotation Path="unit_3" Term="SAP__measures.Unit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/raw_16">
+                <Annotation String="RAW_16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/string">
+                <Annotation String="STRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/sstring">
+                <Annotation String="SSTRING" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/timestamp">
+                <Annotation String="TIMESTAMP" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/timestampl">
+                <Annotation String="TIMESTAMPL" Term="SAP__common.Label"/>
+                <Annotation String="Time Stamp" Term="SAP__common.Heading"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/timn">
+                <Annotation String="TIMN" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/tims">
+                <Annotation String="TIMS" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/unit_3">
+                <Annotation String="UNIT_3" Term="SAP__common.Label"/>
+                <Annotation Term="SAP__common.IsUnit"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/uuid_raw16">
+                <Annotation String="UUID_RAW16" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/uuid_char32">
+                <Annotation String="UUID_CHAR32" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/uuid_char22">
+                <Annotation String="UUID_CHAR22" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/uuid_char26">
+                <Annotation String="UUID_CHAR26" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/uuid_char36">
+                <Annotation String="UUID_CHAR36" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.v1_o401_param_structure(SAP__self.Root_V1Type)/utclong">
+                <Annotation String="UTCLONG" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.Root_V1Type)/PreserveChanges">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation String="TRUE" Term="SAP__common.Label"/>
+                <Annotation String="Data element for domain BOOLE: TRUE (='X') and FALSE (=' ')" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Edit(SAP__self.Root_V1Type)">
+                <Annotation Path="_it/__OperationControl/Edit" Term="SAP__core.OperationAvailable"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftEntityType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Entity ID" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreatedByUser">
+                <Annotation Path="CreatedByUserDescription" Term="SAP__common.Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_draftadministrativeuservh/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-i_draftadministrativedata.createdbyuser'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Draft Created By" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangedByUser">
+                <Annotation Path="LastChangedByUserDescription" Term="SAP__common.Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__common.ValueListReferences">
+                    <Collection>
+                        <String>../../../../srvd_f4/sap/i_draftadministrativeuservh/0001;ps='srvd-*dmo*test_dte_root_o401-0001';va='com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.et-i_draftadministrativedata.lastchangedbyuser'/$metadata</String>
+                    </Collection>
+                </Annotation>
+                <Annotation String="Draft Last Changed By" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftAccessType">
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Access Type" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/InProcessByUser">
+                <Annotation Path="InProcessByUserDescription" Term="SAP__common.Text"/>
+                <Annotation Term="SAP__common.IsUpperCase"/>
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft In Process By" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType">
+                <Annotation String="Draft Administration Data" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Container/I_DraftAdministrativeData">
+                <Annotation Term="SAP__capabilities.SearchRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Searchable"/>
+                        <PropertyValue EnumMember="SAP__capabilities.SearchExpressions/AND SAP__capabilities.SearchExpressions/NOT SAP__capabilities.SearchExpressions/group " Property="UnsupportedExpressions"/>
+                        <PropertyValue Property="SearchSyntax" String="https://url.sap/odata-search"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.FilterRestrictions">
+                    <Record>
+                        <PropertyValue Bool="true" Property="Filterable"/>
+                        <PropertyValue Property="FilterExpressionRestrictions">
+                            <Collection>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="CreationDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                                <Record>
+                                    <PropertyValue Property="Property" PropertyPath="LastChangeDateTime"/>
+                                    <PropertyValue Property="AllowedExpressions" String="SingleRange"/>
+                                </Record>
+                            </Collection>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.ReadRestrictions">
+                    <Record>
+                        <PropertyValue Bool="false" Property="Readable"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.InsertRestrictions">
+                    <Record>
+                        <PropertyValue Bool="false" Property="Insertable"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.DeleteRestrictions">
+                    <Record>
+                        <PropertyValue Bool="false" Property="Deletable"/>
+                    </Record>
+                </Annotation>
+                <Annotation Term="SAP__capabilities.UpdateRestrictions">
+                    <Record>
+                        <PropertyValue Bool="false" Property="Updatable"/>
+                        <PropertyValue Property="QueryOptions">
+                            <Record>
+                                <PropertyValue Bool="true" Property="SelectSupported"/>
+                            </Record>
+                        </PropertyValue>
+                    </Record>
+                </Annotation>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1Type">
+                <Annotation Term="SAP__UI.Facets">
+                    <Collection>
+                        <Record Type="SAP__UI.ReferenceFacet">
+                            <PropertyValue Property="Label" String="Root"/>
+                            <PropertyValue Property="ID" String="Root"/>
+                            <PropertyValue AnnotationPath="@SAP__UI.Identification" Property="Target"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.Identification">
+                    <Collection>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Null"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_null(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Structure"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_structure(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Self"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_self(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="root" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="description" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_ACCP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_accp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_ACCP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_accp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="accp" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_BOOLEAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_boolean(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_BOOLEAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_boolean(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="boolean" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CHAR_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_char_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CHAR_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_char_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="char_1" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CHAR_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_char_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CHAR_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_char_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="char_5" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CLNT"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_clnt(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CLNT"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_clnt(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="clnt" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CUKY"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_cuky(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CUKY"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_cuky(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="cuky" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CURR_16_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_curr_16_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CURR_16_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_curr_16_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="curr_16_2" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CURR_2_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_curr_2_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CURR_2_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_curr_2_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="curr_2_2" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DATN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_datn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DATN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_datn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="datn" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DATS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dats(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DATS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dats(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dats" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DEC_16_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dec_16_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DEC_16_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dec_16_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dec_16_5" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DEC_2_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dec_2_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DEC_2_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dec_2_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dec_2_1" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DECFLOAT16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_decfloat16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DECFLOAT16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_decfloat16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="decfloat16" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DECFLOAT34"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_decfloat34(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DECFLOAT34"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_decfloat34(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="decfloat34" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_dec_10" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_raw" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_scl" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_scl_int" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_dec_10" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_raw" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_scl" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_scl_int" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_S"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_s(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_S"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_s(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_s" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_M"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_m(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_M"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_m(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_m" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_H"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_h(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_H"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_h(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_h" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_D"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_d(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_D"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_d(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_d" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_FLTP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_fltp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_FLTP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_fltp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="fltp" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int1" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int2" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int4" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT8"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int8(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT8"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int8(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int8" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_LANG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_lang(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_LANG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_lang(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lang" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_NUMC_4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_numc_4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_NUMC_4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_numc_4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="numc_4" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_PREC"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_prec(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_PREC"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_prec(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="prec" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_QUAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_quan(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_QUAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_quan(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="quan" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_RAW_16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_raw_16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_RAW_16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_raw_16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="raw_16" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_STRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_string(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_STRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_string(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="string" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_SSTRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_sstring(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_SSTRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_sstring(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="sstring" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMESTAMP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timestamp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMESTAMP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timestamp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timestamp" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMESTAMPL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timestampl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMESTAMPL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timestampl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timestampl" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timn" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_tims(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_tims(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="tims" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UNIT_3"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_unit_3(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UNIT_3"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_unit_3(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="unit_3" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_RAW16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_raw16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_RAW16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_raw16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_raw16" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR32"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char32(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR32"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char32(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char32" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR22"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char22(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR22"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char22(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char22" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR26"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char26(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR26"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char26(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char26" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR36"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char36(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR36"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char36(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char36" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UTCLONG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_utclong(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UTCLONG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_utclong(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="utclong" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lchr_int" Property="Value"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_LCHR"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_lchr(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_LCHR"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_lchr(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lchr" Property="Value"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.LineItem">
+                    <Collection>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Null"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_null(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Structure"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_structure(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="Return Self"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_param_self(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="root" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="description" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_ACCP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_accp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_ACCP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_accp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="accp" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_BOOLEAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_boolean(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_BOOLEAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_boolean(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="boolean" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CHAR_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_char_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CHAR_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_char_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="char_1" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CHAR_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_char_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CHAR_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_char_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="char_5" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CLNT"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_clnt(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CLNT"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_clnt(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="clnt" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CUKY"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_cuky(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CUKY"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_cuky(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="cuky" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CURR_16_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_curr_16_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CURR_16_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_curr_16_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="curr_16_2" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_CURR_2_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_curr_2_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_CURR_2_2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_curr_2_2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="curr_2_2" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DATN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_datn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DATN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_datn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="datn" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DATS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dats(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DATS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dats(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dats" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DEC_16_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dec_16_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DEC_16_5"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dec_16_5(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dec_16_5" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DEC_2_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_dec_2_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DEC_2_1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_dec_2_1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="dec_2_1" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DECFLOAT16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_decfloat16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DECFLOAT16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_decfloat16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="decfloat16" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DECFLOAT34"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_decfloat34(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DECFLOAT34"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_decfloat34(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="decfloat34" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_dec_10" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_raw" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF16_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df16_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF16_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df16_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_scl" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df16_scl_int" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_DEC_10"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_dec_10(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_dec_10" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_RAW"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_raw(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_raw" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DF34_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_df34_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DF34_SCL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_df34_scl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_scl" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="df34_scl_int" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_S"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_s(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_S"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_s(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_s" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_M"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_m(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_M"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_m(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_m" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_H"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_h(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_H"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_h(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_h" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_DURATION_D"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_duration_d(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_DURATION_D"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_duration_d(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="duration_d" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_FLTP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_fltp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_FLTP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_fltp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="fltp" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT1"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int1(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int1" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT2"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int2(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int2" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int4" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_INT8"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_int8(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_INT8"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_int8(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="int8" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_LANG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_lang(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_LANG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_lang(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lang" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_NUMC_4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_numc_4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_NUMC_4"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_numc_4(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="numc_4" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_PREC"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_prec(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_PREC"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_prec(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="prec" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_QUAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_quan(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_QUAN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_quan(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="quan" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_RAW_16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_raw_16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_RAW_16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_raw_16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="raw_16" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_STRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_string(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_STRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_string(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="string" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_SSTRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_sstring(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_SSTRING"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_sstring(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="sstring" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMESTAMP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timestamp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMESTAMP"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timestamp(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timestamp" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMESTAMPL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timestampl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMESTAMPL"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timestampl(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timestampl" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_timn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMN"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_timn(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="timn" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_TIMS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_tims(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_TIMS"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_tims(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="tims" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UNIT_3"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_unit_3(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UNIT_3"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_unit_3(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="unit_3" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_RAW16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_raw16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_RAW16"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_raw16(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_raw16" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR32"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char32(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR32"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char32(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char32" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR22"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char22(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR22"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char22(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char22" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR26"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char26(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR26"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char26(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char26" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UUID_CHAR36"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_uuid_char36(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UUID_CHAR36"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_uuid_char36(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="uuid_char36" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_UTCLONG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_utclong(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_UTCLONG"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_utclong(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="utclong" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lchr_int" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="LMSG_LCHR"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_long_lchr(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataFieldForAction">
+                            <PropertyValue Property="Label" String="SMSG_LCHR"/>
+                            <PropertyValue Property="Action" String="com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.v1_o401_msg_short_lchr(com.sap.gateway.srvd.dmo.test_dte_root_o401.v0001.Root_V1Type)"/>
+                            <PropertyValue EnumMember="SAP__UI.OperationGroupingType/Isolated" Property="InvocationGrouping"/>
+                        </Record>
+                        <Record Type="SAP__UI.DataField">
+                            <PropertyValue Path="lchr" Property="Value"/>
+                            <Annotation EnumMember="SAP__UI.ImportanceType/High" Term="SAP__UI.Importance"/>
+                        </Record>
+                    </Collection>
+                </Annotation>
+                <Annotation Term="SAP__UI.SelectionFields">
+                    <Collection>
+                        <PropertyPath>accp</PropertyPath>
+                        <PropertyPath>boolean</PropertyPath>
+                        <PropertyPath>char_1</PropertyPath>
+                        <PropertyPath>char_5</PropertyPath>
+                        <PropertyPath>clnt</PropertyPath>
+                        <PropertyPath>cuky</PropertyPath>
+                        <PropertyPath>curr_16_2</PropertyPath>
+                        <PropertyPath>curr_2_2</PropertyPath>
+                        <PropertyPath>datn</PropertyPath>
+                        <PropertyPath>dats</PropertyPath>
+                        <PropertyPath>dec_16_5</PropertyPath>
+                        <PropertyPath>dec_2_1</PropertyPath>
+                        <PropertyPath>decfloat16</PropertyPath>
+                        <PropertyPath>decfloat34</PropertyPath>
+                        <PropertyPath>df16_dec_10</PropertyPath>
+                        <PropertyPath>df16_raw</PropertyPath>
+                        <PropertyPath>df16_scl</PropertyPath>
+                        <PropertyPath>df34_dec_10</PropertyPath>
+                        <PropertyPath>df34_raw</PropertyPath>
+                        <PropertyPath>df34_scl</PropertyPath>
+                        <PropertyPath>duration_s</PropertyPath>
+                        <PropertyPath>duration_m</PropertyPath>
+                        <PropertyPath>duration_h</PropertyPath>
+                        <PropertyPath>duration_d</PropertyPath>
+                        <PropertyPath>fltp</PropertyPath>
+                        <PropertyPath>int1</PropertyPath>
+                        <PropertyPath>int2</PropertyPath>
+                        <PropertyPath>int4</PropertyPath>
+                        <PropertyPath>int8</PropertyPath>
+                        <PropertyPath>lang</PropertyPath>
+                        <PropertyPath>numc_4</PropertyPath>
+                        <PropertyPath>prec</PropertyPath>
+                        <PropertyPath>quan</PropertyPath>
+                        <PropertyPath>raw_16</PropertyPath>
+                        <PropertyPath>string</PropertyPath>
+                        <PropertyPath>sstring</PropertyPath>
+                        <PropertyPath>timestamp</PropertyPath>
+                        <PropertyPath>timestampl</PropertyPath>
+                        <PropertyPath>timn</PropertyPath>
+                        <PropertyPath>tims</PropertyPath>
+                        <PropertyPath>unit_3</PropertyPath>
+                        <PropertyPath>uuid_raw16</PropertyPath>
+                        <PropertyPath>uuid_char32</PropertyPath>
+                        <PropertyPath>uuid_char22</PropertyPath>
+                        <PropertyPath>uuid_char26</PropertyPath>
+                        <PropertyPath>uuid_char36</PropertyPath>
+                        <PropertyPath>utclong</PropertyPath>
+                        <PropertyPath>lchr</PropertyPath>
+                    </Collection>
+                </Annotation>
+                <Annotation Path="SAP__Messages" Term="SAP__common.Messages"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftUUID">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft (Technical ID)" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/ProcessingStartDateTime">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft In Process Since" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsKeptByUser">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Is Kept By User" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/EnqueueStartDateTime">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Locked Since" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsCreatedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Created By Me" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsLastChangedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Last Changed By Me" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/DraftIsProcessedByMe">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft In Process By Me" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreatedByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Created By (Description)" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangedByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft Last Changed By (Description)" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/InProcessByUserDescription">
+                <Annotation Term="SAP__UI.Hidden"/>
+                <Annotation String="Draft In Process By (Description)" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/boolean">
+                <Annotation String="Truth Value" Term="SAP__common.Label"/>
+                <Annotation String="Truth Value: True/False" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/lang">
+                <Annotation String="Language Key" Term="SAP__common.Label"/>
+                <Annotation String="L" Term="SAP__common.Heading"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=LANGU" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/timestamp">
+                <Annotation String="Time Stamp" Term="SAP__common.Label"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2Type/timestampl">
+                <Annotation String="Time Stamp" Term="SAP__common.Label"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/CreationDateTime">
+                <Annotation String="Draft Created On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.I_DraftAdministrativeDataType/LastChangeDateTime">
+                <Annotation String="Draft Last Changed On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V2OperationControl/Edit">
+                <Annotation String="Dyn. Action Control" Term="SAP__common.Label"/>
+                <Annotation String="Dynamic Action Control" Term="SAP__common.Heading"/>
+                <Annotation String="Dynamic Action Property" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.Root_V1OperationControl/Edit">
+                <Annotation String="Dyn. Action Control" Term="SAP__common.Label"/>
+                <Annotation String="Dynamic Action Control" Term="SAP__common.Heading"/>
+                <Annotation String="Dynamic Action Property" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/DraftEntityCreationDateTime">
+                <Annotation String="Draft Created On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/DraftEntityLastChangeDateTime">
+                <Annotation String="Draft Last Changed On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/lang">
+                <Annotation String="Language Key" Term="SAP__common.Label"/>
+                <Annotation String="L" Term="SAP__common.Heading"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=LANGU" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/root">
+                <Annotation String="UUID" Term="SAP__common.Label"/>
+                <Annotation String="16 Byte UUID in 16 Bytes (Raw Format)" Term="SAP__common.QuickInfo"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/timestamp">
+                <Annotation String="Time Stamp" Term="SAP__common.Label"/>
+                <Annotation String="UTC Time Stamp in Short Form (YYYYMMDDhhmmss)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMP" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V2_O401/timestampl">
+                <Annotation String="Time Stamp" Term="SAP__common.Label"/>
+                <Annotation String="UTC Time Stamp in Long Form (YYYYMMDDhhmmssmmmuuun)" Term="SAP__common.QuickInfo"/>
+                <Annotation String="urn:sap-com:documentation:key?=type=DE&amp;id=TIMESTAMPL" Term="SAP__common.DocumentationRef"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/DraftEntityCreationDateTime">
+                <Annotation String="Draft Created On" Term="SAP__common.Label"/>
+            </Annotations>
+            <Annotations Target="SAP__self.xDMOxTEST_C_DTE_Root_V1_O401/DraftEntityLastChangeDateTime">
+                <Annotation String="Draft Last Changed On" Term="SAP__common.Label"/>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
+++ b/packages/odata-service-inquirer/test/unit/utils/utils.test.ts
@@ -19,6 +19,10 @@ describe('Utils', () => {
         odataVersion = parseOdataVersion(metadata);
         expect(odataVersion.odataVersion).toBe(OdataVersion.v4);
 
+        metadata = await readFile(join(__dirname, 'fixtures/metadata_v401.xml'), 'utf8');
+        odataVersion = parseOdataVersion(metadata);
+        expect(odataVersion.odataVersion).toBe(OdataVersion.v401);
+
         metadata = await readFile(join(__dirname, 'fixtures/invalid_metadata.xml'), 'utf8');
         expect(() => parseOdataVersion(metadata)).toThrow('The service metadata is invalid.');
     });

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -4,6 +4,7 @@ import { t } from '../i18n';
 import type { Manifest, ManifestNamespace } from '@sap-ux/project-access';
 import { DirName, getMinimumUI5Version, getWebappPath } from '@sap-ux/project-access';
 import type { DataSources, EdmxAnnotationsInfo, OdataService } from '../types';
+import { OdataVersion } from '../types';
 import semVer from 'semver';
 
 interface DataSourceUpdateSettings {
@@ -62,9 +63,11 @@ function enhanceManifestDatasources(
     if (serviceMetadata) {
         settings['localUri'] = `localService/${serviceName}/metadata.xml`;
     }
-    if (serviceVersion === '4') {
+    if (serviceVersion === OdataVersion.v401) {
         settings['odataVersion'] = minimumUi5Version && semVer.satisfies(minimumUi5Version, '>=1.144') ? '4.01' : '4.0';
-    } else if (serviceVersion === '2') {
+    } else if (serviceVersion === OdataVersion.v4) {
+        settings['odataVersion'] = '4.0';
+    } else if (serviceVersion === OdataVersion.v2) {
         settings['odataVersion'] = '2.0';
     }
 
@@ -96,7 +99,7 @@ function enhanceManifestModels(
 ): void {
     const models = manifest?.['sap.ui5']?.models ?? {};
     let modelSettings: ManifestNamespace.Ui5Setting = {};
-    if (serviceVersion === '4') {
+    if (serviceVersion === OdataVersion.v4 || serviceVersion === OdataVersion.v401) {
         if (includeSynchronizationMode) {
             modelSettings['synchronizationMode'] = 'None';
         }

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -24,13 +24,11 @@ interface DataSourceUpdateSettings {
  * @param {Editor} fs - the memfs editor instance
  * @param {string} webappPath - the webapp path of an existing UI5 application
  * @param {DataSourceUpdateSettings} dataSourceUpdateSettings - dataSource settings for update
- * @param {string} minimumUi5Version - minimum UI5 version of the application
  */
 function enhanceManifestDatasources(
     fs: Editor,
     webappPath: string,
-    dataSourceUpdateSettings: DataSourceUpdateSettings,
-    minimumUi5Version?: string
+    dataSourceUpdateSettings: DataSourceUpdateSettings
 ): void {
     const {
         serviceName,
@@ -311,21 +309,16 @@ function enhanceManifest(
     // Enhance model settings for service
     const serviceSettings = Object.assign(service, getModelSettings(minimumUi5Version));
     if (serviceSettings.name && serviceSettings.path && serviceSettings.model !== undefined) {
-        enhanceManifestDatasources(
-            fs,
-            webappPath,
-            {
-                serviceName: serviceSettings.name,
-                servicePath: serviceSettings.path,
-                serviceVersion: serviceSettings.version,
-                manifest,
-                forceServiceUpdate,
-                serviceMetadata: serviceSettings.metadata,
-                serviceRemoteAnnotations: serviceSettings.annotations as EdmxAnnotationsInfo | EdmxAnnotationsInfo[],
-                serviceLocalAnnotations: serviceSettings.localAnnotationsName
-            },
-            minimumUi5Version
-        );
+        enhanceManifestDatasources(fs, webappPath, {
+            serviceName: serviceSettings.name,
+            servicePath: serviceSettings.path,
+            serviceVersion: serviceSettings.version,
+            manifest,
+            forceServiceUpdate,
+            serviceMetadata: serviceSettings.metadata,
+            serviceRemoteAnnotations: serviceSettings.annotations as EdmxAnnotationsInfo | EdmxAnnotationsInfo[],
+            serviceLocalAnnotations: serviceSettings.localAnnotationsName
+        });
         // Add or update existing service model settings for manifest.json
         enhanceManifestModels(
             serviceSettings.name,

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -64,8 +64,7 @@ function enhanceManifestDatasources(
         settings['localUri'] = `localService/${serviceName}/metadata.xml`;
     }
     if (serviceVersion === OdataVersion.v401) {
-        const coercedUi5Version = minimumUi5Version ? semVer.coerce(minimumUi5Version) : null;
-        settings['odataVersion'] = coercedUi5Version && semVer.satisfies(coercedUi5Version, '>=1.144') ? '4.01' : '4.0';
+        settings['odataVersion'] = '4.01';
     } else if (serviceVersion === OdataVersion.v4) {
         settings['odataVersion'] = '4.0';
     } else if (serviceVersion === OdataVersion.v2) {

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -64,7 +64,8 @@ function enhanceManifestDatasources(
         settings['localUri'] = `localService/${serviceName}/metadata.xml`;
     }
     if (serviceVersion === OdataVersion.v401) {
-        settings['odataVersion'] = minimumUi5Version && semVer.satisfies(minimumUi5Version, '>=1.144') ? '4.01' : '4.0';
+        const coercedUi5Version = minimumUi5Version ? semVer.coerce(minimumUi5Version) : null;
+        settings['odataVersion'] = coercedUi5Version && semVer.satisfies(coercedUi5Version, '>=1.144') ? '4.01' : '4.0';
     } else if (serviceVersion === OdataVersion.v4) {
         settings['odataVersion'] = '4.0';
     } else if (serviceVersion === OdataVersion.v2) {

--- a/packages/odata-service-writer/src/types.ts
+++ b/packages/odata-service-writer/src/types.ts
@@ -9,7 +9,8 @@ export interface ExternalServiceCollectionOptions {
 
 export enum OdataVersion {
     v2 = '2',
-    v4 = '4'
+    v4 = '4',
+    v401 = '4.01'
 }
 
 export interface NamespaceAlias {

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -71,10 +71,10 @@ describe('manifest', () => {
         test.each([
             ['1.144.0', '4.01'],
             ['1.150.0', '4.01'],
-            ['1.143.0', '4.0'],
-            [undefined, '4.0']
+            ['1.143.0', '4.01'],
+            [undefined, '4.01']
         ])(
-            'Ensure odataVersion 4.01 is written only when service is v401 and minUI5Version %s >= 1.144',
+            'Ensure odataVersion 4.01 is always written when service is v401, regardless of minUI5Version %s',
             async (minUI5Version, expectedOdataVersion) => {
                 const testManifest = {
                     'sap.app': {

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -32,7 +32,7 @@ describe('manifest', () => {
             ['1.105.0', 'None'],
             [undefined, undefined],
             [['1.120.10', '2.0.0'], undefined],
-            ['1.144.0', undefined, '4.01']
+            ['1.144.0', undefined, '4.0']
         ])(
             'Ensure synchronizationMode is correctly set for minUI5Version %s',
             async (minUI5Version, syncMode, expectedOdataVersion = '4.0') => {
@@ -62,6 +62,42 @@ describe('manifest', () => {
                 await updateManifest('./', service, fs);
                 const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
                 expect(manifestJson['sap.ui5']?.models?.['amodel'].settings?.['synchronizationMode']).toEqual(syncMode);
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual(
+                    expectedOdataVersion
+                );
+            }
+        );
+
+        test.each([
+            ['1.144.0', '4.01'],
+            ['1.150.0', '4.01'],
+            ['1.143.0', '4.0'],
+            [undefined, '4.0']
+        ])(
+            'Ensure odataVersion 4.01 is written only when service is v401 and minUI5Version %s >= 1.144',
+            async (minUI5Version, expectedOdataVersion) => {
+                const testManifest = {
+                    'sap.app': {
+                        id: 'test.update.manifest'
+                    },
+                    'sap.ui5': {
+                        dependencies: {
+                            minUI5Version: minUI5Version
+                        }
+                    }
+                };
+
+                const service: OdataService = {
+                    version: OdataVersion.v401,
+                    client: '123',
+                    model: 'amodel',
+                    name: 'aname',
+                    path: '/a/path'
+                };
+
+                fs.writeJSON('./webapp/manifest.json', testManifest);
+                await updateManifest('./', service, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
                 expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual(
                     expectedOdataVersion
                 );

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -101,6 +101,11 @@ describe('manifest', () => {
                 expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual(
                     expectedOdataVersion
                 );
+                expect(manifestJson['sap.ui5']?.models?.['amodel']?.settings).toMatchObject({
+                    operationMode: 'Server',
+                    autoExpandSelect: true,
+                    earlyRequests: true
+                });
             }
         );
         test('Ensure manifest are updated as expected as in edmx projects', async () => {


### PR DESCRIPTION
## Summary

- Fixes #3995
- Adds `OdataVersion.v401 = '4.01'` to the `OdataVersion` enum in `odata-service-writer`
- Fixes `parseOdataVersion` in `odata-service-inquirer` to correctly detect `Version="4.01"` from service metadata, instead of truncating via `Number.parseInt` (which silently mapped `4.01` → `4`)
- `manifest.ts` unconditionally writes `odataVersion: "4.01"` for `v401` services (mirrors how `v4 → "4.0"` and `v2 → "2.0"`); plain OData V4 services always write `"4.0"`
- Adds `OdataVersion.v401` support to all six `fiori-elements-writer` template types (Worklist, LROP, ALP, OVP, FEOP, FPM) including `supportedODataVersions`, `minimumUi5Version`, and `annotationGenerationSupport`

## Background

Previously, `odataVersion: "4.01"` was written into `manifest.json` for all OData V4 apps when `minUI5Version >= 1.144`, regardless of whether the backend service actually declared OData 4.01. This caused cache buster token generation failures in ABAP appIndex and deployment issues in WorkZone. The fix makes the version driven by what the service metadata actually declares.

## Changes addressing review feedback

- **`entity-helper.ts`** — replaced `Number.parseInt(convertedMetadata.version, 10)` with the shared `parseOdataVersion()` utility, removing the inconsistency where the catalog connection path returned `v401` but the local EDMX file path returned `v4` for the same `Version="4.01"` metadata. Updated `filterAggregateTransformationsOnly` and `getNavigationEntityChoices` to treat `v401` the same as `v4`.
- **`questions.ts`** — extended three `v4`-only conditions (ALP empty-entity error, TreeTable hierarchy qualifier prompt, lrop/worklist annotation questions) to also apply to `v401`.
- **`validators.ts`** — `validateODataVersion` now treats `v401` as satisfying a `v4` requirement (OData 4.01 is backwards-compatible with 4.0); strict equality `v4 !== v401` no longer raises a spurious mismatch error.
- **`utils/index.ts`** — `rawVersion.startsWith('4.01')` → `rawVersion === '4.01'` (exact match).

## Changes addressing post-review propagation gaps

- **`fiori-elements-writer/src/index.ts` + `manifestSettings.ts`** — remapped `v401 → v4` for template path construction; `OdataVersion.v401 = '4.01'` caused paths like `templates/v4.01/` which do not exist, silently producing incomplete output.
- **`entity-helper.ts` `getDefaultTableType`** — expanded `v4`-only guard to include `v401` so ALP/LROP v401 services correctly detect AnalyticalTable and TreeTable types.
- **`alp-questions.ts`** — expanded `tableSelectionMode` prompt guard to include `v401`; previously v401 services fell through to the v2 prompt branch (multiSelect/autoHide/smartVariantManagement).
- **`fiori-app-sub-generator` `getODataVersion`** — fixed to return `OdataVersion.v401` for `Version="4.01"` EDMX; previously the headless generation path silently downgraded v401 to v4, resulting in `"4.0"` written to the manifest.
- **`fiori-app-sub-generator` `FloorplanAttributes`** — added `OdataVersion.v401` to `supportedODataVersion` for all six FE floorplans so `getMinSupportedUI5Version` correctly returns `1.144.0` for v401 instead of falling back to the v4 minimum.
- **`fiori-app-sub-generator` `getRequiredOdataVersion`** — updated to collapse `v401 → v4` when computing the single required version for a floorplan, so FEOP and FPM continue to report `v4` as their version family constraint (which `validateODataVersion` already accepts for v401 services).
- **`odata-service-writer` `enhanceManifestDatasources`** — removed now-unused `minimumUi5Version` parameter (was only needed for the old `semVer.satisfies` conditional that has been replaced by enum-based switching).
- **Changeset** — added `@sap-ux/fiori-generator-shared` (adds `enableVirtualEndpoints` to public `AppConfig` interface) and `@sap-ux/sap-systems-ext-webapp` (removes `systemType` prop from `SystemTypes` component).

## AGENTS.md Non-Conformance

The project guidelines (`AGENTS.md`) recommend avoiding TypeScript enums in favour of union types or const objects. `OdataVersion` is an existing public API enum already exported and consumed across multiple packages — converting it to a union type would be a breaking change outside the scope of this fix. The `v401` value has been added to the existing enum to maintain backward compatibility. Refactoring `OdataVersion` away from an enum is tracked as a separate follow-up.

## Test plan

- [x] `parseOdataVersion` correctly returns `OdataVersion.v401` for a `Version="4.01"` metadata document
- [x] `getEntityChoices` correctly returns `odataVersion === v401` for `Version="4.01"` metadata (local EDMX path now consistent with catalog path)
- [x] `validateODataVersion` accepts `v401` metadata when required version is `v4` (backwards compatible)
- [x] `validateODataVersion` rejects `v401` metadata when required version is `v2`
- [x] `manifest.ts` unconditionally writes `"4.01"` for `v401` services
- [x] `manifest.ts` always writes `"4.0"` for plain `OdataVersion.v4` services
- [x] `getDefaultTableType` returns correct table type (AnalyticalTable/TreeTable) for v401 ALP/LROP services
- [x] `alp-questions.ts` routes v401 services to the v4-style `tableSelectionMode` prompt
- [x] `getODataVersion` returns `OdataVersion.v401` for `Version="4.01"` EDMX in headless generation
- [x] `getMinSupportedUI5Version` returns `1.144.0` for v401 LROP (not the v4 fallback `1.84.0`)
- [x] `getRequiredOdataVersion` returns `OdataVersion.v4` for FEOP and FPM floorplans (v4 family constraint preserved)
- [x] All 89 `odata-service-writer` tests pass
- [x] All 277 `odata-service-inquirer` tests pass
- [x] All 70 `fiori-elements-writer` tests pass
- [x] All 181 `fiori-app-sub-generator` tests pass