### PR TITLE
fix(fiori-mcp-server): download ONNX model at runtime to reduce tgz below npm 100 MB limit

### DIFF
--- a/.changeset/fiori-mcp-server-reduce-tgz-size.md
+++ b/.changeset/fiori-mcp-server-reduce-tgz-size.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+Download ONNX model at runtime to reduce tgz below npm publish 100 MB limit

--- a/packages/fiori-mcp-server/README.md
+++ b/packages/fiori-mcp-server/README.md
@@ -165,6 +165,8 @@ Searches SAP Fiori elements, Annotations, UI5, SAP Fiori tools documentation for
 
 Note: the results are based on the most recent indexed version of UI5 documentation
 
+> **First-use download:** `search_docs` uses a local text-embedding model (`all-MiniLM-L6-v2`, ~90 MB) for semantic search. The model is downloaded from HuggingFace Hub on first use and cached locally (location follows the `HF_HOME` / `TRANSFORMERS_CACHE` environment variables, defaulting to `~/.cache/huggingface/hub`). Subsequent starts load the model from the cache with no network access required.
+
 #### `list_fiori_apps`
 Scans a specified directory to find existing SAP Fiori applications that can be modified.
 

--- a/packages/fiori-mcp-server/scripts/bundle.mjs
+++ b/packages/fiori-mcp-server/scripts/bundle.mjs
@@ -7,8 +7,12 @@
  *   dist/node_modules/onnxruntime-node/   ONNX runtime (native .node files)
  *   dist/prebuilds/                       @zowe/secrets-for-zowe-sdk .node binaries
  *   dist/data/embeddings/                 pre-built binary vector store (embeddings.bin + records.jsonl)
- *   dist/models/Xenova/                   bundled ONNX model for text embeddings
  *   dist/icon.png, dist/icon.svg
+ *
+ * Model strategy:
+ *   The ONNX model (all-MiniLM-L6-v2, ~86 MB) is NOT bundled. It is downloaded
+ *   from HuggingFace Hub on first use and cached in ~/.cache/sap-fiori-mcp/.
+ *   This keeps the published tgz under npm's 100 MB limit.
  *
  * Native binary strategy:
  *   onnxruntime-node — kept external (uses a dynamic require template literal
@@ -263,40 +267,7 @@ const embeddingsOut = path.join(DIST, 'data', 'embeddings');
 copyDir(embeddingsDataDir, embeddingsOut);
 console.log('✓ Copied embeddings data');
 
-// ── Step 6: copy bundled ONNX model ──────────────────────────────────────────
-// text-embedding.ts sets env.localModelPath = path.join(__dirname, 'models')
-// and transformers resolves: localModelPath + '/' + modelId + '/' + filename.
-// The model cache lives at fiori-docs-embeddings/.cache/Xenova/ (set via
-// env.cacheDir in build-embeddings.ts). We copy that cache → dist/models/Xenova,
-// skipping model_quantized.onnx (q8) and keeping only model.onnx (fp32) to match
-// the dtype used by build-embeddings.ts.
-
-const modelCacheDir = path.join(path.dirname(embeddingsPkgJson), '.cache', 'Xenova');
-const modelOutDir = path.join(DIST, 'models', 'Xenova');
-
-function copyDirExclude(src, dst, excludeNames) {
-    fs.mkdirSync(dst, { recursive: true });
-    for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-        if (excludeNames.includes(entry.name)) continue;
-        const s = path.join(src, entry.name);
-        const d = path.join(dst, entry.name);
-        if (entry.isDirectory()) {
-            copyDirExclude(s, d, excludeNames);
-        } else {
-            fs.copyFileSync(s, d);
-        }
-    }
-}
-
-if (fs.existsSync(modelCacheDir)) {
-    copyDirExclude(modelCacheDir, modelOutDir, ['model_quantized.onnx']);
-    console.log('✓ Copied ONNX model (fp32)');
-} else {
-    console.warn('⚠ ONNX model cache not found at', modelCacheDir);
-    console.warn('  Run the embedding pipeline once to populate it, then rebuild.');
-}
-
-// ── Step 7: copy WASM runtime ─────────────────────────────────────────────────
+// ── Step 6: copy WASM runtime ─────────────────────────────────────────────────
 // @huggingface/transformers loads ort-wasm-simd-threaded.jsep.mjs from its own
 // dist/ at runtime via a path relative to the transformers bundle. When inlined
 // by esbuild the WASM load path becomes relative to dist/, so we copy it there.
