### PR TITLE
fix(preview-middleware): Use findCapProjectRoot instead of findProjectRoot for reliable CAP project type detection

### DIFF
--- a/.changeset/preview-middleware-cap-root-detection.md
+++ b/.changeset/preview-middleware-cap-root-detection.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/preview-middleware": patch
+---
+
+FIX: Use findCapProjectRoot instead of findProjectRoot for reliable CAP project type detection when app is started from a subfolder

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -187,7 +187,8 @@ export class FlpSandbox {
         resources: Record<string, string> = {},
         adp?: AdpPreview
     ): Promise<void> {
-        const projectRoot = (await findCapProjectRoot(process.cwd(), false)) ?? (await findProjectRoot(process.cwd(), false, true));
+        const projectRoot =
+            (await findCapProjectRoot(process.cwd(), false)) ?? (await findProjectRoot(process.cwd(), false, true));
         this.projectType = await getProjectType(projectRoot);
         this.createFlexHandler();
         this.flpConfig.libs ??= await this.hasLocateReuseLibsScript();

--- a/packages/preview-middleware/src/base/flp.ts
+++ b/packages/preview-middleware/src/base/flp.ts
@@ -23,6 +23,7 @@ import {
     getProjectType,
     type ProjectType,
     findProjectRoot,
+    findCapProjectRoot,
     type Manifest,
     FileName,
     type ManifestNamespace,
@@ -186,7 +187,7 @@ export class FlpSandbox {
         resources: Record<string, string> = {},
         adp?: AdpPreview
     ): Promise<void> {
-        const projectRoot = await findProjectRoot(process.cwd(), false, true);
+        const projectRoot = (await findCapProjectRoot(process.cwd(), false)) ?? (await findProjectRoot(process.cwd(), false, true));
         this.projectType = await getProjectType(projectRoot);
         this.createFlexHandler();
         this.flpConfig.libs ??= await this.hasLocateReuseLibsScript();

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -1497,7 +1497,6 @@ describe('FlpSandbox', () => {
             expect(mockFindProjectRoot).toHaveBeenCalledWith(process.cwd(), false, true);
         });
 
-
         test('legacy-free label - disables card generator regardless of minor version', async () => {
             const { server, flp } = await setupMiddleware('EDMXBackend');
             mockUi5Version('1.121.0-legacy-free');

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -51,6 +51,7 @@ const actualI18n = await import('@sap-ux/i18n');
 
 // Mock functions for @sap-ux/project-access
 const mockFindProjectRoot = jest.fn<() => Promise<string>>().mockResolvedValue(process.cwd());
+const mockFindCapProjectRoot = jest.fn<typeof actualProjectAccess.findCapProjectRoot>().mockResolvedValue(null);
 const mockGetProjectType = jest.fn<() => Promise<string>>().mockResolvedValue('EDMXBackend');
 const mockCreateProjectAccess = jest.fn<typeof actualProjectAccess.createProjectAccess>();
 const mockCreateApplicationAccess = jest.fn<typeof actualProjectAccess.createApplicationAccess>();
@@ -59,6 +60,7 @@ const mockCreateApplicationAccess = jest.fn<typeof actualProjectAccess.createApp
 jest.unstable_mockModule('@sap-ux/project-access', () => ({
     ...actualProjectAccess,
     findProjectRoot: mockFindProjectRoot,
+    findCapProjectRoot: mockFindCapProjectRoot,
     getProjectType: mockGetProjectType,
     createProjectAccess: mockCreateProjectAccess,
     createApplicationAccess: mockCreateApplicationAccess
@@ -1426,6 +1428,7 @@ describe('FlpSandbox', () => {
         afterEach(() => {
             fetchMock.mockRestore();
             mockGetProjectType.mockResolvedValue('EDMXBackend');
+            mockFindCapProjectRoot.mockResolvedValue(null);
         });
 
         test('EDMXBackend below 1.121 - disables card generator and warns', async () => {
@@ -1477,6 +1480,20 @@ describe('FlpSandbox', () => {
             expect(logger.warn).toHaveBeenCalledWith(
                 expect.stringContaining("does not meet the minimum required version 1.149.0 for project type 'CAPJava'")
             );
+        });
+
+        test('uses CAP root found by findCapProjectRoot for project type detection', async () => {
+            const capRoot = '/cap-project-root';
+            mockFindCapProjectRoot.mockResolvedValue(capRoot);
+            await setupMiddleware('CAPNodejs');
+            expect(mockFindCapProjectRoot).toHaveBeenCalledWith(process.cwd(), false);
+            expect(mockGetProjectType).toHaveBeenCalledWith(capRoot);
+        });
+
+        test('falls back to findProjectRoot when findCapProjectRoot returns null', async () => {
+            mockFindCapProjectRoot.mockResolvedValue(null);
+            await setupMiddleware('EDMXBackend');
+            expect(mockFindProjectRoot).toHaveBeenCalledWith(process.cwd(), false, true);
         });
 
         test('legacy-free label - disables card generator regardless of minor version', async () => {

--- a/packages/preview-middleware/test/unit/base/flp.test.ts
+++ b/packages/preview-middleware/test/unit/base/flp.test.ts
@@ -1493,8 +1493,10 @@ describe('FlpSandbox', () => {
         test('falls back to findProjectRoot when findCapProjectRoot returns null', async () => {
             mockFindCapProjectRoot.mockResolvedValue(null);
             await setupMiddleware('EDMXBackend');
+            expect(mockFindCapProjectRoot).toHaveBeenCalledWith(process.cwd(), false);
             expect(mockFindProjectRoot).toHaveBeenCalledWith(process.cwd(), false, true);
         });
+
 
         test('legacy-free label - disables card generator regardless of minor version', async () => {
             const { server, flp } = await setupMiddleware('EDMXBackend');


### PR DESCRIPTION
# Fix CAP Project Type Detection When App is Started from a Subfolder

### Bug Fix

🐛 Fixed an issue where CAP project type detection would fail when an application is started from a subfolder. Previously, `findProjectRoot` was used exclusively, which could not reliably identify CAP projects when the working directory is a subfolder of the CAP root. The fix prioritizes `findCapProjectRoot` and falls back to `findProjectRoot` only when no CAP root is found.

### Changes

* `.changeset/preview-middleware-cap-root-detection.md`: Added changeset entry documenting the patch fix for `@sap-ux/preview-middleware`.
* `packages/preview-middleware/src/base/flp.ts`: Imported `findCapProjectRoot` from `@sap-ux/project-access` and updated the `init` method to use `findCapProjectRoot(process.cwd(), false)` first, falling back to `findProjectRoot(process.cwd(), false, true)` when no CAP root is detected.
* `packages/preview-middleware/test/unit/base/flp.test.ts`: Added mock for `findCapProjectRoot`, registered it in the module mock, reset it in `afterEach`, and added two new test cases verifying that:
  - The CAP root found by `findCapProjectRoot` is used for project type detection.
  - `findProjectRoot` is used as a fallback when `findCapProjectRoot` returns `null`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.5`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `6e96d319-0d25-44f4-96cd-59ee8fef3d4b`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
