### PR TITLE
feat(`odata-service-inquirer`/`ui5-application-inquirer`): Adds CLI relative path support for app folder paths

### DIFF
--- a/.changeset/yellow-pugs-write.md
+++ b/.changeset/yellow-pugs-write.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/ui5-application-inquirer': minor
+'@sap-ux/odata-service-inquirer': minor
+---
+
+Adds relative path support to CAP and non-CAP target folder prompts

--- a/packages/odata-service-inquirer/src/prompts/datasources/cap-project/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/cap-project/questions.ts
@@ -19,6 +19,7 @@ import {
 } from './types';
 import { validateCapPath } from './validators';
 import { realpath } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
 
 /**
  * Find the specified choice in the list of CAP project choices and return its index.
@@ -97,6 +98,12 @@ export function getLocalCapProjectPrompts(
                 }
             },
             guiOptions: { mandatory: true, breadcrumb: t('prompts.capProject.breadcrumb') },
+            filter: (input: string) => {
+                if (PromptState.isYUI) {
+                    return input;
+                }
+                return input && !isAbsolute(input) ? resolve(input) : input;
+            },
             validate: async (projectPath: string): Promise<string | boolean> => {
                 validCapPath = await validateCapPath(projectPath);
                 // Load the cap paths if the path is valid

--- a/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/__snapshots__/index-api.test.ts.snap
@@ -341,6 +341,7 @@ exports[`API tests getPrompts, i18n is loaded 1`] = `
   },
   {
     "default": [Function],
+    "filter": [Function],
     "guiOptions": {
       "breadcrumb": "CAP Project",
       "mandatory": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -361,6 +361,7 @@ exports[`getQuestions getQuestions 1`] = `
   },
   {
     "default": [Function],
+    "filter": [Function],
     "guiOptions": {
       "breadcrumb": "CAP Project",
       "mandatory": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/cap-project/__snapshots__/questions.test.ts.snap
+++ b/packages/odata-service-inquirer/test/unit/prompts/cap-project/__snapshots__/questions.test.ts.snap
@@ -18,6 +18,7 @@ exports[`getLocalCapProjectPrompts getLocalCapProjectPrompts, returns expected p
   },
   {
     "default": [Function],
+    "filter": [Function],
     "guiOptions": {
       "breadcrumb": "CAP Project",
       "mandatory": true,

--- a/packages/odata-service-inquirer/test/unit/prompts/cap-project/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/cap-project/questions.test.ts
@@ -7,6 +7,7 @@ import type { ListQuestion } from 'inquirer';
 import type { PathLike } from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import os from 'node:os';
+import path from 'node:path';
 import { initI18nOdataServiceInquirer, t } from '../../../../src/i18n';
 import {
     enterCapPathChoiceValue,
@@ -302,6 +303,83 @@ describe('getLocalCapProjectPrompts', () => {
             await (capProjectPathPrompt!.validate as Function)('/any/cap/path');
             expect(realpathSpy).not.toHaveBeenCalled();
         }
+    });
+
+    /**
+     * Load a fresh `getLocalCapProjectPrompts` and `PromptState` with `node:path`'s
+     * `isAbsolute` / `resolve` swapped for the supplied flavor. This lets us deterministically
+     * exercise the `capProjectPath` prompt's filter for both Windows and POSIX paths,
+     * regardless of the OS running the test.
+     *
+     * @param pathImpl - `path.win32` or `path.posix`
+     */
+    function loadQuestionsWithPath(pathImpl: typeof path.win32 | typeof path.posix): {
+        capProjectPathPrompt: any;
+        promptState: typeof PromptState;
+    } {
+        let capProjectPathPrompt: any;
+        let promptState: typeof PromptState;
+        jest.isolateModules(() => {
+            jest.doMock('node:path', () => {
+                const actual = jest.requireActual('node:path');
+                return {
+                    ...actual,
+                    isAbsolute: pathImpl.isAbsolute,
+                    resolve: pathImpl.resolve
+                };
+            });
+            const {
+                getLocalCapProjectPrompts: getPromptsLocal
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+            } = require('../../../../src/prompts/datasources/cap-project/questions');
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            ({ PromptState: promptState } = require('../../../../src/utils'));
+            const prompts = getPromptsLocal();
+            capProjectPathPrompt = prompts.find(
+                (p: { name: string }) => p.name === capInternalPromptNames.capProjectPath
+            );
+        });
+        return { capProjectPathPrompt, promptState: promptState! };
+    }
+
+    test('prompt: capProjectPath - filter (win32)', () => {
+        const { capProjectPathPrompt, promptState } = loadQuestionsWithPath(path.win32);
+        const relInput = 'relative\\cap\\path';
+        const absInput = 'C:\\abs\\cap\\path';
+
+        // CLI mode: relative paths are resolved to absolute paths using win32 semantics
+        promptState.isYUI = false;
+        expect(capProjectPathPrompt.filter(relInput)).toEqual(path.win32.resolve(relInput));
+        // CLI mode: absolute paths pass through unchanged
+        expect(capProjectPathPrompt.filter(absInput)).toEqual(absInput);
+        // CLI mode: empty / undefined input passes through unchanged
+        expect(capProjectPathPrompt.filter('')).toEqual('');
+        expect(capProjectPathPrompt.filter(undefined)).toEqual(undefined);
+
+        // YUI mode: input is returned unchanged regardless of whether it is absolute
+        promptState.isYUI = true;
+        expect(capProjectPathPrompt.filter(relInput)).toEqual(relInput);
+        expect(capProjectPathPrompt.filter(absInput)).toEqual(absInput);
+    });
+
+    test('prompt: capProjectPath - filter (posix)', () => {
+        const { capProjectPathPrompt, promptState } = loadQuestionsWithPath(path.posix);
+        const relInput = 'relative/cap/path';
+        const absInput = '/abs/cap/path';
+
+        // CLI mode: relative paths are resolved to absolute paths using posix semantics
+        promptState.isYUI = false;
+        expect(capProjectPathPrompt.filter(relInput)).toEqual(path.posix.resolve(relInput));
+        // CLI mode: absolute paths pass through unchanged
+        expect(capProjectPathPrompt.filter(absInput)).toEqual(absInput);
+        // CLI mode: empty / undefined input passes through unchanged
+        expect(capProjectPathPrompt.filter('')).toEqual('');
+        expect(capProjectPathPrompt.filter(undefined)).toEqual(undefined);
+
+        // YUI mode: input is returned unchanged regardless of whether it is absolute
+        promptState.isYUI = true;
+        expect(capProjectPathPrompt.filter(relInput)).toEqual(relInput);
+        expect(capProjectPathPrompt.filter(absInput)).toEqual(absInput);
     });
 
     test('prompt: capService', async () => {

--- a/packages/ui5-application-inquirer/src/prompts/index.ts
+++ b/packages/ui5-application-inquirer/src/prompts/index.ts
@@ -63,7 +63,7 @@ export async function getQuestions(
         [promptNames.title]: getTitlePrompt(),
         [promptNames.namespace]: getNamespacePrompt(appName),
         [promptNames.description]: getDescriptionPrompt(),
-        [promptNames.targetFolder]: getTargetFolderPrompt(targetDir, shouldValidateFioriAppFolder),
+        [promptNames.targetFolder]: getTargetFolderPrompt(targetDir, shouldValidateFioriAppFolder, isYUI),
         [promptNames.ui5Version]: getUI5VersionPrompt(ui5Versions, promptOptions?.ui5Version),
         [promptNames.enableTypeScript]: getEnableTypeScriptPrompt(),
         [promptNames.addDeployConfig]: getAddDeployConfigPrompt(

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -117,7 +117,6 @@ export function getDescriptionPrompt(): UI5ApplicationQuestion {
  * @param targetDir provides a default value for the target folder path
  * @param validateFioriAppFolder validates the target folder path as a Fiori app project
  * @param isYUI if true, input is returned unchanged (YUI folder browser already supplies absolute paths)
-
  * @returns the `targetFolder` prompt
  */
 export function getTargetFolderPrompt(

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, resolve } from 'node:path';
 import { searchChoices, ui5VersionsGrouped, getDefaultUI5VersionChoice } from '@sap-ux/inquirer-common';
 import { getMtaPath } from '@sap-ux/project-access';
 import { validateModuleName, validateNamespace, validateFioriAppTargetFolder } from '@sap-ux/project-input-validator';
@@ -115,9 +116,14 @@ export function getDescriptionPrompt(): UI5ApplicationQuestion {
  *
  * @param targetDir provides a default value for the target folder path
  * @param validateFioriAppFolder validates the target folder path as a Fiori app project
+ * @param isYUI
  * @returns the `targetFolder` prompt
  */
-export function getTargetFolderPrompt(targetDir: string, validateFioriAppFolder?: boolean): UI5ApplicationQuestion {
+export function getTargetFolderPrompt(
+    targetDir: string,
+    validateFioriAppFolder?: boolean,
+    isYUI?: boolean
+): UI5ApplicationQuestion {
     return {
         type: 'input',
         name: promptNames.targetFolder,
@@ -129,6 +135,12 @@ export function getTargetFolderPrompt(targetDir: string, validateFioriAppFolder?
             breadcrumb: t('prompts.targetFolder.breadcrumb')
         },
         default: (answers: UI5ApplicationAnswers) => answers.targetFolder || targetDir,
+        filter: (input: string) => {
+            if (isYUI) {
+                return input;
+            }
+            return input && !isAbsolute(input) ? resolve(input) : input;
+        },
         validate: async (target, { name = '' }: UI5ApplicationAnswers): Promise<boolean | string> => {
             if (name.length > 2) {
                 return await validateFioriAppTargetFolder(target, name, validateFioriAppFolder);

--- a/packages/ui5-application-inquirer/src/prompts/prompts1.ts
+++ b/packages/ui5-application-inquirer/src/prompts/prompts1.ts
@@ -116,7 +116,8 @@ export function getDescriptionPrompt(): UI5ApplicationQuestion {
  *
  * @param targetDir provides a default value for the target folder path
  * @param validateFioriAppFolder validates the target folder path as a Fiori app project
- * @param isYUI
+ * @param isYUI if true, input is returned unchanged (YUI folder browser already supplies absolute paths)
+
  * @returns the `targetFolder` prompt
  */
 export function getTargetFolderPrompt(

--- a/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/__snapshots__/ui5-application-inquirer.test.ts.snap
@@ -48,6 +48,7 @@ exports[`ui5-application-inquirer API getPrompts, no options 1`] = `
   },
   {
     "default": [Function],
+    "filter": [Function],
     "guiOptions": {
       "applyDefaultWhenDirty": true,
       "breadcrumb": "Project Path",

--- a/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
+++ b/packages/ui5-application-inquirer/test/unit/prompts/__snapshots__/prompts.test.ts.snap
@@ -48,6 +48,7 @@ exports[`getQuestions getQuestions, no options 1`] = `
   },
   {
     "default": [Function],
+    "filter": [Function],
     "guiOptions": {
       "applyDefaultWhenDirty": true,
       "breadcrumb": "Project Path",

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -268,9 +268,12 @@ describe('getQuestions', () => {
     });
 
     test('getQuestions, prompt: `targetFolder` - filter', async () => {
-        // Use `jest.isolateModules` + `jest.doMock` to swap `path`'s `isAbsolute`/`resolve` for the
-        // posix or win32 flavor so we can deterministically exercise the filter against both
+        // Use `jest.isolateModules` + `jest.doMock` to swap `node:path`'s `isAbsolute`/`resolve` for
+        // the posix or win32 flavor so we can deterministically exercise the filter against both
         // path styles, regardless of the OS running the test.
+        // NOTE: the production code imports from `'node:path'`, so the mock must use that exact
+        // specifier — `jest.doMock('path', ...)` would not intercept it (Jest treats `'path'` and
+        // `'node:path'` as distinct module registry keys).
         const loadTargetFolderPrompt = async (
             pathImpl: typeof path.win32 | typeof path.posix,
             isYUI?: boolean
@@ -278,14 +281,17 @@ describe('getQuestions', () => {
             let targetFolderPromptLocal: any;
             await new Promise<void>((done) => {
                 jest.isolateModules(async () => {
-                    jest.doMock('path', () => {
-                        const actual = jest.requireActual('path');
+                    const pathMockFactory = (): typeof path => {
+                        const actual = jest.requireActual('node:path');
                         return {
                             ...actual,
                             isAbsolute: pathImpl.isAbsolute,
                             resolve: pathImpl.resolve
                         };
-                    });
+                    };
+                    jest.doMock('node:path', pathMockFactory);
+                    // Also mock the bare specifier in case any transitive code uses it
+                    jest.doMock('path', pathMockFactory);
                     // eslint-disable-next-line @typescript-eslint/no-require-imports
                     const { getQuestions: getQuestionsLocal } = require('../../../src/prompts');
                     const localQuestions = await getQuestionsLocal([], undefined, undefined, isYUI);
@@ -297,6 +303,15 @@ describe('getQuestions', () => {
             });
             return targetFolderPromptLocal;
         };
+
+        // Sanity check: confirm the path mock is actually applied. `C:\abs` is absolute under
+        // win32 (passes through) but relative under posix (gets resolved). Without an effective
+        // mock, both calls would use the real platform `path` and one of these assertions would
+        // fail rather than silently pass on a host OS that happens to match the flavor.
+        const win32SanityPrompt = await loadTargetFolderPrompt(path.win32);
+        expect((win32SanityPrompt?.filter as Function)('C:\\abs')).toEqual('C:\\abs');
+        const posixSanityPrompt = await loadTargetFolderPrompt(path.posix);
+        expect((posixSanityPrompt?.filter as Function)('C:\\abs')).toEqual(path.posix.resolve('C:\\abs'));
 
         // win32 CLI: relative paths are resolved using win32 semantics, absolute paths pass through
         const win32Prompt = await loadTargetFolderPrompt(path.win32);

--- a/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
+++ b/packages/ui5-application-inquirer/test/unit/prompts/prompts.test.ts
@@ -10,7 +10,7 @@ import type { UI5Version } from '@sap-ux/ui5-info';
 import { defaultVersion, ui5ThemeIds } from '@sap-ux/ui5-info';
 import type { ListQuestion } from '@sap-ux/inquirer-common';
 import os from 'node:os';
-import { join } from 'node:path';
+import path, { join } from 'node:path';
 
 jest.mock('@sap-ux/project-input-validator', () => {
     return {
@@ -263,6 +263,64 @@ describe('getQuestions', () => {
         targetFolderPrompt = questions.find((question) => question.name === promptNames.targetFolder);
         expect(targetFolderPrompt?.default({})).toEqual(join(os.homedir(), 'projects'));
         expect(validateFioriAppProjectFolderSpy).toHaveBeenCalledWith('/folder/containing/fiori/app');
+
+        // filter is exercised in a dedicated test below (`getQuestions, prompt: \`targetFolder\` - filter`)
+    });
+
+    test('getQuestions, prompt: `targetFolder` - filter', async () => {
+        // Use `jest.isolateModules` + `jest.doMock` to swap `path`'s `isAbsolute`/`resolve` for the
+        // posix or win32 flavor so we can deterministically exercise the filter against both
+        // path styles, regardless of the OS running the test.
+        const loadTargetFolderPrompt = async (
+            pathImpl: typeof path.win32 | typeof path.posix,
+            isYUI?: boolean
+        ): Promise<any> => {
+            let targetFolderPromptLocal: any;
+            await new Promise<void>((done) => {
+                jest.isolateModules(async () => {
+                    jest.doMock('path', () => {
+                        const actual = jest.requireActual('path');
+                        return {
+                            ...actual,
+                            isAbsolute: pathImpl.isAbsolute,
+                            resolve: pathImpl.resolve
+                        };
+                    });
+                    // eslint-disable-next-line @typescript-eslint/no-require-imports
+                    const { getQuestions: getQuestionsLocal } = require('../../../src/prompts');
+                    const localQuestions = await getQuestionsLocal([], undefined, undefined, isYUI);
+                    targetFolderPromptLocal = localQuestions.find(
+                        (q: { name: string }) => q.name === promptNames.targetFolder
+                    );
+                    done();
+                });
+            });
+            return targetFolderPromptLocal;
+        };
+
+        // win32 CLI: relative paths are resolved using win32 semantics, absolute paths pass through
+        const win32Prompt = await loadTargetFolderPrompt(path.win32);
+        const win32Absolute = 'C:\\some\\absolute\\path';
+        expect((win32Prompt?.filter as Function)('relative\\path')).toEqual(path.win32.resolve('relative\\path'));
+        expect((win32Prompt?.filter as Function)(win32Absolute)).toEqual(win32Absolute);
+        expect((win32Prompt?.filter as Function)('')).toEqual('');
+        expect((win32Prompt?.filter as Function)(undefined)).toEqual(undefined);
+
+        // posix CLI: relative paths are resolved using posix semantics, absolute paths pass through
+        const posixPrompt = await loadTargetFolderPrompt(path.posix);
+        const posixAbsolute = '/some/absolute/path';
+        expect((posixPrompt?.filter as Function)('relative/path')).toEqual(path.posix.resolve('relative/path'));
+        expect((posixPrompt?.filter as Function)(posixAbsolute)).toEqual(posixAbsolute);
+        expect((posixPrompt?.filter as Function)('')).toEqual('');
+        expect((posixPrompt?.filter as Function)(undefined)).toEqual(undefined);
+
+        // YUI: input is returned unchanged regardless of path style (folder browser provides absolute paths)
+        const win32YuiPrompt = await loadTargetFolderPrompt(path.win32, true);
+        expect((win32YuiPrompt?.filter as Function)('relative\\path')).toEqual('relative\\path');
+        expect((win32YuiPrompt?.filter as Function)(win32Absolute)).toEqual(win32Absolute);
+        const posixYuiPrompt = await loadTargetFolderPrompt(path.posix, true);
+        expect((posixYuiPrompt?.filter as Function)('relative/path')).toEqual('relative/path');
+        expect((posixYuiPrompt?.filter as Function)(posixAbsolute)).toEqual(posixAbsolute);
     });
 
     test('getQuestions, prompt: `ui5VersionChoice`', async () => {


### PR DESCRIPTION
## Summary

Adds CLI support for entering **relative paths** when prompted for an application target folder, in both CAP and non-CAP flows. When a relative path is entered in CLI mode, it is now resolved against the current working directory before being passed to validation and downstream consumers. YUI behaviour is unchanged — the folder browser already supplies absolute paths.

## Changes

- **`@sap-ux/odata-service-inquirer`** — `capProjectPath` prompt: added a `filter` that resolves relative input to an absolute path in CLI mode (`PromptState.isYUI === false`); absolute input passes through unchanged. ([packages/odata-service-inquirer/src/prompts/datasources/cap-project/questions.ts](packages/odata-service-inquirer/src/prompts/datasources/cap-project/questions.ts))
- **`@sap-ux/ui5-application-inquirer`** — `targetFolder` prompt: added the same filter, gated on the existing `isYUI` argument threaded through `getQuestions` → `getTargetFolderPrompt`. ([packages/ui5-application-inquirer/src/prompts/prompts1.ts](packages/ui5-application-inquirer/src/prompts/prompts1.ts))
- **Tests** — added dedicated filter tests for both prompts. To exercise the filter deterministically across OSes, the tests use `jest.isolateModules` + `jest.doMock` to swap `node:path`'s `isAbsolute`/`resolve` for either `path.win32` or `path.posix`, then re-import the prompts module:
  - win32 CLI: `relative\path` → `path.win32.resolve(...)`, `C:\abs\path` passes through, empty/`undefined` pass through
  - posix CLI: `relative/path` → `path.posix.resolve(...)`, `/abs/path` passes through, empty/`undefined` pass through
  - YUI mode (both flavors): all input passes through unchanged

## Test plan

- [x] `pnpm --filter @sap-ux/odata-service-inquirer test` passes
- [x] `pnpm --filter @sap-ux/ui5-application-inquirer test` passes
- [x] Manual CLI smoke test: enter a relative path at the target-folder prompt and confirm the project is generated under the resolved absolute path
- [x] Manual YUI smoke test: confirm folder-browser-supplied absolute paths still work unchanged
