### PR TITLE
fix(ui5-application-inquirer): only show virtual endpoints prompt whe…

### DIFF
--- a/.changeset/ui5-application-inquirer-virtual-endpoints-condition.md
+++ b/.changeset/ui5-application-inquirer-virtual-endpoints-condition.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/ui5-application-inquirer": patch
+---
+
+fix(ui5-application-inquirer): only show virtual endpoints prompt when hasCdsUi5Plugin or TypeScript is selected

--- a/packages/ui5-application-inquirer/src/prompts/index.ts
+++ b/packages/ui5-application-inquirer/src/prompts/index.ts
@@ -72,7 +72,7 @@ export async function getQuestions(
             isCapProject
         ),
         [promptNames.addFlpConfig]: getAddFlpConfigPrompt(promptOptions?.addFlpConfig),
-        [promptNames.enableVirtualEndpoints]: getEnableVirtualEndpoints(),
+        [promptNames.enableVirtualEndpoints]: getEnableVirtualEndpoints(capCdsInfo),
         [promptNames.showAdvanced]: getShowAdvancedPrompt(),
         [promptNames.ui5Theme]: getUI5ThemePrompt(),
         [promptNames.enableEslint]: getEnableEsLintPrompt(),

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -9,6 +9,7 @@ import type { UI5Version } from '@sap-ux/ui5-info';
 import type { ListChoiceOptions } from 'inquirer';
 import type { UI5ApplicationAnswers, UI5ApplicationPromptOptions, UI5ApplicationQuestion } from '../types';
 import type { ConfirmQuestion, FileBrowserQuestion, InputQuestion, ListQuestion } from '@sap-ux/inquirer-common';
+import type { CdsUi5PluginInfo } from '@sap-ux/project-access';
 
 /**
  * Gets the `name` prompt.
@@ -265,9 +266,10 @@ export function getAddFlpConfigPrompt(
 /**
  * Get the `enableVirtualEndpoints` prompt.
  *
+ * @param capCdsInfo optional CAP CDS plugin info used to determine prompt visibility
  * @returns the `enableVirtualEndpoints` prompt
  */
-export function getEnableVirtualEndpoints(): UI5ApplicationQuestion {
+export function getEnableVirtualEndpoints(capCdsInfo?: CdsUi5PluginInfo): UI5ApplicationQuestion {
     return {
         type: 'confirm',
         name: promptNames.enableVirtualEndpoints,
@@ -276,6 +278,10 @@ export function getEnableVirtualEndpoints(): UI5ApplicationQuestion {
             breadcrumb: t('prompts.enableVirtualEndpoints.breadcrumb')
         },
         message: (): string => t('prompts.enableVirtualEndpoints.message'),
-        default: true
+        default: true,
+        // Only show for CAP Node.js projects that have the cds-ui5-plugin already enabled
+        // or where the user selects TypeScript during prompting.
+        when: (answers: UI5ApplicationAnswers): boolean =>
+            !!(capCdsInfo?.hasMinCdsVersion && (capCdsInfo?.hasCdsUi5Plugin || answers.enableTypeScript))
     };
 }

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -282,6 +282,6 @@ export function getEnableVirtualEndpoints(capCdsInfo?: CdsUi5PluginInfo): UI5App
         // Only show for CAP Node.js projects that have the cds-ui5-plugin already enabled
         // or where the user selects TypeScript during prompting.
         when: (answers: UI5ApplicationAnswers): boolean =>
-            !!(capCdsInfo?.hasMinCdsVersion && (capCdsInfo?.hasCdsUi5Plugin || answers.enableTypeScript))
+            !!(capCdsInfo && (capCdsInfo.hasCdsUi5Plugin || answers.enableTypeScript))
     };
 }

