### PR TITLE
FIX: Remove injection of sapux property into package.json during app download

### DIFF
--- a/.changeset/tough-shirts-think.md
+++ b/.changeset/tough-shirts-think.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/repo-app-import-sub-generator': patch
+---
+
+FIX: Remove injection of sapux property into package.json during app download

--- a/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
+++ b/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
@@ -89,10 +89,6 @@ export function addPackageJsonIfNotFound(projectPath: string, appConfig: AbapRep
     const packageJsonPath = join(projectPath, FileName.Package);
     if (!fs.exists(packageJsonPath)) {
         const packageJson: { name: string; sapux?: boolean } = { name: appConfig.app.id };
-        const freestyleTemplates = new Set<string>(Object.values(FioriFreestyleTemplateType));
-        if (!freestyleTemplates.has(appConfig.template.type)) {
-            packageJson['sapux'] = true;
-        }
         fs.writeJSON(packageJsonPath, packageJson);
     }
 }

--- a/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
+++ b/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
@@ -165,50 +165,13 @@ describe('addPackageJsonIfNotFound', () => {
         jest.clearAllMocks();
     });
 
-    it('should write package.json with sapux:true for an lrop app', () => {
+    it('should write package.json for an app when it does not already exist', () => {
         mockFs.exists.mockReturnValue(false);
         addPackageJsonIfNotFound(
             '/project',
             { app: { id: 'my.app.id' }, template: { type: TemplateType.ListReportObjectPage } } as any,
             mockFs as unknown as Editor
         );
-        expect(mockFs.writeJSON).toHaveBeenCalledWith(join('/project', 'package.json'), {
-            name: 'my.app.id',
-            sapux: true
-        });
-    });
-
-    it('should write package.json with sapux:true for an unknown template type', () => {
-        mockFs.exists.mockReturnValue(false);
-        addPackageJsonIfNotFound(
-            '/project',
-            { app: { id: 'my.app.id' }, template: { type: 'unknown' } } as any,
-            mockFs as unknown as Editor
-        );
-        expect(mockFs.writeJSON).toHaveBeenCalledWith(join('/project', 'package.json'), {
-            name: 'my.app.id',
-            sapux: true
-        });
-    });
-
-    it('should write package.json without sapux for a basic freestyle app', () => {
-        mockFs.exists.mockReturnValue(false);
-        addPackageJsonIfNotFound(
-            '/project',
-            { app: { id: 'my.app.id' }, template: { type: FioriFreestyleTemplateType.Basic } } as any,
-            mockFs as unknown as Editor
-        );
-        expect(mockFs.writeJSON).toHaveBeenCalledWith(join('/project', 'package.json'), { name: 'my.app.id' });
-    });
-
-    it('should write package.json without sapux for a listdetail freestyle app', () => {
-        mockFs.exists.mockReturnValue(false);
-        addPackageJsonIfNotFound(
-            '/project',
-            { app: { id: 'my.app.id' }, template: { type: FioriFreestyleTemplateType.ListDetail } } as any,
-            mockFs as unknown as Editor
-        );
-        expect(mockFs.writeJSON).toHaveBeenCalledWith(join('/project', 'package.json'), { name: 'my.app.id' });
     });
 
     it('should not write package.json when it already exists', () => {

--- a/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
+++ b/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
@@ -172,6 +172,7 @@ describe('addPackageJsonIfNotFound', () => {
             { app: { id: 'my.app.id' }, template: { type: TemplateType.ListReportObjectPage } } as any,
             mockFs as unknown as Editor
         );
+        expect(mockFs.writeJSON).toHaveBeenCalledWith(join('/project', 'package.json'), { name: 'my.app.id' });
     });
 
     it('should not write package.json when it already exists', () => {


### PR DESCRIPTION
  - The `repo-app-import-sub-generator` was injecting `sapux: true` into `package.json` when downloading an app. This property was originally added so that the correct project type is displayed in the Migrator UI. However, adding this caused the migrator from  picking up the project correctly. This was identified in BAS.
                                                                                  
  - Removed the `sapux` injection from `addPackageJsonIfNotFound` due to the migration regression.
  
  related open ux PR https://github.com/SAP/open-ux-tools/pull/4901
                                                                                                                           