### PR TITLE
fix(create): 38324 update system error message 2

### DIFF
--- a/.changeset/fix-create-system-error-message.md
+++ b/.changeset/fix-create-system-error-message.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/create": patch
+---
+
+fix(create): correct error message to use 'update system' instead of 'change system'

--- a/packages/create/src/cli/add/system.ts
+++ b/packages/create/src/cli/add/system.ts
@@ -128,7 +128,7 @@ async function addSystem(params: {
         const existingSystem = await service.read(new BackendSystemKey({ url: params.url, client: params.client }));
         if (existingSystem) {
             const clientSuffix = params.client ? ` (client ${params.client})` : '';
-            logger.error(`System '${params.url}'${clientSuffix} already exists. Use 'change system' to update it.`);
+            logger.error(`System '${params.url}'${clientSuffix} already exists. Use 'update system' to update it.`);
             return;
         }
 


### PR DESCRIPTION
## Description

Fixes incorrect error message in the `add system` command that references a non-existent `change system` command.

## Issue

Closes Internal issue 38324

## Changes

- Updated error message in `packages/create/src/cli/add/system.ts` to correctly reference `update system` instead of `change system`
- The error now reads: "System 'URL' already exists. Use 'update system' to update it."

## Context

The `add system` command was incorrectly telling users to use `change system` to update an existing system, but the actual command is `update system`. This was confusing for users trying to follow the error message guidance.

## Testing

- Built the `@sap-ux/create` package successfully
- All 176 unit tests pass
- Verified that the `update system` command exists in the codebase
- Test coverage remains at 95.94%

## Related PR

This is a follow-up to internal issue 4738 which was previously merged for the same issue.
