### PR TITLE
fix(odata-service-inquirer): Force url revalidation

### DIFF
--- a/.changeset/odata-service-inquirer-force-url-revalidation.md
+++ b/.changeset/odata-service-inquirer-force-url-revalidation.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-inquirer": patch
+---
+
+FIX: Force URL revalidation and reset connection state on system type change

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
@@ -6,7 +6,7 @@ import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { AuthenticationType, BackendSystem, getBackendSystemType } from '@sap-ux/store';
 import type { Answers } from 'inquirer';
 import { t } from '../../../../i18n.js';
-import type { ConnectedSystem } from '../../../../types.js';
+import type { ConnectedSystem, SapSystemType } from '../../../../types.js';
 import { promptNames } from '../../../../types.js';
 import {
     PromptState,
@@ -71,7 +71,7 @@ export function getSystemUrlQuestion<T extends Answers>(
             mandatory: true,
             breadcrumb: true
         },
-        validate: async (url) => {
+        validate: async (url, prevAnswers: NewSystemAnswers) => {
             PromptState.resetConnectedSystem();
             // Backend systems validation supports using a cached connections from a previous step execution to prevent re-authentication (e.g. re-opening a browser window)
             // Only in the case of re-entrance tickets will we reuse an existing connection.
@@ -92,7 +92,8 @@ export function getSystemUrlQuestion<T extends Answers>(
             }
             const valResult = await connectValidator.validateUrl(url, {
                 isSystem: true,
-                odataVersion: convertODataVersionType(requiredOdataVersion)
+                odataVersion: convertODataVersionType(requiredOdataVersion),
+                forceReValidation: true // Always revalidate to return the errors not just the validity of the url
             });
             // If basic auth not required we should have an active connection and be authenticated
             if (valResult === true) {

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
@@ -92,7 +92,8 @@ export function getSystemUrlQuestion<T extends Answers>(
             }
             const valResult = await connectValidator.validateUrl(url, {
                 isSystem: true,
-                odataVersion: convertODataVersionType(requiredOdataVersion)
+                odataVersion: convertODataVersionType(requiredOdataVersion),
+                forceReValidation: true // Always revalidate to return the errors not just the validity of the url
             });
             // If basic auth not required we should have an active connection and be authenticated
             if (valResult === true) {

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/shared-prompts/shared-prompts.ts
@@ -1,12 +1,13 @@
 /**
  * New system prompting questions for re-use in multiple sap-system datasource prompt sets.
  */
+import { Severity } from '@sap-devx/yeoman-ui-types';
 import { type InputQuestion } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { AuthenticationType, BackendSystem, getBackendSystemType } from '@sap-ux/store';
 import type { Answers } from 'inquirer';
 import { t } from '../../../../i18n.js';
-import type { ConnectedSystem, SapSystemType } from '../../../../types.js';
+import type { ConnectedSystem } from '../../../../types.js';
 import { promptNames } from '../../../../types.js';
 import {
     PromptState,
@@ -15,13 +16,12 @@ import {
     removeCircularFromServiceProvider
 } from '../../../../utils/index.js';
 import type { ConnectionValidator, SystemAuthType } from '../../../connectionValidator.js';
-import { type NewSystemAnswers, newSystemPromptNames } from '../new-system/types.js';
-import { suggestSystemName } from '../prompt-helpers.js';
-import { validateSystemName } from '../validators.js';
-import { Severity } from '@sap-devx/yeoman-ui-types';
-import type { SystemSelectionAnswers } from '../system-selection/questions.js';
 import type { AbapOnPremAnswers } from '../abap-on-prem/questions.js';
 import { BasicCredentialsPromptNames } from '../credentials/questions.js';
+import { type NewSystemAnswers, newSystemPromptNames } from '../new-system/types.js';
+import { suggestSystemName } from '../prompt-helpers.js';
+import type { SystemSelectionAnswers } from '../system-selection/questions.js';
+import { validateSystemName } from '../validators.js';
 
 /**
  * Convert the system connection scheme (Service Key, Rentrance Ticket, etc) to the store specific authentication type.
@@ -71,7 +71,7 @@ export function getSystemUrlQuestion<T extends Answers>(
             mandatory: true,
             breadcrumb: true
         },
-        validate: async (url, prevAnswers: NewSystemAnswers) => {
+        validate: async (url) => {
             PromptState.resetConnectedSystem();
             // Backend systems validation supports using a cached connections from a previous step execution to prevent re-authentication (e.g. re-opening a browser window)
             // Only in the case of re-entrance tickets will we reuse an existing connection.
@@ -92,8 +92,7 @@ export function getSystemUrlQuestion<T extends Answers>(
             }
             const valResult = await connectValidator.validateUrl(url, {
                 isSystem: true,
-                odataVersion: convertODataVersionType(requiredOdataVersion),
-                forceReValidation: true // Always revalidate to return the errors not just the validity of the url
+                odataVersion: convertODataVersionType(requiredOdataVersion)
             });
             // If basic auth not required we should have an active connection and be authenticated
             if (valResult === true) {

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/questions.ts
@@ -224,6 +224,8 @@ export async function getSystemConnectionQuestions(
                 if (promptOptions?.systemSelection?.useAutoComplete && (selectedSystem as ListChoiceOptions).value) {
                     selectedSystemAnswer = (selectedSystem as ListChoiceOptions).value;
                 }
+                // Reset the connection state if the system type selection has changed
+                connectionValidator.resetConnectionState(true);
                 return (
                     validateSystemSelection(
                         selectedSystemAnswer,

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/questions.ts
@@ -224,8 +224,6 @@ export async function getSystemConnectionQuestions(
                 if (promptOptions?.systemSelection?.useAutoComplete && (selectedSystem as ListChoiceOptions).value) {
                     selectedSystemAnswer = (selectedSystem as ListChoiceOptions).value;
                 }
-                // Reset the connection state if the system type selection has changed
-                connectionValidator.resetConnectionState(true);
                 return (
                     validateSystemSelection(
                         selectedSystemAnswer,

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/abap-on-prem/questions.test.ts
@@ -189,7 +189,8 @@ describe('questions', () => {
         expect(await (systemUrlQuestion?.validate as Function)(systemUrl)).toBe(true);
         expect(connectionValidatorMock.validateUrl).toHaveBeenCalledWith('https://example.com', {
             isSystem: true,
-            odataVersion: undefined
+            odataVersion: undefined,
+            forceReValidation: true
         });
         // Prompt state should be updated with the connected system
         expect(PromptState.odataService.connectedSystem?.serviceProvider).toEqual(serviceProviderMock);


### PR DESCRIPTION
## Summary

- Force URL revalidation on every validate call by passing `forceReValidation: true` to `connectValidator.validateUrl`, ensuring validation errors are always returned rather than relying on a cached result. This doesnt negatively affect number of network calls as the validate is only triggered on url change or system type change,

internal ref: 38418

## Problem

When navigating back to the URL prompt (e.g., after changing the system type), the connection validator could return a cached validity result without re-running validation — causing errors to be silently swallowed and the UI to show an incorrectly valid state.

## Test plan

- [ ] Verify that changing system type and re-entering a URL triggers a fresh validation (not a cached pass)
- [ ] Verify that a previously valid but now-stale URL correctly shows an error on re-entry
- [ ] Unit test updated: `abap-on-prem/questions.test.ts` asserts `forceReValidation: true` is passed to `validateUrl`
