### PR TITLE
fix: Revert getPackageJSONInfo to previous approach, removing getTemplatePath dependency

### DIFF
--- a/.changeset/stale-swans-retire.md
+++ b/.changeset/stale-swans-retire.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/adp-tooling': patch
+---
+
+FIX: Revert getPackageJSONInfo to previous approach, removing getTemplatePath dependency

--- a/packages/adp-tooling/src/writer/project-utils.ts
+++ b/packages/adp-tooling/src/writer/project-utils.ts
@@ -1,4 +1,5 @@
-import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import type { Editor } from 'mem-fs-editor';
 
@@ -18,6 +19,8 @@ import {
 import type { Package } from '@sap-ux/project-access';
 import { UI5Config, UI5_DEFAULT, getEsmTypesVersion, getTypesPackage, getTypesVersion } from '@sap-ux/ui5-config';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 /**
  * Retrieves the package name and version from the package.json file located two levels up the directory tree.
  *
@@ -30,7 +33,7 @@ export function getPackageJSONInfo(): Package {
     };
 
     try {
-        return JSON.parse(readFileSync(join(getTemplatePath(), '../package.json'), 'utf-8'));
+        return JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
     } catch (e) {
         return defaultPackage;
     }

--- a/packages/adp-tooling/test/unit/writer/project-utils.test.ts
+++ b/packages/adp-tooling/test/unit/writer/project-utils.test.ts
@@ -1,6 +1,9 @@
 import { jest } from '@jest/globals';
-import path, { join } from 'node:path';
+import path, { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Editor } from 'mem-fs-editor';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const realFs = await import('node:fs');
 const mockReadFileSync = jest.fn<typeof realFs.readFileSync>();
@@ -124,6 +127,8 @@ describe('Project Utils', () => {
             const result = getPackageJSONInfo();
 
             expect(result).toEqual(mockJSON);
+            const packageJsonPath = mockReadFileSync.mock.calls[0][0];
+            expect(packageJsonPath).toEqual(join(__dirname, '../../../package.json'));
         });
 
         it('should return default package info on read failure', () => {


### PR DESCRIPTION
Change related to PR -> https://github.com/SAP/open-ux-tools/pull/4835
during bundling we noticed that one line was wrongly changed:
<img width="1100" height="757" alt="image" src="https://github.com/user-attachments/assets/c367d865-d995-4b7e-b269-bf7f613375a0" />

Original logic does not reference to `template` folder - then there is not reason to use `getTemplatePath` fucntion.
In result - in this PR reverting line in `getPackageJSONInfo` to use previous approach to avoid regressions across consumers