### PR TITLE
ci: fix Playwright install on macOS (switch to chromium, bump to 1.60.0)

### DIFF
--- a/.changeset/playwright-bump-1.60.md
+++ b/.changeset/playwright-bump-1.60.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux-private/playwright": patch
+---
+
+chore: upgrade @playwright/test 1.58.2 → 1.60.0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,10 +65,10 @@ jobs:
               with:
                 path: |
                     ~/.cache/ms-playwright
-                key: playwright-browsers-os-ubuntu-latest-node-version-22.x
-            - name: Install playwright chrome browsers
+                key: playwright-browsers-chromium-os-ubuntu-latest-node-version-22.x
+            - name: Install playwright chromium browsers
               if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-              run: npx playwright install chrome
+              run: npx playwright install chromium
             - name: Read UI5 versions from cache
               uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,10 +75,10 @@ jobs:
                         C:\Users\runneradmin\AppData\Local\ms-playwright
                       ${{ runner.os != 'Windows' }}:
                         ~/.cache/ms-playwright
-                  key: playwright-browsers-os-${{ matrix.os }}-node-version-${{ matrix.node-version }}
-            - name: Install playwright chrome browsers
+                  key: playwright-browsers-chromium-os-${{ matrix.os }}-node-version-${{ matrix.node-version }}
+            - name: Install playwright chromium browsers
               if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-              run: npx playwright install chrome
+              run: npx playwright install chromium
             - name: Run integration tests
               run: pnpm run test:integration
               env:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "@changesets/cli": "2.30.0",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "10.0.1",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.60.0",
         "@types/jest": "30.0.0",
         "@types/node": "22.13.14",
         "autoprefixer": "10.4.27",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -34,7 +34,7 @@
         "!dist/**/*.map"
     ],
     "dependencies": {
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.60.0",
         "@sap-ux/logger": "workspace:*",
         "fs-extra": "11.3.4",
         "jest-dev-server": "11.0.0",

--- a/packages/preview-middleware/playwright.config.ts
+++ b/packages/preview-middleware/playwright.config.ts
@@ -35,7 +35,7 @@ const config: PlaywrightTestConfig = {
     projects: [
         {
             name: 'Google Chrome',
-            use: { ...devices['Desktop Chrome'], channel: 'chrome', viewport: { width: 1720, height: 900 } }
+            use: { ...devices['Desktop Chrome'], channel: 'chromium', viewport: { width: 1720, height: 900 } }
         }
     ],
     globalSetup: join(__dirname, './test/integration/utils/global-setup')

--- a/packages/preview-middleware/playwright.config.ts
+++ b/packages/preview-middleware/playwright.config.ts
@@ -34,8 +34,8 @@ const config: PlaywrightTestConfig = {
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'Google Chrome',
-            use: { ...devices['Desktop Chrome'], channel: 'chromium', viewport: { width: 1720, height: 900 } }
+            name: 'Chromium',
+            use: { ...devices['Desktop Chrome'], viewport: { width: 1720, height: 900 } }
         }
     ],
     globalSetup: join(__dirname, './test/integration/utils/global-setup')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 10.0.1
         version: 10.0.1(eslint@10.0.3)
       '@playwright/test':
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.60.0
+        version: 1.60.0
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -3655,8 +3655,8 @@ importers:
   packages/playwright:
     dependencies:
       '@playwright/test':
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.60.0
+        version: 1.60.0
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger
@@ -5444,8 +5444,8 @@ importers:
   tests/integration/adaptation-editor:
     dependencies:
       '@playwright/test':
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.60.0
+        version: 1.60.0
       '@sap-ux-private/playwright':
         specifier: workspace:*
         version: link:../../../packages/playwright
@@ -8718,8 +8718,8 @@ packages:
     resolution: {integrity: sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA==}
     engines: {node: '>=18'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16170,11 +16170,6 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -16191,11 +16186,6 @@ packages:
         optional: true
       playwright-core:
         optional: true
-
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   playwright@1.60.0:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
@@ -23191,9 +23181,9 @@ snapshots:
       playwright-core: 1.60.0
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -32680,10 +32670,7 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.58.2: {}
-
-  playwright-core@1.60.0:
-    optional: true
+  playwright-core@1.60.0: {}
 
   playwright-extra@4.3.6(playwright-core@1.60.0)(playwright@1.60.0):
     dependencies:
@@ -32695,18 +32682,11 @@ snapshots:
       - supports-color
     optional: true
 
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
-
   playwright@1.60.0:
     dependencies:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   pluralize@2.0.0: {}
 

--- a/tests/integration/adaptation-editor/package.json
+++ b/tests/integration/adaptation-editor/package.json
@@ -21,7 +21,7 @@
         "@sap-ux-private/playwright": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/yaml": "workspace:*",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.60.0",
         "adm-zip": "0.5.16",
         "dotenv": "17.4.2",
         "express": "4.22.1",

--- a/tests/integration/adaptation-editor/playwright.config.ts
+++ b/tests/integration/adaptation-editor/playwright.config.ts
@@ -69,7 +69,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         name: `${version}`,
         use: {
             ...devices['Desktop Chrome'],
-            channel: 'chromium',
             viewport: { width: 1720, height: 900 },
             ui5Version: version
         }

--- a/tests/integration/adaptation-editor/playwright.config.ts
+++ b/tests/integration/adaptation-editor/playwright.config.ts
@@ -69,7 +69,7 @@ const config: PlaywrightTestConfig<TestOptions> = {
         name: `${version}`,
         use: {
             ...devices['Desktop Chrome'],
-            channel: 'chrome',
+            channel: 'chromium',
             viewport: { width: 1720, height: 900 },
             ui5Version: version
         }


### PR DESCRIPTION
## Summary

Two CI fixes to unblock Playwright integration tests on macOS:

- **Switch from Chrome stable to bundled Chromium** — Google's Chrome `.dmg` URL now returns a 302 redirect that Playwright's `reinstall_chrome_stable_mac.sh` doesn't follow (uses `curl --retry 3 -o` without `-L`), so `npx playwright install chrome` fails on macOS runners. Switching the test channel to `chromium` makes Playwright download from `cdn.playwright.dev` and avoids the broken redirect path.
- **Upgrade `@playwright/test` 1.58.2 → 1.60.0** — 1.58.2's chromium post-download extraction hangs on macOS arm64 + Node 24 (observed in CI: 44 min idle after the 100% download progress line, before the "downloaded to ..." line). 1.60.0 fixes this.

Cache keys for the Playwright browser cache were bumped to `playwright-browsers-chromium-...` so old Chrome-containing caches don't get restored on the first run.

### Changes

- `packages/preview-middleware/playwright.config.ts`, `tests/integration/adaptation-editor/playwright.config.ts`: `channel: 'chrome'` → `'chromium'`
- `.github/workflows/pipeline.yml`, `.github/workflows/integration-tests.yml`: install step uses `npx playwright install chromium`; cache key prefix updated
- `package.json`, `tests/integration/adaptation-editor/package.json`, `packages/playwright/package.json`: `@playwright/test` → `1.60.0`
- Changeset: `@sap-ux-private/playwright` patch (runtime dep change)

## Test plan

- [ ] CI/CD Pipeline run completes successfully on ubuntu / windows / macOS for Node 22.x and 24.x
- [ ] `Install playwright chromium browsers` step finishes within ~30s on every OS
- [ ] Integration tests pass against the chromium channel