@@ -310,14 +281,14 @@ if (fs.existsSync(wasmSrc)) {
     console.warn('⚠ WASM file not found at', wasmSrc);
 }
 
-// ── Step 8: copy icons ────────────────────────────────────────────────────────
+// ── Step 7: copy icons ────────────────────────────────────────────────────────
 
 for (const icon of ['icon.png', 'icon.svg']) {
     fs.copyFileSync(path.join(PKG_ROOT, 'assets', icon), path.join(DIST, icon));
 }
 console.log('✓ Copied icons');
 
-// ── Step 9: scrub nested package.json files ──────────────────────────────────
+// ── Step 8: scrub nested package.json files ──────────────────────────────────
 // Remove dependency/script fields from package.json files inside dist/node_modules/
 // so package managers (bun, npm) don't try to resolve or run them at install time.
 

--- a/packages/fiori-mcp-server/scripts/bundle.mjs
+++ b/packages/fiori-mcp-server/scripts/bundle.mjs
@@ -11,7 +11,9 @@
  *
  * Model strategy:
  *   The ONNX model (all-MiniLM-L6-v2, ~86 MB) is NOT bundled. It is downloaded
- *   from HuggingFace Hub on first use and cached in ~/.cache/sap-fiori-mcp/.
+ *   from HuggingFace Hub on first use and cached in the default @huggingface/transformers
+ *   cache directory (respects HF_HOME / TRANSFORMERS_CACHE env vars; defaults to
+ *   ~/.cache/huggingface/hub on Linux/macOS).
  *   This keeps the published tgz under npm's 100 MB limit.
  *
  * Native binary strategy:

--- a/packages/fiori-mcp-server/src/tools/services/text-embedding.ts
+++ b/packages/fiori-mcp-server/src/tools/services/text-embedding.ts
@@ -2,11 +2,6 @@
  * Text embedding service for converting text queries to vectors.
  */
 
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 /**
  * Simple text embedding service that uses the same model as the build process.
  */
@@ -24,14 +19,10 @@ export class TextEmbeddingService {
 
         try {
             // Dynamically import the ES Module
-            const { pipeline, env } = await import('@huggingface/transformers');
+            const { pipeline } = await import('@huggingface/transformers');
 
-            // Point at the bundled model directory (dist/models/) so the ONNX model is loaded
-            // from the package itself rather than downloaded from HuggingFace Hub at runtime.
-            env.localModelPath = path.join(__dirname, 'models');
-            env.allowRemoteModels = false;
-
-            // Use the same model as the build process
+            // Model (~86 MB) is downloaded from HuggingFace Hub on first use and
+            // cached in the default transformers cache directory.
             this.pipeline = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
 
             this.initialized = true;

--- a/packages/fiori-mcp-server/test/unit/tools/services/text-embedding.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/services/text-embedding.test.ts
@@ -3,11 +3,7 @@ import { jest } from '@jest/globals';
 // Mock the transformers module
 const mockPipeline = jest.fn<any>();
 jest.unstable_mockModule('@huggingface/transformers', () => ({
-    pipeline: mockPipeline,
-    env: {
-        localModelPath: '',
-        allowRemoteModels: false
-    }
+    pipeline: mockPipeline
 }));
 
 const { TextEmbeddingService } = await import('../../../../src/tools/services/text-embedding.js');


### PR DESCRIPTION
## Summary

- Removes the bundled fp32 ONNX model (`all-MiniLM-L6-v2`, ~86 MB) from `dist/` — it is now downloaded from HuggingFace Hub on first use and cached by the default `@huggingface/transformers` cache mechanism
- Drops the Step 6 model-copy block from `bundle.mjs` (including the `copyDirExclude` helper that was only used there)
- Removes `env.localModelPath`, `env.allowRemoteModels = false`, and the unused `path`/`fileURLToPath`/`__dirname` imports from `text-embedding.ts`
- Updates the test mock accordingly — `env` is no longer touched so the mock no longer needs to fake it

**Result:** tgz drops from 166 MB → **86 MB**, under npm's 100 MB publish limit.

## Test plan

- [ ] `pnpm --filter @sap-ux/fiori-mcp-server... build` succeeds — `dist/models/` no longer appears in the layout
- [ ] `pnpm --filter @sap-ux/fiori-mcp-server test` — `text-embedding.test.ts` passes at 100% coverage
- [ ] `pnpm pack` inside `packages/fiori-mcp-server` produces a tgz ≤ 100 MB
- [ ] On first `npx @sap-ux/fiori-mcp-server` run, the model downloads and caches correctly; subsequent runs use the cache