### PR TITLE
fix(preview-middleware): add missing changeset to republish with control-property-editor 1.0.1

### DIFF
--- a/.changeset/preview-middleware-cpe-dependency-bump.md
+++ b/.changeset/preview-middleware-cpe-dependency-bump.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/preview-middleware": patch
+---
+
+fix: republish to pick up control-property-editor 1.0.1 (1.0.0 was unpublished from npm)


### PR DESCRIPTION
## Summary

Follow-up to #4744.

PR #4744 added a changeset to bump `@sap-ux/control-property-editor` from `1.0.0` → `1.0.1` (to avoid the npm block on re-publishing `1.0.0`), but `@sap-ux/preview-middleware` depends on `control-property-editor` and was not re-published. Consumers installing `preview-middleware` would get a resolved lockfile pointing at the unpublished `control-property-editor@1.0.0`.

This adds the missing patch changeset for `preview-middleware` to trigger a re-publish.

Ref: https://github.wdf.sap.corp/ux-engineering/tools-suite/issues/38343#issuecomment-17795094

## Test plan

- [ ] `pnpm validate:changesets` passes
- [ ] CI release job publishes `@sap-ux/preview-middleware` with `control-property-editor@1.0.1` resolved