### PR TITLE
fix(@sap-ux/store): extract .keyring from Zowe SDK fallback load path

### DIFF
--- a/.changeset/store-fix-zowe-fallback-keyring.md
+++ b/.changeset/store-fix-zowe-fallback-keyring.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/store": patch
+---
+
+FIX: Fallback Zowe SDK load path now correctly extracts .keyring sub-object, restoring credential retrieval for ABAP deployments

--- a/packages/store/src/secure-store/index.ts
+++ b/packages/store/src/secure-store/index.ts
@@ -61,7 +61,7 @@ function loadZoweSecretSdk(log: Logger): typeof zoweKeyring | undefined {
             log.debug(`Discovered fallback directories: ${JSON.stringify(fallbackPaths)}`);
             for (const path of fallbackPaths) {
                 try {
-                    log.debug(`Attempting to load Zowe secrets SDK from: ${path}`);
+                    log.debug(`Attempting to load Zowe secrets SDK .keyring from: ${path}`);
                     return typeof __non_webpack_require__ === 'function'
                         ? __non_webpack_require__(path).keyring
                         : require(path).keyring;

--- a/packages/store/src/secure-store/index.ts
+++ b/packages/store/src/secure-store/index.ts
@@ -53,7 +53,7 @@ function loadZoweSecretSdk(log: Logger): typeof zoweKeyring | undefined {
 
         return require('@zowe/secrets-for-zowe-sdk').keyring;
     } catch (primaryError) {
-        log.warn(errorString(primaryError));
+        log.debug(errorString(primaryError));
         log.debug('Attempting to load Zowe secrets SDK from fallback locations.');
 
         try {

--- a/packages/store/src/secure-store/index.ts
+++ b/packages/store/src/secure-store/index.ts
@@ -63,8 +63,8 @@ function loadZoweSecretSdk(log: Logger): typeof zoweKeyring | undefined {
                 try {
                     log.debug(`Attempting to load Zowe secrets SDK from: ${path}`);
                     return typeof __non_webpack_require__ === 'function'
-                        ? __non_webpack_require__(path)
-                        : require(path);
+                        ? __non_webpack_require__(path).keyring
+                        : require(path).keyring;
                 } catch (fallbackError) {
                     log.warn(`Failed to load Zowe secrets SDK from ${path}: ${errorString(fallbackError)}`);
                 }

--- a/packages/store/test/unit/secure-store/index.test.ts
+++ b/packages/store/test/unit/secure-store/index.test.ts
@@ -118,6 +118,35 @@ describe('getSecureStore', () => {
             expect(getSecureStore(nullLogger)).toBeInstanceOf(KeyStoreManager);
         });
 
+        it('returns KeyStoreManager with functional keyring extracted from fallback module', async () => {
+            const mockKeyring = {
+                setPassword: jest.fn(),
+                getPassword: jest.fn<() => Promise<string | null>>().mockResolvedValue(null),
+                deletePassword: jest.fn(),
+                findCredentials: jest.fn()
+            };
+            // Direct load fails
+            mockRequireForZowe.mockImplementationOnce(() => {
+                throw new Error('Cannot find module @zowe/secrets-for-zowe-sdk');
+            });
+            // Fallback returns full module shape, as the real SDK does on disk
+            mockRequireForZowe.mockReturnValueOnce({ keyring: mockKeyring });
+
+            mockExistsSync.mockImplementation((p) => {
+                if (typeof p === 'string' && p.includes('extensions')) return true;
+                if (typeof p === 'string' && p.includes('package.json')) return true;
+                return false;
+            });
+            mockReaddirSync.mockReturnValue(['sapse.sap-ux-application-modeler-extension-1.14.1']);
+
+            const store = getSecureStore(nullLogger);
+            expect(store).toBeInstanceOf(KeyStoreManager);
+
+            // retrieve() must call getPassword on the actual keyring, not the wrapper module
+            await store.retrieve('service', 'key');
+            expect(mockKeyring.getPassword).toHaveBeenCalledWith('service', 'key');
+        });
+
         it('returns DummyStore if zowe sdk cannot be loaded and no fallback paths exist', () => {
             mockExistsSync.mockReturnValue(false);
             mockReaddirSync.mockReturnValue([]);

--- a/packages/store/test/unit/secure-store/index.test.ts
+++ b/packages/store/test/unit/secure-store/index.test.ts
@@ -133,8 +133,12 @@ describe('getSecureStore', () => {
             mockRequireForZowe.mockReturnValueOnce({ keyring: mockKeyring });
 
             mockExistsSync.mockImplementation((p) => {
-                if (typeof p === 'string' && p.includes('extensions')) return true;
-                if (typeof p === 'string' && p.includes('package.json')) return true;
+                if (typeof p === 'string' && p.includes('extensions')) {
+                    return true;
+                }
+                if (typeof p === 'string' && p.includes('package.json')) {
+                    return true;
+                }
                 return false;
             });
             mockReaddirSync.mockReturnValue(['sapse.sap-ux-application-modeler-extension-1.14.1']);


### PR DESCRIPTION
## Summary

- `loadZoweSecretSdk()` fallback path returned the full module object (`{ keyring: {...} }`) instead of the `.keyring` sub-object
- `KeyStoreManager` received the wrong shape, so `this.keyring.getPassword()` threw `TypeError: this.keyring.getPassword is not a function`
- Error was caught and swallowed → silent credential failure → 401 / `socket hang up` on ABAP deployment

The current fix shows;
```
info abap-deploy-task ZE2EABAP Creating archive with UI5 build result.
info abap-deploy-task ZE2EABAP Archive created.
2026-06-24 15:43:36 warn    main: Cannot find module '@zowe/secrets-for-zowe-sdk'
Require stack:
- /Users/I313149/Documents/dev/ze2e_project_abap-2026-05-061231/node_modules/@sap/ux-ui5-tooling/dist/cli/index.cjs 
info abap-deploy-task ZE2EABAP Starting to deploy.
info abap-deploy-task ZE2EABAP ZE2EABAP found on target system: false
```

## Root Cause

Asymmetry between primary and fallback load paths in `packages/store/src/secure-store/index.ts`:

```ts
// Primary (correct)
return require('@zowe/secrets-for-zowe-sdk').keyring;

// Fallback (was buggy — missing .keyring)
return typeof __non_webpack_require__ === 'function'
    ? __non_webpack_require__(path)   // fixed: + .keyring
    : require(path);                  // fixed: + .keyring
```

## Changes

- `packages/store/src/secure-store/index.ts` — add `.keyring` to both fallback return branches
- `packages/store/test/unit/secure-store/index.test.ts` — add regression test that calls `retrieve()` on the fallback-loaded store and asserts `getPassword` is invoked (not just `instanceof` check)

## Test Plan

- [ ] `pnpm --filter @sap-ux/store test` passes (173 tests, 16 suites)
- [ ] New test `returns KeyStoreManager with functional keyring extracted from fallback module` fails on old code, passes on fix
- [ ] Verify ABAP deploy reads stored credentials without prompting on a project without `@zowe/secrets-for-zowe-sdk` in `node_modules`

Closes #4885