### PR TITLE
move `restoreServiceProviderLoggers` to `@sap-ux/fiori-generator-shared`

### DIFF
--- a/.changeset/move-restore-service-provider-loggers-to-shared.md
+++ b/.changeset/move-restore-service-provider-loggers-to-shared.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux/fiori-generator-shared': patch
+'@sap-ux/fiori-app-sub-generator': patch
+---
+
+refactor: move restoreServiceProviderLoggers to @sap-ux/fiori-generator-shared

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -1,5 +1,5 @@
 import { convert } from '@sap-ux/annotation-converter';
-import type { Annotations, ServiceProvider } from '@sap-ux/axios-extension';
+import type { Annotations } from '@sap-ux/axios-extension';
 import { isAbapEnvironmentOnBtp, isAppStudio } from '@sap-ux/btp-utils';
 import type { CapRuntime, CapService } from '@sap-ux/cap-config-writer';
 import { checkCdsUi5PluginEnabled, getAppLaunchText } from '@sap-ux/cap-config-writer';
@@ -316,27 +316,4 @@ export async function getAnnotations(
     }
 }
 
-/**
- * Restore the loggers for the service provider if they are missing.
- * This is necessary because the service provider may have been serialized and deserialized, which can lead to missing loggers which contain circular refs.
- * Not doing this will result in the loggers being undefined when trying to access them, and calling services will throw.
- *
- * @param logger - The logger instance to be restored.
- * @param serviceProvider - The service provider object that may have missing loggers.
- * @returns The service provider with restored loggers.
- */
-export function restoreServiceProviderLoggers(
-    logger: Logger,
-    serviceProvider?: ServiceProvider
-): ServiceProvider | undefined {
-    // Restore the loggers if missing.
-    for (const service in (serviceProvider as any)?.services) {
-        if ((serviceProvider as any).services?.[service].log && !(serviceProvider as any).services[service].log.info) {
-            (serviceProvider as any).services[service].log = logger;
-        }
-    }
-    if (serviceProvider?.log && !serviceProvider.log.info) {
-        serviceProvider.log = logger;
-    }
-    return serviceProvider;
-}
+export { restoreServiceProviderLoggers } from '@sap-ux/fiori-generator-shared';

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -316,4 +316,5 @@ export async function getAnnotations(
     }
 }
 
+/** @deprecated Import directly from `@sap-ux/fiori-generator-shared` instead. */
 export { restoreServiceProviderLoggers } from '@sap-ux/fiori-generator-shared';

--- a/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import type { Annotations, ServiceProvider } from '@sap-ux/axios-extension';
+import type { Annotations } from '@sap-ux/axios-extension';
 import type { DebugOptions, FioriOptions } from '@sap-ux/launch-config';
 import type { CapService } from '@sap-ux/odata-service-inquirer';
 import { DatasourceType, OdataVersion } from '@sap-ux/odata-service-inquirer';
@@ -70,8 +70,7 @@ const {
     getMinSupportedUI5Version,
     getODataVersion,
     getReadMeDataSourceLabel,
-    getRequiredOdataVersion,
-    restoreServiceProviderLoggers
+    getRequiredOdataVersion
 } = await import('../../../src/utils/common.js');
 
 describe('Test utils', () => {
@@ -393,26 +392,5 @@ describe('Test utils', () => {
             expect(mockCreateLaunchConfig).toHaveBeenCalledWith(projectPath, expectedFioriOptions, editor, {});
             expect(mockWriteApplicationInfoSettings).toHaveBeenCalledWith(projectPath);
         });
-    });
-
-    test('restoreServiceProviderLoggers should re-add removed log ref', () => {
-        const logger = {
-            info: jest.fn(),
-            warn: jest.fn(),
-            error: jest.fn()
-        } as unknown as Logger;
-
-        const serviceProvider = {
-            log: {},
-            services: {
-                service1: { log: {} },
-                service2: { log: {} }
-            }
-        } as unknown as ServiceProvider;
-
-        const restoredServiceProvider = restoreServiceProviderLoggers(logger, serviceProvider);
-        expect(restoredServiceProvider?.log).toBe(logger);
-        expect((restoredServiceProvider as any)?.services.service1.log).toBe(logger);
-        expect((restoredServiceProvider as any)?.services.service2.log).toBe(logger);
     });
 });

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -29,6 +29,7 @@
         "!dist/**/*.map"
     ],
     "dependencies": {
+        "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/telemetry": "workspace:*",
@@ -48,7 +49,6 @@
         "@types/vscode": "1.110.0",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
-        "@sap-ux/axios-extension": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/store": "workspace:*"
     },

