### PR TITLE
fix(ci): remove registry-url from release job setup-node to fix OIDC publish

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -181,7 +181,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: 22.x
-                  registry-url: 'https://registry.npmjs.org'
             - name: Setup pnpm
               uses: pnpm/action-setup@v4.1.0
             - name: Cache pnpm modules


### PR DESCRIPTION
## Summary

- Removes `registry-url: 'https://registry.npmjs.org'` from the `setup-node` step in the `release` job
- When `registry-url` is set, `actions/setup-node` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into the runner `.npmrc`. Since `NODE_AUTH_TOKEN` is never set in this workflow, npm resolves the token as empty and publishes unauthenticated — causing E404 for every scoped package
- Without `registry-url`, npm's OIDC trusted publishing flow operates cleanly via `ACTIONS_ID_TOKEN_REQUEST_TOKEN` + `NPM_CONFIG_PROVENANCE=true`

## Root cause

Since switching to OIDC trusted publishing (#4673), every release attempt has failed with:
```
E404 Not Found - PUT https://registry.npmjs.org/@sap-ux%2f<package> - Not found
'@sap-ux/<package>@x.y.z' is not in this registry.
```

The provenance statements were being successfully signed and published to sigstore, but the actual `npm publish` PUT was unauthenticated. `registry-url` in `setup-node` was the culprit — it placed a broken `_authToken` placeholder in the npmrc that prevented the OIDC auth path from working.

## Test plan

- [ ] Verify the `release` job completes successfully after merging
- [ ] Confirm packages are published to npmjs.com with provenance