### PR TITLE
tbi(generators): pass logger instance to writers

### DIFF
--- a/.changeset/plain-moments-go.md
+++ b/.changeset/plain-moments-go.md
@@ -2,4 +2,4 @@
 '@sap-ux/fiori-app-sub-generator': patch
 ---
 
-pass logger instance to writers
+FEAT: pass logger instance to writers

--- a/.changeset/plain-moments-go.md
+++ b/.changeset/plain-moments-go.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-app-sub-generator': patch
+---
+
+pass logger instance to writers

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -381,14 +381,14 @@ export class FioriAppGenerator extends Generator {
                     this.state,
                     !!service.capService || this.options.generateIndexHtml
                 );
-                await generateFioriFreestyleApp(destRoot, ffApp, this.fs);
+                await generateFioriFreestyleApp(destRoot, ffApp, this.fs, FioriAppGenerator.logger);
                 appConfig = ffApp;
             } else {
                 const feApp = await transformState<FioriElementsApp<{}>>(
                     this.state,
                     !!service.capService || this.options.generateIndexHtml
                 );
-                await generateFioriElementsApp(destRoot, feApp, this.fs);
+                await generateFioriElementsApp(destRoot, feApp, this.fs, FioriAppGenerator.logger);
                 appConfig = feApp;
             }
 

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
@@ -224,7 +224,8 @@ describe('Test FioriAppGenerator', () => {
             expect(testFloorplan.generateMockFunc).toHaveBeenCalledWith(
                 appPath,
                 appConfigMocked,
-                expect.objectContaining({ commit: expect.any(Function) })
+                expect.objectContaining({ commit: expect.any(Function) }),
+                expect.objectContaining({ info: expect.any(Function), error: expect.any(Function) })
             );
             expect(TelemetryHelper.createTelemetryData).toHaveBeenCalledWith({
                 Template: t(`floorplans.label.${floorplan}`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33512,7 +33512,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1(debug@4.3.4)
+      axios: 1.16.1
     optional: true
 
   retry@0.12.0: {}


### PR DESCRIPTION
- pass logger instance to writers so it can be used by them