### PR TITLE
fix(preview-middleware): remove static import and use type-only imports to avoid eager sap.ui.rta load

### DIFF
--- a/.changeset/empty-hotels-lay.md
+++ b/.changeset/empty-hotels-lay.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux-private/preview-middleware-client': patch
+---
+
+fix: remove static import and use type-only imports to avoid eager sap.ui.rta load

--- a/packages/preview-middleware-client/src/cpe/changes/generic-change.ts
+++ b/packages/preview-middleware-client/src/cpe/changes/generic-change.ts
@@ -5,7 +5,7 @@ import FlexChange from 'sap/ui/fl/Change';
 import JsControlTreeModifier from 'sap/ui/core/util/reflection/JsControlTreeModifier';
 import Log from 'sap/base/Log';
 import { getError } from '../../utils/error.js';
-import { AppComponent } from 'sap/ui/rta/RuntimeAuthoring';
+import type { AppComponent } from 'sap/ui/rta/RuntimeAuthoring';
 import { getConfigMapControlIdMap } from '../../utils/fe-v4.js';
 import { PropertyValue } from '@sap-ux-private/control-property-editor-common';
 

--- a/packages/preview-middleware-client/src/utils/additional-change-info.ts
+++ b/packages/preview-middleware-client/src/utils/additional-change-info.ts
@@ -1,5 +1,5 @@
 import type Component from 'sap/ui/core/Component';
-import FlexChange from 'sap/ui/fl/Change';
+import type FlexChange from 'sap/ui/fl/Change';
 import {
     getAddXMLAdditionalInfo,
     type AddXMLAdditionalInfo,

--- a/packages/preview-middleware-client/src/utils/changes.ts
+++ b/packages/preview-middleware-client/src/utils/changes.ts
@@ -1,5 +1,6 @@
-import FlexChange, { ChangeDefinition } from 'sap/ui/fl/Change';
-import FlexCommand from 'sap/ui/rta/command/FlexCommand';
+import type FlexChange from 'sap/ui/fl/Change';
+import type { ChangeDefinition } from 'sap/ui/fl/Change';
+import type FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import { AddXMLChangeContent } from '../cpe/additional-change-info/add-xml-additional-info.js';
 import { ADD_XML_CHANGE } from '../cpe/changes/generic-change';
 

--- a/packages/preview-middleware-client/src/utils/fe-v4.ts
+++ b/packages/preview-middleware-client/src/utils/fe-v4.ts
@@ -6,10 +6,9 @@ import XMLView from 'sap/ui/core/mvc/XMLView';
 import type { FlexSettings, Manifest } from 'sap/ui/rta/RuntimeAuthoring';
 
 import { isA } from './core.js';
-import CommandFactory from 'sap/ui/rta/command/CommandFactory';
 import { getOverlay } from '../cpe/utils.js';
 import UI5Element from 'sap/ui/core/Element';
-import FlexCommand from 'sap/ui/rta/command/FlexCommand';
+import type FlexCommand from 'sap/ui/rta/command/FlexCommand';
 import TableAPI from 'sap/fe/macros/table/TableAPI';
 
 export type MacroTable = TableAPI & {
@@ -142,6 +141,7 @@ export async function createManifestPropertyChange(
         selector: manifestPropertyChange.selector
     };
 
+    const CommandFactory = (await import('sap/ui/rta/command/CommandFactory')).default;
     const command = await CommandFactory.getCommandFor(
         modifiedControl,
         'appDescriptor',


### PR DESCRIPTION
# fix(preview-middleware-client): Remove Static Imports to Avoid Eager `sap.ui.rta` Load

### Bug Fix

🐛 Converts static imports of `sap/ui/rta` and `sap/ui/fl` modules to `type`-only imports (or dynamic imports where a runtime value is needed) to prevent the `sap.ui.rta` library from being loaded eagerly at module initialization time.

### Changes

* `.changeset/empty-hotels-lay.md`: Added changeset entry documenting the patch fix for `@sap-ux-private/preview-middleware-client`.

* `src/cpe/changes/generic-change.ts`: Changed `import { AppComponent }` to `import type { AppComponent }` from `sap/ui/rta/RuntimeAuthoring` to eliminate the static runtime dependency.

* `src/utils/additional-change-info.ts`: Changed `import FlexChange` to `import type FlexChange` from `sap/ui/fl/Change` to make it a type-only import.

* `src/utils/changes.ts`: Replaced combined static import of `FlexChange` and `ChangeDefinition` from `sap/ui/fl/Change` and static import of `FlexCommand` from `sap/ui/rta/command/FlexCommand` with separate `type`-only imports for all three.

* `src/utils/fe-v4.ts`: 
  - Removed static `import CommandFactory from 'sap/ui/rta/command/CommandFactory'` and replaced it with a dynamic `await import(...)` inside the function body, ensuring the module is only loaded when actually needed.
  - Changed `import FlexCommand` to `import type FlexCommand` from `sap/ui/rta/command/FlexCommand`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.25.0`

- Correlation ID: `d9c9d067-3271-4d96-bd30-16ad03a8f832`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
