### PR TITLE
fix: add fiori docs package metadata

### DIFF
--- a/.changeset/fiori-docs-embeddings-metadata.md
+++ b/.changeset/fiori-docs-embeddings-metadata.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-docs-embeddings": patch
+---
+
+Add npm homepage and bugs metadata for the fiori docs embeddings package.

--- a/packages/fiori-docs-embeddings/package.json
+++ b/packages/fiori-docs-embeddings/package.json
@@ -8,6 +8,10 @@
         "url": "https://github.com/SAP/open-ux-tools.git",
         "directory": "packages/fiori-docs-embeddings"
     },
+    "homepage": "https://github.com/SAP/open-ux-tools/tree/main/packages/fiori-docs-embeddings#readme",
+    "bugs": {
+        "url": "https://github.com/SAP/open-ux-tools/issues"
+    },
     "private": false,
     "scripts": {
         "build-compile": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- adds `homepage` metadata for `@sap-ux/fiori-docs-embeddings`
- adds the repository issue tracker as the package `bugs.url`

## Validation
- `node` package metadata assertion passed
- `npm_config_ignore_scripts=true npm pack --dry-run --json` in `packages/fiori-docs-embeddings`
- `git diff --check`
