### PR TITLE
fix(eslint-plugin): Streamline plugin meta information

### DIFF
--- a/.changeset/eslint-plugin-fiori-tools-streamline-meta.md
+++ b/.changeset/eslint-plugin-fiori-tools-streamline-meta.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+FIX: Streamline plugin meta — remove duplicate inline meta with stale hardcoded version, add namespace to single exported meta constant

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -31,9 +31,10 @@ const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 
  * Plugin meta information (required for ESLint 9).
  * Contains the plugin name and version.
  */
-export const meta = {
+const meta = {
     name: packageJson.name,
-    version: packageJson.version
+    version: packageJson.version,
+    namespace: '@sap-ux/fiori-tools'
 };
 
 /**
@@ -52,11 +53,7 @@ const fioriRules = rules as Plugin['rules'];
  * Contains plugin metadata, supported languages, rules, and processors.
  */
 const plugin: Plugin = {
-    meta: {
-        name: packageJson.name,
-        version: '0.0.1',
-        namespace: '@sap-ux/fiori-tools'
-    },
+    meta,
     languages,
     rules: fioriRules,
     processors: {}

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -31,7 +31,7 @@ const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 
  * Plugin meta information (required for ESLint 9).
  * Contains the plugin name and version.
  */
-const meta = {
+export const meta = {
     name: packageJson.name,
     version: packageJson.version,
     namespace: '@sap-ux/fiori-tools'

--- a/packages/eslint-plugin-fiori-tools/test/eslint-plugin.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/eslint-plugin.test.ts
@@ -153,6 +153,8 @@ export default class Component extends UIComponent {
         // Verify plugin has meta and rules
         const pluginDef = firstConfig.plugins?.['@sap-ux/fiori-tools'];
         expect(pluginDef?.meta).toBeDefined();
+        expect(pluginDef?.meta?.namespace).toBe('@sap-ux/fiori-tools');
+        expect(pluginDef?.meta?.version).toBe(plugin.meta.version);
         expect(pluginDef?.rules).toBeDefined();
     });
 
@@ -168,6 +170,8 @@ export default class Component extends UIComponent {
         // Verify plugin has meta, languages, and rules
         const pluginDef = firstConfig.plugins?.['@sap-ux/fiori-tools'];
         expect(pluginDef?.meta).toBeDefined();
+        expect(pluginDef?.meta?.namespace).toBe('@sap-ux/fiori-tools');
+        expect(pluginDef?.meta?.version).toBe(plugin.meta.version);
         expect(pluginDef?.languages).toBeDefined();
         expect(pluginDef?.rules).toBeDefined();
     });


### PR DESCRIPTION
Streamline meta information
- Remove stale hardcoded version: '0.0.1'
- Make sure, namespace is included
[- Keep named export for "meta" because it is used to check the version in Page Map]