### PR TITLE
fix(eslint-plugin-fiori-tools): support ESLint 10 by upgrading @babel/eslint-parser to v8

### DIFF
--- a/.changeset/eslint-plugin-fiori-tools-eslint-10-support.md
+++ b/.changeset/eslint-plugin-fiori-tools-eslint-10-support.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/eslint-plugin-fiori-tools': minor
+---
+
+fix: support ESLint 10 by upgrading `@babel/eslint-parser` and `@babel/core` to `8.0.0-rc.6` and adding `@babel/parser@8.0.0-rc.6` as a runtime dependency. This avoids `@babel/eslint-parser`'s `createRequire` failing to load `@babel/parser@8` (pure ESM) under pnpm's strict `node_modules` isolation, where `@babel/parser` is otherwise not visible from the consumer's resolution paths.

--- a/packages/eslint-plugin-fiori-tools/eslint.config.mjs
+++ b/packages/eslint-plugin-fiori-tools/eslint.config.mjs
@@ -6,7 +6,12 @@ const __dirname = import.meta.dirname;
 
 export default [
     {
-        ignores: ['config/**/eslintrc*.js', 'test/global-setup.js', 'jest.resolver.cjs']
+        ignores: [
+            'config/**/eslintrc*.js',
+            'test/global-setup.js',
+            'jest.resolver.cjs',
+            'test/babel-eslint-parser.transformer.cjs'
+        ]
     },
     ...base,
     {

--- a/packages/eslint-plugin-fiori-tools/jest.config.mjs
+++ b/packages/eslint-plugin-fiori-tools/jest.config.mjs
@@ -12,6 +12,19 @@ export default {
         // which deadlocks under Jest's --experimental-vm-modules.
         '^synckit$': '<rootDir>/test/__mocks__/synckit.cjs'
     },
+    transform: {
+        // Patch @babel/eslint-parser's index.js (see transformer header for rationale).
+        // This rule must come before ts-jest's default `^.+\\.[jt]s$` so it wins for the
+        // matched path; Jest applies the first matching transform.
+        '@babel[\\\\/]eslint-parser[\\\\/]lib[\\\\/]index\\.js$':
+            '<rootDir>/test/babel-eslint-parser.transformer.cjs',
+        ...baseConfig.transform
+    },
+    transformIgnorePatterns: [
+        // Override jest.base's pattern to additionally allow @babel/eslint-parser through
+        // the transform pipeline so our patcher above runs on it.
+        'node_modules/(?!(?:.*?/)?(@sap-ux|@sap-ux-private|@sap/ux-cds-compiler-facade|@sap-devx[+/]yeoman-ui-types|@babel[+/]eslint-parser)/)'
+    ],
     coveragePathIgnorePatterns: [
         'src/types.ts',
         'src/language/annotations/types.ts',

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -21,7 +21,8 @@
         "format": "prettier --write '**/*.{js,json,ts,yaml,yml}' --ignore-path ../../.prettierignore",
         "lint": "eslint",
         "lint:fix": "eslint --fix",
-        "test": "cross-env \"NODE_OPTIONS=--experimental-vm-modules\" jest --ci --forceExit --detectOpenHandles --colors --maxWorkers=50%"
+        "test": "cross-env \"NODE_OPTIONS=--experimental-vm-modules\" jest --ci --forceExit --detectOpenHandles --colors --maxWorkers=50%",
+        "tgz:package": "pnpm pack"
     },
     "devDependencies": {
         "@jest/globals": "30.3.0",
@@ -32,8 +33,9 @@
         "@types/semver": "7.7.1"
     },
     "dependencies": {
-        "@babel/core": "7.29.0",
-        "@babel/eslint-parser": "^7.28.5",
+        "@babel/core": "8.0.0-rc.6",
+        "@babel/eslint-parser": "8.0.0-rc.6",
+        "@babel/parser": "8.0.0-rc.6",
         "@eslint/js": "10.0.1",
         "@eslint/json": "0.14.0",
         "@eslint/core": "1.1.1",

--- a/packages/eslint-plugin-fiori-tools/test/babel-eslint-parser.transformer.cjs
+++ b/packages/eslint-plugin-fiori-tools/test/babel-eslint-parser.transformer.cjs
@@ -6,7 +6,6 @@
 // --experimental-vm-modules because the VM-modules runtime cannot satisfy a sync CJS-style
 // require for a pure-ESM module like @babel/parser@8. Production runtime is unaffected:
 // Node 22.12+ supports require(esm) natively, so the unpatched parser loads fine there.
-// Upstream tracking issue: https://github.com/babel/babel/issues/<TBD-after-filing>
 module.exports = {
     process(sourceText) {
         const importReplaced = sourceText.replace(

--- a/packages/eslint-plugin-fiori-tools/test/babel-eslint-parser.transformer.cjs
+++ b/packages/eslint-plugin-fiori-tools/test/babel-eslint-parser.transformer.cjs
@@ -1,0 +1,29 @@
+'use strict';
+
+// Jest transformer that string-patches @babel/eslint-parser@8.0.0-rc.6/lib/index.js so
+// it imports @babel/parser statically instead of via createRequire(). The shipped parser
+// uses createRequire(import.meta.url).require('@babel/parser') which throws under Jest's
+// --experimental-vm-modules because the VM-modules runtime cannot satisfy a sync CJS-style
+// require for a pure-ESM module like @babel/parser@8. Production runtime is unaffected:
+// Node 22.12+ supports require(esm) natively, so the unpatched parser loads fine there.
+// Upstream tracking issue: https://github.com/babel/babel/issues/<TBD-after-filing>
+module.exports = {
+    process(sourceText) {
+        const importReplaced = sourceText.replace(
+            "import { createRequire } from 'node:module';",
+            "import * as babelParser from '@babel/parser';"
+        );
+        const requireRemoved = importReplaced.replace(
+            /const require\$1 = createRequire\(import\.meta\.url\);\s*const babelParser = require\$1\(require\$1\.resolve\("@babel\/parser",\s*\{\s*paths:\s*\[require\$1\.resolve\("@babel\/core\/package\.json"\)\]\s*\}\)\);/,
+            ''
+        );
+        if (importReplaced === sourceText || requireRemoved === importReplaced) {
+            throw new Error(
+                '[babel-eslint-parser.transformer] Failed to patch @babel/eslint-parser/lib/index.js: ' +
+                    'expected createRequire-based @babel/parser load not found. ' +
+                    'The upstream source has likely changed — update the transformer.'
+            );
+        }
+        return { code: requireRemoved };
+    }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1553,7 +1553,7 @@ importers:
         version: 25.10.10(typescript@5.9.3)
       jest-scss-transform:
         specifier: 1.0.4
-        version: 1.0.4(babel-jest@30.3.0(@babel/core@7.29.0))
+        version: 1.0.4(babel-jest@30.3.0(@babel/core@8.0.0-rc.6))
       npm-run-all2:
         specifier: 8.0.4
         version: 8.0.4
@@ -1592,7 +1592,7 @@ importers:
         version: 3.0.0(typescript@5.9.3)
       ts-jest:
         specifier: 29.4.9
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.27.4)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.13.14)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@8.0.0-rc.6)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@8.0.0-rc.6))(esbuild@0.27.4)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.13.14)(typescript@5.9.3)))(typescript@5.9.3)
       uuid:
         specifier: 11.1.1
         version: 11.1.1
