### PR TITLE
fix(fiori-mcp-server): handle CLI help and version flags

### DIFF
--- a/.changeset/fiori-mcp-cli-info-flags.md
+++ b/.changeset/fiori-mcp-cli-info-flags.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+Handle top-level help and version CLI flags before starting the MCP server.

--- a/packages/fiori-mcp-server/src/cli.ts
+++ b/packages/fiori-mcp-server/src/cli.ts
@@ -1,0 +1,63 @@
+import { PACKAGE_VERSION } from './package-info.js';
+
+interface CliOutput {
+    stdout: (message: string) => void;
+    stderr: (message: string) => void;
+}
+
+const HELP_TEXT = `Usage: fiori-mcp [options]
+
+SAP Fiori - Model Context Protocol (MCP) server
+
+Options:
+  -h, --help       display help for command
+  -v, --version    display version number
+  --log-level=<level>  set log level`;
+
+/**
+ * Checks whether an option is handled by server startup instead of metadata flag handling.
+ *
+ * @param arg - CLI argument.
+ * @returns True when the option should be left for server startup.
+ */
+function isPassthroughOption(arg: string): boolean {
+    return arg.startsWith('--log-level=');
+}
+
+/**
+ * Handles top-level CLI metadata flags before starting the MCP server.
+ *
+ * @param argv - CLI arguments without node and script path.
+ * @param output - Output writers used for stdout and stderr.
+ * @returns True when the caller should skip server startup.
+ */
+export function handleCliInfoFlags(
+    argv = process.argv.slice(2),
+    output: CliOutput = {
+        stdout: (message: string): void => {
+            process.stdout.write(`${message}\n`);
+        },
+        stderr: (message: string): void => {
+            process.stderr.write(`${message}\n`);
+        }
+    }
+): boolean {
+    if (argv.includes('--help') || argv.includes('-h')) {
+        output.stdout(HELP_TEXT);
+        return true;
+    }
+
+    if (argv.includes('--version') || argv.includes('-v')) {
+        output.stdout(PACKAGE_VERSION);
+        return true;
+    }
+
+    const unknownOption = argv.find((arg) => arg.startsWith('-') && !isPassthroughOption(arg));
+    if (unknownOption) {
+        output.stderr(`Unknown option: ${unknownOption}`);
+        process.exitCode = 1;
+        return true;
+    }
+
+    return false;
+}

--- a/packages/fiori-mcp-server/src/index.ts
+++ b/packages/fiori-mcp-server/src/index.ts
@@ -2,10 +2,13 @@
 
 import { FioriFunctionalityServer } from './server.js';
 import { logger } from './utils/logger.js';
+import { handleCliInfoFlags } from './cli.js';
 
