### PR TITLE
fix(eslint-plugin-fiori-tools): bundle @babel/* to fix conflicts with ui5-tooling-transpile

### DIFF
--- a/.changeset/eslint-plugin-bundle-babel.md
+++ b/.changeset/eslint-plugin-bundle-babel.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+fix(eslint-plugin-fiori-tools): bundle @babel/core, @babel/eslint-parser, @babel/parser to prevent version conflicts with ui5-tooling-transpile in consumer projects

--- a/packages/eslint-plugin-fiori-tools/esbuild.mjs
+++ b/packages/eslint-plugin-fiori-tools/esbuild.mjs
@@ -1,10 +1,16 @@
 import { context, build } from 'esbuild';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// Resolve @babel/eslint-parser's worker from this package's dependency tree.
+const req = createRequire(join(__dirname, 'package.json'));
+const babelEslintParserDir = dirname(req.resolve('@babel/eslint-parser'));
+const babelEslintParserWorker = resolve(babelEslintParserDir, 'worker/index.js');
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -20,17 +26,41 @@ const cjsCompatBanner = [
     'var __dirname=__cjsDirname(__filename);'
 ].join('');
 
+// @babel/eslint-parser@8 loads @babel/parser via createRequire() at runtime,
+// which breaks in consumer projects where @babel/parser isn't a direct dependency.
+// This plugin intercepts the file during bundling and replaces the dynamic require
+// with a static import so esbuild can bundle @babel/parser directly.
+// Note: WorkerClient spawns lib/worker/index.js via new Worker(path.resolve(import.meta.dirname,
+// "../lib/worker/index.js")) — that path resolves correctly once we add the worker as an entry point.
+const patchBabelEslintParser = {
+    name: 'patch-babel-eslint-parser',
+    setup(build) {
+        build.onLoad({ filter: /@babel[\\/]eslint-parser[\\/]lib[\\/]index\.js$/ }, (args) => {
+            let source = readFileSync(args.path, 'utf8');
+            const patched = source.replace(
+                /const require\$1 = createRequire\(import\.meta\.url\);\nconst babelParser = require\$1\(require\$1\.resolve\("@babel\/parser",\s*\{\s*paths:\s*\[require\$1\.resolve\("@babel\/core\/package\.json"\)\]\s*\}\)\);/,
+                'import * as babelParser from "@babel/parser";'
+            );
+            if (patched === source) {
+                throw new Error(
+                    '[patch-babel-eslint-parser] Failed to patch @babel/eslint-parser/lib/index.js: ' +
+                    'the createRequire-based @babel/parser load was not found. ' +
+                    'The upstream source has likely changed — update the patch in esbuild.mjs.'
+                );
+            }
+            return { contents: patched, loader: 'js' };
+        });
+    }
+};
+
 // eslint is a peerDependency provided by the consumer.
 // @typescript-eslint/eslint-plugin and @typescript-eslint/parser are runtime dependencies —
 // marking them external drops the ~3.5 MB typescript.js from the bundle.
-// @babel/* are peerDependencies of @babel/eslint-parser — required dynamically at runtime.
+// @babel/* are bundled (not external) so consumers don't need them as direct dependencies.
 const externalDependencies = [
     'eslint',
     '@typescript-eslint/eslint-plugin',
-    '@typescript-eslint/parser',
-    '@babel/core',
-    '@babel/eslint-parser',
-    '@babel/parser'
+    '@typescript-eslint/parser'
 ];
 
 /** @type {import('esbuild').BuildOptions} */
