### PR TITLE
Revert generator-odata-downloader to cjs

### DIFF
--- a/.changeset/neat-eyes-love.md
+++ b/.changeset/neat-eyes-love.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/generator-odata-downloader': patch
+---
+
+revert odata-downloader to cjs

--- a/packages/generator-odata-downloader/esbuild.mjs
+++ b/packages/generator-odata-downloader/esbuild.mjs
@@ -27,7 +27,7 @@ const stubNpmModulesPlugin = {
     }));
 
     build.onLoad({ filter: /.*/, namespace: 'stub-npm-modules' }, () => ({
-      contents: 'export default {};',
+      contents: 'module.exports = {};',
       loader: 'js'
     }));
   }
@@ -78,7 +78,7 @@ const copyPrebuildsPlugin = {
 build({
   entryPoints: ['src/app/index.ts'],
   bundle: true,
-  format: 'esm',
+  format: 'cjs',
   outfile: 'generators/app/index.js',
   minify: production,
   sourcemap: !production,
@@ -87,5 +87,7 @@ build({
   logLevel: 'info',
   external: ['vscode', '@sap-devx/yeoman-ui-types'],
   mainFields: ["module", "main"],
+  banner: { js: "const __importMetaUrl=require('url').pathToFileURL(__filename).href;" },
+  define: { 'import.meta.url': '__importMetaUrl' },
   plugins: [stubNpmModulesPlugin, copyPrebuildsPlugin]
 }).catch(() => process.exit(1));


### PR DESCRIPTION
- fixes crashing of generator-odata-downloader
- generator was changed to esm in https://github.com/SAP/open-ux-tools/pull/4565
- based on changelog https://github.com/SAP/open-ux-tools/blob/35c834e1d26f49a22f419bbea16687256228ce1c/packages/generator-odata-downloader/CHANGELOG.md#L82 this change was in error.

### Changes

* `packages/generator-odata-downloader/esbuild.mjs`:
  - Changed the build `format` from `'esm'` back to `'cjs'`
  - Updated the stub npm modules plugin to use `module.exports = {};` instead of `export default {};` to align with CJS output
  - Added `banner` and `define` options to handle `import.meta.url` compatibility within the CJS bundle, ensuring any ESM-style `import.meta.url` references are properly resolved at runtime