### PR TITLE
fix(odata-service-writer): add builder.resources.excludes to ui5 yaml files

### DIFF
--- a/.changeset/odata-service-writer-builder-excludes.md
+++ b/.changeset/odata-service-writer-builder-excludes.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-writer": patch
+---
+
+FIX: add builder.resources.excludes to ui5.yaml and ui5-local.yaml when adding an OData service

--- a/packages/odata-service-writer/src/update.ts
+++ b/packages/odata-service-writer/src/update.ts
@@ -55,8 +55,9 @@ function extendBackendMiddleware(
     service: OdataService,
     ui5Config: UI5Config,
     ui5ConfigPath: string,
-    update = false
+    update: boolean = false
 ): void {
+    ui5Config.addBuilderResourceExcludes();
     if (update) {
         ui5Config.updateBackendToFioriToolsProxyMiddleware(service.previewSettings as ProxyBackend);
     } else {
@@ -102,12 +103,10 @@ async function updateUI5YamlConfigs(
 
     if (paths.ui5Yaml) {
         ui5Config = await UI5Config.newInstance(fs.read(paths.ui5Yaml));
-        ui5Config.addBuilderResourceExcludes();
         extendBackendMiddleware(fs, service, ui5Config, paths.ui5Yaml);
 
         if (paths.ui5LocalYaml) {
             ui5LocalConfig = await UI5Config.newInstance(fs.read(paths.ui5LocalYaml));
-            ui5LocalConfig.addBuilderResourceExcludes();
             extendBackendMiddleware(fs, service, ui5LocalConfig, paths.ui5LocalYaml);
         }
     }

--- a/packages/odata-service-writer/src/update.ts
+++ b/packages/odata-service-writer/src/update.ts
@@ -102,10 +102,12 @@ async function updateUI5YamlConfigs(
 
     if (paths.ui5Yaml) {
         ui5Config = await UI5Config.newInstance(fs.read(paths.ui5Yaml));
+        ui5Config.addBuilderResourceExcludes();
         extendBackendMiddleware(fs, service, ui5Config, paths.ui5Yaml);
 
         if (paths.ui5LocalYaml) {
             ui5LocalConfig = await UI5Config.newInstance(fs.read(paths.ui5LocalYaml));
+            ui5LocalConfig.addBuilderResourceExcludes();
             extendBackendMiddleware(fs, service, ui5LocalConfig, paths.ui5LocalYaml);
         }
     }

--- a/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
+++ b/packages/odata-service-writer/test/__snapshots__/index.test.ts.snap
@@ -22,7 +22,12 @@ Object {
     "state": "modified",
   },
   "ui5-local.yaml": Object {
-    "contents": "server:
+    "contents": "builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
+server:
   customMiddleware:
     - name: fiori-tools-proxy
       afterMiddleware: compression
@@ -73,6 +78,11 @@ Object {
         annotations:
           - localPath: ./webapp/localService/mainService/sepmra_annotations_tech_name.xml
             urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='sepmra_annotations_tech_name',Version='0001')/$value/
+builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
 ",
     "state": "modified",
   },
@@ -91,6 +101,11 @@ Object {
         backend:
           - path: /sap
             url: http://localhost
+builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
 ",
     "state": "modified",
   },
@@ -2802,7 +2817,12 @@ Object {
     "state": "modified",
   },
   "ui5-local.yaml": Object {
-    "contents": "server:
+    "contents": "builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
+server:
   customMiddleware:
     - name: fiori-tools-proxy
       afterMiddleware: compression
@@ -2853,6 +2873,11 @@ Object {
         annotations:
           - localPath: ./webapp/localService/mainService/SEPM_XYZ_SERVICE.xml
             urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='%2FSEPM_XYZ%2FSERVICE',Version='0001')/$value/
+builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
 ",
     "state": "modified",
   },
@@ -2871,6 +2896,11 @@ Object {
         backend:
           - path: /sap
             url: http://localhost
+builder:
+  resources:
+    excludes:
+      - /test/**
+      - /localService/**
 ",
     "state": "modified",
   },

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -125,32 +125,37 @@ describe('generate', () => {
                 fs
             );
             expect(fs.read(join(testDir, 'ui5-mock.yaml'))).toMatchInlineSnapshot(`
-                            "resources:
-                              configuration: {}
-                            server:
-                              customMiddleware:
-                                - name: fiori-tools-proxy
-                                  afterMiddleware: compression
-                                  configuration:
-                                    ignoreCertErrors: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
-                                    backend:
-                                      - path: /sap
-                                        url: https://localhost/updated
-                                - name: sap-fe-mockserver
-                                  beforeMiddleware: csp
-                                  configuration:
-                                    mountPath: /
-                                    services:
-                                      - urlPath: /sap
-                                        metadataPath: ./webapp/localService/mainService/metadata.xml
-                                        mockdataPath: ./webapp/localService/mainService/data
-                                        generateMockData: true
-                                        resolveExternalServiceReferences: true
-                                    annotations:
-                                      - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
-                                        urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
-                            "
-                    `);
+                "resources:
+                  configuration: {}
+                builder:
+                  resources:
+                    excludes:
+                      - /test/**
+                      - /localService/**
+                server:
+                  customMiddleware:
+                    - name: fiori-tools-proxy
+                      afterMiddleware: compression
+                      configuration:
+                        ignoreCertErrors: false # If set to true, certificate errors will be ignored. E.g. self-signed certificates will be accepted
+                        backend:
+                          - path: /sap
+                            url: https://localhost/updated
+                    - name: sap-fe-mockserver
+                      beforeMiddleware: csp
+                      configuration:
+                        mountPath: /
+                        services:
+                          - urlPath: /sap
+                            metadataPath: ./webapp/localService/mainService/metadata.xml
+                            mockdataPath: ./webapp/localService/mainService/data
+                            generateMockData: true
+                            resolveExternalServiceReferences: true
+                        annotations:
+                          - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
+                            urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+                "
+            `);
             // Value List references are saved
             expect(
                 fs.read(
@@ -570,6 +575,11 @@ describe('generate', () => {
                             apiHub: true
                             scp: false
                             pathPrefix: /~prefix
+                builder:
+                  resources:
+                    excludes:
+                      - /test/**
+                      - /localService/**
                 "
             `);
             // verify the updated package.json

--- a/packages/odata-service-writer/test/unit/index.test.ts
+++ b/packages/odata-service-writer/test/unit/index.test.ts
@@ -1081,6 +1081,11 @@ describe('update', () => {
                         - /resources
                         - /test-resources
                       url: https://ui5.sap.com
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-local.yaml'))).toMatchInlineSnapshot(`
@@ -1110,6 +1115,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-mock.yaml'))).toMatchInlineSnapshot(`
@@ -1139,6 +1149,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         // No changes in package.json expected
@@ -1227,6 +1242,11 @@ describe('update', () => {
                         - /resources
                         - /test-resources
                       url: https://ui5.sap.com
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-local.yaml'))).toMatchInlineSnapshot(`
@@ -1256,6 +1276,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-mock.yaml'))).toMatchInlineSnapshot(`
@@ -1285,6 +1310,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         // No changes in package.json expected
@@ -1360,6 +1390,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/SEPMRA_PROD_MAN.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='SEPMRA_PROD_MAN',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         // Value List references are saved
@@ -1660,6 +1695,11 @@ describe('update', () => {
                         - /resources
                         - /test-resources
                       url: https://ui5.sap.com
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-local.yaml'))).toMatchInlineSnapshot(`
@@ -1689,6 +1729,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/DIFFERENT_ANNOTATION.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='DIFFERENT_ANNOTATION',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.read(join(testDir, 'ui5-mock.yaml'))).toMatchInlineSnapshot(`
@@ -1718,6 +1763,11 @@ describe('update', () => {
                     annotations:
                       - localPath: ./webapp/localService/mainService/DIFFERENT_ANNOTATION.xml
                         urlPath: /sap/opu/odata/IWFND/CATALOGSERVICE;v=2/Annotations(TechnicalName='DIFFERENT_ANNOTATION',Version='0001')/$value/
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         // No changes in package.json expected
@@ -1812,6 +1862,11 @@ describe('update', () => {
                         - /resources
                         - /test-resources
                       url: https://ui5.sap.com
+            builder:
+              resources:
+                excludes:
+                  - /test/**
+                  - /localService/**
             "
         `);
         expect(fs.exists(join(testDir, 'ui5-local.yaml'))).toBe(false);


### PR DESCRIPTION
Fixes #4756

## Summary

- `@sap-ux/odata-service-writer`: calls `addBuilderResourceExcludes()` on `ui5.yaml` and `ui5-local.yaml` when updating middleware config — ensures `/test/**` and `/localService/**` are written to `builder.resources.excludes` in both files when an OData service is added to an existing project

## Questions for review

- Should `builder.resources.excludes` also be added to `ui5-local.yaml`? Issue #4756 specifies `ui5.yaml` and `ui5-deploy.yaml` — `ui5-local.yaml` is dev-only (mockserver). Included here but open to removing if not appropriate.

## Test plan

- [ ] `pnpm --filter @sap-ux/odata-service-writer test`
- [ ] `pnpm validate:changesets`