### PR TITLE
fix(ui-prompting): readability of code preview in storybook examples

### DIFF
--- a/.changeset/quiet-mails-shake.md
+++ b/.changeset/quiet-mails-shake.md
@@ -1,0 +1,6 @@
+---
+'@sap-ux-private/ui-prompting-examples': patch
+'@sap-ux/ui-prompting': patch
+---
+
+FIX: Code preview in Storybook examples was hard to read due to background color

--- a/examples/ui-prompting-examples/src/addons/preview/component.tsx
+++ b/examples/ui-prompting-examples/src/addons/preview/component.tsx
@@ -18,7 +18,7 @@ export const CodePreview = (props: { active?: boolean }): React.ReactElement => 
         answers: {},
         codeSnippets: []
     });
-    const theme = useTheme() as { base: string };
+    const theme = useTheme();
 
     useEffect(function () {
         const handleMessage = (responseAction: Actions) => {
@@ -55,7 +55,7 @@ export const CodePreview = (props: { active?: boolean }): React.ReactElement => 
             <div
                 style={{
                     height: '100%',
-                    background: theme.base === 'dark' ? '#1a1a1a' : '#ffffff'
+                    background: 'base' in theme && theme.base === 'dark' ? '#1a1a1a' : '#ffffff'
                 }}>
                 {preview.codeSnippets.map((snippet) => (
                     <Form.Field label={snippet.fileName} key={snippet.fileName}>

--- a/examples/ui-prompting-examples/src/addons/preview/component.tsx
+++ b/examples/ui-prompting-examples/src/addons/preview/component.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { addons } from 'storybook/manager-api';
 import { UPDATE_CODE_SNIPPET, getWebSocket, onMessageAttach } from '../../utils/index.js';
 import type { Actions } from '../../utils/index.js';
+import { useTheme } from 'storybook/theming';
 
 getWebSocket(false);
 
@@ -17,6 +18,7 @@ export const CodePreview = (props: { active?: boolean }): React.ReactElement => 
         answers: {},
         codeSnippets: []
     });
+    const theme = useTheme() as { base: string };
 
     useEffect(function () {
         const handleMessage = (responseAction: Actions) => {
@@ -50,7 +52,11 @@ export const CodePreview = (props: { active?: boolean }): React.ReactElement => 
 
     return (
         <AddonPanel key="panel" active={active}>
-            <div>
+            <div
+                style={{
+                    height: '100%',
+                    background: theme.base === 'dark' ? '#1a1a1a' : '#ffffff'
+                }}>
                 {preview.codeSnippets.map((snippet) => (
                     <Form.Field label={snippet.fileName} key={snippet.fileName}>
                         <SyntaxHighlighter language={snippet.language ?? 'html'}>{snippet.content}</SyntaxHighlighter>

--- a/packages/ui-prompting/.storybook/addons/preview.tsx
+++ b/packages/ui-prompting/.storybook/addons/preview.tsx
@@ -1,6 +1,7 @@
 import { AddonPanel, Form, SyntaxHighlighter } from 'storybook/internal/components';
 import React, { useEffect, useState } from 'react';
 import { addons } from 'storybook/manager-api';
+import { useTheme } from 'storybook/theming';
 
 const storageKey = 'storybook-answers';
 function getCurrentAnswers(): string {
@@ -10,6 +11,7 @@ function getCurrentAnswers(): string {
 export const CodePreview = (props: { active?: boolean }): React.ReactElement => {
     const { active = false } = props;
     const [answers, setAnswers] = useState(getCurrentAnswers());
+    const theme = useTheme();
     useEffect(() => {
         window.addEventListener('storage', (event: StorageEvent) => {
             if (event.key !== storageKey) {
@@ -27,9 +29,15 @@ export const CodePreview = (props: { active?: boolean }): React.ReactElement => 
 
     return (
         <AddonPanel key="panel" active={active}>
-            <Form.Field label="Answers">
-                <SyntaxHighlighter language="json">{answers}</SyntaxHighlighter>
-            </Form.Field>
+            <div
+                style={{
+                    height: '100%',
+                    background: theme.base === 'dark' ? '#1a1a1a' : '#ffffff'
+                }}>
+                <Form.Field label="Answers">
+                    <SyntaxHighlighter language="json">{answers}</SyntaxHighlighter>
+                </Form.Field>
+            </div>
         </AddonPanel>
     );
 };


### PR DESCRIPTION
In [PR](https://github.com/SAP/open-ux-tools/pull/4565) storybook version was changed from `8.6.17` to `10.4.0`
In result we noticed that preview of code in storybook examples are hardly readable because of background:
before:
<img width="736" height="237" alt="image" src="https://github.com/user-attachments/assets/f9f2043c-d0f1-49c1-8f37-ccfa81fee4a2" />

after adjusting background
<img width="672" height="218" alt="image" src="https://github.com/user-attachments/assets/d26c2857-3e79-4dec-a76d-92162e61cf2d" />
<img width="752" height="405" alt="image" src="https://github.com/user-attachments/assets/31787c6a-4022-4812-93cb-d99279080cde" />
:
