### PR TITLE
fix(odata-downloader): Multiple fixes and adds ouput tab link (`Show Logs`) to the odata downloader

### DIFF
--- a/.changeset/late-sloths-show.md
+++ b/.changeset/late-sloths-show.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/generator-odata-downloader': patch
+---
+
+Adds `Show Logs` link`

--- a/packages/generator-odata-downloader/src/data-download/prompts/prompts.ts
+++ b/packages/generator-odata-downloader/src/data-download/prompts/prompts.ts
@@ -330,6 +330,12 @@ function getEntitySelectionPrompt(
                 };
             }
             return undefined;
+        },
+        showOutputTabLink: () => {
+            return {
+                show: true,
+                linkMessage: t('prompts.relatedEntitySelection.openLogs')
+            };
         }
     } as CheckBoxQuestion;
 }

--- a/packages/generator-odata-downloader/src/data-download/prompts/prompts.ts
+++ b/packages/generator-odata-downloader/src/data-download/prompts/prompts.ts
@@ -333,7 +333,7 @@ function getEntitySelectionPrompt(
         },
         showOutputTabLink: () => {
             return {
-                show: true,
+                show: !!result,
                 linkMessage: t('prompts.relatedEntitySelection.openLogs')
             };
         }

--- a/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
+++ b/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
@@ -30,7 +30,8 @@
             }
         },
         "relatedEntitySelection": {
-            "message": "Select entities for data download (pre-selected entities are referenced by the application)"
+            "message": "Select entities for data download (pre-selected entities are referenced by the application)",
+            "openLogs": "Open logs"
         },
         "toggleSelection": {
             "message": "Reset selection",

--- a/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
+++ b/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
@@ -31,7 +31,7 @@
         },
         "relatedEntitySelection": {
             "message": "Select entities for data download (pre-selected entities are referenced by the application)",
-            "openLogs": "Open Logs"
+            "openLogs": "Show Logs"
         },
         "toggleSelection": {
             "message": "Reset selection",

--- a/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
+++ b/packages/generator-odata-downloader/src/translations/odataDownloadGenerator.i18n.json
@@ -31,7 +31,7 @@
         },
         "relatedEntitySelection": {
             "message": "Select entities for data download (pre-selected entities are referenced by the application)",
-            "openLogs": "Open logs"
+            "openLogs": "Open Logs"
         },
         "toggleSelection": {
             "message": "Reset selection",

--- a/packages/generator-odata-downloader/test/prompts/prompts.test.ts
+++ b/packages/generator-odata-downloader/test/prompts/prompts.test.ts
@@ -842,6 +842,17 @@ describe('Test prompts', () => {
                 jest.useRealTimers();
             });
         });
+
+        describe('showOutputTabLink', () => {
+            it('should show output tab link with localized link message', () => {
+                const showOutputTabLinkFn = (entitySelectionPrompt as any).showOutputTabLink;
+                expect(showOutputTabLinkFn).toBeDefined();
+                expect(showOutputTabLinkFn()).toEqual({
+                    show: true,
+                    linkMessage: realT('prompts.relatedEntitySelection.openLogs')
+                });
+            });
+        });
     });
 
     describe('Reset Selection Prompt', () => {

--- a/packages/generator-odata-downloader/test/prompts/prompts.test.ts
+++ b/packages/generator-odata-downloader/test/prompts/prompts.test.ts
@@ -844,13 +844,45 @@ describe('Test prompts', () => {
         });
 
         describe('showOutputTabLink', () => {
-            it('should show output tab link with localized link message', () => {
+            it('should not show output tab link before validate has produced a result', () => {
                 const showOutputTabLinkFn = (entitySelectionPrompt as any).showOutputTabLink;
                 expect(showOutputTabLinkFn).toBeDefined();
                 expect(showOutputTabLinkFn()).toEqual({
+                    show: false,
+                    linkMessage: realT('prompts.relatedEntitySelection.openLogs')
+                });
+            });
+
+            it('should show output tab link after a successful validate', async () => {
+                jest.useFakeTimers();
+                const mockChoices = [createMockChoice('Entity1', 'to_Entity1', 'Entity1Set')];
+                const mockQueryResult = { odataQueryResult: [{ id: 1 }] };
+                mockGetData.mockResolvedValue(mockQueryResult);
+
+                const result = await getODataDownloaderPrompts();
+                result.answers.application.relatedEntityChoices.choices = mockChoices;
+                result.answers.application.referencedEntities = {
+                    listEntity: createListEntity([{ name: 'TravelID', type: 'Edm.String', value: 'testKey' }])
+                };
+
+                const freshEntityPrompt = result.questions.find(
+                    (q: any) => q.name === promptNames.relatedEntitySelection
+                ) as CheckBoxQuestion;
+
+                const selectedEntities = [mockChoices[0].value];
+                const validatePromise = freshEntityPrompt.validate!(selectedEntities, {
+                    [promptNames.relatedEntitySelection]: selectedEntities,
+                    'entityKeyIdx:0': 'testKey'
+                });
+                jest.advanceTimersByTime(1000);
+                await validatePromise;
+
+                expect((freshEntityPrompt as any).showOutputTabLink()).toEqual({
                     show: true,
                     linkMessage: realT('prompts.relatedEntitySelection.openLogs')
                 });
+
+                jest.useRealTimers();
             });
         });
     });


### PR DESCRIPTION
## Summary

**Internal issues: 38412, 38439**

Adds the  **Show Logs** link on the OData downloader's related-entity selection prompt, fix `pnpm compile` for the package (remove esm specific code from source for now), fixes hierarchy bug.

### Feature
- `getEntitySelectionPrompt` now returns `showOutputTabLink` with `show: !!result` so the link appears once a query result is available, with the localized label from a new i18n key `prompts.relatedEntitySelection.openLogs`
- Unit tests cover both states (link hidden before validate, shown after a successful validate)

### `pnpm compile` fix
The package was failing `tsc --build` and, when run from compiled output, breaking with `exports is not defined in ES module scope` because tsc was emitting `.js` files into the same path as the esbuild bundle and Node 22 was syntax-detecting `import.meta.url` and loading the file as ESM.
- [tsconfig.json](packages/generator-odata-downloader/tsconfig.json): set `emitDeclarationOnly: true` so tsc emits only `.d.ts` and no longer overwrites the esbuild bundle
- [src/data-download/utils.ts](packages/generator-odata-downloader/src/data-download/utils.ts): replaced `createRequire(import.meta.url)` with `createRequire(__filename)` so source is CJS-clean
- [jest.config.mjs](packages/generator-odata-downloader/jest.config.mjs): added `globals: { __filename: import.meta.filename }` so the source pattern still works under ESM jest
- [src/utils/i18n.ts](packages/generator-odata-downloader/src/utils/i18n.ts), [src/telemetry/index.ts](packages/generator-odata-downloader/src/telemetry/index.ts): dropped `with { type: 'json' }` import attributes (CJS-incompatible — `resolveJsonModule` already permits the plain JSON imports)
- [src/data-download/prompts/prompt-helpers.ts](packages/generator-odata-downloader/src/data-download/prompts/prompt-helpers.ts): `UIAnnotationTypes.ReferenceFacet` / `CollectionFacet` replaced with their string-literal values to satisfy `isolatedModules` (avoids `TS2748: Cannot access ambient const enums`)

### Hierarchy parent-property fix
`resolveParentPropertyFromFile` was returning `constraints[0]?.targetProperty`, but the constraint-based code path on the same function (line 412) returns `sourceProperty`. The file-based fallback was therefore returning the wrong side of the referential constraint for nav-prop hierarchies (e.g. `_Parent` on `PPS_PurchaseOrderItem`).
- [src/data-download/utils.ts](packages/generator-odata-downloader/src/data-download/utils.ts): return `sourceProperty` so file-fallback and constraint-based resolution agree
- [test/test-data/.../mockdata/PPS_PurOrdItemHierarchy.js](packages/generator-odata-downloader/test/test-data/test-apps/purchaseorder/webapp/localService/mockdata/PPS_PurOrdItemHierarchy.js), [test/test-data/.../mockdata/PPS_PurchaseOrderItem.js](packages/generator-odata-downloader/test/test-data/test-apps/purchaseorder/webapp/localService/mockdata/PPS_PurchaseOrderItem.js): swap `sourceProperty`/`targetProperty` in the fixtures so they reflect real OData semantics (source = local FK on this entity, target = key on parent entity)

## Test plan

- [x] `pnpm --filter @sap-ux/generator-odata-downloader compile` passes
- [x] `pnpm --filter @sap-ux/generator-odata-downloader bundle` produces `generators/app/index.js` (CJS)
- [x] `pnpm --filter @sap-ux/generator-odata-downloader test` passes (Entity Selection Prompt suite includes new `showOutputTabLink` cases; nav-prop hierarchy tests still pass with the swapped fixture)
- [x] Manually run the OData downloader generator and confirm the **Open Logs** link is hidden until a query result is available, and visible afterwards
- [x] Clicking the link opens the output / logs tab
- [x] Run the generator against a service with a nav-prop hierarchy  and confirm the parent property is correctly identified from a pre-existing mock file