-const server = new FioriFunctionalityServer();
-try {
-    await server.run();
-} catch (error) {
-    logger.error(`Server error: ${error}`);
+if (!handleCliInfoFlags()) {
+    const server = new FioriFunctionalityServer();
+    try {
+        await server.run();
+    } catch (error) {
+        logger.error(`Server error: ${error}`);
+    }
 }

--- a/packages/fiori-mcp-server/test/unit/cli.test.ts
+++ b/packages/fiori-mcp-server/test/unit/cli.test.ts
@@ -1,0 +1,157 @@
+import { jest } from '@jest/globals';
+import { PACKAGE_VERSION } from '../../src/package-info.js';
+import { handleCliInfoFlags } from '../../src/cli.js';
+
+function createOutput() {
+    return {
+        stdout: jest.fn(),
+        stderr: jest.fn()
+    };
+}
+
+describe('CLI metadata flags', () => {
+    let originalExitCode: typeof process.exitCode;
+
+    beforeEach(() => {
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+        process.exitCode = originalExitCode;
+    });
+
+    it.each(['--help', '-h'])('prints help for %s and skips server startup', (flag) => {
+        const output = createOutput();
+
+        const handled = handleCliInfoFlags([flag], output);
+
+        expect(handled).toBe(true);
+        expect(output.stdout).toHaveBeenCalledWith(expect.stringContaining('Usage: fiori-mcp'));
+        expect(output.stdout).toHaveBeenCalledWith(expect.stringContaining('SAP Fiori'));
+        expect(output.stderr).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it.each(['--version', '-v'])('prints version for %s and skips server startup', (flag) => {
+        const output = createOutput();
+
+        const handled = handleCliInfoFlags([flag], output);
+
+        expect(handled).toBe(true);
+        expect(output.stdout).toHaveBeenCalledWith(PACKAGE_VERSION);
+        expect(output.stderr).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('rejects unknown top-level options before server startup', () => {
+        const output = createOutput();
+
+        const handled = handleCliInfoFlags(['--definitely-not-a-real-flag'], output);
+
+        expect(handled).toBe(true);
+        expect(output.stderr).toHaveBeenCalledWith('Unknown option: --definitely-not-a-real-flag');
+        expect(output.stdout).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('does not handle normal server startup', () => {
+        const output = createOutput();
+
+        const handled = handleCliInfoFlags([], output);
+
+        expect(handled).toBe(false);
+        expect(output.stdout).not.toHaveBeenCalled();
+        expect(output.stderr).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('keeps log-level as a server startup option', () => {
+        const output = createOutput();
+
+        const handled = handleCliInfoFlags(['--log-level=debug'], output);
+
+        expect(handled).toBe(false);
+        expect(output.stdout).not.toHaveBeenCalled();
+        expect(output.stderr).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+});
+
+describe('CLI entrypoint', () => {
+    const originalArgv = process.argv;
+    let originalExitCode: typeof process.exitCode;
+    let stdoutWrite: jest.SpiedFunction<typeof process.stdout.write>;
+    let stderrWrite: jest.SpiedFunction<typeof process.stderr.write>;
+
+    async function importEntrypoint(args: string[]) {
+        jest.resetModules();
+        process.argv = ['node', 'fiori-mcp', ...args];
+
+        const run = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+        const FioriFunctionalityServer = jest.fn().mockImplementation(() => ({
+            run
+        }));
+
+        jest.unstable_mockModule('../../src/server', () => ({
+            FioriFunctionalityServer
+        }));
+
+        await import('../../src/index.js');
+        return { FioriFunctionalityServer, run };
+    }
+
+    beforeEach(() => {
+        originalExitCode = process.exitCode;
+        process.exitCode = undefined;
+        stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        stderrWrite = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        process.exitCode = originalExitCode;
+        jest.restoreAllMocks();
+        jest.resetModules();
+    });
+
+    it.each(['--help', '-h'])('skips server startup for %s', async (flag) => {
+        const { FioriFunctionalityServer, run } = await importEntrypoint([flag]);
+
+        expect(FioriFunctionalityServer).not.toHaveBeenCalled();
+        expect(run).not.toHaveBeenCalled();
+        expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('Usage: fiori-mcp'));
+        expect(stderrWrite).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it.each(['--version', '-v'])('skips server startup for %s', async (flag) => {
+        const { FioriFunctionalityServer, run } = await importEntrypoint([flag]);
+
+        expect(FioriFunctionalityServer).not.toHaveBeenCalled();
+        expect(run).not.toHaveBeenCalled();
+        expect(stdoutWrite).toHaveBeenCalledWith(`${PACKAGE_VERSION}\n`);
+        expect(stderrWrite).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    it('skips server startup for unknown top-level options', async () => {
+        const { FioriFunctionalityServer, run } = await importEntrypoint(['--definitely-not-a-real-flag']);
+
+        expect(FioriFunctionalityServer).not.toHaveBeenCalled();
+        expect(run).not.toHaveBeenCalled();
+        expect(stderrWrite).toHaveBeenCalledWith('Unknown option: --definitely-not-a-real-flag\n');
+        expect(stdoutWrite).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+    });
+
+    it('starts the server for log-level options', async () => {
+        const { FioriFunctionalityServer, run } = await importEntrypoint(['--log-level=debug']);
+
+        expect(FioriFunctionalityServer).toHaveBeenCalledTimes(1);
+        expect(run).toHaveBeenCalledTimes(1);
+        expect(stdoutWrite).not.toHaveBeenCalled();
+        expect(stderrWrite).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Handle top-level --help/-h and --version/-v before starting the MCP server.
- Reject unknown top-level options with exit code 1 while keeping --log-level=<level> as a server startup option.
- Add helper and entrypoint coverage for the CLI metadata flag branches.

Fixes #4785

## Validation
- npx --yes pnpm@11.1.2 --filter @sap-ux/fiori-mcp-server exec cross-env NODE_OPTIONS='--experimental-vm-modules' jest --runTestsByPath test/unit/cli.test.ts --runInBand
- npx --yes pnpm@11.1.2 --filter @sap-ux/fiori-mcp-server build-compile
- npx --yes pnpm@11.1.2 --filter @sap-ux/fiori-mcp-server lint (0 errors, existing warnings)
- npx --yes prettier@3.8.1 --check packages/fiori-mcp-server/src/index.ts packages/fiori-mcp-server/src/cli.ts packages/fiori-mcp-server/test/unit/cli.test.ts .changeset/fiori-mcp-cli-info-flags.md
- git diff --check
- npx --yes pnpm@11.1.2 --filter @sap-ux/fiori-mcp-server build
- Dist smoke: --help/-h exit 0 with usage, --version/-v exit 0 with 1.1.2, unknown flag exits 1