### PR TITLE
fix(ui5-test-writer): use js files for FPM opa tests

### DIFF
--- a/.changeset/strict-symbols-raise.md
+++ b/.changeset/strict-symbols-raise.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-test-writer': patch
+---
+
+force js file for fpm opa tests

--- a/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
+++ b/packages/ui5-test-writer/src/fiori-elements-opa-writer.ts
@@ -677,9 +677,11 @@ function writePageObject(
     fs: Editor,
     dotFileExtension: DotFileExtension
 ): void {
+    // FPM has no .ts template; force .js regardless of the configured extension
+    const ext = pageConfig.template === 'FPM' ? DotFileExtension.JS : dotFileExtension;
     fs.copyTpl(
-        join(rootTemplateDirPath, 'integration', 'pages', `${pageConfig.template}${dotFileExtension}`),
-        join(testOutDirPath, 'integration', 'pages', `${pageConfig.targetKey}${dotFileExtension}`),
+        join(rootTemplateDirPath, 'integration', 'pages', `${pageConfig.template}${ext}`),
+        join(testOutDirPath, 'integration', 'pages', `${pageConfig.targetKey}${ext}`),
         pageConfig,
         undefined,
         {


### PR DESCRIPTION
- ts files are not fully implemented for FPM projects.
- generator crashes as it tries to copy a ts file for OPA tests that does not exist