### PR TITLE
fix(fiori-mcp-server): skill generation only in case of actual changes

### DIFF
--- a/.changeset/social-snails-invent.md
+++ b/.changeset/social-snails-invent.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/create': patch
+---
+
+fix: create cli skill generation only in case of real changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,11 +348,11 @@ BUMP: Upgrade i18next 25.8.18 → 25.8.20
 
 Every changeset summary **must** start with one of these prefixes (enforced by `pnpm validate:changesets`):
 
-| Prefix | Use for |
-|---|---|
-| `FEAT:` | New features or behaviour additions |
-| `FIX:` | Bug fixes, security patches, CVE upgrades |
-| `BUMP:` | Dependency-only upgrades with no behaviour change |
+| Prefix             | Use for                                           |
+|--------------------|---------------------------------------------------|
+| `FEAT:` or `feat:` | New features or behaviour additions               |
+| `FIX:`  or `fix:`  | Bug fixes, security patches, CVE upgrades         |
+| `BUMP:` or `bump:` | Dependency-only upgrades with no behaviour change |
 
 Do **not** include the package name in the summary — it is already declared in the frontmatter.
 

--- a/packages/create/scripts/generate-skill.js
+++ b/packages/create/scripts/generate-skill.js
@@ -76,7 +76,27 @@ try {
     }
     const commandsSection = injectReferencePointers(readme.slice(commandsIndex));
 
-    const frontmatter = `---
+    // Only write if the dynamic commands content changed.
+    // Frontmatter and BEHAVIOR_GUIDANCE are static (defined in this script), so comparing
+    // just commandsSection is sufficient and avoids fragile version-stripping logic.
+    // This prevents a SKILL.md diff — and the MCP review it triggers — on every
+    // @sap-ux/create release where only the package version bumped but no commands changed.
+    const existingSkill = fs.existsSync(SKILL_OUTPUT_PATH)
+        ? fs.readFileSync(SKILL_OUTPUT_PATH, 'utf8')
+        : '';
+
+    // Extract the commands section from the existing file for comparison.
+    // Everything from "# [Commands]" onwards is the dynamic part — frontmatter
+    // and BEHAVIOR_GUIDANCE are static so we don't need to compare them.
+    const existingCommandsIndex = existingSkill.indexOf('# [Commands]');
+    const existingCommandsSection = existingCommandsIndex !== -1
+        ? existingSkill.slice(existingCommandsIndex)
+        : '';
+
+    if (commandsSection === existingCommandsSection) {
+        console.log('ℹ️  SKILL.md content unchanged — skipping write.');
+    } else {
+        const frontmatter = `---
 name: sap-fiori-create-cli
 description: Run, invoke, and test the @sap-ux/create CLI — generate, add, convert, remove, update, change, list, get commands for SAP Fiori projects. Use when asked to run sap-ux, invoke create CLI, add config to a project, generate adaptation-project, or test any sap-ux/create subcommand.
 argument-hint: command and subcommand (e.g., add mockserver-config, generate adaptation-project)
@@ -86,12 +106,11 @@ metadata:
 ---
 
 `;
-
-    const skill = frontmatter + BEHAVIOR_GUIDANCE + '\n---\n\n' + commandsSection;
-
-    fs.mkdirSync(path.dirname(SKILL_OUTPUT_PATH), { recursive: true });
-    fs.writeFileSync(SKILL_OUTPUT_PATH, skill, 'utf8');
-    console.log(`✅ SKILL.md generated successfully at ${SKILL_OUTPUT_PATH}`);
+        const newSkill = frontmatter + BEHAVIOR_GUIDANCE + '\n---\n\n' + commandsSection;
+        fs.mkdirSync(path.dirname(SKILL_OUTPUT_PATH), { recursive: true });
+        fs.writeFileSync(SKILL_OUTPUT_PATH, newSkill, 'utf8');
+        console.log(`✅ SKILL.md generated successfully at ${SKILL_OUTPUT_PATH}`);
+    }
 } catch (error) {
     console.error('❌ Failed to generate SKILL.md:', error.message);
     process.exit(1);


### PR DESCRIPTION
# fix(fiori-mcp-server): Skip SKILL.md Generation When Commands Are Unchanged

### Bug Fix

🐛 Fixed an issue where `SKILL.md` was regenerated on every `@sap-ux/create` release, even when no actual command changes occurred. This unnecessary regeneration was triggered by version bumps in the package metadata, causing spurious diffs and unneeded MCP reviews.

The fix compares only the dynamic `# [Commands]` section of the existing `SKILL.md` against the newly generated content. Since the frontmatter and `BEHAVIOR_GUIDANCE` sections are static and defined within the script itself, version-stripping logic is unnecessary — only the commands content needs to be compared.

### Changes

* `.changeset/social-snails-invent.md`: Added a changeset entry marking this as a patch fix for `@sap-ux/create`.
* `packages/create/scripts/generate-skill.js`: Updated the skill generation script to:
  - Read the existing `SKILL.md` file (if present) and extract its `# [Commands]` section.
  - Compare the extracted commands section against the newly generated one.
  - Skip the file write and log an informational message if no changes are detected.
  - Only write the updated `SKILL.md` when the commands content has actually changed.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.11`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.ready_for_review`
- Correlation ID: `b773f1bf-ba01-4fa8-8965-a1ca0ea6ae4f`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
</details>