@@ -1986,11 +1986,14 @@ importers:
   packages/eslint-plugin-fiori-tools:
     dependencies:
       '@babel/core':
-        specifier: 7.29.0
-        version: 7.29.0
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6
       '@babel/eslint-parser':
-        specifier: ^7.28.5
-        version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.1)
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)
+      '@babel/parser':
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6
       '@eslint/config-helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -4219,7 +4222,7 @@ importers:
         version: 25.10.10(typescript@5.9.3)
       jest-scss-transform:
         specifier: 1.0.4
-        version: 1.0.4(babel-jest@30.3.0(@babel/core@7.29.0))
+        version: 1.0.4(babel-jest@30.3.0(@babel/core@8.0.0-rc.6))
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -5891,24 +5894,40 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0-rc.6':
+    resolution: {integrity: sha512-Ru0EdYEptXbJGAGDMsenx+RcelHazuj8spqi7l0geXEPXv0X7qVisqWX+2pMaEZsWhS3Q6Um7oITwhnLe0cHJQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@8.0.0-rc.6':
+    resolution: {integrity: sha512-9ikfbIp7PCtV/mo8NYrzag1TYInVJAKLwpSoA28+3Bl5z1KVYt5ZGvBZD57yJlf/0HsCntlTlHHodu+eMpUffQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/eslint-parser@7.28.6':
-    resolution: {integrity: sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+  '@babel/core@8.0.0-rc.6':
+    resolution: {integrity: sha512-89SVbTu7p+M/W052SFC7R5QuQYgypfuO6HmBBbhA/Kzl6gME8Ly2QrVpIegvTxmcQKOzAPIxiEIfNk+Jxd26mw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/eslint-parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-qVHD7K5PyUXj57bsJWbyT5V9JtOX/4dtX9QSQpqGfBG4xiVE/mrCYCT25Ih+wHvISR98Lctl9BtvEUtGyYsrvA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
-      '@babel/core': ^7.11.0
-      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
+      '@babel/core': ^8.0.0-rc.6
+      eslint: ^9.0.0 || ^10.0.0
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/generator@8.0.0-rc.6':
+    resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
@@ -5917,6 +5936,10 @@ packages:
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@8.0.0-rc.6':
+    resolution: {integrity: sha512-jqQD45/yUSy63U8zs9hE5FMXS8J1TLAI/NTMx76C6xWO021e13gJACQvuGmEF7syloC39LkkKwhqtAbMku1rwg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-create-class-features-plugin@7.28.6':
     resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
@@ -5946,6 +5969,10 @@ packages:
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0-rc.6':
+    resolution: {integrity: sha512-ZF5FsxE4y7Eb6DiEbsLW3Gz3e73U/Uq3/ZotWf/moxv0DnZziXSMnW/tcXJF8b1mQE8XJnwPNSQOksKcKTz8kQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
@@ -5989,13 +6016,25 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@8.0.0-rc.6':
+    resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@8.0.0-rc.6':
+    resolution: {integrity: sha512-uonhzCIL2Vf0xA10g5C0zD5thR7a6XxOSwZAzYfyl8n2zEev5bAB9J4b2oZ7u5YkyqdONfkptl2DesvW2P56Kg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-wrap-function@7.28.6':
     resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
@@ -6005,9 +6044,18 @@ packages:
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@8.0.0-rc.6':
+    resolution: {integrity: sha512-kTTqnw+Ubp1/WGXiIpDcl+WYVGTUVGjrQKswGI9VOamk7eWVf5ZYOcCB+o1UxaaHjs/L+QK7IRPlyP7vg579OQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0-rc.6':
+    resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
@@ -6520,13 +6568,25 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0-rc.6':
+    resolution: {integrity: sha512-CZFjZblLiIUEFghbB3sKs3rpYrwo65rLIklw/gNpwBm326cU6TH/xzvJZlZ+H9HpDi00eDXqNJR8CtEKW3oc/A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.0-rc.6':
+    resolution: {integrity: sha512-/txuBViGaE9gpM8MSGShru1O2Bzp3zb3m/XKZNUsNv2SyNn++lKDDIWkiIQ/345j2FBy7CHiYTZuKhewHWyefw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0-rc.6':
+    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -7824,9 +7884,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
-    resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -9898,6 +9955,9 @@ packages:
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/glob@9.0.0':
     resolution: {integrity: sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==}
     deprecated: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.
@@ -9948,6 +10008,9 @@ packages:
 
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -12743,10 +12806,6 @@ packages:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint-visitor-keys@2.1.0:
-    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
-    engines: {node: '>=10'}
-
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -13796,6 +13855,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -14466,6 +14528,9 @@ packages:
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -15620,6 +15685,9 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   odata-query@8.0.5:
     resolution: {integrity: sha512-uteX6kmx4Y8LkEjdLuhXagI2GXQbJHvmfbI6z4PKcGj7vv5bLM6cX3vrBQsLr2JQStk0MUouRtkcja4pQhFKhg==}
@@ -19829,7 +19897,14 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0-rc.6':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.0': {}
+
+  '@babel/compat-data@8.0.0-rc.6': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -19851,13 +19926,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.1)':
+  '@babel/core@8.0.0-rc.6':
     dependencies:
-      '@babel/core': 7.29.0
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      '@babel/code-frame': 8.0.0-rc.6
+      '@babel/generator': 8.0.0-rc.6
+      '@babel/helper-compilation-targets': 8.0.0-rc.6
+      '@babel/helpers': 8.0.0-rc.6
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/template': 8.0.0-rc.6
+      '@babel/traverse': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      find-up-simple: 1.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.1
+      semver: 7.7.4
+
+  '@babel/eslint-parser@8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       eslint: 9.39.1
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      semver: 7.7.4
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -19865,6 +19959,15 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@8.0.0-rc.6':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -19878,6 +19981,14 @@ snapshots:
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
+
+  '@babel/helper-compilation-targets@8.0.0-rc.6':
+    dependencies:
+      '@babel/compat-data': 8.0.0-rc.6
+      '@babel/helper-validator-option': 8.0.0-rc.6
+      browserslist: 4.28.1
+      lru-cache: 7.18.3
+      semver: 7.7.4
 
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -19921,6 +20032,8 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@8.0.0-rc.6': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -19978,9 +20091,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@8.0.0-rc.6': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@8.0.0-rc.6': {}
+
   '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helper-validator-option@8.0.0-rc.6': {}
 
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
@@ -19995,9 +20114,18 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
+  '@babel/helpers@8.0.0-rc.6':
+    dependencies:
+      '@babel/template': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@8.0.0-rc.6':
+    dependencies:
+      '@babel/types': 8.0.0-rc.6
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -20043,9 +20171,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
@@ -20053,9 +20191,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
@@ -20068,14 +20216,29 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
@@ -20088,9 +20251,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
@@ -20098,9 +20271,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
@@ -20108,9 +20291,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
@@ -20118,9 +20311,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.0-rc.6)':
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
@@ -20623,6 +20826,12 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
+  '@babel/template@8.0.0-rc.6':
+    dependencies:
+      '@babel/code-frame': 8.0.0-rc.6
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -20635,10 +20844,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.0-rc.6':
+    dependencies:
+      '@babel/code-frame': 8.0.0-rc.6
+      '@babel/generator': 8.0.0-rc.6
+      '@babel/helper-globals': 8.0.0-rc.6
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/template': 8.0.0-rc.6
+      '@babel/types': 8.0.0-rc.6
+      obug: 2.1.1
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@8.0.0-rc.6':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0-rc.6
+      '@babel/helper-validator-identifier': 8.0.0-rc.6
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -22152,10 +22376,6 @@ snapshots:
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
-
-  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
-    dependencies:
-      eslint-scope: 5.1.1
 
   '@noble/hashes@1.8.0': {}
 
@@ -24759,6 +24979,8 @@ snapshots:
       '@types/jsonfile': 6.1.4
       '@types/node': 20.0.0
 
+  '@types/gensync@1.0.5': {}
+
   '@types/glob@9.0.0':
     dependencies:
       glob: 13.0.1
@@ -24819,6 +25041,8 @@ snapshots:
       '@types/node': 22.13.14
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
+
+  '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -26325,6 +26549,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@30.3.0(@babel/core@8.0.0-rc.6):
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@jest/transform': 30.3.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.3.0(@babel/core@8.0.0-rc.6)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.105.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(esbuild@0.27.4)):
     dependencies:
       '@babel/core': 7.29.0
@@ -26407,11 +26644,36 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
+  babel-preset-current-node-syntax@1.2.0(@babel/core@8.0.0-rc.6):
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@8.0.0-rc.6)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.0-rc.6)
+
   babel-preset-jest@30.3.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jest-hoist: 30.3.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+
+  babel-preset-jest@30.3.0(@babel/core@8.0.0-rc.6):
+    dependencies:
+      '@babel/core': 8.0.0-rc.6
+      babel-plugin-jest-hoist: 30.3.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@8.0.0-rc.6)
 
   babel-preset-transform-ui5@7.8.1(@babel/core@7.29.0):
     dependencies:
@@ -28204,8 +28466,6 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-visitor-keys@2.1.0: {}
-
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
@@ -29555,6 +29815,8 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -30315,6 +30577,10 @@ snapshots:
     dependencies:
       babel-jest: 30.3.0(@babel/core@7.29.0)
 
+  jest-scss-transform@1.0.4(babel-jest@30.3.0(@babel/core@8.0.0-rc.6)):
+    dependencies:
+      babel-jest: 30.3.0(@babel/core@8.0.0-rc.6)
+
   jest-snapshot@30.3.0:
     dependencies:
       '@babel/core': 7.29.0
@@ -30465,6 +30731,8 @@ snapshots:
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -31780,6 +32048,8 @@ snapshots:
   objectorarray@1.0.5: {}
 
   obuf@1.1.2: {}
+
+  obug@2.1.1: {}
 
   odata-query@8.0.5:
     dependencies:
@@ -33540,7 +33810,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1(debug@4.3.4)
+      axios: 1.16.1
     optional: true
 
   retry@0.12.0: {}
@@ -34888,6 +35158,27 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.4.1
       babel-jest: 30.3.0(@babel/core@7.29.0)
+      esbuild: 0.27.4
+      jest-util: 30.4.1
+
+  ts-jest@29.4.9(@babel/core@8.0.0-rc.6)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@8.0.0-rc.6))(esbuild@0.27.4)(jest-util@30.4.1)(jest@30.3.0(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.13.14)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.3.0(@types/node@22.13.14)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@22.13.14)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 8.0.0-rc.6
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.4.1
+      babel-jest: 30.3.0(@babel/core@8.0.0-rc.6)
       esbuild: 0.27.4
       jest-util: 30.4.1
 


### PR DESCRIPTION
internal issue 38344

## Summary

- Upgrade `@babel/eslint-parser` and `@babel/core` to `8.0.0-rc.6` and add `@babel/parser@8.0.0-rc.6` as a runtime dependency. This is enough to make the plugin work under ESLint 10 + pnpm strict isolation; no bundling is required.