--- a/packages/fiori-generator-shared/src/index.ts
+++ b/packages/fiori-generator-shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './environment.js';
 export * from './system-utils.js';
 export * from './telemetry/index.js';
 export * from './logging/logWrapper.js';
+export * from './logging/serviceProvider.js';
 export * from './types/index.js';
 export { getPackageScripts } from './npm-package-scripts/getPackageScripts.js';
 export { getBootstrapResourceUrls } from './ui5/ui5.js';

--- a/packages/fiori-generator-shared/src/logging/logWrapper.ts
+++ b/packages/fiori-generator-shared/src/logging/logWrapper.ts
@@ -1,3 +1,4 @@
+import type { ServiceProvider } from '@sap-ux/axios-extension';
 import type { Log, Logger as SapUxLogger, Transport } from '@sap-ux/logger';
 import type {
     getExtensionLoggerOpts,
@@ -290,4 +291,29 @@ export class LogWrapper implements ILogWrapper, SapUxLogger {
         LogWrapper.logAtLevel(`warn`, 'Log method `child(options)` not implemented. Returning current logger.');
         return this;
     }
+}
+
+/**
+ * Restore the loggers for the service provider if they are missing.
+ * This is necessary because the service provider may have been serialized and deserialized, which can lead to missing loggers which contain circular refs.
+ * Not doing this will result in the loggers being undefined when trying to access them, and calling services will throw.
+ *
+ * @param logger - The logger instance to be restored.
+ * @param serviceProvider - The service provider object that may have missing loggers.
+ * @returns The service provider with restored loggers.
+ */
+export function restoreServiceProviderLoggers(
+    logger: SapUxLogger,
+    serviceProvider?: ServiceProvider
+): ServiceProvider | undefined {
+    // Restore the loggers if missing.
+    for (const service in (serviceProvider as any)?.services) {
+        if ((serviceProvider as any).services?.[service].log && !(serviceProvider as any).services[service].log.info) {
+            (serviceProvider as any).services[service].log = logger;
+        }
+    }
+    if (serviceProvider?.log && !serviceProvider.log.info) {
+        serviceProvider.log = logger;
+    }
+    return serviceProvider;
 }

--- a/packages/fiori-generator-shared/src/logging/logWrapper.ts
+++ b/packages/fiori-generator-shared/src/logging/logWrapper.ts
@@ -1,4 +1,3 @@
-import type { ServiceProvider } from '@sap-ux/axios-extension';
 import type { Log, Logger as SapUxLogger, Transport } from '@sap-ux/logger';
 import type {
     getExtensionLoggerOpts,
@@ -291,29 +290,4 @@ export class LogWrapper implements ILogWrapper, SapUxLogger {
         LogWrapper.logAtLevel(`warn`, 'Log method `child(options)` not implemented. Returning current logger.');
         return this;
     }
-}
-
-/**
- * Restore the loggers for the service provider if they are missing.
- * This is necessary because the service provider may have been serialized and deserialized, which can lead to missing loggers which contain circular refs.
- * Not doing this will result in the loggers being undefined when trying to access them, and calling services will throw.
- *
- * @param logger - The logger instance to be restored.
- * @param serviceProvider - The service provider object that may have missing loggers.
- * @returns The service provider with restored loggers.
- */
-export function restoreServiceProviderLoggers(
-    logger: SapUxLogger,
-    serviceProvider?: ServiceProvider
-): ServiceProvider | undefined {
-    // Restore the loggers if missing.
-    for (const service in (serviceProvider as any)?.services) {
-        if ((serviceProvider as any).services?.[service].log && !(serviceProvider as any).services[service].log.info) {
-            (serviceProvider as any).services[service].log = logger;
-        }
-    }
-    if (serviceProvider?.log && !serviceProvider.log.info) {
-        serviceProvider.log = logger;
-    }
-    return serviceProvider;
 }

--- a/packages/fiori-generator-shared/src/logging/serviceProvider.ts
+++ b/packages/fiori-generator-shared/src/logging/serviceProvider.ts
@@ -1,0 +1,26 @@
+import type { ServiceProvider } from '@sap-ux/axios-extension';
+import type { Logger as AppLogger } from '@sap-ux/logger';
+
+/**
+ * Restore the loggers for the service provider if they are missing.
+ * This is necessary because the service provider may have been serialized and deserialized, which can lead to missing loggers which contain circular refs.
+ * Not doing this will result in the loggers being undefined when trying to access them, and calling services will throw.
+ *
+ * @param logger - The logger instance to be restored.
+ * @param serviceProvider - The service provider object that may have missing loggers.
+ * @returns The service provider with restored loggers.
+ */
+export function restoreServiceProviderLoggers(
+    logger: AppLogger,
+    serviceProvider?: ServiceProvider
+): ServiceProvider | undefined {
+    for (const service in (serviceProvider as any)?.services) {
+        if ((serviceProvider as any).services?.[service].log && !(serviceProvider as any).services[service].log.info) {
+            (serviceProvider as any).services[service].log = logger;
+        }
+    }
+    if (serviceProvider?.log && !serviceProvider.log.info) {
+        serviceProvider.log = logger;
+    }
+    return serviceProvider;
+}