--- a/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
@@ -111,6 +111,7 @@ exports[`ui5-application-inquirer API getPrompts, no options 1`] = `
     "message": [Function],
     "name": "enableVirtualEndpoints",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": false,

--- a/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -111,6 +111,7 @@ exports[`getQuestions getQuestions, no options 1`] = `
     "message": [Function],
     "name": "enableVirtualEndpoints",
     "type": "confirm",
+    "when": [Function],
   },
   {
     "default": false,

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -443,13 +443,28 @@ describe('getQuestions', () => {
         expect((enableVirtualEndpointsQuestion?.message as Function)()).toMatchInlineSnapshot(
             `"Use Virtual Endpoints for Local Preview"`
         );
+        // Non-CAP: `when` should return false regardless of answers
+        expect((enableVirtualEndpointsQuestion?.when as Function)({ enableTypeScript: true })).toBe(false);
 
-        // CAP project with cds version
+        // CAP project with cds version but no hasCdsUi5Plugin and no TypeScript
         questions = await getQuestions([], {}, mockCdsInfo);
         enableVirtualEndpointsQuestion = questions.find(
             (question) => question.name === promptNames.enableVirtualEndpoints
         );
         expect(enableVirtualEndpointsQuestion).toBeDefined();
+        // hasCdsUi5Plugin=false and enableTypeScript=false → when should return false
+        expect((enableVirtualEndpointsQuestion?.when as Function)({ enableTypeScript: false })).toBe(false);
+        // hasCdsUi5Plugin=false but enableTypeScript=true → when should return true
+        expect((enableVirtualEndpointsQuestion?.when as Function)({ enableTypeScript: true })).toBe(true);
+
+        // CAP project with hasCdsUi5Plugin enabled
+        questions = await getQuestions([], {}, { ...mockCdsInfo, hasCdsUi5Plugin: true });
+        enableVirtualEndpointsQuestion = questions.find(
+            (question) => question.name === promptNames.enableVirtualEndpoints
+        );
+        expect(enableVirtualEndpointsQuestion).toBeDefined();
+        // hasCdsUi5Plugin=true → when should return true regardless of TypeScript
+        expect((enableVirtualEndpointsQuestion?.when as Function)({ enableTypeScript: false })).toBe(true);
 
         // CAP project with cds-ui5 plugin disabled and hasMinCdsVersion is false
         questions = await getQuestions(


### PR DESCRIPTION
…n hasCdsUi5Plugin or TypeScript selected

Fixes #38236. The enableVirtualEndpoints prompt was shown for any CAP Node.js project with hasMinCdsVersion=true regardless of whether cds-ui5-plugin was present or TypeScript was selected.

Added a 'when' condition to getEnableVirtualEndpoints() that gates the prompt on: capCdsInfo.hasMinCdsVersion && (capCdsInfo.hasCdsUi5Plugin || answers.enableTypeScript) so it only appears for the two valid use-cases per #32607.

## Description

Related to internal bug
**BUG - App-gen - Virtual endpoints prompt shown for CAP Node.js apps regardless of TypeScript selection or cds-ui5-plugin presence #38236**

- Added `capCdsInfo?: CdsUi5PluginInfo` parameter so the prompt has access to the CAP project info

*`packages/ui5-application-inquirer/src/prompts/index.ts`*
- Pass `capCdsInfo` through to `getEnableVirtualEndpoints(capCdsInfo)`

**Tests**
- Extended the `enableVirtualEndpoints` test to assert the `when` condition behaviour for all cases:
- Non-CAP project → hidden
- CAP Node.js, `hasCdsUi5Plugin=false`, TypeScript not selected → hidden ✅ (bug fix)
- CAP Node.js, `hasCdsUi5Plugin=false`, TypeScript selected → shown
- CAP Node.js, `hasCdsUi5Plugin=true` → shown
- CAP Java / `hasMinCdsVersion=false` → hidden (existing behaviour, unchanged)
- Updated snapshots to include the new `when: [Function]` property


- Manual test confirmed: prompt is no longer shown for a CAP Node.js project without `cds-ui5-plugin` when JavaScript is selected