### PR TITLE
fix(fiori-docs-embeddings): validate inputs to prevent argument injection and path traversal

### DIFF
--- a/.changeset/fiori-docs-embeddings-security-fixes.md
+++ b/.changeset/fiori-docs-embeddings-security-fixes.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-docs-embeddings": patch
+---
+
+FIX: Validate GitHub host/token inputs to prevent argument injection; validate output path to prevent path traversal

--- a/packages/fiori-docs-embeddings/src/scripts/build-local-docs.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/build-local-docs.ts
@@ -188,11 +188,11 @@ class FpmDocumentationBuilder {
 
         // Validate that host and token contain only safe characters to prevent argument injection
         // Host must be a valid hostname (alphanumeric, dots, hyphens only)
-        if (!/^[a-zA-Z0-9.\-]+$/.test(this.githubHost)) {
+        if (!/^[a-zA-Z0-9.-]+$/.test(this.githubHost)) {
             throw new Error('Invalid GitHub host: must contain only alphanumeric characters, dots, and hyphens');
         }
         // Token must not contain characters that could break URL or shell argument parsing
-        if (!/^[a-zA-Z0-9._\-]+$/.test(this.githubToken)) {
+        if (!/^[a-zA-Z0-9._-]+$/.test(this.githubToken)) {
             throw new Error(
                 'Invalid GitHub token: must contain only alphanumeric characters, dots, underscores, and hyphens'
             );

--- a/packages/fiori-docs-embeddings/src/scripts/build-local-docs.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/build-local-docs.ts
@@ -185,6 +185,18 @@ class FpmDocumentationBuilder {
         if (!this.githubHost || !this.githubToken) {
             throw new Error('GitHub host and token are required');
         }
+
+        // Validate that host and token contain only safe characters to prevent argument injection
+        // Host must be a valid hostname (alphanumeric, dots, hyphens only)
+        if (!/^[a-zA-Z0-9.\-]+$/.test(this.githubHost)) {
+            throw new Error('Invalid GitHub host: must contain only alphanumeric characters, dots, and hyphens');
+        }
+        // Token must not contain characters that could break URL or shell argument parsing
+        if (!/^[a-zA-Z0-9._\-]+$/.test(this.githubToken)) {
+            throw new Error(
+                'Invalid GitHub token: must contain only alphanumeric characters, dots, underscores, and hyphens'
+            );
+        }
     }
 
     /**

--- a/packages/fiori-docs-embeddings/src/scripts/load-readme-from-npm.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/load-readme-from-npm.ts
@@ -1,5 +1,5 @@
 import { writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import type { Packument } from '@npm/types';
 import { ToolsLogger } from '@sap-ux/logger';
 
@@ -53,9 +53,19 @@ async function fetchAndSaveReadme(packageName: string, logger: ToolsLogger): Pro
     logger.info(`Fetching README for ${packageName}...`);
     const readmeContent = await getPackageReadme(packageName, logger);
     if (readmeContent) {
-        const outputFileName = `${packageName.split('/').pop()}-README.md`;
+        const baseName = packageName.split('/').pop();
+        if (!baseName || baseName.includes('..') || baseName.includes('/') || baseName.includes('\\')) {
+            logger.error(`Invalid package name: ${packageName}`);
+            return;
+        }
+        const outputFileName = `${baseName}-README.md`;
         try {
-            const outputPath = join('data_local', outputFileName);
+            const outputDir = resolve('data_local');
+            const outputPath = join(outputDir, outputFileName);
+            // Ensure the resolved path stays within the intended directory
+            if (!outputPath.startsWith(outputDir + sep)) {
+                throw new Error(`Path traversal detected: ${outputPath}`);
+            }
             await writeFile(outputPath, enhanceReadmeContent(readmeContent), 'utf-8');
             logger.info(`Successfully saved README to './data_local'`);
         } catch (error) {

--- a/packages/fiori-docs-embeddings/src/scripts/load-readme-from-npm.ts
+++ b/packages/fiori-docs-embeddings/src/scripts/load-readme-from-npm.ts
@@ -54,7 +54,7 @@ async function fetchAndSaveReadme(packageName: string, logger: ToolsLogger): Pro
     const readmeContent = await getPackageReadme(packageName, logger);
     if (readmeContent) {
         const baseName = packageName.split('/').pop();
-        if (!baseName || baseName.includes('..') || baseName.includes('/') || baseName.includes('\\')) {
+        if (!baseName || baseName.includes('..') || baseName.includes('\\')) {
             logger.error(`Invalid package name: ${packageName}`);
             return;
         }

--- a/packages/fiori-docs-embeddings/test/build-fpm-docs.test.ts
+++ b/packages/fiori-docs-embeddings/test/build-fpm-docs.test.ts
@@ -105,6 +105,28 @@ describe('FpmDocumentationBuilder', () => {
                 'GitHub host and token are required'
             );
         });
+
+        it('should throw error when GitHub host contains invalid characters', async () => {
+            process.env.GITHUB_HOST = 'github.test.com; rm -rf /';
+            process.env.GITHUB_TOKEN = 'valid-token-123';
+
+            const builder = new FpmDocumentationBuilder();
+
+            await expect((builder as any).initializeGitHubConfig()).rejects.toThrow(
+                'Invalid GitHub host: must contain only alphanumeric characters, dots, and hyphens'
+            );
+        });
+
+        it('should throw error when GitHub token contains invalid characters', async () => {
+            process.env.GITHUB_HOST = 'github.test.com';
+            process.env.GITHUB_TOKEN = 'token with spaces';
+
+            const builder = new FpmDocumentationBuilder();
+
+            await expect((builder as any).initializeGitHubConfig()).rejects.toThrow(
+                'Invalid GitHub token: must contain only alphanumeric characters, dots, underscores, and hyphens'
+            );
+        });
     });
 
     describe('directoryExists', () => {

--- a/packages/fiori-docs-embeddings/test/load-readme-from-npm.test.ts
+++ b/packages/fiori-docs-embeddings/test/load-readme-from-npm.test.ts
@@ -107,6 +107,38 @@ describe('download readme from npmjs', () => {
         );
     });
 
+    it('should reject package names containing double-dot traversal', async () => {
+        process.argv = ['node', 'script.js', '..'];
+        global.fetch = jest.fn<typeof fetch>().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({
+                readme: testReadmeContent
+            })
+        } as any);
+
+        const script = await import('../src/scripts/load-readme-from-npm.js');
+        await script.execution;
+
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid package name'));
+        expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject package names containing backslash traversal', async () => {
+        process.argv = ['node', 'script.js', 'foo\\..\\bar'];
+        global.fetch = jest.fn<typeof fetch>().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({
+                readme: testReadmeContent
+            })
+        } as any);
+
+        const script = await import('../src/scripts/load-readme-from-npm.js');
+        await script.execution;
+
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid package name'));
+        expect(mockWriteFile).not.toHaveBeenCalled();
+    });
+
     it('should handle no package name error', async () => {
         //this test should always be the last one because we are overriding process.argv
         process.argv = ['node', 'script.js'];


### PR DESCRIPTION
## Summary

- **`build-local-docs.ts`**: Validate `githubHost` and `githubToken` (from env vars or interactive prompt) against allowlists before interpolating them into the git clone URL. A malformed host or token could otherwise inject extra arguments into the `git` command spawned via `child_process.spawn`.
- **`load-readme-from-npm.ts`**: Validate the `baseName` derived from the CLI `packageName` argument, and verify the resolved output path stays inside `data_local/` before writing. Prevents path traversal attacks (e.g. `../../../etc/passwd`) via a crafted package name argument.

Fixes two SonarCloud Major/Vulnerability findings.

## Test plan

- [ ] `pnpm --filter @sap-ux/fiori-docs-embeddings lint` — 0 errors
- [ ] `pnpm --filter @sap-ux/fiori-docs-embeddings test` — all 220 tests pass
- [ ] Changeset included for `@sap-ux/fiori-docs-embeddings` (patch)