--- a/packages/fiori-generator-shared/test/logging/logWrapper.test.ts
+++ b/packages/fiori-generator-shared/test/logging/logWrapper.test.ts
@@ -25,8 +25,8 @@ jest.unstable_mockModule('@vscode-logging/logger', () => ({
     getExtensionLogger: mockGetExtensionLogger
 }));
 
-const { createCLILogger, DefaultLogger, LogWrapper, restoreServiceProviderLoggers } =
-    await import('../../src/logging/logWrapper.js');
+const { createCLILogger, DefaultLogger, LogWrapper } = await import('../../src/logging/logWrapper.js');
+const { restoreServiceProviderLoggers } = await import('../../src/logging/serviceProvider.js');
 
 describe('Test logWrapper', () => {
     afterEach(() => {

--- a/packages/fiori-generator-shared/test/logging/logWrapper.test.ts
+++ b/packages/fiori-generator-shared/test/logging/logWrapper.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 import type { ChildLoggerOptions, Logger as SapUxLogger, Transport } from '@sap-ux/logger';
 import type { IVSCodeExtLogger } from '@vscode-logging/logger';
 import type { Logger as YoLogger } from 'yeoman-environment';
+import type { ServiceProvider } from '@sap-ux/axios-extension';
 
 const mockGetExtensionLogger = jest.fn().mockReturnValue({
     fatal: jest.fn(),
@@ -24,7 +25,8 @@ jest.unstable_mockModule('@vscode-logging/logger', () => ({
     getExtensionLogger: mockGetExtensionLogger
 }));
 
-const { createCLILogger, DefaultLogger, LogWrapper } = await import('../../src/logging/logWrapper.js');
+const { createCLILogger, DefaultLogger, LogWrapper, restoreServiceProviderLoggers } =
+    await import('../../src/logging/logWrapper.js');
 
 describe('Test logWrapper', () => {
     afterEach(() => {
@@ -156,5 +158,33 @@ describe('Test logWrapper', () => {
         expect(yoLoggerSpy).toHaveBeenLastCalledWith(
             expect.stringContaining('Log method `child(options)` not implemented.')
         );
+    });
+});
+
+describe('restoreServiceProviderLoggers', () => {
+    test('restoreServiceProviderLoggers should re-add removed log ref', () => {
+        const logger = {
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn()
+        } as unknown as SapUxLogger;
+
+        const serviceProvider = {
+            log: {},
+            services: {
+                service1: { log: {} },
+                service2: { log: {} }
+            }
+        } as unknown as ServiceProvider;
+
+        const restoredServiceProvider = restoreServiceProviderLoggers(logger, serviceProvider);
+        expect(restoredServiceProvider?.log).toBe(logger);
+        expect((restoredServiceProvider as any)?.services.service1.log).toBe(logger);
+        expect((restoredServiceProvider as any)?.services.service2.log).toBe(logger);
+    });
+
+    test('should return undefined when no serviceProvider given', () => {
+        const logger = { info: jest.fn() } as unknown as SapUxLogger;
+        expect(restoreServiceProviderLoggers(logger, undefined)).toBeUndefined();
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2579,6 +2579,9 @@ importers:
 
   packages/fiori-generator-shared:
     dependencies:
+      '@sap-ux/axios-extension':
+        specifier: workspace:*
+        version: link:../axios-extension
       '@sap-ux/btp-utils':
         specifier: workspace:*
         version: link:../btp-utils
@@ -2613,9 +2616,6 @@ importers:
       '@jest/globals':
         specifier: 30.3.0
         version: 30.3.0
-      '@sap-ux/axios-extension':
-        specifier: workspace:*
-        version: link:../axios-extension
       '@sap-ux/logger':
         specifier: workspace:*
         version: link:../logger


### PR DESCRIPTION
- move `restoreServiceProviderLoggers` utility for fixing serialised `ServiceProvider` instances that have lost their logger references due to circular ref stripping in [odata-inquirer](https://github.com/SAP/open-ux-tools/blob/f248546af126cac3de6ec3cdbc23554692077f9c/packages/odata-service-inquirer/src/utils/index.ts#L142). 

- Needed by other generators that consume `@sap-ux/fiori-generator-shared` so can be reused