### PR TITLE
test: stabilize flaky CI tests (repo-app-import, fiori-elements lrop)

### DIFF
--- a/packages/fiori-elements-writer/test/lrop.test.ts
+++ b/packages/fiori-elements-writer/test/lrop.test.ts
@@ -463,7 +463,7 @@ describe(`Fiori Elements template: ${TEST_NAME}`, () => {
                 await projectChecks(testPath, config, debug?.debugFull);
             });
         },
-        120000 // Increased to 120s - lrop_v4_addtests with test generation can take 60s+ on Windows CI
+        240000 // Increased to 240s - lrop_v4_addtests with test generation can exceed 120s on Windows CI
     );
 
     test('should generate manifest with correct routing and context paths when parameterised main entity is selected', async () => {

--- a/packages/repo-app-import-sub-generator/test/app.test.ts
+++ b/packages/repo-app-import-sub-generator/test/app.test.ts
@@ -286,7 +286,7 @@ function verifyGeneratedFiles(testOutputDir: string, appId: string, testFixtureD
 }
 
 // Increase timeout for heavy generator lifecycle execution in ESM mode (Windows + NTFS + ESM resolution is ~3-5x slower)
-jest.setTimeout(150000);
+jest.setTimeout(240000);
 
 describe('Repo App Download', () => {
     const testFixture = new TestFixture();
@@ -385,7 +385,7 @@ describe('Repo App Download', () => {
         copyFilesToExtractedProjectPath(testFixtureDir, extractedProjectPath);
         mockIsValidPromptState.mockReturnValue(true);
         mockGetAppConfig.mockResolvedValue(appConfig);
-        mockHandleWorkspaceConfig.mockResolvedValue({
+        mockHandleWorkspaceConfig.mockReturnValue({
             launchJsonPath: join(testOutputDir, '.vscode', 'launch.json'),
             cwd: testOutputDir,
             workspaceFolderUri: 'testUri',
@@ -437,7 +437,7 @@ describe('Repo App Download', () => {
         mockSendTelemetry.mockRejectedValue(new Error(errorMsg));
         mockIsValidPromptState.mockReturnValue(true);
         mockGetAppConfig.mockResolvedValue(appConfig);
-        mockHandleWorkspaceConfig.mockResolvedValue({
+        mockHandleWorkspaceConfig.mockReturnValue({
             launchJsonPath: join(testOutputDir, '.vscode', 'launch.json'),
             cwd: testOutputDir,
             workspaceFolderUri: 'testUri',
@@ -478,7 +478,7 @@ describe('Repo App Download', () => {
             copyFilesToExtractedProjectPath(testFixtureDir, extractedProjectPath);
             mockIsValidPromptState.mockReturnValue(true);
             mockGetAppConfig.mockResolvedValue(appConfig);
-            mockHandleWorkspaceConfig.mockResolvedValue({
+            mockHandleWorkspaceConfig.mockReturnValue({
                 launchJsonPath: join(testOutputDir, '.vscode', 'launch.json'),
                 cwd: testOutputDir,
                 workspaceFolderUri: undefined,


### PR DESCRIPTION
## Summary
- Fixes the most-frequent flaky tests observed across all branches over the last 4 weeks of CI runs (Nx Cloud).
- `repo-app-import-sub-generator/test/app.test.ts`: replace `mockResolvedValue` with `mockReturnValue` for `handleWorkspaceConfig` (called synchronously in source); bump file-level `jest.setTimeout` from 150s to 240s. The mock-type mismatch caused the workspace path to evaluate to `undefined` mid-flow on slower runners, leading to intermittent failures of "Should successfully run app download from repository", "...when Quick Deploy App Config is provided", "Should execute post app gen hook event when postGenCommand is provided", and "Should not throw error in end phase if telemetry fails".
- `fiori-elements-writer/test/lrop.test.ts`: bump per-test `test.each` timeout from 120s to 240s. The file-level timeout is 360s but the per-test override was hitting the limit on Windows CI for `lrop_v4_addtests`-style configs.

Both packages are test-only changes — no changeset required per AGENTS.md.

## Test plan
- [x] Local run of `pnpm --filter @sap-ux/repo-app-import-sub-generator test` passes (8/8 in ~25s on macOS)
- [ ] CI matrix passes on Ubuntu, macOS, Windows × Node 20/22/24
- [ ] No regressions in other packages