### PR TITLE
Reverts #4858 — ADP preview `/i18n/...properties` pass-through

### DIFF
--- a/.changeset/revert-adp-tooling-i18n-passthrough.md
+++ b/.changeset/revert-adp-tooling-i18n-passthrough.md
@@ -1,0 +1,9 @@
+---
+"@sap-ux/adp-tooling": patch
+---
+
+FIX: Revert the `/i18n/...properties` pass-through introduced in #4858.
+
+The pass-through was structurally correct for the bug it targeted (substituting partial ADP bundles for the base app's complete bundle, which broke `{@i18n>...}` annotation lookups like `UI.LineItem` headers) — but it regresses adaptation projects whose `appdescr_variant` does not declare an `appdescr_ui5_addNewModelEnhanceWith` for the `i18n` model. Those projects previously relied on the local `/i18n/i18n.properties` being 302-redirected to surface ADP-local keys, and pass-through silently drops those keys.
+
+The proper fix requires the backend merger to support `createIfMissing: true` on `appdescr_ui5_addNewModelEnhanceWith` so the generator can layer customer keys onto the FEV2-safe `@i18n` model unconditionally. That work is scoped at the merger side and cannot be safely downported in the current release window. Reverting until it ships and the generator emits the matching change.

--- a/.changeset/revert-adp-tooling-i18n-passthrough.md
+++ b/.changeset/revert-adp-tooling-i18n-passthrough.md
@@ -4,6 +4,6 @@
 
 FIX: Revert the `/i18n/...properties` pass-through introduced in #4858.
 
-The pass-through was structurally correct for the bug it targeted (substituting partial ADP bundles for the base app's complete bundle, which broke `{@i18n>...}` annotation lookups like `UI.LineItem` headers) — but it regresses adaptation projects whose `appdescr_variant` does not declare an `appdescr_ui5_addNewModelEnhanceWith` for the `i18n` model. Those projects previously relied on the local `/i18n/i18n.properties` being 302-redirected to surface ADP-local keys, and pass-through silently drops those keys.
+In adaptation projects built on top of Fiori Elements V2 ListReport/ObjectPage base apps, FEV2's `TemplateComponent` rebuilds the `i18n` model on every template view, which shadows the ADP's local `i18n.properties` once requests fall through to the base app. Customer-defined keys are no longer reachable from inside the editor's bindings.
 
-The proper fix requires the backend merger to support `createIfMissing: true` on `appdescr_ui5_addNewModelEnhanceWith` so the generator can layer customer keys onto the FEV2-safe `@i18n` model unconditionally. That work is scoped at the merger side and cannot be safely downported in the current release window. Reverting until it ships and the generator emits the matching change.
+The proper fix requires moving customer keys to the FEV2-safe `@i18n` model (backend merger + generator changes) and cannot be safely downported in this release window. A corrected fix will be reapplied once that support is in place.

--- a/packages/adp-tooling/src/preview/adp-preview.ts
+++ b/packages/adp-tooling/src/preview/adp-preview.ts
@@ -237,16 +237,6 @@ export class AdpPreview {
             res.send(JSON.stringify(this.descriptor.manifest, undefined, 2));
         } else if (req.path === '/Component-preload.js') {
             res.status(404).send();
-        } else if (req.path.startsWith('/i18n/') && req.path.endsWith('.properties')) {
-            // i18n .properties files (default, locale variants, and per-page bundles such
-            // as /i18n/ListReport/<entity>/i18n.properties) must always fall through to
-            // the base app's resource server. The ADP webapp may also contain an
-            // i18n.properties file with prefixed customer keys, but those are merged
-            // into the model at runtime via appdescr_ui5_addNewModelEnhanceWith — not
-            // by substituting the entire bundle here. Substituting hides the base app's
-            // translations and breaks {@i18n>...} lookups (e.g. column header labels in
-            // UI.LineItem).
-            next();
         } else {
             // check if the requested file exists in the file system (replace .js with .* for typescript)
             const files = await this.project.byGlob(req.path.replace('.js', '.*'));

--- a/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
+++ b/packages/adp-tooling/test/unit/preview/adp-preview.test.ts
@@ -388,7 +388,6 @@ describe('AdaptationProject', () => {
 
         afterEach(() => {
             global.__SAP_UX_MANIFEST_SYNC_REQUIRED__ = false;
-            mockProject.byGlob.mockClear();
         });
 
         test('should return early when cfBuildPath is set', async () => {
@@ -556,9 +555,6 @@ describe('AdaptationProject', () => {
             const app = express();
             app.use(adp.descriptor.url, adp.proxy.bind(adp));
             app.get(`${mockMergedDescriptor.url}/original.file`, next);
-            // Catch i18n .properties pass-throughs so tests can verify proxy() called next()
-            // without redirecting. Mirrors how fiori-tools-proxy would handle them in real runs.
-            app.get(new RegExp(`^${mockMergedDescriptor.url}/i18n/.*\\.properties$`), next);
             app.use((req) => fail(`${req.path} should have been intercepted.`));
 
             server = supertest(app);
@@ -570,7 +566,6 @@ describe('AdaptationProject', () => {
 
         afterEach(() => {
             global.__SAP_UX_MANIFEST_SYNC_REQUIRED__ = false;
-            mockProject.byGlob.mockClear();
         });
 
         test('/manifest.json with sync', async () => {
@@ -605,26 +600,6 @@ describe('AdaptationProject', () => {
         test('/original.file', async () => {
             await server.get(`${mockMergedDescriptor.url}/original.file`).expect(200);
             expect(next).toHaveBeenCalled();
-        });
-
-        test('/i18n/i18n.properties is passed through (not redirected)', async () => {
-            const response = await server.get(`${mockMergedDescriptor.url}/i18n/i18n.properties`);
-
-            expect(response.status).toBe(200);
-            expect(mockProject.byGlob).not.toHaveBeenCalled();
-        });
-
-        test('/i18n/i18n_de.properties (locale variant) is passed through', async () => {
-            const response = await server.get(`${mockMergedDescriptor.url}/i18n/i18n_de.properties`);
-            expect(response.status).toBe(200);
-            expect(mockProject.byGlob).not.toHaveBeenCalled();
-        });
-
-        test('/i18n/ListReport/Foo/i18n.properties (per-page bundle) is passed through', async () => {
-            const response = await server.get(`${mockMergedDescriptor.url}/i18n/ListReport/Foo/i18n.properties`);
-
-            expect(response.status).toBe(200);
-            expect(mockProject.byGlob).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
#4858 stopped the ADP preview from redirecting `/i18n/...properties` requests to local workspace files, so they fall through to the base app instead. Structurally that is the right behaviour, and it correctly fixed the `{@i18n>...}` annotation lookups it targeted.

  However, in adaptation projects built on top of Fiori Elements V2 ListReport/ObjectPage base apps, FEV2's `TemplateComponent` rebuilds the `i18n` model on every template view and replaces it with one seeded from the base app's bundle. Once requests pass through, the base app's i18n logic effectively shadows the ADP's local `i18n.properties` inside every template, so customer-defined keys are no longer reachable from inside the editor's bindings — even though the local file is served correctly.

The proper fix requires moving customer keys to the FEV2-safe `@i18n` model (backend merger + generator changes) and cannot be safely downported in this release window. Reverting restores the pre-#4858 behaviour, which has a smaller and better-understood failure mode for the affected customers.

A corrected fix will be reapplied once the backend and generator support is in place.

  ### What changes

  - Reverts `662e3c358e` — restores `AdpPreview.proxy()` and the related tests to the pre-#4858 state.
  - Adds a patch changeset for `@sap-ux/adp-tooling`.

  ### Verification

  - `pnpm --filter @sap-ux/adp-tooling test` — 793/793 pass.
  - Manual: FEV2-based adaptation projects again resolve their local `i18n.properties` keys inside ListReport/ObjectPage views.