### PR TITLE
fix: loadModuleFromProject fails on Window with error Only URLs with …

### DIFF
--- a/.changeset/breezy-paws-follow.md
+++ b/.changeset/breezy-paws-follow.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/project-access': patch
+---
+
+`loadModuleFromProject` throws error on Windows: `Only URLs with a scheme in: file, data, node, and electron are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`

--- a/packages/project-access/src/project/module-loader.ts
+++ b/packages/project-access/src/project/module-loader.ts
@@ -6,6 +6,7 @@ import type { Logger } from '@sap-ux/logger';
 import { getNodeModulesPath } from './dependencies.js';
 import { FileName, moduleCacheRoot } from '../constants.js';
 import { execNpmCommand } from '../command/index.js';
+import { pathToFileURL } from 'node:url';
 
 const require = createRequire(import.meta.url);
 
@@ -40,7 +41,7 @@ export async function loadModuleFromProject<T>(projectRoot: string, moduleName: 
     let module: T;
     try {
         const modulePath = await getModulePath(projectRoot, moduleName);
-        module = (await import(modulePath)) as T;
+        module = (await import(pathToFileURL(modulePath).href)) as T;
     } catch (error) {
         throw Error(`Module '${moduleName}' not installed in project '${projectRoot}'.\n${error.toString()}`);
     }

--- a/packages/project-access/test/project/module-loader.test.ts
+++ b/packages/project-access/test/project/module-loader.test.ts
@@ -37,6 +37,18 @@ jest.unstable_mockModule('node:fs', () => ({
     existsSync: mockExistsSync
 }));
 
+// Mock node:url module
+const realUrl = await import('node:url');
+const mockPathToFileURL = jest.fn<typeof realUrl.pathToFileURL>(realUrl.pathToFileURL);
+jest.unstable_mockModule('node:url', () => ({
+    ...realUrl,
+    default: {
+        ...realUrl.default,
+        pathToFileURL: mockPathToFileURL
+    },
+    pathToFileURL: mockPathToFileURL
+}));
+
 // Mock fs/promises module
 const realFsPromises = await import('node:fs/promises');
 const mockRm = jest.fn<typeof promisesMock.rm>(realFsPromises.rm);
@@ -66,6 +78,7 @@ describe('Test loadModuleFromProject()', () => {
             '@sap-ux/ui5-config'
         );
         expect(typeof projectModule).toEqual('object');
+        expect(mockPathToFileURL).toHaveBeenCalledTimes(1);
     });
 
     test('Module not install in project, should throw error', async () => {


### PR DESCRIPTION
Scenario:
1. use Windows OS
2. Use app with `"@sap/ux-specification` devDependency
3. Call `loadModuleFromProject` and pass path to app and `"@sap/ux-specification`

`loadModuleFromProject` throws error on `Windows`: `Only URLs with a scheme in: file, data, node, and electron are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`