### PR TITLE
fix: revert generator-adp to cjs

### DIFF
--- a/.changeset/generator-adp-revert-cjs.md
+++ b/.changeset/generator-adp-revert-cjs.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/generator-adp': patch
+---
+
+revert generator-adp to cjs

--- a/packages/generator-adp/jest.config.mjs
+++ b/packages/generator-adp/jest.config.mjs
@@ -1,5 +1,29 @@
 import baseConfig from '../../jest.base.mjs';
-const config = { ...baseConfig };
+// The package emits CommonJS (see tsconfig.json) so the yeoman-ui-types VSCode
+// extension's bundled yeoman-environment 3.x can `Object.assign` registration
+// metadata onto the generator class — ESM module namespace objects are sealed
+// and that fails with
+// "Cannot add property resolved, object is not extensible".
+//
+// Tests still run as ESM (with `jest.unstable_mockModule` and top-level
+// `await import()`) so we override ts-jest's tsconfig here to force
+// `module: ESNext` for tests only.
+const config = {
+    ...baseConfig,
+    transform: {
+        '^.+\\.[jt]s$': [
+            'ts-jest',
+            {
+                ...baseConfig.transform['^.+\\.[jt]s$'][1],
+                tsconfig: {
+                    ...baseConfig.transform['^.+\\.[jt]s$'][1].tsconfig,
+                    module: 'ESNext',
+                    moduleResolution: 'Bundler'
+                }
+            }
+        ]
+    }
+};
 config.snapshotFormat = {
     escapeString: false,
     printBasicPrototype: false

--- a/packages/generator-adp/jest.config.mjs
+++ b/packages/generator-adp/jest.config.mjs
@@ -8,15 +8,31 @@ import baseConfig from '../../jest.base.mjs';
 // Tests still run as ESM (with `jest.unstable_mockModule` and top-level
 // `await import()`) so we override ts-jest's tsconfig here to force
 // `module: ESNext` for tests only.
+const TS_PATTERN = '^.+\\.[jt]s$';
+const baseTsTransform = baseConfig.transform?.[TS_PATTERN];
+if (
+    !Array.isArray(baseTsTransform) ||
+    baseTsTransform[0] !== 'ts-jest' ||
+    typeof baseTsTransform[1] !== 'object' ||
+    baseTsTransform[1] === null
+) {
+    throw new Error(
+        `Unexpected shape for baseConfig.transform[${TS_PATTERN}] in ../../jest.base.mjs — expected ` +
+            `["ts-jest", { tsconfig: ..., ... }]. Update packages/generator-adp/jest.config.mjs to match.`
+    );
+}
+const [, baseTsOptions] = baseTsTransform;
+
 const config = {
     ...baseConfig,
     transform: {
-        '^.+\\.[jt]s$': [
+        ...baseConfig.transform,
+        [TS_PATTERN]: [
             'ts-jest',
             {
-                ...baseConfig.transform['^.+\\.[jt]s$'][1],
+                ...baseTsOptions,
                 tsconfig: {
-                    ...baseConfig.transform['^.+\\.[jt]s$'][1].tsconfig,
+                    ...baseTsOptions.tsconfig,
                     module: 'ESNext',
                     moduleResolution: 'Bundler'
                 }

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -12,7 +12,6 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue"
     },
-    "type": "module",
     "license": "Apache-2.0",
     "main": "generators/app/index.js",
     "scripts": {

--- a/packages/generator-adp/src/utils/deps.ts
+++ b/packages/generator-adp/src/utils/deps.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import * as util from 'node:util';
 import { readFileSync } from 'node:fs';
 import { exec } from 'node:child_process';
@@ -6,30 +6,19 @@ import { exec } from 'node:child_process';
 import type { Package } from '@sap-ux/project-access';
 
 /**
- * Resolves the directory of this source/compiled file in a way that works
- * under both the published CommonJS build (where `__dirname` is provided by
- * Node) and ts-jest's ESM test transform (where it isn't, so we fall back
- * to the source path derived from `__filename`).
- *
- * @returns {string} Absolute directory path of this module at runtime.
- */
-function resolveModuleDir(): string {
-    if (typeof __dirname !== 'undefined') {
-        return __dirname;
-    }
-    if (typeof __filename !== 'undefined') {
-        return dirname(__filename);
-    }
-    return process.cwd();
-}
-
-/**
  * Reads the package.json of the current package.
+ *
+ * Uses Node's CJS `__dirname` global at runtime (the package compiles to
+ * CommonJS — see tsconfig.json). Under ts-jest's ESM test transform
+ * `__dirname` is undefined and we fall back to `process.cwd()`, which
+ * jest sets to the package root — so the upward walk to `package.json`
+ * still lands on the right file.
  *
  * @returns {Package} Package.json of the current package.
  */
 export function getPackageInfo(): Package {
-    return JSON.parse(readFileSync(join(resolveModuleDir(), '../../package.json'), 'utf-8'));
+    const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+    return JSON.parse(readFileSync(join(moduleDir, '../../package.json'), 'utf-8'));
 }
 
 /**

--- a/packages/generator-adp/src/utils/deps.ts
+++ b/packages/generator-adp/src/utils/deps.ts
@@ -1,12 +1,27 @@
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import * as util from 'node:util';
 import { readFileSync } from 'node:fs';
 import { exec } from 'node:child_process';
 
 import type { Package } from '@sap-ux/project-access';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+/**
+ * Resolves the directory of this source/compiled file in a way that works
+ * under both the published CommonJS build (where `__dirname` is provided by
+ * Node) and ts-jest's ESM test transform (where it isn't, so we fall back
+ * to the source path derived from `__filename`).
+ *
+ * @returns {string} Absolute directory path of this module at runtime.
+ */
+function resolveModuleDir(): string {
+    if (typeof __dirname !== 'undefined') {
+        return __dirname;
+    }
+    if (typeof __filename !== 'undefined') {
+        return dirname(__filename);
+    }
+    return process.cwd();
+}
 
 /**
  * Reads the package.json of the current package.
@@ -14,7 +29,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * @returns {Package} Package.json of the current package.
  */
 export function getPackageInfo(): Package {
-    return JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+    return JSON.parse(readFileSync(join(resolveModuleDir(), '../../package.json'), 'utf-8'));
 }
 
 /**

--- a/packages/generator-adp/src/utils/deps.ts
+++ b/packages/generator-adp/src/utils/deps.ts
@@ -17,7 +17,7 @@ import type { Package } from '@sap-ux/project-access';
  * @returns {Package} Package.json of the current package.
  */
 export function getPackageInfo(): Package {
-    const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+    const moduleDir = typeof __dirname === 'undefined' ? process.cwd() : __dirname;
     return JSON.parse(readFileSync(join(moduleDir, '../../package.json'), 'utf-8'));
 }
 

--- a/packages/generator-adp/src/utils/i18n.ts
+++ b/packages/generator-adp/src/utils/i18n.ts
@@ -4,7 +4,7 @@ import type { i18n as i18nNext, TOptions } from 'i18next';
 import { addi18nResourceBundle as addInquirerCommonResourceBundle } from '@sap-ux/inquirer-common';
 import { addi18nResourceBundle as addProjectInputValidatorBundle } from '@sap-ux/project-input-validator';
 
-import translations from '../translations/generator-adp.i18n.json' with { type: 'json' };
+import translations from '../translations/generator-adp.i18n.json';
 
 const adpGeneratorI18nNamespace = 'generator-adp';
 export const i18n: i18nNext = i18next.createInstance();

--- a/packages/generator-adp/src/utils/templates.ts
+++ b/packages/generator-adp/src/utils/templates.ts
@@ -1,31 +1,19 @@
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-
-/**
- * Resolves the directory of this source/compiled file in a way that works
- * under both the published CommonJS build (where `__dirname` is provided by
- * Node) and ts-jest's ESM test transform (where it isn't).
- *
- * @returns {string} Absolute directory path of this module at runtime.
- */
-function resolveModuleDir(): string {
-    if (typeof __dirname !== 'undefined') {
-        return __dirname;
-    }
-    if (typeof __filename !== 'undefined') {
-        return dirname(__filename);
-    }
-    return process.cwd();
-}
+import { join } from 'node:path';
 
 /**
  * This function is used to get the path to the templates directory when this generator is bundled inside `@sap/generator-fiori`.
  * It is used to overwrite the templates directory.
  *
+ * Uses Node's CJS `__dirname` global at runtime (the package compiles to
+ * CommonJS — see tsconfig.json). Under ts-jest's ESM test transform
+ * `__dirname` is undefined and we fall back to `process.cwd()`.
+ *
  * @returns {string | undefined} The path to the templates directory.
  */
 export function getTemplatesOverwritePath(): string | undefined {
-    const templatePath = join(resolveModuleDir(), 'templates');
+    const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+    const templatePath = join(moduleDir, 'templates');
     if (existsSync(templatePath)) {
         return templatePath;
     }

--- a/packages/generator-adp/src/utils/templates.ts
+++ b/packages/generator-adp/src/utils/templates.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
  * @returns {string | undefined} The path to the templates directory.
  */
 export function getTemplatesOverwritePath(): string | undefined {
-    const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+    const moduleDir = typeof __dirname === 'undefined' ? process.cwd() : __dirname;
     const templatePath = join(moduleDir, 'templates');
     if (existsSync(templatePath)) {
         return templatePath;

--- a/packages/generator-adp/src/utils/templates.ts
+++ b/packages/generator-adp/src/utils/templates.ts
@@ -1,7 +1,22 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolves the directory of this source/compiled file in a way that works
+ * under both the published CommonJS build (where `__dirname` is provided by
+ * Node) and ts-jest's ESM test transform (where it isn't).
+ *
+ * @returns {string} Absolute directory path of this module at runtime.
+ */
+function resolveModuleDir(): string {
+    if (typeof __dirname !== 'undefined') {
+        return __dirname;
+    }
+    if (typeof __filename !== 'undefined') {
+        return dirname(__filename);
+    }
+    return process.cwd();
+}
 
 /**
  * This function is used to get the path to the templates directory when this generator is bundled inside `@sap/generator-fiori`.
@@ -10,7 +25,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * @returns {string | undefined} The path to the templates directory.
  */
 export function getTemplatesOverwritePath(): string | undefined {
-    const templatePath = join(__dirname, 'templates');
+    const templatePath = join(resolveModuleDir(), 'templates');
     if (existsSync(templatePath)) {
         return templatePath;
     }

--- a/packages/generator-adp/test/unit/utils/deps.test.ts
+++ b/packages/generator-adp/test/unit/utils/deps.test.ts
@@ -49,6 +49,7 @@ describe('installDependencies', () => {
 describe('getPackageInfo', () => {
     afterEach(() => {
         jest.clearAllMocks();
+        delete (globalThis as Record<string, unknown>).__dirname;
     });
 
     it('should return the correct package.json', async () => {
@@ -56,5 +57,18 @@ describe('getPackageInfo', () => {
         const result = getPackageInfo();
 
         expect(result).toEqual(mockPackage);
+    });
+
+    it('should resolve the package.json path via __dirname when defined (CJS runtime)', () => {
+        // The compiled CJS build runs with Node's `__dirname` global defined.
+        // Under ts-jest's ESM transform it is undefined, so we simulate it
+        // here to exercise the production code path.
+        (globalThis as Record<string, unknown>).__dirname = '/abs/generators/utils';
+        mockReadFileSync.mockReturnValue(JSON.stringify(mockPackage));
+
+        const result = getPackageInfo();
+
+        expect(result).toEqual(mockPackage);
+        expect(mockReadFileSync).toHaveBeenCalledWith('/abs/package.json', 'utf-8');
     });
 });

--- a/packages/generator-adp/test/unit/utils/deps.test.ts
+++ b/packages/generator-adp/test/unit/utils/deps.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { join } from 'node:path';
 
 const mockExec = jest.fn<typeof realChildProcess.exec>();
 const mockReadFileSync = jest.fn<typeof realFs.readFileSync>();
@@ -63,12 +64,14 @@ describe('getPackageInfo', () => {
         // The compiled CJS build runs with Node's `__dirname` global defined.
         // Under ts-jest's ESM transform it is undefined, so we simulate it
         // here to exercise the production code path.
-        (globalThis as Record<string, unknown>).__dirname = '/abs/generators/utils';
+        const fakeDir = join('abs', 'generators', 'utils');
+        (globalThis as Record<string, unknown>).__dirname = fakeDir;
         mockReadFileSync.mockReturnValue(JSON.stringify(mockPackage));
 
         const result = getPackageInfo();
 
+        const expectedPath = join(fakeDir, '..', '..', 'package.json');
         expect(result).toEqual(mockPackage);
-        expect(mockReadFileSync).toHaveBeenCalledWith('/abs/package.json', 'utf-8');
+        expect(mockReadFileSync).toHaveBeenCalledWith(expectedPath, 'utf-8');
     });
 });

--- a/packages/generator-adp/test/unit/utils/templates.test.ts
+++ b/packages/generator-adp/test/unit/utils/templates.test.ts
@@ -8,16 +8,22 @@ jest.unstable_mockModule('node:fs', () => ({
 
 const { getTemplatesOverwritePath } = await import('../../../src/utils/templates.js');
 
-// In the published CJS build, `getTemplatesOverwritePath` resolves the
-// templates folder relative to the compiled module (`generators/utils/`).
-// Under ts-jest's ESM test transform `__dirname`/`__filename` are not
-// defined, so the implementation falls back to `process.cwd()` and the
-// expected path is the package root joined with `templates`.
-const expectedPath = join(process.cwd(), 'templates');
+// Mirror getTemplatesOverwritePath's `__dirname || process.cwd()` resolution
+// so this expectation stays correct regardless of whether the jest config
+// runs tests as ESM (where __dirname is undefined and the function falls
+// back to process.cwd()) or as CJS (where __dirname is the compiled module
+// directory). See packages/generator-adp/src/utils/templates.ts.
+declare const __dirname: string | undefined;
+const moduleDir = typeof __dirname !== 'undefined' ? __dirname : process.cwd();
+const expectedPath = join(moduleDir, 'templates');
 
 describe('getTemplatesOverwritePath', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>).__dirname;
     });
 
     it('should return template path when templates directory exists', () => {
@@ -38,5 +44,18 @@ describe('getTemplatesOverwritePath', () => {
         expect(result).toBeUndefined();
         expect(mockExistsSync).toHaveBeenCalledWith(expectedPath);
         expect(mockExistsSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should resolve the templates path via __dirname when defined (CJS runtime)', () => {
+        // The compiled CJS build runs with Node's `__dirname` global defined.
+        // Under ts-jest's ESM transform it is undefined, so we simulate it
+        // here to exercise the production code path.
+        (globalThis as Record<string, unknown>).__dirname = '/abs/generators/utils';
+        mockExistsSync.mockReturnValue(true);
+
+        const result = getTemplatesOverwritePath();
+
+        expect(result).toBe('/abs/generators/utils/templates');
+        expect(mockExistsSync).toHaveBeenCalledWith('/abs/generators/utils/templates');
     });
 });

--- a/packages/generator-adp/test/unit/utils/templates.test.ts
+++ b/packages/generator-adp/test/unit/utils/templates.test.ts
@@ -50,12 +50,14 @@ describe('getTemplatesOverwritePath', () => {
         // The compiled CJS build runs with Node's `__dirname` global defined.
         // Under ts-jest's ESM transform it is undefined, so we simulate it
         // here to exercise the production code path.
-        (globalThis as Record<string, unknown>).__dirname = '/abs/generators/utils';
+        const fakeDir = join('abs', 'generators', 'utils');
+        (globalThis as Record<string, unknown>).__dirname = fakeDir;
         mockExistsSync.mockReturnValue(true);
 
         const result = getTemplatesOverwritePath();
 
-        expect(result).toBe('/abs/generators/utils/templates');
-        expect(mockExistsSync).toHaveBeenCalledWith('/abs/generators/utils/templates');
+        const expected = join(fakeDir, 'templates');
+        expect(result).toBe(expected);
+        expect(mockExistsSync).toHaveBeenCalledWith(expected);
     });
 });

--- a/packages/generator-adp/test/unit/utils/templates.test.ts
+++ b/packages/generator-adp/test/unit/utils/templates.test.ts
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 const mockExistsSync = jest.fn() as jest.Mock;
 
 jest.unstable_mockModule('node:fs', () => ({
@@ -9,10 +8,12 @@ jest.unstable_mockModule('node:fs', () => ({
 
 const { getTemplatesOverwritePath } = await import('../../../src/utils/templates.js');
 
-// The source code derives __dirname from import.meta.url, so compute
-// the expected path relative to the actual source file location.
-const srcUtilsDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'src', 'utils');
-const expectedPath = join(srcUtilsDir, 'templates');
+// In the published CJS build, `getTemplatesOverwritePath` resolves the
+// templates folder relative to the compiled module (`generators/utils/`).
+// Under ts-jest's ESM test transform `__dirname`/`__filename` are not
+// defined, so the implementation falls back to `process.cwd()` and the
+// expected path is the package root joined with `templates`.
+const expectedPath = join(process.cwd(), 'templates');
 
 describe('getTemplatesOverwritePath', () => {
     beforeEach(() => {

--- a/packages/generator-adp/tsconfig.json
+++ b/packages/generator-adp/tsconfig.json
@@ -6,7 +6,9 @@
   ],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "generators"
+    "outDir": "generators",
+    "module": "commonjs",
+    "moduleResolution": "node"
   },
   "references": [
     {


### PR DESCRIPTION
Fix for [4790](https://github.com/SAP/open-ux-tools/issues/4790)

- fixes crashing of generator-adp
- generator was changed to esm in https://github.com/SAP/open-ux-tools/pull/4565