### PR TITLE
chore(fiori-mcp-server): add homepage metadata

### DIFF
--- a/.changeset/gentle-fiori-mcp-homepage.md
+++ b/.changeset/gentle-fiori-mcp-homepage.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+Add package homepage metadata for the Fiori MCP server.

--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -18,6 +18,7 @@
     "bugs": {
         "url": "https://github.com/SAP/open-ux-tools/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Afiori-mcp-server"
     },
+    "homepage": "https://github.com/SAP/open-ux-tools/tree/main/packages/fiori-mcp-server#readme",
     "type": "module",
     "license": "Apache-2.0",
     "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add the missing npm `homepage` metadata for `@sap-ux/fiori-mcp-server`
- Include a patch changeset for the package metadata update

## Notes
- Metadata-only change
- No runtime code, dependencies, exports, generated files, or build behavior changed

## Verification
- `node - <<'NODE' ... NODE` package metadata assertion
- `cd packages/fiori-mcp-server && npm pack --dry-run --ignore-scripts --json`
- `git diff --check`