### PR TITLE
fix(odata-service-writer): derive manifest odataVersion from EDMX metadata

### DIFF
--- a/.changeset/fix-odata-service-writer-manifest-version.md
+++ b/.changeset/fix-odata-service-writer-manifest-version.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-writer": patch
+---
+
+fix(odata-service-writer): derive manifest odataVersion from EDMX metadata instead of minUI5Version

--- a/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
+++ b/packages/fiori-app-sub-generator/test/int/fiori-elements/expected-output/headless/lrop_v4_no_ui5_version/webapp/manifest.json
@@ -31,7 +31,7 @@
             "annotation"
           ],
           "localUri": "localService/mainService/metadata.xml",
-          "odataVersion": "4.01"
+          "odataVersion": "4.0"
         }
       }
     }

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -27,7 +27,12 @@ interface DataSourceUpdateSettings {
  * @returns '4.01' when applicable, undefined otherwise
  */
 function getOdataVersionFromMetadata(metadata: string): string | undefined {
-    const match = metadata.match(/<(?:\w+:)?Edmx[^>]+Version="([^"]+)"/);
+    // Scan only the opening tag to avoid ReDoS on large metadata strings.
+    const tagEnd = metadata.indexOf('>');
+    if (tagEnd === -1) {
+        return undefined;
+    }
+    const match = metadata.slice(0, tagEnd).match(/Version="([^"]+)"/);
     return match?.[1] === '4.01' ? '4.01' : undefined;
 }
 

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -30,7 +30,7 @@ function getOdataVersionFromMetadata(metadata: string): string | undefined {
     // Scan only the first 500 chars to avoid processing large metadata strings.
     // The XML declaration (<?xml ...?>) may precede the root <edmx:Edmx Version="..."> tag,
     // so we cannot stop at the first '>'.
-    const match = metadata.slice(0, 500).match(/Version="([^"]+)"/);
+    const match = /Version="([^"]+)"/.exec(metadata.slice(0, 500));
     return match?.[1] === '4.01' ? '4.01' : undefined;
 }
 

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -4,6 +4,7 @@ import { t } from '../i18n';
 import type { Manifest, ManifestNamespace } from '@sap-ux/project-access';
 import { DirName, getMinimumUI5Version, getWebappPath } from '@sap-ux/project-access';
 import type { DataSources, EdmxAnnotationsInfo, OdataService } from '../types';