@@ -47,12 +77,14 @@ const buildOptions = {
     entryPoints: [
         { in: join(__dirname, 'src/index.ts'), out: 'index' },
         { in: join(__dirname, 'src/project-context/artifacts.ts'), out: 'project-context/artifacts' },
-        { in: join(__dirname, 'src/worker-getPathMappingsSync.ts'), out: 'worker-getPathMappingsSync' }
+        { in: join(__dirname, 'src/worker-getPathMappingsSync.ts'), out: 'worker-getPathMappingsSync' },
+        { in: babelEslintParserWorker, out: 'worker/index' }
     ],
     minify: production,
     sourcemap: !production,
     banner: { js: cjsCompatBanner },
-    external: externalDependencies
+    external: externalDependencies,
+    plugins: [patchBabelEslintParser]
 };
 
 if (watch) {

--- a/packages/eslint-plugin-fiori-tools/esbuild.mjs
+++ b/packages/eslint-plugin-fiori-tools/esbuild.mjs
@@ -8,9 +8,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Resolve @babel/eslint-parser's worker from this package's dependency tree.
+// Resolve via package.json (not the main entry) so dirname() gives the package
+// root regardless of where the main field points.
 const req = createRequire(join(__dirname, 'package.json'));
-const babelEslintParserDir = dirname(req.resolve('@babel/eslint-parser'));
-const babelEslintParserWorker = resolve(babelEslintParserDir, 'worker/index.js');
+const babelEslintParserRoot = dirname(req.resolve('@babel/eslint-parser/package.json'));
+const babelEslintParserWorker = resolve(babelEslintParserRoot, 'lib/worker/index.js');
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -38,7 +40,7 @@ const patchBabelEslintParser = {
         build.onLoad({ filter: /@babel[\\/]eslint-parser[\\/]lib[\\/]index\.js$/ }, (args) => {
             let source = readFileSync(args.path, 'utf8');
             const patched = source.replace(
-                /const require\$1 = createRequire\(import\.meta\.url\);\nconst babelParser = require\$1\(require\$1\.resolve\("@babel\/parser",\s*\{\s*paths:\s*\[require\$1\.resolve\("@babel\/core\/package\.json"\)\]\s*\}\)\);/,
+                /const require\$1 = createRequire\(import\.meta\.url\);\r?\nconst babelParser = require\$1\(require\$1\.resolve\("@babel\/parser",\s*\{\s*paths:\s*\[require\$1\.resolve\("@babel\/core\/package\.json"\)\]\s*\}\)\);/,
                 'import * as babelParser from "@babel/parser";'
             );
             if (patched === source) {

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -27,13 +27,13 @@
         "tgz:package": "pnpm pack"
     },
     "dependencies": {
-        "@babel/core": "8.0.0-rc.6",
-        "@babel/eslint-parser": "8.0.0-rc.6",
-        "@babel/parser": "8.0.0-rc.6",
         "@typescript-eslint/eslint-plugin": "8.57.2",
         "@typescript-eslint/parser": "8.57.2"
     },
     "devDependencies": {
+        "@babel/core": "8.0.0-rc.6",
+        "@babel/eslint-parser": "8.0.0-rc.6",
+        "@babel/parser": "8.0.0-rc.6",
         "@eslint/js": "10.0.1",
         "@eslint/json": "0.14.0",
         "@eslint/core": "1.1.1",

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -393,7 +393,6 @@ const prodConfig: Linter.Config[] = [
             ecmaVersion: 'latest',
             parserOptions: {
                 requireConfigFile: false,
-                sourceType: 'module',
                 babelOptions: {
                     parserOpts: {
                         plugins: ['typescript']
@@ -420,7 +419,6 @@ const testConfig: Linter.Config[] = [
             ecmaVersion: 'latest',
             parserOptions: {
                 requireConfigFile: false,
-                sourceType: 'module',
                 babelOptions: {
                     parserOpts: {
                         plugins: ['typescript']

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -389,8 +389,16 @@ const prodConfig: Linter.Config[] = [
 
         languageOptions: {
             parser: babelParser,
+            sourceType: 'module',
+            ecmaVersion: 'latest',
             parserOptions: {
-                requireConfigFile: false
+                requireConfigFile: false,
+                sourceType: 'module',
+                babelOptions: {
+                    parserOpts: {
+                        plugins: ['typescript']
+                    }
+                }
             },
             globals: globalsConfig
         },
@@ -408,8 +416,16 @@ const testConfig: Linter.Config[] = [
 
         languageOptions: {
             parser: babelParser,
+            sourceType: 'module',
+            ecmaVersion: 'latest',
             parserOptions: {
-                requireConfigFile: false
+                requireConfigFile: false,
+                sourceType: 'module',
+                babelOptions: {
+                    parserOpts: {
+                        plugins: ['typescript']
+                    }
+                }
             },
             globals: globalsConfig
         },
@@ -504,9 +520,9 @@ export const configs: Record<string, Linter.Config[]> = {
                 }
             }
         },
-        ...typescriptConfig,
         ...prodConfig,
-        ...testConfig
+        ...testConfig,
+        ...typescriptConfig
     ],
     'recommended-for-s4hana': [
         {
@@ -518,9 +534,9 @@ export const configs: Record<string, Linter.Config[]> = {
                 }
             }
         },
-        ...typescriptConfig,
         ...prodConfig,
         ...testConfig,
+        ...typescriptConfig,
         ...fioriLanguageConfig
     ]
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1985,15 +1985,6 @@ importers:
 
   packages/eslint-plugin-fiori-tools:
     dependencies:
-      '@babel/core':
-        specifier: 8.0.0-rc.6
-        version: 8.0.0-rc.6
-      '@babel/eslint-parser':
-        specifier: 8.0.0-rc.6
-        version: 8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)
-      '@babel/parser':
-        specifier: 8.0.0-rc.6
-        version: 8.0.0-rc.6
       '@typescript-eslint/eslint-plugin':
         specifier: 8.57.2
         version: 8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3)
@@ -2004,6 +1995,15 @@ importers:
         specifier: ^8.57.2
         version: 8.57.2(eslint@9.39.1)(typescript@5.9.3)
     devDependencies:
+      '@babel/core':
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6
+      '@babel/eslint-parser':
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)
+      '@babel/parser':
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6
       '@eslint/config-helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -33509,7 +33509,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1(debug@4.3.4)
+      axios: 1.16.1
     optional: true
 
   retry@0.12.0: {}


### PR DESCRIPTION
## Summary

- **Root cause**: `@babel/core@8.0.0-rc.6` shipped as a runtime `dependency` of `eslint-plugin-fiori-tools` gets hoisted to the top-level `node_modules` in flat package managers (npm/yarn), overriding the `@babel/core@7` that `ui5-tooling-transpile` relies on. Babel 8's stricter parser then rejects valid UI5 TypeScript patterns like `BaseComponent.prototype.init.call`, breaking `fiori run` for TypeScript projects.
- **Fix**: Bundle `@babel/core`, `@babel/eslint-parser`, and `@babel/parser` into the plugin output via esbuild. Consumers no longer need these in their own `node_modules`.
- **Config fixes exposed by bundling**: `@babel/eslint-parser` now correctly respects ESLint's merged `languageOptions` — required adding `sourceType: 'module'`, `ecmaVersion: 'latest'`, and `babelOptions.parserOpts.plugins: ['typescript']` to the babel parser config blocks, and moving `typescriptConfig` last in the exported arrays so `tsParser` wins for `.ts` files.

## Changes

- **`esbuild.mjs`**: Added `patchBabelEslintParser` esbuild plugin that replaces `@babel/eslint-parser`'s runtime `createRequire`-based `@babel/parser` load with a static import (enabling bundling); added `lib/worker/index.js` as a separate entry point so `WorkerClient`'s hardcoded relative path resolves correctly from the bundle; removed `@babel/core/eslint-parser/parser` from externals.
- **`package.json`**: Moved `@babel/core`, `@babel/eslint-parser`, `@babel/parser` from `dependencies` → `devDependencies`.
- **`src/index.ts`**: Added `sourceType: 'module'`, `ecmaVersion: 'latest'`, and `babelOptions.parserOpts.plugins: ['typescript']` to both babel parser config blocks; moved `typescriptConfig` last in exported arrays.

## Test plan

- [ ] `npm run lint` in a newly generated Fiori TypeScript app produces 0 parse errors
- [ ] `fiori run` with `ui5-tooling-transpile` still transpiles TypeScript correctly (no `@babel/core` version conflict)
- [ ] `pnpm lint` passes in the monorepo
- [ ] CI passes