### PR TITLE
fix(fiori-mcp-server): replace negated typeof checks to avoid SonarQube findings

### DIFF
--- a/.changeset/fiori-mcp-server-sonar-negated-condition.md
+++ b/.changeset/fiori-mcp-server-sonar-negated-condition.md
@@ -2,4 +2,4 @@
 "@sap-ux/fiori-mcp-server": patch
 ---
 
-fix(fiori-mcp-server): replace negated typeof checks to avoid SonarQube findings
+Replace negated typeof checks to avoid SonarQube findings

--- a/.changeset/fiori-mcp-server-sonar-negated-condition.md
+++ b/.changeset/fiori-mcp-server-sonar-negated-condition.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+fix(fiori-mcp-server): replace negated typeof checks to avoid SonarQube findings

--- a/packages/fiori-mcp-server/src/package-info.ts
+++ b/packages/fiori-mcp-server/src/package-info.ts
@@ -10,6 +10,6 @@ function readPackageJson(): { name: string; version: string } {
     return require('../package.json') as { name: string; version: string };
 }
 
-export const PACKAGE_NAME: string = typeof __PACKAGE_NAME__ !== 'undefined' ? __PACKAGE_NAME__ : readPackageJson().name;
+export const PACKAGE_NAME: string = typeof __PACKAGE_NAME__ === 'undefined' ? readPackageJson().name : __PACKAGE_NAME__;
 export const PACKAGE_VERSION: string =
-    typeof __PACKAGE_VERSION__ !== 'undefined' ? __PACKAGE_VERSION__ : readPackageJson().version;
+    typeof __PACKAGE_VERSION__ === 'undefined' ? readPackageJson().version : __PACKAGE_VERSION__;


### PR DESCRIPTION
## Summary

Follow-up to #4746.

- Replace `typeof x !== 'undefined' ? x : fallback` with `typeof x === 'undefined' ? fallback : x` in `packages/fiori-mcp-server/src/package-info.ts` to avoid SonarQube negated-condition findings

## Test plan

- [ ] Existing unit tests pass
- [ ] No new lint errors introduced