### PR TITLE
fix: bump control-property-editor past unpublishable 1.0.0

### DIFF
--- a/.changeset/control-property-editor-republish-fix.md
+++ b/.changeset/control-property-editor-republish-fix.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/control-property-editor": patch
+---
+
+fix: bump version to 1.0.1 to avoid npm publish conflict with previously unpublished 1.0.0


### PR DESCRIPTION
## Summary

- Adds a patch changeset for `@sap-ux/control-property-editor` to bump from `1.0.0` → `1.0.1`
- Version `1.0.0` was previously published and unpublished on npm; the registry permanently blocks republishing the same version slot
- The CI release job failed with `E400: Cannot publish over previously published version "1.0.0"` ([failed run](https://github.com/SAP/open-ux-tools/actions/runs/26694678493/job/78680504986))

## Test plan

- [ ] CI release job successfully publishes `@sap-ux/control-property-editor@1.0.1` after changeset versioning runs