### PR TITLE
fix(ui-components): Fixed UIDropdown background overflowing past rounded borders.

### DIFF
--- a/.changeset/thick-emus-wink.md
+++ b/.changeset/thick-emus-wink.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+Fixed UIDropdown background overflowing past rounded borders.

--- a/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
+++ b/packages/ui-components/src/components/UIDropdown/UIDropdown.scss
@@ -16,6 +16,7 @@
 .ts-SelectBox {
     .ms-Dropdown {
         background: $dropdown-input-background;
+        border-radius: $dropdown-input-border-radius;
         .ms-Dropdown-title {
             background: transparent;
             height: $dropdown-input-height;


### PR DESCRIPTION
Styling issue, that background overflowing past rounded borders:
<img width="512" height="286" alt="image" src="https://github.com/user-attachments/assets/e331b48e-325e-4532-a4fe-d0de93d4a2cf" />

after fix:
<img width="729" height="288" alt="image" src="https://github.com/user-attachments/assets/8c383f7b-0b0d-4c3b-9e73-2715faaf3ac4" />

