### PR TITLE
fix(ci): exchange GitHub OIDC token for npm granular access token before publish

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -221,14 +221,18 @@ jobs:
               run: |
                   RESPONSE=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
                     "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm")
-                  OIDC_TOKEN=$(echo "$RESPONSE" | jq -r '.value')
+                  OIDC_TOKEN=$(echo "$RESPONSE" | jq -r '.value // empty')
+                  if [ -z "$OIDC_TOKEN" ]; then
+                    echo "Failed to obtain OIDC token from GitHub. Ensure the job has 'id-token: write' permission."
+                    exit 1
+                  fi
                   NPM_TOKEN_RESPONSE=$(curl -sS -X POST \
                     -H "Content-Type: application/json" \
                     -H "Authorization: Bearer ${OIDC_TOKEN}" \
                     "https://registry.npmjs.org/-/npm/v1/tokens/gat/")
                   NPM_TOKEN=$(echo "$NPM_TOKEN_RESPONSE" | jq -r '.token // empty')
                   if [ -z "$NPM_TOKEN" ]; then
-                    echo "Failed to get npm token: $NPM_TOKEN_RESPONSE"
+                    echo "Failed to get npm token. Check the OIDC configuration and npm trusted publishing settings."
                     exit 1
                   fi
                   echo "::add-mask::$NPM_TOKEN"
@@ -241,7 +245,6 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
                   NPM_CONFIG_PROVENANCE: true
-                  NPM_TOKEN: ${{ env.NPM_TOKEN }}
             - name: Detect extension publication
               if: steps.changesetPublish.outputs.published == 'true'
               run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -217,6 +217,22 @@ jobs:
                   regex: false
             - name: Run build
               run: pnpm run build
+            - name: Get npm token via OIDC
+              run: |
+                  RESPONSE=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm")
+                  OIDC_TOKEN=$(echo "$RESPONSE" | jq -r '.value')
+                  NPM_TOKEN_RESPONSE=$(curl -sS -X POST \
+                    -H "Content-Type: application/json" \
+                    -H "Authorization: Bearer ${OIDC_TOKEN}" \
+                    "https://registry.npmjs.org/-/npm/v1/tokens/gat/")
+                  NPM_TOKEN=$(echo "$NPM_TOKEN_RESPONSE" | jq -r '.token // empty')
+                  if [ -z "$NPM_TOKEN" ]; then
+                    echo "Failed to get npm token: $NPM_TOKEN_RESPONSE"
+                    exit 1
+                  fi
+                  echo "::add-mask::$NPM_TOKEN"
+                  echo "NPM_TOKEN=$NPM_TOKEN" >> $GITHUB_ENV
             - name: 'Publish to npmjs'
               id: changesetPublish
               uses: changesets/action@v1.7.0
@@ -225,6 +241,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.ACCESS_PAT }}
                   NPM_CONFIG_PROVENANCE: true
+                  NPM_TOKEN: ${{ env.NPM_TOKEN }}
             - name: Detect extension publication
               if: steps.changesetPublish.outputs.published == 'true'
               run: |

--- a/.npmrc
+++ b/.npmrc
@@ -15,5 +15,4 @@ save-prefix=''
 stream=true
 engine-strict=true
 link-workspace-packages=true
-provenance=true
 

--- a/.npmrc
+++ b/.npmrc
@@ -15,4 +15,5 @@ save-prefix=''
 stream=true
 engine-strict=true
 link-workspace-packages=true
+provenance=true
 


### PR DESCRIPTION
## Summary

- Adds a `Get npm token via OIDC` step before publish that manually exchanges the GitHub Actions OIDC token for a short-lived npm granular access token
- Passes the resulting token as `NPM_TOKEN` to the `changesets/action` publish step
- Reverts `provenance=true` from `.npmrc` (not needed — provenance attestation is separate from auth)

## Root cause

`pnpm` does **not** implement npm's OIDC trusted publishing auth exchange. It has its own publish implementation (`libnpmpublish`) that only supports `_authToken`-based auth. When no token is present, pnpm returns `ENEEDAUTH`.

npm's OIDC auth exchange (where the npm CLI calls `ACTIONS_ID_TOKEN_REQUEST_URL` and exchanges with `registry.npmjs.org/-/npm/v1/tokens/gat/`) is an npm CLI-specific feature that pnpm doesn't replicate.

The fix manually performs this exchange in a workflow step and injects the resulting token so `changesets/action` (which detects `NPM_TOKEN` and writes it to `.npmrc`) can pass it through to pnpm.

## Test plan

- [ ] Verify `Get npm token via OIDC` step succeeds and produces a masked token
- [ ] Verify the `release` job completes successfully and packages are published to npmjs.com with provenance