### PR TITLE
fix(odata-service-inquirer): Explicitly set connect type

### DIFF
--- a/.changeset/odata-service-inquirer-explicit-connect-type.md
+++ b/.changeset/odata-service-inquirer-explicit-connect-type.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-inquirer": patch
+---
+
+FIX: Explicitly set connect type to abap_catalog when no connection path is provided

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -3,9 +3,10 @@ import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { validateClient } from '@sap-ux/project-input-validator';
 import type { InputQuestion, Question } from 'inquirer';
 import { t } from '../../../../i18n.js';
-import type { OdataServiceAnswers, OdataServicePromptOptions, SystemNamePromptOptions } from '../../../../types.js';
 import type {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
+    OdataServiceAnswers,
+    OdataServicePromptOptions,
+    SystemNamePromptOptions,
     ServiceSelectionPromptOptions
 } from '../../../../types.js';
 import { isBackendSystemKeyExisting, PromptState } from '../../../../utils/index.js';

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/abap-on-prem/questions.ts
@@ -3,11 +3,10 @@ import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import { validateClient } from '@sap-ux/project-input-validator';
 import type { InputQuestion, Question } from 'inquirer';
 import { t } from '../../../../i18n.js';
-import {
-    type OdataServiceAnswers,
-    type OdataServicePromptOptions,
-    type ServiceSelectionPromptOptions,
-    type SystemNamePromptOptions
+import type { OdataServiceAnswers, OdataServicePromptOptions, SystemNamePromptOptions } from '../../../../types.js';
+import type {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
+    ServiceSelectionPromptOptions
 } from '../../../../types.js';
 import { isBackendSystemKeyExisting, PromptState } from '../../../../utils/index.js';
 import { ConnectionValidator } from '../../../connectionValidator.js';

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -20,8 +20,9 @@ import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 import type { Answers, ListChoiceOptions, Question } from 'inquirer';
 import { t } from '../../../../i18n.js';
-
-import type { OdataServicePromptOptions, ServiceSelectionPromptOptions } from '../../../../types.js';
+import type { ServiceSelectionPromptOptions } from '../../../../types.js';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
+import type { OdataServicePromptOptions } from '../../../../types.js';
 import { promptNames } from '../../../../types.js';
 import {
     areArraysEquivalent,
@@ -32,6 +33,7 @@ import {
 import type { ConnectionValidator } from '../../../connectionValidator.js';
 import LoggerHelper from '../../../logger-helper.js';
 import { errorHandler } from '../../../prompt-helpers.js';
+import { getValueHelpDownloadPrompt } from '../external-services/value-help-download.js';
 import {
     getSelectedServiceLabel,
     getSelectedServiceMessage,
@@ -41,7 +43,6 @@ import {
 } from '../service-selection/service-helper.js';
 import type { SystemSelectionAnswers } from '../system-selection/index.js';
 import { type ServiceAnswer } from './types.js';
-import { getValueHelpDownloadPrompt } from '../external-services/value-help-download.js';
 
 const cliServicePromptName = 'cliServiceSelection';
 

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -20,9 +20,8 @@ import { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { ConvertedMetadata } from '@sap-ux/vocabularies-types';
 import type { Answers, ListChoiceOptions, Question } from 'inquirer';
 import { t } from '../../../../i18n.js';
-import type { ServiceSelectionPromptOptions } from '../../../../types.js';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
-import type { OdataServicePromptOptions } from '../../../../types.js';
+import type { ServiceSelectionPromptOptions, OdataServicePromptOptions } from '../../../../types.js';
+
 import { promptNames } from '../../../../types.js';
 import {
     areArraysEquivalent,

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -10,7 +10,7 @@ import {
 } from '@sap-ux/btp-utils';
 import { ERROR_TYPE } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
-import { type BackendSystemKey, type BackendSystem } from '@sap-ux/store';
+import { type BackendSystemKey, type BackendSystem, ConnectionType } from '@sap-ux/store';
 import type { ListChoiceOptions } from 'inquirer';
 import { t } from '../../../../i18n.js';
 import type { ConnectedSystem, DestinationFilters } from '../../../../types.js';
@@ -83,7 +83,7 @@ export async function connectWithBackendSystem(
                 isSystem: true,
                 odataVersion: convertODataVersionType(requiredOdataVersion),
                 systemAuthType: 'reentranceTicket',
-                connectType: connectPath ? 'odata_path' : undefined // Assumption that if a connection path is provided its an odata service endpoint
+                connectType: connectPath ? 'odata_path' : 'abap_catalog' // Assumption that if a connection path is provided its an odata service endpoint
             });
         } else if (backendSystem.serviceKeys) {
             // Legacy backend system support
@@ -101,7 +101,7 @@ export async function connectWithBackendSystem(
                     isSystem: true,
                     odataVersion: convertODataVersionType(requiredOdataVersion),
                     sapClient: backendSystem.client,
-                    connectType: connectPath ? 'odata_path' : undefined // Assumption that if a connection path is provided its an odata service endpoint
+                    connectType: connectPath ? 'odata_path' : 'abap_catalog' // Assumption that if a connection path is provided its an odata service endpoint
                 }
             ));
             // If authentication failed with existing credentials the user will be prompted to enter new credentials.

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/system-selection/prompt-helpers.ts
@@ -10,7 +10,7 @@ import {
 } from '@sap-ux/btp-utils';
 import { ERROR_TYPE } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
-import { type BackendSystemKey, type BackendSystem, ConnectionType } from '@sap-ux/store';
+import { type BackendSystemKey, type BackendSystem } from '@sap-ux/store';
 import type { ListChoiceOptions } from 'inquirer';
 import { t } from '../../../../i18n.js';
 import type { ConnectedSystem, DestinationFilters } from '../../../../types.js';

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -1,13 +1,15 @@
-import type { Annotations, ServiceProvider, ODataServiceInfo, ExternalService } from '@sap-ux/axios-extension';
+import type { Annotations, ExternalService, ServiceProvider } from '@sap-ux/axios-extension';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
+import type { ODataServiceInfo } from '@sap-ux/axios-extension';
 import type { Destination } from '@sap-ux/btp-utils';
+import type { CapService } from '@sap-ux/cap-config-writer';
+import type { TableSelectionMode, TableType } from '@sap-ux/fiori-elements-writer';
 import type { CommonPromptOptions, YUIQuestion } from '@sap-ux/inquirer-common';
 import type { OdataVersion } from '@sap-ux/odata-service-writer';
 import type { BackendSystem } from '@sap-ux/store';
 import type { ListChoiceOptions } from 'inquirer';
-import type { CapService } from '@sap-ux/cap-config-writer';
-import type { EntityAnswer, NavigationEntityAnswer } from './prompts/edmx/entity-helper.js';
-import type { TableSelectionMode, TableType } from '@sap-ux/fiori-elements-writer';
 import type { serviceUrlInternalPromptNames } from './prompts/datasources/service-url/types.js';
+import type { EntityAnswer, NavigationEntityAnswer } from './prompts/edmx/entity-helper.js';
 
 /**
  * This file contains types that are exported by the module and are needed for consumers using the APIs `prompt` and `getPrompts`.

--- a/packages/odata-service-inquirer/src/types.ts
+++ b/packages/odata-service-inquirer/src/types.ts
@@ -1,6 +1,5 @@
-import type { Annotations, ExternalService, ServiceProvider } from '@sap-ux/axios-extension';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- required by TS doc links
-import type { ODataServiceInfo } from '@sap-ux/axios-extension';
+import type { Annotations, ExternalService, ServiceProvider, ODataServiceInfo } from '@sap-ux/axios-extension';
+
 import type { Destination } from '@sap-ux/btp-utils';
 import type { CapService } from '@sap-ux/cap-config-writer';
 import type { TableSelectionMode, TableType } from '@sap-ux/fiori-elements-writer';

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/prompt-helpers.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/system-selection/prompt-helpers.test.ts
@@ -304,4 +304,53 @@ describe('connectWithBackendSystem', () => {
 
         loggerWarnSpy.mockRestore();
     });
+
+    test('should pass connectType abap_catalog when no connectPath is given and odata_path when connectPath is given', async () => {
+        // Given a reentrance ticket backend system
+        const backendSystem: BackendSystem = {
+            name: 'Cloud System',
+            url: 'https://cloud.system.com',
+            authenticationType: 'reentranceTicket',
+            systemType: 'AbapCloud',
+            connectionType: 'abap_catalog'
+        };
+        mockGetService.mockImplementation(() => ({
+            read: jest.fn().mockResolvedValue(backendSystem)
+        }));
+
+        const validateUrlMock = jest.fn().mockResolvedValue(true);
+        const mockConnectionValidator = {
+            validateUrl: validateUrlMock,
+            serviceProvider: { name: 'mockProvider' },
+            setConnectedSystem: jest.fn()
+        } as unknown as ConnectionValidator;
+
+        const backendKey = BackendSystemKey.from(backendSystem);
+
+        // When connectWithBackendSystem is called without a connectPath
+        await connectWithBackendSystem(backendKey, mockConnectionValidator);
+
+        // Then connectType should be abap_catalog
+        expect(validateUrlMock).toHaveBeenCalledWith(
+            'https://cloud.system.com',
+            expect.objectContaining({ connectType: 'abap_catalog' })
+        );
+
+        validateUrlMock.mockClear();
+
+        // When connectWithBackendSystem is called with a connectPath
+        await connectWithBackendSystem(
+            backendKey,
+            mockConnectionValidator,
+            undefined,
+            undefined,
+            '/sap/opu/odata/sap/MY_SERVICE'
+        );
+
+        // Then connectType should be odata_path
+        expect(validateUrlMock).toHaveBeenCalledWith(
+            'https://cloud.system.com/sap/opu/odata/sap/MY_SERVICE',
+            expect.objectContaining({ connectType: 'odata_path' })
+        );
+    });
 });


### PR DESCRIPTION
## Summary

- Explicitly set `connectType` to `'abap_catalog'` when no connection path is provided in `connectWithBackendSystem`, replacing the previous `undefined` fallback

## Problem

When `connectPath` was not provided, `connectType` was set to `undefined`, leaving the connection validator without an explicit type hint. This could cause the validator to apply incorrectly the previous connection type, skipping catalog-specific logic, leading to connection issues for ABAP on-premise systems without a specific service path. This does not affect the flows which rely on the previous setting behaviour (re-auth using creds for example)

## Test plan

- [ ] Verify ABAP on-premise system connection succeeds without a connection path (reentrance ticket and basic auth flows)
- [ ] Verify connection with an explicit `connectPath` still uses `'odata_path'`
- [ ] Confirm no regression in existing system selection tests
