### PR TITLE
feat(ui5-test-writer): Improve test stability using workarounds to read missing values

### DIFF
--- a/.changeset/ui5-test-writer-microchart-identifier.md
+++ b/.changeset/ui5-test-writer-microchart-identifier.md
@@ -1,0 +1,19 @@
+---
+'@sap-ux/ui5-test-writer': patch
+---
+
+fix(ui5-test-writer): emit chartId/chartType identifier instead of title for iCheckMicroChart, and skip UI.Hidden sections
+
+The Object Page test generator now emits `iCheckMicroChart({ chartId, chartType })` instead of the
+title-based `iCheckMicroChart("<title>")` form whenever the underlying `UI.Chart` annotation can be
+resolved from the OData metadata or its referenced annotation files. Title-based output is kept as a
+fallback when the chart annotation cannot be located or its `ChartType` cannot be mapped to a known
+microchart class. Annotation files declared via `manifest.json -> sap.app.dataSources.<service>.settings.annotations`
+are now loaded together with the service metadata when extracting features.
+
+The same metadata pipeline is also used to detect `UI.Hidden` annotations on Object Page header
+facets, body sections, and sub-sections — sections marked `UI.Hidden = true` (and, conservatively,
+any `UI.Hidden` expression) are now omitted from the generated tests, which previously caused
+runtime failures for apps that hide sections dynamically. Hidden sections are kept in the
+intermediate feature data with a `hidden` flag so they can be re-enabled in the future when
+expression evaluation against the test API becomes possible.