+import { OdataVersion } from '../types';
 import semVer from 'semver';
 
 interface DataSourceUpdateSettings {
@@ -18,18 +19,29 @@ interface DataSourceUpdateSettings {
 }
 
 /**
+ * Extracts the OData version string to write to manifest.json from raw EDMX metadata.
+ * Only returns a value when the EDMX declares Version="4.01".
+ * All other version distinctions (v2 vs v4) remain the caller's responsibility.
+ *
+ * @param metadata - raw EDMX XML string
+ * @returns '4.01' when applicable, undefined otherwise
+ */
+function getOdataVersionFromMetadata(metadata: string): string | undefined {
+    const match = metadata.match(/<(?:\w+:)?Edmx[^>]+Version="([^"]+)"/);
+    return match?.[1] === '4.01' ? '4.01' : undefined;
+}
+
+/**
  * Updates service data in manifest.json.
  *
  * @param {Editor} fs - the memfs editor instance
  * @param {string} webappPath - the webapp path of an existing UI5 application
  * @param {DataSourceUpdateSettings} dataSourceUpdateSettings - dataSource settings for update
- * @param {string} minimumUi5Version - minimum UI5 version of the application
  */
 function enhanceManifestDatasources(
     fs: Editor,
     webappPath: string,
-    dataSourceUpdateSettings: DataSourceUpdateSettings,
-    minimumUi5Version?: string
+    dataSourceUpdateSettings: DataSourceUpdateSettings
 ): void {
     const {
         serviceName,
@@ -62,10 +74,16 @@ function enhanceManifestDatasources(
     if (serviceMetadata) {
         settings['localUri'] = `localService/${serviceName}/metadata.xml`;
     }
-    if (serviceVersion === '4') {
-        settings['odataVersion'] = minimumUi5Version && semVer.satisfies(minimumUi5Version, '>=1.144') ? '4.01' : '4.0';
-    } else if (serviceVersion === '2') {
-        settings['odataVersion'] = '2.0';
+    // Derive the manifest odataVersion: for v4 services, check EDMX metadata first (to detect 4.01),
+    // then fall back to the passed service version enum.
+    let odataVersionToWrite: string | undefined;
+    if (serviceVersion === OdataVersion.v4) {
+        odataVersionToWrite = (serviceMetadata && getOdataVersionFromMetadata(serviceMetadata)) || '4.0';
+    } else if (serviceVersion === OdataVersion.v2) {
+        odataVersionToWrite = '2.0';
+    }
+    if (odataVersionToWrite) {
+        settings['odataVersion'] = odataVersionToWrite;
     }
 
     // Create or update service dataSource in manifest.json for service
@@ -96,7 +114,7 @@ function enhanceManifestModels(
 ): void {
     const models = manifest?.['sap.ui5']?.models ?? {};
     let modelSettings: ManifestNamespace.Ui5Setting = {};
-    if (serviceVersion === '4') {
+    if (serviceVersion === OdataVersion.v4) {
         if (includeSynchronizationMode) {
             modelSettings['synchronizationMode'] = 'None';
         }
@@ -308,21 +326,16 @@ function enhanceManifest(
     // Enhance model settings for service
     const serviceSettings = Object.assign(service, getModelSettings(minimumUi5Version));
     if (serviceSettings.name && serviceSettings.path && serviceSettings.model !== undefined) {
-        enhanceManifestDatasources(
-            fs,
-            webappPath,
-            {
-                serviceName: serviceSettings.name,
-                servicePath: serviceSettings.path,
-                serviceVersion: serviceSettings.version,
-                manifest,
-                forceServiceUpdate,
-                serviceMetadata: serviceSettings.metadata,
-                serviceRemoteAnnotations: serviceSettings.annotations as EdmxAnnotationsInfo | EdmxAnnotationsInfo[],
-                serviceLocalAnnotations: serviceSettings.localAnnotationsName
-            },
-            minimumUi5Version
-        );
+        enhanceManifestDatasources(fs, webappPath, {
+            serviceName: serviceSettings.name,
+            servicePath: serviceSettings.path,
+            serviceVersion: serviceSettings.version,
+            manifest,
+            forceServiceUpdate,
+            serviceMetadata: serviceSettings.metadata,
+            serviceRemoteAnnotations: serviceSettings.annotations as EdmxAnnotationsInfo | EdmxAnnotationsInfo[],
+            serviceLocalAnnotations: serviceSettings.localAnnotationsName
+        });
         // Add or update existing service model settings for manifest.json
         enhanceManifestModels(
             serviceSettings.name,

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -27,12 +27,10 @@ interface DataSourceUpdateSettings {
  * @returns '4.01' when applicable, undefined otherwise
  */
 function getOdataVersionFromMetadata(metadata: string): string | undefined {
-    // Scan only the opening tag to avoid ReDoS on large metadata strings.
-    const tagEnd = metadata.indexOf('>');
-    if (tagEnd === -1) {
-        return undefined;
-    }
-    const match = metadata.slice(0, tagEnd).match(/Version="([^"]+)"/);
+    // Scan only the first 500 chars to avoid processing large metadata strings.
+    // The XML declaration (<?xml ...?>) may precede the root <edmx:Edmx Version="..."> tag,
+    // so we cannot stop at the first '>'.
+    const match = metadata.slice(0, 500).match(/Version="([^"]+)"/);
     return match?.[1] === '4.01' ? '4.01' : undefined;
 }
 

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -25,17 +25,17 @@ describe('manifest', () => {
         afterEach(() => {
             jest.restoreAllMocks();
         });
-        test.each([
-            ['1.110.0', 'None'],
-            ['1.115.0', undefined],
-            ['', undefined],
-            ['1.105.0', 'None'],
-            [undefined, undefined],
-            [['1.120.10', '2.0.0'], undefined],
-            ['1.144.0', undefined, '4.01']
+        test.each<[string | string[] | undefined, string | undefined, string]>([
+            ['1.110.0', 'None', '4.0'],
+            ['1.115.0', undefined, '4.0'],
+            ['', undefined, '4.0'],
+            ['1.105.0', 'None', '4.0'],
+            [undefined, undefined, '4.0'],
+            [['1.120.10', '2.0.0'], undefined, '4.0'],
+            ['1.144.0', undefined, '4.0']
         ])(
             'Ensure synchronizationMode is correctly set for minUI5Version %s',
-            async (minUI5Version, syncMode, expectedOdataVersion = '4.0') => {
+            async (minUI5Version, syncMode, expectedOdataVersion) => {
                 const testManifest = {
                     'sap.app': {
                         id: 'test.update.manifest'
@@ -67,6 +67,44 @@ describe('manifest', () => {
                 );
             }
         );
+        describe('odataVersion written to manifest.json', () => {
+            const baseManifest = { 'sap.app': { id: 'test.odata.version' } };
+            const baseService = { client: '123', model: 'amodel', name: 'aname', path: '/a/path' };
+
+            test('v4 service with EDMX metadata declaring Version="4.01" writes 4.01', async () => {
+                const metadata =
+                    '<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"></edmx:Edmx>';
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v4, metadata }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.01');
+            });
+
+            test('v4 service with EDMX metadata not declaring 4.01 writes 4.0', async () => {
+                const metadata =
+                    '<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"></edmx:Edmx>';
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v4, metadata }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.0');
+            });
+
+            test('v4 service with no metadata writes 4.0', async () => {
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v4 }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.0');
+            });
+
+            test('v2 service with metadata writes 2.0 regardless of EDMX version', async () => {
+                const metadata =
+                    '<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"></edmx:Edmx>';
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v2, metadata }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('2.0');
+            });
+        });
         test('Ensure manifest are updated as expected as in edmx projects', async () => {
             const testManifest = {
                 'sap.app': {

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -113,6 +113,15 @@ describe('manifest', () => {
                 const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
                 expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.01');
             });
+
+            test('v4 service with XML declaration preceding root element writes 4.01', async () => {
+                const metadata =
+                    '<?xml version="1.0" encoding="utf-8"?>\n<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"></edmx:Edmx>';
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v4, metadata }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.01');
+            });
         });
         test('Ensure manifest are updated as expected as in edmx projects', async () => {
             const testManifest = {

--- a/packages/odata-service-writer/test/unit/manifest.test.ts
+++ b/packages/odata-service-writer/test/unit/manifest.test.ts
@@ -104,6 +104,15 @@ describe('manifest', () => {
                 const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
                 expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('2.0');
             });
+
+            test('v4 service with Version attribute after namespace declaration writes 4.01', async () => {
+                const metadata =
+                    '<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.01"></edmx:Edmx>';
+                fs.writeJSON('./webapp/manifest.json', baseManifest);
+                await updateManifest('./', { ...baseService, version: OdataVersion.v4, metadata }, fs);
+                const manifestJson = fs.readJSON('./webapp/manifest.json') as Partial<Manifest>;
+                expect(manifestJson['sap.app']?.dataSources?.['aname'].settings?.['odataVersion']).toEqual('4.01');
+            });
         });
         test('Ensure manifest are updated as expected as in edmx projects', async () => {
             const testManifest = {


### PR DESCRIPTION
## Summary

- Fixes #3995: `manifest.json` now writes `odataVersion: "4.01"` only when the service EDMX metadata explicitly declares `Version="4.01"`
- V4 services without a 4.01 metadata declaration write `"4.0"` (fixes the regression from #36500 that wrote `"4.01"` for all V4 apps on UI5 >= 1.144)
- V2 services always write `"2.0"` regardless of EDMX content
- Changes are scoped to `odata-service-writer` only — no inquirer or sub-generator changes

## Test plan

- [ ] `pnpm --filter @sap-ux/odata-service-writer test` — 89 tests passing
- [ ] New tests cover: `4.01` detected from EDMX metadata, `4.0` fallback (with/without metadata), V2 immunity to EDMX version field
- [ ] `pnpm --filter @sap-ux/odata-service-writer lint` — 0 errors