### PR TITLE
fix(ci): add provenance=true to .npmrc to enable pnpm OIDC trusted publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -15,4 +15,5 @@ save-prefix=''
 stream=true
 engine-strict=true
 link-workspace-packages=true
+provenance=true
 


### PR DESCRIPTION
## Summary

- Adds `provenance=true` to `.npmrc` so pnpm passes `--provenance` to `npm publish`
- This triggers npm's OIDC token exchange with the npm registry, enabling trusted publishing without a `NPM_TOKEN` secret

## Root cause

After #4683 removed `registry-url` from `setup-node` (fixing the empty `_authToken` placeholder), the release job now gets `ENEEDAUTH` on every package.

The issue: `NPM_CONFIG_PROVENANCE=true` is set in the workflow env, but **pnpm does not honour `NPM_CONFIG_*` env vars** the way npm does. Without provenance being explicitly requested, pnpm publishes without triggering the OIDC token exchange, so npm sees no auth at all.

Setting `provenance=true` in `.npmrc` causes pnpm to pass `--provenance` to each `npm publish` call, which initiates the OIDC handshake via `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and obtains a short-lived npm token automatically.

## Test plan

- [ ] Verify the `release` job completes successfully after merging
- [ ] Confirm packages are published to npmjs.com with provenance attestations