--- a/packages/ui5-test-writer/src/types.ts
+++ b/packages/ui5-test-writer/src/types.ts
@@ -114,6 +114,7 @@ export type BodySubSectionFeatureData = {
     order: number;
     fields: SectionFormField[];
     tableColumns: TableColumnFeatureData;
+    hidden?: boolean | 'dynamic';
 };
 
 export type BodySectionFeatureData = {
@@ -125,6 +126,7 @@ export type BodySectionFeatureData = {
     fields: SectionFormField[];
     tableColumns: TableColumnFeatureData;
     subSections: BodySubSectionFeatureData[];
+    hidden?: boolean | 'dynamic';
 };
 
 export type ObjectPageFeatures = {
@@ -134,6 +136,10 @@ export type ObjectPageFeatures = {
     headerDescription?: string;
     headerSections?: HeaderSectionFeatureData[];
     bodySections?: BodySectionFeatureData[];
+    /** Number of header sections that will render at runtime (those with `hidden !== true`). */
+    headerSectionsRenderableCount?: number;
+    /** Number of body sections that will render at runtime (those with `hidden !== true`). */
+    bodySectionsRenderableCount?: number;
 };
 
 export type ListReportFeatures = {
@@ -208,8 +214,17 @@ export type HeaderSectionFeatureData = {
     custom?: boolean;
     collection?: boolean;
     microChart?: boolean;
+    microChartId?: string;
+    microChartType?: string;
     form?: boolean;
     stashed?: boolean | string;
+    /**
+     * Indicates whether the section's `UI.Hidden` annotation hides it.
+     * - true: literal `UI.Hidden = true` (or annotation present with no value); test is skipped.
+     * - 'dynamic': annotation is a path/expression the generator cannot evaluate; test is emitted as a comment.
+     * - false / undefined: section is visible.
+     */
+    hidden?: boolean | 'dynamic';
     fields?: FormField[];
 };
 

--- a/packages/ui5-test-writer/src/utils/facetUtils.ts
+++ b/packages/ui5-test-writer/src/utils/facetUtils.ts
@@ -1,0 +1,118 @@
+import type { Logger } from '@sap-ux/logger';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
+import type { CollectionFacet, FacetTypes } from '@sap-ux/vocabularies-types/vocabularies/UI';
+import { UIAnnotationTypes } from '@sap-ux/vocabularies-types/vocabularies/UI';
+
+export type FacetCollectionName = 'HeaderFacets' | 'Facets';
+
+/** Identifies a facet by either its referenced annotation path or its `ID`. */
+export interface FacetIdentifier {
+    target?: string;
+    id?: string;
+}
+
+/**
+ * Returns the resolved hidden state of the facet from its `UI.Hidden` annotation:
+ * `true` for literal `UI.Hidden = true`, `'dynamic'` for path/expression forms (which cannot
+ * be evaluated at generation time), and `false` for absent or `UI.Hidden = false` annotations.
+ *
+ * @param pageEntitySetName - the page entity set name from the page configuration
+ * @param facetCollection - which facet collection to inspect on the entity type
+ * @param identifier - target/id of the facet to look up
+ * @param metadata - converted metadata of the main service (with merged annotations)
+ * @param log - optional logger
+ * @returns the hidden state, or `false` when nothing can be determined
+ */
+export function isFacetHidden(
+    pageEntitySetName: string | undefined,
+    facetCollection: FacetCollectionName,
+    identifier: FacetIdentifier,
+    metadata: ConvertedMetadata | undefined,
+    log?: Logger
+): boolean | 'dynamic' {
+    if (!metadata || !pageEntitySetName || (!identifier.target && !identifier.id)) {
+        return false;
+    }
+    try {
+        const entitySet = metadata.entitySets.find((es) => es.name === pageEntitySetName);
+        if (!entitySet?.entityType) {
+            return false;
+        }
+        const uiAnnotations = entitySet.entityType.annotations?.UI as Record<string, unknown> | undefined;
+        const facets = uiAnnotations?.[facetCollection] as FacetTypes[] | undefined;
+        if (!Array.isArray(facets)) {
+            return false;
+        }
+        const facet = findFacet(facets, identifier);
+        return resolveHiddenState(facet?.annotations?.UI?.Hidden);
+    } catch (error) {
+        log?.debug(
+            `Failed to check facet hidden state for ${facetCollection} ${identifier.id ?? identifier.target ?? ''}: ${(error as Error).message}`
+        );
+        return false;
+    }
+}
+
+/**
+ * Recursively searches the given facet collection for a facet matching the identifier,
+ * descending into `CollectionFacet.Facets` so sub-section identifiers also resolve.
+ *
+ * @param facets - facet collection to search
+ * @param identifier - identifier to match against
+ * @returns the matching facet, or undefined if none was found
+ */
+function findFacet(facets: FacetTypes[], identifier: FacetIdentifier): FacetTypes | undefined {
+    for (const facet of facets) {
+        if (matchesIdentifier(facet, identifier)) {
+            return facet;
+        }
+        if (facet.$Type === UIAnnotationTypes.CollectionFacet) {
+            const nested = findFacet((facet as CollectionFacet).Facets ?? [], identifier);
+            if (nested) {
+                return nested;
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Tests whether a facet matches the given identifier on either its `Target.value` or its `ID`.
+ *
+ * @param facet - facet candidate from the metadata
+ * @param identifier - identifier to match against
+ * @returns `true` if the facet matches by `Target.value` or by `ID`
+ */
+function matchesIdentifier(facet: FacetTypes, identifier: FacetIdentifier): boolean {
+    if (identifier.target) {
+        const facetTarget = (facet as { Target?: { value?: string } }).Target?.value;
+        if (facetTarget && facetTarget === identifier.target) {
+            return true;
+        }
+    }
+    if (identifier.id && facet.ID?.toString() === identifier.id) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Resolves the runtime hidden state from a `UI.Hidden` annotation value.
+ * `UI.Hidden` defaults to `true` when present without a value; expression forms (Path, If, …)
+ * cannot be evaluated at generation time and are reported as `'dynamic'`.
+ *
+ * @param hidden - the value of `annotations.UI.Hidden`
+ * @returns the resolved hidden state
+ */
+function resolveHiddenState(hidden: unknown): boolean | 'dynamic' {
+    if (hidden === undefined || hidden === null) {
+        return false;
+    }
+    if (hidden === false) {
+        return false;
+    }
+    if (hidden === true) {
+        return true;
+    }
+    return 'dynamic';
+}

--- a/packages/ui5-test-writer/src/utils/listReportUtils.ts
+++ b/packages/ui5-test-writer/src/utils/listReportUtils.ts
@@ -16,8 +16,6 @@ import {
     getAggregations
 } from './modelUtils';
 import type { ConvertedMetadata, EntitySet } from '@sap-ux/vocabularies-types';
-import { parse } from '@sap-ux/edmx-parser';
-import { convert } from '@sap-ux/annotation-converter';
 import type { PageWithModelV4 } from '@sap/ux-specification/dist/types/src/parser/application';
 import type { Manifest } from '@sap-ux/project-access';
 
@@ -42,13 +40,13 @@ export function buildButtonState(buttonState?: ButtonState): {
 /**
  * Safely checks button visibility with error handling.
  *
- * @param metadata - The OData metadata XML content
+ * @param metadata - converted OData metadata
  * @param entitySetName - The name of the entity set
  * @param log - Optional logger instance
  * @returns Button visibility result or undefined if error occurs
  */
 export function safeCheckButtonVisibility(
-    metadata: string,
+    metadata: ConvertedMetadata,
     entitySetName: string,
     log?: Logger
 ): ButtonVisibilityResult | undefined {
@@ -63,14 +61,14 @@ export function safeCheckButtonVisibility(
 /**
  * Safely checks action button states with error handling.
  *
- * @param metadata - The OData metadata XML content
+ * @param metadata - converted OData metadata
  * @param entitySetName - The name of the entity set
  * @param actionNames - List of action names to check
  * @param log - Optional logger instance
  * @returns Array of action button states or empty array if error occurs
  */
 export function safeCheckActionButtonStates(
-    metadata: string,
+    metadata: ConvertedMetadata,
     entitySetName: string,
     actionNames: string[],
     log?: Logger
@@ -123,14 +121,14 @@ export function isALPFromManifest(manifest: Manifest, targetKey?: string): boole
  *
  * @param listReportPage - the List Report page containing the tree model with feature definitions
  * @param log - optional logger instance
- * @param metadata - optional metadata for the OPA test generation
+ * @param metadata - optional converted metadata for the OPA test generation
  * @param manifest - optional application manifest, used to detect ALP configuration
  * @returns feature data extracted from the List Report page model
  */
 export function getListReportFeatures(
     listReportPage: PageWithModelV4,
     log?: Logger,
-    metadata?: string,
+    metadata?: ConvertedMetadata,
     manifest?: Manifest
 ): ListReportFeatures {
     const buttonVisibility =
@@ -173,14 +171,16 @@ export function getToolBarActions(pageModel: TreeModel): TreeAggregations {
  * Checks the visibility and enabled state of create and delete buttons for a given entity set
  * by analyzing OData Capabilities annotations in the metadata.
  *
- * @param metadataXml The OData metadata XML content as a string
+ * @param convertedMetadata The converted OData metadata
  * @param entitySetName The name of the entity set to check
  * @returns ButtonVisibilityResult containing the state of create and delete buttons
- * @throws {Error} If metadata cannot be parsed or entity set is not found
+ * @throws {Error} If the entity set cannot be found
  */
-export function checkButtonVisibility(metadataXml: string, entitySetName: string): ButtonVisibilityResult {
+export function checkButtonVisibility(
+    convertedMetadata: ConvertedMetadata,
+    entitySetName: string
+): ButtonVisibilityResult {
     try {
-        const convertedMetadata: ConvertedMetadata = convert(parse(metadataXml));
         const entitySet = convertedMetadata.entitySets.find((es: EntitySet) => es.name === entitySetName);
 
         if (!entitySet) {
@@ -270,19 +270,18 @@ function analyzeRestriction(
 /**
  * Checks the state of action buttons defined in UI.LineItem annotations for a given entity set.
  *
- * @param metadataXml The OData metadata XML content as a string
+ * @param convertedMetadata The converted OData metadata
  * @param entitySetName The name of the entity set to check
  * @param actionNames Optional list of action names to filter (e.g., ['Check', 'deductDiscount']). If not provided, returns all actions.
  * @returns ActionButtonsResult containing the list of action buttons and their states
- * @throws {Error} If metadata cannot be parsed or entity set is not found
+ * @throws {Error} If the entity set cannot be found
  */
 export function checkActionButtonStates(
-    metadataXml: string,
+    convertedMetadata: ConvertedMetadata,
     entitySetName: string,
     actionNames?: string[]
 ): ActionButtonsResult {
     try {
-        const convertedMetadata: ConvertedMetadata = convert(parse(metadataXml));
         const entitySet = convertedMetadata.entitySets.find((es: EntitySet) => es.name === entitySetName);
 
         if (!entitySet) {

--- a/packages/ui5-test-writer/src/utils/microChartUtils.ts
+++ b/packages/ui5-test-writer/src/utils/microChartUtils.ts
@@ -1,0 +1,173 @@
+import type { Logger } from '@sap-ux/logger';
+import type { ConvertedMetadata, EntityType, NavigationProperty } from '@sap-ux/vocabularies-types';
+import type { Chart, PresentationVariant } from '@sap-ux/vocabularies-types/vocabularies/UI';
+import { UIAnnotationTerms } from '@sap-ux/vocabularies-types/vocabularies/UI';
+
+const UI_VOCABULARY_NAMESPACE = 'com.sap.vocabularies.UI.v1.';
+
+// Mirrors the switch in `sap.fe.macros.MicroChart.createMicroChartId` — note the non-obvious
+// mappings (Donut→Radial, Pie→HarveyBall, Bar→Comparison).
+const CHART_TYPE_TO_MICROCHART_CLASS: Record<string, string> = {
+    'UI.ChartType/Bullet': 'BulletMicroChart',
+    'UI.ChartType/Donut': 'RadialMicroChart',
+    'UI.ChartType/Pie': 'HarveyBallMicroChart',
+    'UI.ChartType/BarStacked': 'StackedBarMicroChart',
+    'UI.ChartType/Area': 'AreaMicroChart',
+    'UI.ChartType/Column': 'ColumnMicroChart',
+    'UI.ChartType/Bar': 'ComparisonMicroChart',
+    'UI.ChartType/Line': 'LineMicroChart'
+};
+
+interface ParsedTarget {
+    navPath: string;
+    term: string;
+    qualifier?: string;
+}
+
+/**
+ * Splits a `Target` schema key value (e.g. `_NavProp/com.sap.vocabularies.UI.v1.Chart#Q`) into
+ * navigation path, term suffix (without UI namespace) and qualifier.
+ *
+ * @param targetValue - the raw value of the section's `Target` schema key
+ * @returns parsed components, or undefined if the value is not a recognised annotation path
+ */
+function parseAnnotationTarget(targetValue: string): ParsedTarget | undefined {
+    if (!targetValue) {
+        return undefined;
+    }
+    const lastSlash = targetValue.lastIndexOf('/');
+    const navPath = lastSlash >= 0 ? targetValue.slice(0, lastSlash) : '';
+    const remainder = lastSlash >= 0 ? targetValue.slice(lastSlash + 1) : targetValue;
+
+    const hashIndex = remainder.indexOf('#');
+    const fullTerm = hashIndex >= 0 ? remainder.slice(0, hashIndex) : remainder;
+    const qualifier = hashIndex >= 0 ? remainder.slice(hashIndex + 1) : undefined;
+
+    if (!fullTerm) {
+        return undefined;
+    }
+    const term = fullTerm.startsWith(UI_VOCABULARY_NAMESPACE)
+        ? fullTerm.slice(UI_VOCABULARY_NAMESPACE.length)
+        : fullTerm;
+
+    return { navPath, term, qualifier };
+}
+
+/**
+ * Walks navigation properties along the given path starting at the page entity type.
+ *
+ * @param pageEntityType - entity type to start from
+ * @param navPath - navigation path with `/` separators; can be empty
+ * @returns the entity type at the end of the navigation chain, or undefined if a segment is missing
+ */
+function walkNavigationPath(pageEntityType: EntityType, navPath: string): EntityType | undefined {
+    if (!navPath) {
+        return pageEntityType;
+    }
+    let currentType: EntityType | undefined = pageEntityType;
+    const segments = navPath.split('/').filter((segment) => segment.length > 0);
+    for (const segment of segments) {
+        const navProperty: NavigationProperty | undefined = currentType?.navigationProperties?.find(
+            (property: NavigationProperty): boolean => property.name === segment
+        );
+        if (!navProperty) {
+            return undefined;
+        }
+        currentType = navProperty.targetType;
+    }
+    return currentType;
+}
+
+/**
+ * Looks up a UI annotation on the entity type by term suffix and optional qualifier.
+ *
+ * @param entityType - the entity type to search
+ * @param term - term suffix without the `com.sap.vocabularies.UI.v1.` namespace
+ * @param qualifier - optional qualifier
+ * @returns the matching UI annotation, or undefined if not found
+ */
+function findUIAnnotation(entityType: EntityType, term: string, qualifier?: string): unknown {
+    const uiAnnotations = entityType.annotations?.UI as Record<string, unknown> | undefined;
+    if (!uiAnnotations) {
+        return undefined;
+    }
+    const key = qualifier ? `${term}#${qualifier}` : term;
+    return uiAnnotations[key];
+}
+
+/**
+ * Follows `Visualizations[0]` of a `UI.PresentationVariant`, the same indirection the runtime
+ * MicroChart macro performs.
+ *
+ * @param presentationVariant - the resolved PresentationVariant annotation
+ * @returns the referenced Chart annotation, or undefined if the indirection cannot be followed
+ */
+function resolveChartFromPresentationVariant(presentationVariant: PresentationVariant): Chart | undefined {
+    const firstVisualization = presentationVariant.Visualizations?.[0];
+    const target = firstVisualization?.$target;
+    if (target?.term === UIAnnotationTerms.Chart) {
+        return target as Chart;
+    }
+    return undefined;
+}
+
+/**
+ * Resolves the runtime MicroChart class name used as the `chartType` portion of the OPA5
+ * control id, by looking up the section's annotation in the converted metadata and mapping
+ * its `ChartType`.
+ *
+ * @param targetValue - the value of the section's `Target` schema key from the spec model
+ * @param pageEntitySetName - the page entity set name from the page configuration
+ * @param metadata - converted metadata of the main service (with merged annotations)
+ * @param log - optional logger
+ * @returns the runtime microchart class name, or undefined if it cannot be resolved
+ */
+export function resolveMicroChartType(
+    targetValue: string | undefined,
+    pageEntitySetName: string | undefined,
+    metadata: ConvertedMetadata | undefined,
+    log?: Logger
+): string | undefined {
+    if (!targetValue || !pageEntitySetName || !metadata) {
+        return undefined;
+    }
+    try {
+        const parsed = parseAnnotationTarget(targetValue);
+        if (!parsed) {
+            return undefined;
+        }
+        const pageEntitySet = metadata.entitySets.find((entitySet) => entitySet.name === pageEntitySetName);
+        if (!pageEntitySet?.entityType) {
+            return undefined;
+        }
+        const targetEntityType = walkNavigationPath(pageEntitySet.entityType, parsed.navPath);
+        if (!targetEntityType) {
+            return undefined;
+        }
+        const annotation = findUIAnnotation(targetEntityType, parsed.term, parsed.qualifier);
+        if (!annotation) {
+            return undefined;
+        }
+
+        let chart: Chart | undefined;
+        const annotationTerm = (annotation as { term?: string }).term;
+        if (annotationTerm === UIAnnotationTerms.Chart) {
+            chart = annotation as Chart;
+        } else if (annotationTerm === UIAnnotationTerms.PresentationVariant) {
+            chart = resolveChartFromPresentationVariant(annotation as PresentationVariant);
+        }
+
+        if (!chart) {
+            return undefined;
+        }
+
+        const chartType = chart.ChartType?.toString();
+        if (!chartType) {
+            return undefined;
+        }
+        return CHART_TYPE_TO_MICROCHART_CLASS[chartType];
+    } catch (error) {
+        log?.debug(`Failed to resolve microchart type for target '${targetValue}': ${(error as Error).message}`);
+        return undefined;
+    }
+}

--- a/packages/ui5-test-writer/src/utils/modelUtils.ts
+++ b/packages/ui5-test-writer/src/utils/modelUtils.ts
@@ -15,6 +15,8 @@ import type { AppFeatures, FPMFeatures } from '../types';
 import { getObjectPageFeatures, getObjectPages } from './objectPageUtils';
 import { getFilterFieldNames, getListReportFeatures } from './listReportUtils';
 import { extractTableColumnsFromNode } from './tableUtils';
+import { loadServiceMetadata } from './xmlMetadataUtils';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 
 export interface AggregationItem extends TreeAggregation {
     description: string;
@@ -61,7 +63,7 @@ export interface PageWithModelV4WithProperties extends PageWithModelV4 {
  * @param basePath - the absolute target path where the application will be generated
  * @param fs - optional mem-fs editor instance
  * @param log - optional logger instance
- * @param metadata - optional metadata for the OPA test generation
+ * @param metadata - optional pre-read OData metadata XML for the OPA test generation
  * @param manifest - optional application manifest, used to detect ALP configuration
  * @returns feature data extracted from the application model
  */
@@ -77,7 +79,7 @@ export async function getAppFeatures(
     let listReportPage: PageWithModelV4 | null = null;
     let objectPages: PageWithModelV4[] | null = null;
     let fpmPage: PageWithModelV4 | null = null;
-    let projectMetadata = metadata;
+    let convertedMetadata: ConvertedMetadata | undefined;
     // Read application model to extract control information needed for test generation
     // specification and readApp might not be available due to specification version, fail gracefully
     try {
@@ -86,12 +88,7 @@ export async function getAppFeatures(
         const specification = await appAccess.getSpecification<Specification>();
         const appModel: ReadAppResult = await specification.readApp({ app: appAccess, fs: fs });
 
-        if (!projectMetadata) {
-            const metadataPath = appAccess.project?.apps['']?.services?.mainService?.local;
-            if (metadataPath) {
-                projectMetadata = fs?.read(metadataPath);
-            }
-        }
+        convertedMetadata = await loadServiceMetadata(appAccess, fs, log, metadata);
 
         listReportPage = appModel?.applicationModel ? getListReportPage(appModel.applicationModel) : listReportPage;
         objectPages = appModel?.applicationModel ? getObjectPages(appModel.applicationModel) : objectPages;
@@ -112,11 +109,16 @@ export async function getAppFeatures(
     // attempt to get individual feature data
     try {
         if (listReportPage) {
-            featureData.listReport = getListReportFeatures(listReportPage, log, projectMetadata, manifest);
+            featureData.listReport = getListReportFeatures(listReportPage, log, convertedMetadata, manifest);
         }
         if (objectPages) {
             log?.warn('Extracting Object Page features from application model');
-            featureData.objectPages = await getObjectPageFeatures(objectPages, listReportPage?.name, log);
+            featureData.objectPages = await getObjectPageFeatures(
+                objectPages,
+                listReportPage?.name,
+                log,
+                convertedMetadata
+            );
             log?.warn('objectPages features extracted: ' + JSON.stringify(featureData.objectPages));
         }
         if (fpmPage) {

--- a/packages/ui5-test-writer/src/utils/objectPageUtils.ts
+++ b/packages/ui5-test-writer/src/utils/objectPageUtils.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@sap-ux/logger';
 import type { ApplicationModel } from '@sap/ux-specification/dist/types/src/parser';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 import type {
     FormField,
     SectionFormField,
@@ -20,6 +21,8 @@ import {
 } from './modelUtils';
 import { extractTableColumnsFromNode } from './tableUtils';
 import { PageTypeV4 } from '@sap/ux-specification/dist/types/src/common/page';
+import { resolveMicroChartType } from './microChartUtils';
+import { isFacetHidden } from './facetUtils';
 
 /**
  * Extracts feature data for object pages from the application model.
@@ -27,12 +30,14 @@ import { PageTypeV4 } from '@sap/ux-specification/dist/types/src/common/page';
  * @param objectPages - the array of object pages extracted from the application model
  * @param listReportPageKey - the key of the List Report page in the application model, used to find navigation routes to object pages
  * @param log - optional logger instance
+ * @param metadata - optional converted metadata of the main service, used to resolve microchart types
  * @returns a record of object page feature data
  */
 export async function getObjectPageFeatures(
     objectPages: PageWithModelV4[],
     listReportPageKey?: string,
-    log?: Logger
+    log?: Logger,
+    metadata?: ConvertedMetadata
 ): Promise<ObjectPageFeatures[]> {
     const objectPageFeatures: ObjectPageFeatures[] = [];
     if (!objectPages || objectPages.length === 0) {
@@ -51,9 +56,11 @@ export async function getObjectPageFeatures(
             listReportPageKey
         );
         // extract header sections (facets)
-        pageFeatureData.headerSections = extractObjectPageHeaderSectionsData(objectPage);
+        pageFeatureData.headerSections = extractObjectPageHeaderSectionsData(objectPage, metadata, log);
         // extract body sections
-        pageFeatureData.bodySections = extractObjectPageBodySectionsData(objectPage);
+        pageFeatureData.bodySections = extractObjectPageBodySectionsData(objectPage, metadata, log);
+        pageFeatureData.headerSectionsRenderableCount = countRenderableSections(pageFeatureData.headerSections);
+        pageFeatureData.bodySectionsRenderableCount = countRenderableSections(pageFeatureData.bodySections);
         objectPageFeatures.push(pageFeatureData);
     }
 
@@ -112,9 +119,15 @@ function getObjectPageNavigationParents(
  *  Extracts header sections data from an object page model.
  *
  * @param objectPage - object page from the application model
+ * @param metadata - optional converted metadata of the main service, used to resolve microchart types
+ * @param log - optional logger instance
  * @returns header sections data
  */
-function extractObjectPageHeaderSectionsData(objectPage: PageWithModelV4): HeaderSectionFeatureData[] {
+function extractObjectPageHeaderSectionsData(
+    objectPage: PageWithModelV4,
+    metadata?: ConvertedMetadata,
+    log?: Logger
+): HeaderSectionFeatureData[] {
     const headerSections: HeaderSectionFeatureData[] = [];
     if (objectPage.model) {
         const headerAggregation = getAggregations(objectPage.model.root)['header'];
@@ -126,15 +139,31 @@ function extractObjectPageHeaderSectionsData(objectPage: PageWithModelV4): Heade
                 // if no identifier can be found for the section, it is not possible to reliably identify it in tests, so skip it
                 return;
             }
+            const isMicroChart = isSectionMicroChart(section);
+            const targetValue = getSectionTargetValue(section);
             const sectionData: HeaderSectionFeatureData = {
                 facetId: facetId,
                 stashed: getSectionStashedFlag(section),
                 custom: section.custom,
-                microChart: isSectionMicroChart(section),
+                microChart: isMicroChart,
                 form: isFormSection(section),
                 // collection: false // TODO: find out how to identify collection facets
-                title: section.title
+                title: section.title,
+                hidden: isFacetHidden(
+                    objectPage.entitySet,
+                    'HeaderFacets',
+                    { target: targetValue, id: facetId },
+                    metadata,
+                    log
+                )
             };
+            if (isMicroChart) {
+                const microChartType = resolveMicroChartType(targetValue, objectPage.entitySet, metadata, log);
+                if (microChartType) {
+                    sectionData.microChartId = facetId;
+                    sectionData.microChartType = microChartType;
+                }
+            }
             if (sectionData.form) {
                 sectionData.fields = getHeaderSectionFormFields(section);
             }
@@ -145,19 +174,45 @@ function extractObjectPageHeaderSectionsData(objectPage: PageWithModelV4): Heade
 }
 
 /**
+ * Counts sections that will render at runtime (those whose `hidden` is not `true`).
+ * Sections marked `'dynamic'` are counted because they may render — the test for them is
+ * emitted as a comment regardless.
+ *
+ * @param sections - the section list to count
+ * @returns the renderable count
+ */
+function countRenderableSections(sections: { hidden?: boolean | 'dynamic' }[] | undefined): number {
+    return (sections ?? []).filter((section) => section.hidden !== true).length;
+}
+
+/**
+ * @param section - section entry from ux specification
+ * @returns the value of the section's `Target` schema key, or undefined if not present
+ */
+function getSectionTargetValue(section: SectionItem): string | undefined {
+    return section?.schema?.keys?.find((key) => key.name === 'Target')?.value;
+}
+
+/**
  * Extracts body sections data from an object page model.
  *
  * @param objectPage - object page from the application model
+ * @param metadata - optional converted metadata of the main service, used to detect `UI.Hidden` facets
+ * @param log - optional logger instance
  * @returns body sections data including sub-sections
  */
-function extractObjectPageBodySectionsData(objectPage: PageWithModelV4): BodySectionFeatureData[] {
+function extractObjectPageBodySectionsData(
+    objectPage: PageWithModelV4,
+    metadata?: ConvertedMetadata,
+    log?: Logger
+): BodySectionFeatureData[] {
     const bodySections: BodySectionFeatureData[] = [];
     if (objectPage.model) {
         const sectionsAggregation = getAggregations(objectPage.model.root)['sections'];
         const sections = getAggregations(sectionsAggregation) as Record<string, BodySectionItem>;
         Object.entries(sections).forEach(([sectionKey, section]) => {
             const sectionId = getSectionIdentifier(section) ?? sectionKey;
-            const subSections = extractBodySubSectionsData(section, sectionId);
+            const subSections = extractBodySubSectionsData(section, sectionId, objectPage.entitySet, metadata, log);
             bodySections.push({
                 id: sectionId,
                 navigationProperty: getNavigationPropertyFromKey(sectionKey),
@@ -166,7 +221,14 @@ function extractObjectPageBodySectionsData(objectPage: PageWithModelV4): BodySec
                 order: section?.order ?? -1, // put a negative order number to signal that order was not in spec
                 fields: section.custom || section.isTable ? [] : extractFormFields(section),
                 tableColumns: section.custom || !section.isTable ? {} : extractTableColumnsFromNode(section),
-                subSections
+                subSections,
+                hidden: isFacetHidden(
+                    objectPage.entitySet,
+                    'Facets',
+                    { target: getSectionTargetValue(section), id: sectionId },
+                    metadata,
+                    log
+                )
             });
         });
     }
@@ -179,9 +241,18 @@ function extractObjectPageBodySectionsData(objectPage: PageWithModelV4): BodySec
  *
  * @param section - body section entry from the application model
  * @param parentSectionId - identifier of the parent section (used as fallback key prefix)
+ * @param pageEntitySet - the page entity set name; used together with `metadata` to detect `UI.Hidden` sub-sections
+ * @param metadata - optional converted metadata of the main service
+ * @param log - optional logger instance
  * @returns array of sub-section feature data
  */
-function extractBodySubSectionsData(section: SectionItem, parentSectionId: string): BodySubSectionFeatureData[] {
+function extractBodySubSectionsData(
+    section: SectionItem,
+    parentSectionId: string,
+    pageEntitySet?: string,
+    metadata?: ConvertedMetadata,
+    log?: Logger
+): BodySubSectionFeatureData[] {
     const subSections: BodySubSectionFeatureData[] = [];
     const subSectionsAggregation = getAggregations(section)['subSections'];
     const subSectionItems = getAggregations(subSectionsAggregation) as Record<string, BodySectionItem>;
@@ -194,7 +265,14 @@ function extractBodySubSectionsData(section: SectionItem, parentSectionId: strin
             custom: !!subSection.custom,
             order: subSection?.order ?? -1, // put a negative order number to signal that order was not in spec
             fields: subSection.custom || subSection.isTable ? [] : extractFormFields(subSection),
-            tableColumns: subSection.custom || !subSection.isTable ? {} : extractTableColumnsFromNode(subSection)
+            tableColumns: subSection.custom || !subSection.isTable ? {} : extractTableColumnsFromNode(subSection),
+            hidden: isFacetHidden(
+                pageEntitySet,
+                'Facets',
+                { target: getSectionTargetValue(subSection), id: subSectionId },
+                metadata,
+                log
+            )
         });
     });
     return subSections;

--- a/packages/ui5-test-writer/src/utils/xmlMetadataUtils.ts
+++ b/packages/ui5-test-writer/src/utils/xmlMetadataUtils.ts
@@ -1,0 +1,118 @@
+import type { Editor } from 'mem-fs-editor';
+import type { Logger } from '@sap-ux/logger';
+import type { ApplicationAccess } from '@sap-ux/project-access';
+import type { ConvertedMetadata, RawMetadata } from '@sap-ux/vocabularies-types';
+import { parse, merge } from '@sap-ux/edmx-parser';
+import { convert } from '@sap-ux/annotation-converter';
+
+const MAIN_APP_KEY = '';
+const MAIN_SERVICE_KEY = 'mainService';
+const METADATA_FILE_ID = 'metadata';
+const ANNOTATION_FILE_ID_PREFIX = 'annotation';
+
+interface XmlSource {
+    fileIdentification: string;
+    xml: string;
+}
+
+/**
+ * Reads an XML file from the mem-fs editor, swallowing read errors.
+ *
+ * @param filePath - absolute path to the XML file
+ * @param fs - mem-fs editor used to read the file
+ * @param log - optional logger
+ * @returns XML content, or undefined if the file is missing or unreadable
+ */
+function readXmlFile(filePath: string, fs?: Editor, log?: Logger): string | undefined {
+    if (!fs) {
+        return undefined;
+    }
+    try {
+        const content = fs.read(filePath);
+        return content || undefined;
+    } catch (error) {
+        log?.debug(`Could not read XML file ${filePath}: ${(error as Error).message}`);
+        return undefined;
+    }
+}
+
+/**
+ * Collects metadata and annotation XML sources for the main OData service.
+ *
+ * @param appAccess - application access from project-access
+ * @param fs - mem-fs editor used to read the XML files
+ * @param log - optional logger
+ * @param metadataOverride - optional pre-read metadata XML; when provided, annotation files are skipped
+ * @returns metadata + annotation XML sources for the main OData service
+ */
+function collectServiceXmlSources(
+    appAccess: ApplicationAccess | undefined,
+    fs?: Editor,
+    log?: Logger,
+    metadataOverride?: string
+): XmlSource[] {
+    const sources: XmlSource[] = [];
+
+    if (metadataOverride) {
+        sources.push({ fileIdentification: METADATA_FILE_ID, xml: metadataOverride });
+        return sources;
+    }
+
+    const service = appAccess?.project?.apps[MAIN_APP_KEY]?.services?.[MAIN_SERVICE_KEY];
+
+    if (service?.local) {
+        const metadataXml = readXmlFile(service.local, fs, log);
+        if (metadataXml) {
+            sources.push({ fileIdentification: METADATA_FILE_ID, xml: metadataXml });
+        }
+    }
+
+    service?.annotations?.forEach((annotation, index) => {
+        if (annotation.local) {
+            const annotationXml = readXmlFile(annotation.local, fs, log);
+            if (annotationXml) {
+                sources.push({
+                    fileIdentification: `${ANNOTATION_FILE_ID_PREFIX}_${index}`,
+                    xml: annotationXml
+                });
+            }
+        }
+    });
+
+    return sources;
+}
+
+/**
+ * Loads the OData metadata of the main service together with its referenced local annotation files,
+ * and returns the converted metadata model.
+ *
+ * This module is the single home for all XML loading and parsing in this package; other utilities
+ * should consume the returned `ConvertedMetadata` rather than dealing with raw XML.
+ *
+ * @param appAccess - application access from project-access (provides resolved service paths)
+ * @param fs - mem-fs editor used to read the XML files
+ * @param log - optional logger
+ * @param metadataOverride - optional pre-read metadata XML; when provided, annotation files are skipped
+ * @returns converted metadata, or undefined if no XML could be loaded or conversion failed
+ */
+export async function loadServiceMetadata(
+    appAccess: ApplicationAccess | undefined,
+    fs?: Editor,
+    log?: Logger,
+    metadataOverride?: string
+): Promise<ConvertedMetadata | undefined> {
+    const sources = collectServiceXmlSources(appAccess, fs, log, metadataOverride);
+
+    if (sources.length === 0) {
+        return undefined;
+    }
+
+    try {
+        const parsed: RawMetadata[] = sources.map((entry) => parse(entry.xml, entry.fileIdentification));
+        const mergedRaw = parsed.length > 1 ? merge(...parsed) : parsed[0];
+        return convert(mergedRaw);
+    } catch (error) {
+        log?.debug(`Failed to parse or convert service metadata: ${(error as Error).message}`);
+        return undefined;
+    }
+}

--- a/packages/ui5-test-writer/templates/v4/integration/ObjectPageJourney.js
+++ b/packages/ui5-test-writer/templates/v4/integration/ObjectPageJourney.js
@@ -42,8 +42,24 @@ sap.ui.define([
 <% if (headerSections?.length > 0) { -%>
         opaTest("Check header facets of the Object Page", function (Given, When, Then) {
 <% headerSections.forEach(function(section) { -%>
-<% if (section.microChart) { -%>
+<% if (section.hidden === true) { -%>
+            // Test skipped for header facet "<%- section.facetId %>" - UI.Hidden annotation is set to true
+<% } else if (section.hidden === 'dynamic') { -%>
+            // Test skipped for header facet "<%- section.facetId %>" - UI.Hidden annotation is an expression which the generator is unable to resolve.
+            // Uncomment and adjust if the expression is known to evaluate to false at runtime:
+<% if (section.microChart && section.microChartId && section.microChartType) { -%>
+            // Then.onThe<%- name%>.onHeader().iCheckMicroChart({ chartId: "<%- section.microChartId %>", chartType: "<%- section.microChartType %>" });
+<% } else if (section.microChart) { -%>
+            // Then.onThe<%- name%>.onHeader().iCheckMicroChart("<%- section.title %>");
+<% } else { -%>
+            // Then.onThe<%- name%>.onHeader().iCheckHeaderFacet({ facetId: "<%- section.facetId %>" });
+<% } -%>
+<% } else if (section.microChart) { -%>
+<% if (section.microChartId && section.microChartType) { -%>
+            Then.onThe<%- name%>.onHeader().iCheckMicroChart({ chartId: "<%- section.microChartId %>", chartType: "<%- section.microChartType %>" });
+<% } else { -%>
             Then.onThe<%- name%>.onHeader().iCheckMicroChart("<%- section.title %>");
+<% } -%>
 <% } else { -%>
             Then.onThe<%- name%>.onHeader().iCheckHeaderFacet({ facetId: "<%- section.facetId %>" });
 <% if (section.form) { -%>
@@ -62,16 +78,33 @@ sap.ui.define([
 
 <% if (bodySections?.length > 0 && !isStandalone) { -%>
         opaTest("Check body sections of the Object Page", function (Given, When, Then) {
-<% if (bodySections?.length > 1) { -%>
-            Then.onThe<%- name%>.iCheckNumberOfSections(<%- bodySections.length %>);
+<% if (bodySectionsRenderableCount > 1) { -%>
+            Then.onThe<%- name%>.iCheckNumberOfSections(<%- bodySectionsRenderableCount %>);
 <% } -%>
 <% bodySections.forEach(function(section) { -%>
-<% if (bodySections.length > 1) { -%>
+<% if (section.hidden === true) { -%>
+            // Test skipped for body section "<%- section.id %>" - UI.Hidden annotation is set to true
+<% } else if (section.hidden === 'dynamic') { -%>
+            // Test skipped for body section "<%- section.id %>" - UI.Hidden annotation is an expression which the generator is unable to resolve.
+            // Uncomment and adjust if the expression is known to evaluate to false at runtime:
+<% if (bodySectionsRenderableCount > 1) { -%>
+            // When.onThe<%- name%>.iPressSectionIconTabFilterButton("<%- section.id %>");
+<% } -%>
+            // Then.onThe<%- name%>.iCheckSection({ section: "<%- section.id %>" });
+<% } else { -%>
+<% if (bodySectionsRenderableCount > 1) { -%>
             When.onThe<%- name%>.iPressSectionIconTabFilterButton("<%- section.id %>");
 <% } -%>
             Then.onThe<%- name%>.iCheckSection({ section: "<%- section.id %>" });
 <% if (section?.subSections?.length > 0) { -%>
 <% section.subSections.forEach(function(subSection) { -%>
+<% if (subSection.hidden === true) { -%>
+            // Test skipped for sub-section "<%- subSection.id %>" - UI.Hidden annotation is set to true
+<% } else if (subSection.hidden === 'dynamic') { -%>
+            // Test skipped for sub-section "<%- subSection.id %>" - UI.Hidden annotation is an expression which the generator is unable to resolve.
+            // Uncomment and adjust if the expression is known to evaluate to false at runtime:
+            // Then.onThe<%- name%>.iCheckSubSection({ section: "<%- subSection.id %>" });
+<% } else { -%>
             //When.onThe<%- name%>.iGoToSection({ section: "<%- section.id %>", subSection: "<%- subSection.id %>" });
             Then.onThe<%- name%>.iCheckSubSection({ section: "<%- subSection.id %>" });
 <% if (subSection.fields && subSection.fields.length > 0) { -%>
@@ -82,6 +115,7 @@ sap.ui.define([
 <% if (subSection.tableColumns && Object.keys(subSection.tableColumns).length > 0 && subSection.navigationProperty) { -%>
             Then.onThe<%- name%>.onTable({ property: "<%- subSection.navigationProperty %>" }).iCheckColumns(<%- JSON.stringify(subSection.tableColumns) %>);
 <% } -%>
+<% } -%>
 <% }) -%>
 <% } else { -%>
 <% if (section.fields && section.fields.length > 0) { -%>
@@ -91,6 +125,7 @@ sap.ui.define([
 <% } -%>
 <% if (section.tableColumns && Object.keys(section.tableColumns).length > 0 && section.navigationProperty) { -%>
             Then.onThe<%- name%>.onTable({ property: "<%- section.navigationProperty %>" }).iCheckColumns(<%- JSON.stringify(section.tableColumns) %>);
+<% } -%>
 <% } -%>
 <% } -%>
 <% }) -%>

--- a/packages/ui5-test-writer/test/unit/fiori-elements.test.ts
+++ b/packages/ui5-test-writer/test/unit/fiori-elements.test.ts
@@ -34,6 +34,12 @@ jest.mock('../../src/utils/opaQUnitUtils', () => ({
     addPathsToQUnitJs: (...args: unknown[]) => addPathsToQUnitJsMock(...args)
 }));
 
+const loadServiceMetadataMock = jest.fn();
+jest.mock('../../src/utils/xmlMetadataUtils', () => ({
+    ...(jest.requireActual('../../src/utils/xmlMetadataUtils') as object),
+    loadServiceMetadata: (...args: unknown[]) => loadServiceMetadataMock(...args)
+}));
+
 describe('ui5-test-writer', () => {
     let fs: Editor | undefined;
     const debug = !!process.env['UX_DEBUG'];
@@ -50,6 +56,11 @@ describe('ui5-test-writer', () => {
             addPathsToQUnitJs: typeof addPathsToQUnitJsMock;
         }>('../../src/utils/opaQUnitUtils');
         addPathsToQUnitJsMock.mockImplementation(realAddPaths);
+    });
+
+    beforeEach(() => {
+        loadServiceMetadataMock.mockReset();
+        loadServiceMetadataMock.mockResolvedValue(undefined);
     });
 
     function prepareTestFiles(testConfigurationName: string): string {
@@ -655,6 +666,109 @@ describe('ui5-test-writer', () => {
             expect(bookingObjPageJourneyContent).toContain('onTable({ property: "_Supplements" }).iCheckColumns(');
             expect(bookingObjPageJourneyContent).toContain('"ConnectionId":{"header":"Connection"}');
             expect(bookingObjPageJourneyContent).toContain('"AirportCode":{"header":"Airport"}');
+        });
+
+        it('emits the chartId/chartType identifier when metadata resolves the chart type', async () => {
+            readAppMock.mockResolvedValueOnce(JSON.parse(appModels.V4_WITH_SUB_OBJECT_PAGE));
+            loadServiceMetadataMock.mockResolvedValueOnce({
+                entitySets: [
+                    {
+                        name: 'Booking',
+                        entityType: {
+                            navigationProperties: [],
+                            annotations: {
+                                UI: {
+                                    'Chart#SupplementPrice': {
+                                        term: 'com.sap.vocabularies.UI.v1.Chart',
+                                        ChartType: 'UI.ChartType/Line'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            });
+            const projectDir = prepareTestFiles('LROPv4');
+            fs = await generateOPAFiles(projectDir, {}, metadata, fs);
+
+            const bookingObjPageJourneyContent =
+                fs.dump()['test/test-output/LROPv4/webapp/test/integration/BookingObjectPageJourney.js'].contents;
+            expect(bookingObjPageJourneyContent).toContain(
+                'iCheckMicroChart({ chartId: "Chart::SupplementPrice", chartType: "LineMicroChart" })'
+            );
+            expect(bookingObjPageJourneyContent).not.toContain('iCheckMicroChart("Supplement Price")');
+        });
+
+        it('skips assertions for sections marked UI.Hidden in metadata', async () => {
+            readAppMock.mockResolvedValueOnce(JSON.parse(appModels.V4_WITH_SUB_OBJECT_PAGE));
+            loadServiceMetadataMock.mockResolvedValueOnce({
+                entitySets: [
+                    {
+                        name: 'Booking',
+                        entityType: {
+                            navigationProperties: [],
+                            annotations: {
+                                UI: {
+                                    HeaderFacets: [
+                                        {
+                                            $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                            Target: { value: 'com.sap.vocabularies.UI.v1.Chart#SupplementPrice' },
+                                            annotations: { UI: { Hidden: true } }
+                                        }
+                                    ],
+                                    Facets: [
+                                        {
+                                            $Type: 'com.sap.vocabularies.UI.v1.CollectionFacet',
+                                            ID: 'FlightData',
+                                            Facets: [],
+                                            annotations: { UI: { Hidden: true } }
+                                        },
+                                        {
+                                            $Type: 'com.sap.vocabularies.UI.v1.CollectionFacet',
+                                            ID: 'PriceData',
+                                            Facets: [],
+                                            annotations: { UI: { Hidden: { $Path: 'isHiddenProp' } } }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            });
+            const projectDir = prepareTestFiles('LROPv4');
+            fs = await generateOPAFiles(projectDir, {}, metadata, fs);
+
+            const bookingObjPageJourneyContent =
+                fs.dump()['test/test-output/LROPv4/webapp/test/integration/BookingObjectPageJourney.js'].contents;
+            // Hidden=true header facet emits a skip comment, no actual assertion
+            expect(bookingObjPageJourneyContent).toContain(
+                '// Test skipped for header facet "Chart::SupplementPrice" - UI.Hidden annotation is set to true'
+            );
+            expect(bookingObjPageJourneyContent).not.toMatch(/^\s*Then\.[^/]*iCheckMicroChart/m);
+            // Hidden=true body section emits a skip comment, no actual assertion
+            expect(bookingObjPageJourneyContent).toContain(
+                '// Test skipped for body section "FlightData" - UI.Hidden annotation is set to true'
+            );
+            expect(bookingObjPageJourneyContent).not.toMatch(
+                /^\s*Then\.[^/]*iCheckSection\(\{ section: "FlightData" \}\)/m
+            );
+            // Dynamic Hidden body section emits an explanation + commented-out assertion
+            expect(bookingObjPageJourneyContent).toContain(
+                '// Test skipped for body section "PriceData" - UI.Hidden annotation is an expression which the generator is unable to resolve.'
+            );
+            expect(bookingObjPageJourneyContent).toContain(
+                '// Then.onTheBookingObjectPage.iCheckSection({ section: "PriceData" });'
+            );
+            expect(bookingObjPageJourneyContent).not.toMatch(
+                /^\s*Then\.[^/]*iCheckSection\(\{ section: "PriceData" \}\)/m
+            );
+            // Visible body section is still asserted
+            expect(bookingObjPageJourneyContent).toMatch(
+                /^\s*Then\.[^/]*iCheckSection\(\{ section: "BookingDetails" \}\)/m
+            );
+            // Section count reflects only renderable sections (FlightData hidden=true is excluded; PriceData dynamic is included)
+            expect(bookingObjPageJourneyContent).toContain('iCheckNumberOfSections(2)');
         });
     });
 });

--- a/packages/ui5-test-writer/test/unit/utils/facetUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/facetUtils.test.ts
@@ -1,0 +1,225 @@
+import type { Logger } from '@sap-ux/logger';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
+import { isFacetHidden } from '../../../src/utils/facetUtils';
+
+/**
+ * Builds a minimal `ConvertedMetadata` stub from a compact spec.
+ *
+ * @param spec - description of entity sets and the UI annotations attached to their entity types
+ * @param spec.entitySets - entity sets directly reachable from the page
+ * @returns a minimal ConvertedMetadata stub for the test
+ */
+function buildMetadata(spec: {
+    entitySets: {
+        name: string;
+        entityType: { uiAnnotations?: Record<string, unknown> };
+    }[];
+}): ConvertedMetadata {
+    return {
+        entitySets: spec.entitySets.map((es) => ({
+            name: es.name,
+            entityType: { annotations: { UI: es.entityType.uiAnnotations ?? {} } }
+        }))
+    } as unknown as ConvertedMetadata;
+}
+
+describe('isFacetHidden()', () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn()
+        } as unknown as Logger;
+    });
+
+    test('returns false when metadata is undefined', () => {
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'X' }, undefined)).toBe(false);
+    });
+
+    test('returns false when entity set name is missing', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(isFacetHidden(undefined, 'HeaderFacets', { id: 'X' }, metadata)).toBe(false);
+    });
+
+    test('returns false when neither target nor id is provided', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', {}, metadata)).toBe(false);
+    });
+
+    test('returns false when entity set is not in metadata', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(isFacetHidden('Missing', 'HeaderFacets', { id: 'X' }, metadata, mockLogger)).toBe(false);
+    });
+
+    test('returns false when no facets collection exists on the entity type', () => {
+        const metadata = buildMetadata({ entitySets: [{ name: 'TestSet', entityType: {} }] });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'X' }, metadata)).toBe(false);
+    });
+
+    test('returns true for a HeaderFacet with UI.Hidden = true (matched by Target)', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            HeaderFacets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    Target: { value: 'com.sap.vocabularies.UI.v1.Chart#X' },
+                                    annotations: { UI: { Hidden: true } }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(
+            isFacetHidden('TestSet', 'HeaderFacets', { target: 'com.sap.vocabularies.UI.v1.Chart#X' }, metadata)
+        ).toBe(true);
+    });
+
+    test('returns true for a HeaderFacet with UI.Hidden = true (matched by ID)', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            HeaderFacets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    ID: 'MyFacet',
+                                    annotations: { UI: { Hidden: true } }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'MyFacet' }, metadata)).toBe(true);
+    });
+
+    test('returns false when UI.Hidden = false', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            HeaderFacets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    ID: 'MyFacet',
+                                    annotations: { UI: { Hidden: false } }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'MyFacet' }, metadata)).toBe(false);
+    });
+
+    test('returns false when no UI.Hidden annotation is present', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            HeaderFacets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    ID: 'MyFacet',
+                                    annotations: { UI: {} }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'MyFacet' }, metadata)).toBe(false);
+    });
+
+    test("returns 'dynamic' for an expression-form UI.Hidden value", () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            HeaderFacets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    ID: 'MyFacet',
+                                    annotations: { UI: { Hidden: { $Path: 'someProperty' } } }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'MyFacet' }, metadata)).toBe('dynamic');
+    });
+
+    test('descends into CollectionFacet.Facets to find a hidden sub-section', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            Facets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.CollectionFacet',
+                                    ID: 'Outer',
+                                    Facets: [
+                                        {
+                                            $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                            ID: 'Inner',
+                                            annotations: { UI: { Hidden: true } }
+                                        }
+                                    ],
+                                    annotations: { UI: {} }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        expect(isFacetHidden('TestSet', 'Facets', { id: 'Inner' }, metadata)).toBe(true);
+    });
+
+    test('does not match a facet in the wrong collection', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            Facets: [
+                                {
+                                    $Type: 'com.sap.vocabularies.UI.v1.ReferenceFacet',
+                                    ID: 'BodyOnly',
+                                    annotations: { UI: { Hidden: true } }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        // Looking for the same id in HeaderFacets should not find the body facet
+        expect(isFacetHidden('TestSet', 'HeaderFacets', { id: 'BodyOnly' }, metadata)).toBe(false);
+    });
+});

--- a/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/listReportUtils.test.ts
@@ -19,6 +19,19 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PageWithModelV4 } from '@sap/ux-specification/dist/types/src/parser/application';
 import type { Manifest } from '@sap-ux/project-access';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
+import { parse } from '@sap-ux/edmx-parser';
+import { convert } from '@sap-ux/annotation-converter';
+
+/**
+ * Parses and converts an OData metadata XML string into the shape these utilities consume.
+ *
+ * @param xml - OData metadata XML
+ * @returns the converted metadata
+ */
+function toConvertedMetadata(xml: string): ConvertedMetadata {
+    return convert(parse(xml));
+}
 
 describe('Test buildButtonState()', () => {
     test('should return visible false when buttonState is undefined', () => {
@@ -128,14 +141,14 @@ describe('Test safeCheckButtonVisibility()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = safeCheckButtonVisibility(validMetadata, 'TestSet', mockLogger);
+        const result = safeCheckButtonVisibility(toConvertedMetadata(validMetadata), 'TestSet', mockLogger);
         expect(result).toBeDefined();
         expect(result?.create).toBeDefined();
         expect(result?.delete).toBeDefined();
     });
 
-    test('should return undefined and log debug when metadata is invalid', () => {
-        const result = safeCheckButtonVisibility('invalid xml', 'TestSet', mockLogger);
+    test('should return undefined and log debug when metadata structure is malformed', () => {
+        const result = safeCheckButtonVisibility({} as ConvertedMetadata, 'TestSet', mockLogger);
         expect(result).toBeUndefined();
         expect(mockLogger.debug).toHaveBeenCalled();
     });
@@ -150,19 +163,22 @@ describe('Test safeCheckButtonVisibility()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = safeCheckButtonVisibility(validMetadata, 'NonExistentEntitySet', mockLogger);
+        const result = safeCheckButtonVisibility(
+            toConvertedMetadata(validMetadata),
+            'NonExistentEntitySet',
+            mockLogger
+        );
         expect(result).toBeUndefined();
         expect(mockLogger.debug).toHaveBeenCalled();
     });
 
     test('should handle missing logger gracefully', () => {
-        const result = safeCheckButtonVisibility('invalid xml', 'TestSet');
+        const result = safeCheckButtonVisibility({} as ConvertedMetadata, 'TestSet');
         expect(result).toBeUndefined();
     });
 
-    test('should log error message when parse error occurs', () => {
-        const invalidMetadata = '<invalid>xml</invalid>';
-        safeCheckButtonVisibility(invalidMetadata, 'TestSet', mockLogger);
+    test('should log error message when an entity set lookup fails', () => {
+        safeCheckButtonVisibility({} as ConvertedMetadata, 'TestSet', mockLogger);
         expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining('Failed to check button visibility'));
     });
 });
@@ -196,13 +212,13 @@ describe('Test safeCheckActionButtonStates()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = safeCheckActionButtonStates(validMetadata, 'TestSet', [], mockLogger);
+        const result = safeCheckActionButtonStates(toConvertedMetadata(validMetadata), 'TestSet', [], mockLogger);
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);
     });
 
-    test('should return empty array and log debug when metadata is invalid', () => {
-        const result = safeCheckActionButtonStates('invalid xml', 'TestSet', [], mockLogger);
+    test('should return empty array and log debug when metadata structure is malformed', () => {
+        const result = safeCheckActionButtonStates({} as ConvertedMetadata, 'TestSet', [], mockLogger);
         expect(result).toEqual([]);
         expect(mockLogger.debug).toHaveBeenCalled();
     });
@@ -217,13 +233,18 @@ describe('Test safeCheckActionButtonStates()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = safeCheckActionButtonStates(validMetadata, 'NonExistentEntitySet', [], mockLogger);
+        const result = safeCheckActionButtonStates(
+            toConvertedMetadata(validMetadata),
+            'NonExistentEntitySet',
+            [],
+            mockLogger
+        );
         expect(result).toEqual([]);
         expect(mockLogger.debug).toHaveBeenCalled();
     });
 
     test('should handle missing logger gracefully', () => {
-        const result = safeCheckActionButtonStates('invalid xml', 'TestSet', []);
+        const result = safeCheckActionButtonStates({} as ConvertedMetadata, 'TestSet', []);
         expect(result).toEqual([]);
     });
 
@@ -244,7 +265,7 @@ describe('Test safeCheckActionButtonStates()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = safeCheckActionButtonStates(validMetadata, 'TestSet', [], mockLogger);
+        const result = safeCheckActionButtonStates(toConvertedMetadata(validMetadata), 'TestSet', [], mockLogger);
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);
     });
@@ -354,7 +375,7 @@ describe('Test checkButtonVisibility()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkButtonVisibility(minimalMetadata, 'TestSet');
+        const result = checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.create).toEqual({ visible: true, enabled: true });
         expect(result.delete).toEqual({ visible: true, enabled: true });
     });
@@ -378,15 +399,15 @@ describe('Test checkButtonVisibility()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkButtonVisibility(minimalMetadata, 'TestSet');
+        const result = checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'TestSet');
         // When no restrictions, defaults to visible and enabled
         expect(result.create.visible).toBe(true);
         expect(result.create.enabled).toBe(true);
     });
 
-    test('should throw error when metadata is invalid', () => {
+    test('should throw error when metadata structure is malformed', () => {
         expect(() => {
-            checkButtonVisibility('invalid xml', 'TestSet');
+            checkButtonVisibility({} as ConvertedMetadata, 'TestSet');
         }).toThrow('Failed to analyze button visibility');
     });
 
@@ -402,7 +423,7 @@ describe('Test checkButtonVisibility()', () => {
 </edmx:Edmx>`;
 
         expect(() => {
-            checkButtonVisibility(minimalMetadata, 'NonExistentSet');
+            checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'NonExistentSet');
         }).toThrow("Entity set 'NonExistentSet' not found in metadata");
     });
 
@@ -428,7 +449,7 @@ describe('Test checkButtonVisibility()', () => {
 </edmx:Edmx>`;
 
         // When restrictions are not present, function returns defaults
-        const result = checkButtonVisibility(minimalMetadata, 'TestSet');
+        const result = checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.create.visible).toBe(true);
         expect(result.create.enabled).toBe(true);
         expect(result.delete.visible).toBe(true);
@@ -454,7 +475,7 @@ describe('Test checkButtonVisibility()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkButtonVisibility(minimalMetadata, 'TestSet');
+        const result = checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'TestSet');
         // When no restrictions are defined, defaults to enabled
         expect(result.delete.visible).toBe(true);
         expect(result.delete.enabled).toBe(true);
@@ -555,7 +576,7 @@ describe('Test checkActionButtonStates()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.actions).toEqual([]);
         expect(result.entityType).toBe('TestEntity');
     });
@@ -579,7 +600,7 @@ describe('Test checkActionButtonStates()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.actions).toEqual([]);
         expect(result.entityType).toBe('TestEntity');
     });
@@ -596,7 +617,7 @@ describe('Test checkActionButtonStates()', () => {
 </edmx:Edmx>`;
 
         expect(() => {
-            checkActionButtonStates(minimalMetadata, 'NonExistentSet');
+            checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'NonExistentSet');
         }).toThrow("Entity set 'NonExistentSet' not found in metadata");
     });
 
@@ -621,13 +642,13 @@ describe('Test checkActionButtonStates()', () => {
 </edmx:Edmx>`;
 
         // When entity type exists, function should succeed
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.entityType).toBe('TestEntity');
     });
 
-    test('should handle invalid metadata gracefully', () => {
+    test('should handle malformed metadata gracefully', () => {
         expect(() => {
-            checkActionButtonStates('invalid xml', 'TestSet');
+            checkActionButtonStates({} as ConvertedMetadata, 'TestSet');
         }).toThrow('Failed to analyze action button states');
     });
 
@@ -650,7 +671,7 @@ describe('Test checkActionButtonStates()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet', ['Check']);
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet', ['Check']);
         expect(result.actions).toBeDefined();
         expect(Array.isArray(result.actions)).toBe(true);
         // When no LineItem annotation, returns empty array
@@ -675,7 +696,7 @@ describe('Test checkActionButtonStates()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.actions).toBeDefined();
         expect(Array.isArray(result.actions)).toBe(true);
         expect(result.actions).toEqual([]);
@@ -700,16 +721,15 @@ describe('Test checkActionButtonStates()', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkActionButtonStates(minimalMetadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(minimalMetadata), 'TestSet');
         expect(result.actions).toEqual([]);
         expect(result.entityType).toBe('TestEntity');
     });
 
     test('should handle error case and wrap it in Failed to analyze message', () => {
-        // Test the catch block error handling
-        const invalidXml = 'completely broken xml <>';
+        // Test the catch block error handling - malformed metadata triggers the inner error
         expect(() => {
-            checkActionButtonStates(invalidXml, 'TestSet');
+            checkActionButtonStates({} as ConvertedMetadata, 'TestSet');
         }).toThrow('Failed to analyze action button states');
     });
 
@@ -718,7 +738,7 @@ describe('Test checkActionButtonStates()', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Test with Travel entity set which has LineItem annotations
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         expect(result).toBeDefined();
         expect(result.entityType).toBe('TravelType');
@@ -738,7 +758,10 @@ describe('Test checkActionButtonStates()', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Test filtering by action name - looking for specific actions
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel', ['setToBooked', 'deductDiscount']);
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel', [
+            'setToBooked',
+            'deductDiscount'
+        ]);
 
         expect(result).toBeDefined();
         expect(Array.isArray(result.actions)).toBe(true);
@@ -758,7 +781,7 @@ describe('Test checkActionButtonStates()', () => {
     test('should extract InvocationGrouping from real metadata', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Check if any actions have InvocationGrouping
         const actionsWithGrouping = result.actions.filter((a) => a.invocationGrouping);
@@ -773,7 +796,7 @@ describe('Test checkActionButtonStates()', () => {
         // This tests the extractActionMethodName internal function through the public API
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Actions should have properly extracted method names
         if (result.actions.length > 0) {
@@ -791,7 +814,7 @@ describe('Test checkActionButtonStates()', () => {
         // Test with fixture that has OperationAvailable annotations
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Some actions should have enabled state based on OperationAvailable
         if (result.actions.length > 0) {
@@ -810,7 +833,7 @@ describe('Test checkActionButtonStates()', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Get all actions without filtering
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Each action should have an enabled state determined by OperationAvailable annotation
         expect(result.actions.length).toBeGreaterThanOrEqual(0);
@@ -824,7 +847,7 @@ describe('Test checkActionButtonStates()', () => {
         // This tests the extractEnumMemberValue internal function
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Filter actions that have InvocationGrouping
         const actionsWithGrouping = result.actions.filter((a) => a.invocationGrouping);
@@ -861,7 +884,7 @@ describe('Test internal helper function coverage through public APIs', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkButtonVisibility(minimalMetadata, 'TestSet');
+        const result = checkButtonVisibility(toConvertedMetadata(minimalMetadata), 'TestSet');
         // When no restrictions, should return default state
         expect(result.create.visible).toBe(true);
         expect(result.create.enabled).toBe(true);
@@ -874,7 +897,7 @@ describe('Test internal helper function coverage through public APIs', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Test with Booking entity which may have restrictions
-        const result = checkButtonVisibility(fixtureMetadata, 'Booking');
+        const result = checkButtonVisibility(toConvertedMetadata(fixtureMetadata), 'Booking');
 
         // The result should be defined with create and delete properties
         expect(result).toBeDefined();
@@ -888,7 +911,7 @@ describe('Test internal helper function coverage through public APIs', () => {
         // The fixture has path-based restrictions like _Booking/__DeleteByAssociationControl
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkButtonVisibility(fixtureMetadata, 'Booking');
+        const result = checkButtonVisibility(toConvertedMetadata(fixtureMetadata), 'Booking');
 
         // Should handle path-based enabled state
         expect(result).toBeDefined();
@@ -960,7 +983,7 @@ describe('Test internal helper function coverage through public APIs', () => {
     test('should test checkButtonVisibility error wrapping', () => {
         // Test that errors are properly wrapped with context message
         try {
-            checkButtonVisibility('', 'TestSet');
+            checkButtonVisibility({} as ConvertedMetadata, 'TestSet');
             fail('Should have thrown error');
         } catch (error) {
             expect(error).toBeInstanceOf(Error);
@@ -973,13 +996,15 @@ describe('Test internal helper function coverage through public APIs', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Get actions from Travel entity
-        const allActions = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const allActions = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // If there are actions, try filtering by one of them
         if (allActions.actions.length > 0) {
             const firstActionName = allActions.actions[0].action.split('.').pop()?.split('(')[0];
             if (firstActionName) {
-                const filtered = checkActionButtonStates(fixtureMetadata, 'Travel', [firstActionName]);
+                const filtered = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel', [
+                    firstActionName
+                ]);
                 // The filtered result should contain actions
                 expect(filtered.actions.length).toBeGreaterThanOrEqual(0);
             }
@@ -990,12 +1015,12 @@ describe('Test internal helper function coverage through public APIs', () => {
         // Test that findActionStates can match by label as well as action name
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const allActions = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const allActions = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Try to filter by label if actions have labels
         if (allActions.actions.length > 0 && allActions.actions[0].label) {
             const firstLabel = allActions.actions[0].label;
-            const filtered = checkActionButtonStates(fixtureMetadata, 'Travel', [firstLabel]);
+            const filtered = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel', [firstLabel]);
 
             // Should be able to find actions by label
             expect(filtered.actions).toBeDefined();
@@ -1007,7 +1032,7 @@ describe('Test internal helper function coverage through public APIs', () => {
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
         // Call without actionNames parameter
-        const result = checkActionButtonStates(fixtureMetadata, 'Travel');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Travel');
 
         // Should extract all actions
         expect(result.actions).toBeDefined();
@@ -1026,7 +1051,7 @@ describe('Test internal helper function coverage through public APIs', () => {
         // Test with Booking entity which may have different annotations
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'Booking');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'Booking');
 
         // Should successfully parse even if structure is different
         expect(result).toBeDefined();
@@ -1038,7 +1063,7 @@ describe('Test internal helper function coverage through public APIs', () => {
         // Test with another entity to cover more code paths
         const fixtureMetadata = readFileSync(join(__dirname, '../../fixtures/metadata.xml'), 'utf8');
 
-        const result = checkActionButtonStates(fixtureMetadata, 'BookingSupplement');
+        const result = checkActionButtonStates(toConvertedMetadata(fixtureMetadata), 'BookingSupplement');
 
         expect(result).toBeDefined();
         expect(result.entityType).toBeDefined();
@@ -1088,7 +1113,7 @@ describe('Test internal helper function coverage through public APIs', () => {
     </edmx:DataServices>
 </edmx:Edmx>`;
 
-        const result = checkActionButtonStates(metadata, 'TestSet');
+        const result = checkActionButtonStates(toConvertedMetadata(metadata), 'TestSet');
         expect(result.actions).toBeDefined();
         expect(Array.isArray(result.actions)).toBe(true);
 
@@ -1304,7 +1329,7 @@ describe('Test getListReportFeatures()', () => {
             name: 'test'
         };
 
-        const result = getListReportFeatures(mockPageModel, mockLogger, validMetadata);
+        const result = getListReportFeatures(mockPageModel, mockLogger, toConvertedMetadata(validMetadata));
 
         expect(result).toBeDefined();
         expect(result.createButton).toBeDefined();
@@ -1414,7 +1439,7 @@ describe('Test getListReportFeatures()', () => {
         </Schema>
     </edmx:DataServices>
 </edmx:Edmx>`;
-        const result = getListReportFeatures(mockPageModel, mockLogger, validMetadata);
+        const result = getListReportFeatures(mockPageModel, mockLogger, toConvertedMetadata(validMetadata));
 
         expect(result.createButton?.visible).toBe(false);
         expect(result.deleteButton?.visible).toBe(false);
@@ -1532,7 +1557,7 @@ describe('Test getListReportFeatures()', () => {
             name: 'test'
         };
 
-        const result = getListReportFeatures(completePageModel, mockLogger, validMetadata);
+        const result = getListReportFeatures(completePageModel, mockLogger, toConvertedMetadata(validMetadata));
 
         // Verify all components are integrated
         expect(result.filterBarItems).toHaveLength(2);

--- a/packages/ui5-test-writer/test/unit/utils/microChartUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/microChartUtils.test.ts
@@ -1,0 +1,214 @@
+import type { Logger } from '@sap-ux/logger';
+import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
+import { resolveMicroChartType } from '../../../src/utils/microChartUtils';
+
+const PRESENTATION_VARIANT_TERM = 'com.sap.vocabularies.UI.v1.PresentationVariant';
+const CHART_TERM = 'com.sap.vocabularies.UI.v1.Chart';
+
+/**
+ * Builds a minimal `ConvertedMetadata` stub from a compact spec.
+ *
+ * @param spec - description of entity sets and the UI annotations attached to their entity types
+ * @param spec.entitySets - entity sets directly reachable from the page
+ * @param spec.entityTypeMap - lookup of entity types referenced via navigation properties
+ * @returns a minimal ConvertedMetadata stub for the test
+ */
+function buildMetadata(spec: {
+    entitySets: {
+        name: string;
+        entityType: {
+            navigationProperties?: { name: string; targetTypeName: string }[];
+            uiAnnotations?: Record<string, unknown>;
+        };
+    }[];
+    entityTypeMap?: Record<string, { uiAnnotations?: Record<string, unknown> }>;
+}): ConvertedMetadata {
+    // Resolve targetType references inside navigationProperties from entityTypeMap
+    const entitySets = spec.entitySets.map((es) => {
+        const navProps = (es.entityType.navigationProperties ?? []).map((np) => ({
+            name: np.name,
+            targetType: {
+                annotations: { UI: spec.entityTypeMap?.[np.targetTypeName]?.uiAnnotations ?? {} },
+                navigationProperties: []
+            }
+        }));
+        return {
+            name: es.name,
+            entityType: {
+                annotations: { UI: es.entityType.uiAnnotations ?? {} },
+                navigationProperties: navProps
+            }
+        };
+    });
+    return { entitySets } as unknown as ConvertedMetadata;
+}
+
+describe('resolveMicroChartType()', () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn()
+        } as unknown as Logger;
+    });
+
+    test('returns undefined when target value is missing', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(resolveMicroChartType(undefined, 'X', metadata)).toBeUndefined();
+    });
+
+    test('returns undefined when entity set name is missing', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#X', undefined, metadata)).toBeUndefined();
+    });
+
+    test('returns undefined when metadata is undefined', () => {
+        expect(resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#X', 'TestSet', undefined)).toBeUndefined();
+    });
+
+    test('returns undefined when entity set is not found in metadata', () => {
+        const metadata = buildMetadata({ entitySets: [] });
+        expect(
+            resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#X', 'Missing', metadata, mockLogger)
+        ).toBeUndefined();
+    });
+
+    test('resolves a direct UI.Chart annotation to its mapped microchart class', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            'Chart#Revenue': { term: CHART_TERM, ChartType: 'UI.ChartType/Line' }
+                        }
+                    }
+                }
+            ]
+        });
+        const result = resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#Revenue', 'TestSet', metadata);
+        expect(result).toBe('LineMicroChart');
+    });
+
+    test('maps each known UI.ChartType enum to the runtime class name', () => {
+        const cases: { chartType: string; expected: string }[] = [
+            { chartType: 'UI.ChartType/Bullet', expected: 'BulletMicroChart' },
+            { chartType: 'UI.ChartType/Donut', expected: 'RadialMicroChart' },
+            { chartType: 'UI.ChartType/Pie', expected: 'HarveyBallMicroChart' },
+            { chartType: 'UI.ChartType/BarStacked', expected: 'StackedBarMicroChart' },
+            { chartType: 'UI.ChartType/Area', expected: 'AreaMicroChart' },
+            { chartType: 'UI.ChartType/Column', expected: 'ColumnMicroChart' },
+            { chartType: 'UI.ChartType/Bar', expected: 'ComparisonMicroChart' },
+            { chartType: 'UI.ChartType/Line', expected: 'LineMicroChart' }
+        ];
+        cases.forEach(({ chartType, expected }) => {
+            const metadata = buildMetadata({
+                entitySets: [
+                    {
+                        name: 'TestSet',
+                        entityType: {
+                            uiAnnotations: {
+                                'Chart#Q': { term: CHART_TERM, ChartType: chartType }
+                            }
+                        }
+                    }
+                ]
+            });
+            expect(resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#Q', 'TestSet', metadata)).toBe(expected);
+        });
+    });
+
+    test('returns undefined when the chart type is not in the supported mapping', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: {
+                            'Chart#Q': { term: CHART_TERM, ChartType: 'UI.ChartType/Combination' }
+                        }
+                    }
+                }
+            ]
+        });
+        expect(resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#Q', 'TestSet', metadata)).toBeUndefined();
+    });
+
+    test('returns undefined when the annotation is missing', () => {
+        const metadata = buildMetadata({
+            entitySets: [{ name: 'TestSet', entityType: { uiAnnotations: {} } }]
+        });
+        expect(resolveMicroChartType('com.sap.vocabularies.UI.v1.Chart#Missing', 'TestSet', metadata)).toBeUndefined();
+    });
+
+    test('walks navigation properties to resolve a chart on a related entity type', () => {
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        navigationProperties: [{ name: '_NavProp', targetTypeName: 'TargetEntity' }]
+                    }
+                }
+            ],
+            entityTypeMap: {
+                TargetEntity: {
+                    uiAnnotations: {
+                        'Chart#Q': { term: CHART_TERM, ChartType: 'UI.ChartType/Column' }
+                    }
+                }
+            }
+        });
+        const result = resolveMicroChartType('_NavProp/com.sap.vocabularies.UI.v1.Chart#Q', 'TestSet', metadata);
+        expect(result).toBe('ColumnMicroChart');
+    });
+
+    test('follows PresentationVariant.Visualizations[0] to resolve the chart type', () => {
+        const chartAnnotation = { term: CHART_TERM, ChartType: 'UI.ChartType/Bullet' };
+        const presentationVariant = {
+            term: PRESENTATION_VARIANT_TERM,
+            Visualizations: [{ $target: chartAnnotation }]
+        };
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: { 'PresentationVariant#PV': presentationVariant }
+                    }
+                }
+            ]
+        });
+        const result = resolveMicroChartType('com.sap.vocabularies.UI.v1.PresentationVariant#PV', 'TestSet', metadata);
+        expect(result).toBe('BulletMicroChart');
+    });
+
+    test('returns undefined when PresentationVariant has no Visualizations', () => {
+        const presentationVariant = { term: PRESENTATION_VARIANT_TERM, Visualizations: [] };
+        const metadata = buildMetadata({
+            entitySets: [
+                {
+                    name: 'TestSet',
+                    entityType: {
+                        uiAnnotations: { 'PresentationVariant#PV': presentationVariant }
+                    }
+                }
+            ]
+        });
+        expect(
+            resolveMicroChartType('com.sap.vocabularies.UI.v1.PresentationVariant#PV', 'TestSet', metadata)
+        ).toBeUndefined();
+    });
+
+    test('returns undefined when nav property cannot be resolved', () => {
+        const metadata = buildMetadata({
+            entitySets: [{ name: 'TestSet', entityType: {} }]
+        });
+        expect(
+            resolveMicroChartType('_Missing/com.sap.vocabularies.UI.v1.Chart#Q', 'TestSet', metadata)
+        ).toBeUndefined();
+    });
+});

--- a/packages/ui5-test-writer/test/unit/utils/objectPageUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/objectPageUtils.test.ts
@@ -521,6 +521,7 @@ describe('Test getObjectPageFeatures()', () => {
         const objectPage = {
             name: 'objectPage1',
             pageType: 'ObjectPage',
+            entitySet: 'TestEntities',
             model: {
                 root: {
                     aggregations: {
@@ -532,7 +533,13 @@ describe('Test getObjectPageFeatures()', () => {
                                             title: 'Chart Section',
                                             custom: false,
                                             schema: {
-                                                keys: [{ name: 'ID', value: 'chartFacet' }],
+                                                keys: [
+                                                    { name: 'ID', value: 'chartFacet' },
+                                                    {
+                                                        name: 'Target',
+                                                        value: 'com.sap.vocabularies.UI.v1.Chart#TestQualifier'
+                                                    }
+                                                ],
                                                 dataType: 'ChartDefinition'
                                             },
                                             properties: {
@@ -561,6 +568,73 @@ describe('Test getObjectPageFeatures()', () => {
         const result = await getObjectPageFeatures([objectPage] as PageWithModelV4[], 'listReportPage', mockLogger);
         expect(result[0].headerSections?.[0].microChart).toBe(true);
         expect(result[0].headerSections?.[0].form).toBe(false);
+        expect(result[0].headerSections?.[0].microChartId).toBeUndefined();
+        expect(result[0].headerSections?.[0].microChartType).toBeUndefined();
+    });
+
+    test('should populate microChartId/microChartType when metadata resolves the chart type', async () => {
+        const objectPage = {
+            name: 'objectPage1',
+            pageType: 'ObjectPage',
+            entitySet: 'TestEntities',
+            model: {
+                root: {
+                    aggregations: {
+                        header: {
+                            aggregations: {
+                                sections: {
+                                    aggregations: {
+                                        section1: {
+                                            title: 'Revenue',
+                                            custom: false,
+                                            schema: {
+                                                keys: [
+                                                    { name: 'ID', value: 'Chart::Revenue' },
+                                                    {
+                                                        name: 'Target',
+                                                        value: 'com.sap.vocabularies.UI.v1.Chart#Revenue'
+                                                    }
+                                                ],
+                                                dataType: 'ChartDefinition'
+                                            },
+                                            properties: { stashed: { freeText: false } },
+                                            aggregations: {}
+                                        } as unknown as TreeAggregation
+                                    }
+                                } as unknown as TreeAggregation
+                            } as unknown as TreeAggregation
+                        } as unknown as TreeAggregation
+                    }
+                } as unknown as TreeAggregation,
+                name: 'test',
+                schema: {}
+            }
+        };
+        const metadata = {
+            entitySets: [
+                {
+                    name: 'TestEntities',
+                    entityType: {
+                        annotations: {
+                            UI: {
+                                'Chart#Revenue': {
+                                    term: 'com.sap.vocabularies.UI.v1.Chart',
+                                    ChartType: 'UI.ChartType/Line'
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        };
+        const result = await getObjectPageFeatures(
+            [objectPage] as PageWithModelV4[],
+            'listReportPage',
+            mockLogger,
+            metadata as never
+        );
+        expect(result[0].headerSections?.[0].microChartId).toBe('Chart::Revenue');
+        expect(result[0].headerSections?.[0].microChartType).toBe('LineMicroChart');
     });
 
     test('should identify form sections', async () => {

--- a/packages/ui5-test-writer/test/unit/utils/xmlMetadataUtils.test.ts
+++ b/packages/ui5-test-writer/test/unit/utils/xmlMetadataUtils.test.ts
@@ -1,0 +1,130 @@
+import type { Editor } from 'mem-fs-editor';
+import type { Logger } from '@sap-ux/logger';
+import type { ApplicationAccess } from '@sap-ux/project-access';
+import { loadServiceMetadata } from '../../../src/utils/xmlMetadataUtils';
+
+const METADATA_XML = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:DataServices>
+        <Schema Namespace="TestService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityType Name="TestEntity">
+                <Key>
+                    <PropertyRef Name="ID"/>
+                </Key>
+                <Property Name="ID" Type="Edm.String"/>
+            </EntityType>
+            <EntityContainer Name="EntityContainer">
+                <EntitySet Name="TestSet" EntityType="TestService.TestEntity"/>
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>`;
+
+const ANNOTATION_XML = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+        <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI" />
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="local">
+            <Annotations Target="TestService.TestEntity">
+                <Annotation Term="UI.Chart" Qualifier="Annotated">
+                    <Record Type="UI.ChartDefinitionType">
+                        <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+                    </Record>
+                </Annotation>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>`;
+
+function createEditorMock(files: Record<string, string | undefined>): Editor {
+    return {
+        read: jest.fn((filePath: string) => {
+            if (!(filePath in files)) {
+                throw new Error(`File not found: ${filePath}`);
+            }
+            return files[filePath];
+        })
+    } as unknown as Editor;
+}
+
+function createAppAccessMock(metadataLocal?: string, annotationLocals: string[] = []): ApplicationAccess | undefined {
+    return {
+        project: {
+            apps: {
+                '': {
+                    services: {
+                        mainService: {
+                            local: metadataLocal,
+                            annotations: annotationLocals.map((local) => ({ local }))
+                        }
+                    }
+                }
+            }
+        }
+    } as unknown as ApplicationAccess;
+}
+
+describe('loadServiceMetadata()', () => {
+    let mockLogger: Logger;
+
+    beforeEach(() => {
+        mockLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn()
+        } as unknown as Logger;
+    });
+
+    test('returns undefined when no XML can be located', async () => {
+        const result = await loadServiceMetadata(undefined, undefined, mockLogger);
+        expect(result).toBeUndefined();
+    });
+
+    test('returns converted metadata when only metadata XML is present', async () => {
+        const fs = createEditorMock({ '/svc/metadata.xml': METADATA_XML });
+        const appAccess = createAppAccessMock('/svc/metadata.xml');
+        const result = await loadServiceMetadata(appAccess, fs, mockLogger);
+        expect(result).toBeDefined();
+        expect(result?.entitySets.find((es) => es.name === 'TestSet')).toBeDefined();
+    });
+
+    test('merges annotation files with metadata when both are present', async () => {
+        const fs = createEditorMock({
+            '/svc/metadata.xml': METADATA_XML,
+            '/svc/annotations.xml': ANNOTATION_XML
+        });
+        const appAccess = createAppAccessMock('/svc/metadata.xml', ['/svc/annotations.xml']);
+        const result = await loadServiceMetadata(appAccess, fs, mockLogger);
+        expect(result).toBeDefined();
+        const entityType = result?.entitySets.find((es) => es.name === 'TestSet')?.entityType;
+        const annotations = entityType?.annotations.UI as Record<string, unknown> | undefined;
+        expect(annotations?.['Chart#Annotated']).toBeDefined();
+    });
+
+    test('uses the provided metadata override and skips annotation files', async () => {
+        const fs = createEditorMock({});
+        const appAccess = createAppAccessMock(undefined, ['/svc/annotations.xml']);
+        const result = await loadServiceMetadata(appAccess, fs, mockLogger, METADATA_XML);
+        expect(result).toBeDefined();
+        // fs.read should not be called because the override is used and annotations are skipped
+        expect((fs.read as jest.Mock).mock.calls).toHaveLength(0);
+    });
+
+    test('skips unreadable annotation files but keeps metadata', async () => {
+        const fs = createEditorMock({ '/svc/metadata.xml': METADATA_XML });
+        const appAccess = createAppAccessMock('/svc/metadata.xml', ['/svc/missing.xml']);
+        const result = await loadServiceMetadata(appAccess, fs, mockLogger);
+        expect(result).toBeDefined();
+        expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining('/svc/missing.xml'));
+    });
+
+    test('returns undefined when service has no readable XML files', async () => {
+        const fs = createEditorMock({});
+        const appAccess = createAppAccessMock();
+        const result = await loadServiceMetadata(appAccess, fs, mockLogger);
+        expect(result).toBeUndefined();
+    });
+});


### PR DESCRIPTION
- introduces parsing and merging of metadata + annotations to read values missing from spec model
- read ChartType for stable MicroChart test
- read UI.Hidden for ObjectPage sections and subsections to properly skip hidden facets

Internal issue
36742