### PR TITLE
fix(fiori-docs-embeddings): cache Xenova model downloads to avoid HuggingFace 429 in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,6 +39,13 @@ jobs:
                       ${{ matrix.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
             - name: Install pnpm modules
               run: pnpm install --frozen-lockfile
+            - name: Cache Xenova model downloads
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+              with:
+                  path: packages/fiori-docs-embeddings/.cache
+                  key: xenova-model-cache-${{ matrix.os }}-${{ hashFiles('packages/fiori-docs-embeddings/package.json') }}
+                  restore-keys: |
+                      xenova-model-cache-${{ matrix.os }}-
             - name: Run build
               run: pnpm run build
               env:

--- a/packages/fiori-docs-embeddings/.gitignore
+++ b/packages/fiori-docs-embeddings/.gitignore
@@ -1,4 +1,5 @@
 .claude
+.cache
 node_modules/
 dist/**/*
 .env

--- a/packages/fiori-docs-embeddings/src/scripts/build-embeddings.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/build-embeddings.ts
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
-import { pipeline, type FeatureExtractionPipeline } from '@xenova/transformers';
+import { pipeline, env, type FeatureExtractionPipeline } from '@xenova/transformers';
 import { connect } from '@lancedb/lancedb';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ToolsLogger, type Logger } from '@sap-ux/logger';
+
+// Store downloaded models under the package root so the CI cache step can
+// target a stable path regardless of the pnpm store layout.
+const __dirname = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+env.cacheDir = path.join(__dirname, '.cache');
 
 interface ProgressCallback {
     status: string;

--- a/packages/fiori-docs-embeddings/src/scripts/build-embeddings.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/build-embeddings.ts
@@ -9,8 +9,8 @@ import { ToolsLogger, type Logger } from '@sap-ux/logger';
 
 // Store downloaded models under the package root so the CI cache step can
 // target a stable path regardless of the pnpm store layout.
-const __dirname = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
-env.cacheDir = path.join(__dirname, '.cache');
+const packageRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+env.cacheDir = path.join(packageRoot, '.cache');
 
 interface ProgressCallback {
     status: string;

--- a/packages/fiori-docs-embeddings/test/build-embeddings.test.ts
+++ b/packages/fiori-docs-embeddings/test/build-embeddings.test.ts
@@ -16,7 +16,8 @@ jest.unstable_mockModule('@sap-ux/logger', () => ({
 }));
 
 jest.unstable_mockModule('@xenova/transformers', () => ({
-    pipeline: mockPipeline
+    pipeline: mockPipeline,
+    env: { cacheDir: '' }
 }));
 
 jest.unstable_mockModule('@lancedb/lancedb', () => ({


### PR DESCRIPTION
## Summary

- Redirects `env.cacheDir` in `build-embeddings.ts` to `packages/fiori-docs-embeddings/.cache` — a stable path independent of pnpm store layout
- Adds a CI cache step in `pipeline.yml` keyed on `package.json` (catches `@xenova/transformers` version changes) so the model is only downloaded from HuggingFace once per OS, then restored from cache on subsequent runs
- Adds `.cache` to `.gitignore` so it's never accidentally committed

## Root cause

`@xenova/transformers` v2 downloads the `Xenova/all-MiniLM-L6-v2` model files from HuggingFace Hub on every fresh CI run, hitting the anonymous rate limit (HTTP 429). The default cache dir is buried inside the pnpm store at a version-specific path that isn't preserved between runs.

## Test plan

- [ ] Verify first CI run downloads model and populates the cache
- [ ] Verify subsequent CI runs restore from cache and skip HuggingFace requests
- [ ] Verify build passes without 429 errors