### PR TITLE
fix: replace ACCESS_PAT with GitHub App token for version job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -137,14 +137,21 @@ jobs:
         environment: release
         permissions:
             contents: write
+            id-token: write
         outputs:
             changes: ${{ steps.changesetVersion.outputs.changes }} # map step output to job output
         steps:
+            - name: Generate app token
+              id: app-token
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout code repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
             - name: Use Node.js 22.x
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:


### PR DESCRIPTION
## Summary
- Replaces the personal `ACCESS_PAT` secret with a short-lived GitHub App token generated via `actions/create-github-app-token`
- The GitHub App is installed on this repo and added to the branch protection bypass list for `main`
- Adds `APP_ID` and `APP_PRIVATE_KEY` as environment secrets in the `release` environment

## Test plan
- [ ] Merge this PR to `main`
- [ ] Verify the next `version` job run pushes the changeset commit to `main` without the `GH006` protected branch error