### PR TITLE
fix(jest-environment-ui5): update loglevel to log-level

### DIFF
--- a/packages/jest-environment-ui5/src/env/ui5Environment.js
+++ b/packages/jest-environment-ui5/src/env/ui5Environment.js
@@ -50,7 +50,7 @@ function initUI5Environment(globalWindow, pathMappingFn, isV2, ui5Version) {
     globalWindow.window['sap-ui-config'] = {
         bindingSyntax: 'complex',
         'xx-waitForTheme': false,
-        loglevel: process.env.BUILD_TYPE === 'production' ? 'ERROR' : 'INFO',
+        'log-level': process.env.BUILD_TYPE === 'production' ? 'ERROR' : 'INFO',
         libs: 'sap.ui.core, sap.m', //, sap.ui.mdc, sap.ui.fl",
         language: 'EN',
         async: true,


### PR DESCRIPTION
Avoid: `[DEPRECATED] configuration option 'sap-ui-loglevel' given in global configuration. Please use 'sap-ui-log-level' instead.`