### PR TITLE
fix: enable npm provenance for OIDC trusted publishing

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -234,6 +234,7 @@ jobs:
                   publish: pnpm ci:publish
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
+                  NPM_CONFIG_PROVENANCE: true
             - name: Detect extension publication
               if: steps.changesetPublish.outputs.published == 'true'
               run: |


### PR DESCRIPTION
## Summary

- Adds `NPM_CONFIG_PROVENANCE: true` to the `Publish to npmjs` step env in the release job

## Why

After switching to OIDC trusted publishing in #4673, all package publishes fail with `E404 Not Found`. The root cause: `changesets/action@v1.7.0` detects OIDC is available but does nothing with it — it just logs a message and runs the publish script. Without `--provenance` (or the equivalent env var), npm never exchanges the GitHub OIDC token for a short-lived session token, so every `npm publish` call goes out with an invalid/empty `_authToken`.

Setting `NPM_CONFIG_PROVENANCE=true` tells npm to exchange the OIDC token automatically (using `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, already available because `id-token: write` is set on the release job).

The env var is scoped to the CI step only — not added to `.npmrc` — so local runs are unaffected.

## Test plan

- [ ] Merge to main and verify the next release job publishes successfully without E404 errors