### PR TITLE
chore: add fiori mcp server homepage metadata

### DIFF
--- a/.changeset/fiori-mcp-homepage.md
+++ b/.changeset/fiori-mcp-homepage.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+Add homepage metadata for the Fiori MCP server package.

--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -15,6 +15,7 @@
         "url": "https://github.com/SAP/open-ux-tools.git",
         "directory": "packages/fiori-mcp-server"
     },
+    "homepage": "https://github.com/SAP/open-ux-tools/tree/main/packages/fiori-mcp-server#readme",
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Afiori-mcp-server"
     },


### PR DESCRIPTION
## Summary
- Add homepage metadata for the Fiori MCP server npm package.
- Point npm users and tooling to the package README in this repository.

## Verification
- `node -e "const p=require('./packages/fiori-mcp-server/package.json'); console.log(p.homepage)"`
- `git diff --check`

Related public microbounty lead: https://github.com/charles-openclaw/charles-microbounties/issues/419
