### PR TITLE
fix: rename sap-fiori skill to sap-fiori-app-development

### DIFF
--- a/.changeset/curvy-mice-tell.md
+++ b/.changeset/curvy-mice-tell.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+fix: rename skill name to sap-fiori-app-development

--- a/.changeset/curvy-mice-tell.md
+++ b/.changeset/curvy-mice-tell.md
@@ -2,4 +2,4 @@
 '@sap-ux/fiori-mcp-server': patch
 ---
 
-fix: rename skill name to sap-fiori-app-development
+FIX: rename skill name to sap-fiori-app-development

--- a/packages/fiori-mcp-server/skills/sap-fiori-app-development/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-app-development/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: sap-fiori
-description: 'Guidelines for creation and development of SAP Fiori UI as part of CAP or standalone Fiori projects. Use this skill for every new Fiori Elements application or when modifying an existing one.'
+name: sap-fiori-app-development
+description: 'Guidelines for SAP Fiori app development for CAP and standalone projects. Use this skill when creating or modifying SAP Fiori Elements applications.'
 argument-hint: 'fiori elements application creation or modification'
 metadata:
   author: sap-fiori-tools
-  version: "0.0.1"
+  version: "0.0.2"
 ---
 
-# SAP Fiori UI Guidelines (CAP & Standalone Projects)
+# SAP Fiori App Development Guidelines (CAP & Standalone Projects)
 
 ## General Guidelines (Applicable to CAP and Standalone Fiori Projects)
 


### PR DESCRIPTION
# Fix: Rename SAP Fiori Skill to `sap-fiori-app-development`

### Bug Fix

🐛 Renames the SAP Fiori MCP skill from `sap-fiori` to `sap-fiori-app-development` to better reflect its purpose, and updates the associated metadata and descriptions accordingly.

### Changes

* `.changeset/curvy-mice-tell.md`: Added a patch changeset entry documenting the skill rename for `@sap-ux/fiori-mcp-server`.
* `packages/fiori-mcp-server/skills/sap-fiori-app-development/SKILL.md`: Renamed the skill from `sap-fiori` to `sap-fiori-app-development`, updated the description to be more concise, bumped the version from `0.0.1` to `0.0.2`, and updated the document heading from "SAP Fiori UI Guidelines" to "SAP Fiori App Development Guidelines".

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `2723bc38-b38a-4fc0-9045-cfc524d48096`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
