### PR TITLE
chore(jest-environment-ui5): add support metadata

### DIFF
--- a/.changeset/tiny-ui5-apples.md
+++ b/.changeset/tiny-ui5-apples.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/jest-environment-ui5": patch
+---
+
+FIX: Add package homepage and issue tracker metadata

--- a/packages/jest-environment-ui5/package.json
+++ b/packages/jest-environment-ui5/package.json
@@ -7,6 +7,10 @@
         "url": "https://github.com/SAP/open-ux-tools.git",
         "directory": "packages/jest-environment-ui5"
     },
+    "bugs": {
+        "url": "https://github.com/SAP/open-ux-tools/issues"
+    },
+    "homepage": "https://github.com/SAP/open-ux-tools/tree/main/packages/jest-environment-ui5#readme",
     "license": "Apache-2.0",
     "private": false,
     "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@sap-ux/jest-environment-ui5`
- add a package homepage pointing to the package README in this repository

## Verification
- `node -e "const p=require('./packages/jest-environment-ui5/package.json'); if (p.homepage !== 'https://github.com/SAP/open-ux-tools/tree/main/packages/jest-environment-ui5#readme') throw new Error('homepage mismatch'); if (p.bugs?.url !== 'https://github.com/SAP/open-ux-tools/issues') throw new Error('bugs mismatch'); console.log(JSON.stringify({homepage:p.homepage, bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @sap-ux/jest-environment-ui5 run lint` (passes with existing JSDoc warnings)
- `corepack pnpm --filter @sap-ux/jest-environment-ui5 run test-ut`
- `npm pack --dry-run --ignore-scripts --json ./packages/jest-environment-ui5`