### PR TITLE
Remove transpilled files for ts app and clean up template in readme

### DIFF
--- a/.changeset/fix-ui5-abap-repo-download-ts.md
+++ b/.changeset/fix-ui5-abap-repo-download-ts.md
@@ -1,0 +1,7 @@
+---
+"@sap-ux/repo-app-import-sub-generator": patch
+"@sap-ux/ui5-application-writer": minor
+"@sap-ux/fiori-app-sub-generator": minor
+---
+
+FIX: Set up TypeScript development environment after downloading a TypeScript app from ABAP repository

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -58,7 +58,8 @@ import {
     initI18nFioriAppSubGenerator,
     restoreServiceProviderLoggers,
     t,
-    updateDependentStep
+    updateDependentStep,
+    getFloorplanLabel
 } from '../utils/index.js';
 import { runPostGenerationTasks } from './end.js';
 import type { FioriAppGeneratorOptions } from './fioriAppGeneratorOptions.js';
@@ -398,9 +399,7 @@ export class FioriAppGenerator extends Generator {
             );
 
             TelemetryHelper.createTelemetryData({
-                Template: t(`floorplans.label.${floorplan}`, {
-                    odataVersion: service.version
-                }),
+                Template: getFloorplanLabel(floorplan, service.version),
                 DataSource: service.source,
                 UI5Version: project.ui5Version || latestVersionString,
                 Theme: project.ui5Theme,

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
@@ -4,7 +4,7 @@ import type { Editor } from 'mem-fs-editor';
 import { basename, join } from 'node:path';
 import type { ApiHubConfig, State } from '../types/index.js';
 import { DEFAULT_CAP_HOST } from '../types/index.js';
-import { getLaunchText, getReadMeDataSourceLabel, isAbapCloud, t } from '../utils/index.js';
+import { getLaunchText, getReadMeDataSourceLabel, isAbapCloud, t, getFloorplanLabel } from '../utils/index.js';
 
 /**
  * Writes app related information files - README.md & .appGenInfo.json.
@@ -30,9 +30,7 @@ export async function writeAppGenInfoFiles(
     fs: Editor,
     existingAppGenInfo?: Partial<AppGenInfo>
 ): Promise<void> {
-    const templateLabel = t(`floorplans.label.${floorplan}`, {
-        odataVersion: service.version
-    });
+    const templateLabel = getFloorplanLabel(floorplan, service.version);
 
     const datasourceLabel = getReadMeDataSourceLabel(
         service.source,

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -318,3 +318,14 @@ export async function getAnnotations(
 
 /** @deprecated Import directly from `@sap-ux/fiori-generator-shared` instead. */
 export { restoreServiceProviderLoggers } from '@sap-ux/fiori-generator-shared';
+
+/**
+ * Returns the human-readable display label for a given floorplan/template type.
+ *
+ * @param templateType - the template type string (e.g. 'lrop', 'fpm')
+ * @param odataVersion - the OData version string (e.g. 'v2', 'v4')
+ * @returns the display label (e.g. 'List Report Page V4', 'Custom Page V4')
+ */
+export function getFloorplanLabel(templateType: string, odataVersion?: string): string {
+    return t(`floorplans.label.${templateType}`, { defaultValue: templateType, odataVersion });
+}

--- a/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
@@ -67,6 +67,7 @@ const {
     getAnnotations,
     getAppId,
     getCdsAnnotations,
+    getFloorplanLabel,
     getMinSupportedUI5Version,
     getODataVersion,
     getReadMeDataSourceLabel,
@@ -392,5 +393,21 @@ describe('Test utils', () => {
             expect(mockCreateLaunchConfig).toHaveBeenCalledWith(projectPath, expectedFioriOptions, editor, {});
             expect(mockWriteApplicationInfoSettings).toHaveBeenCalledWith(projectPath);
         });
+    });
+});
+
+describe('getFloorplanLabel', () => {
+    test('returns translated label for known template types', () => {
+        expect(getFloorplanLabel('lrop')).toBe('List Report Page');
+        expect(getFloorplanLabel('fpm')).toBe('Custom Page');
+        expect(getFloorplanLabel('worklist')).toBe('Worklist Page');
+        expect(getFloorplanLabel('alp')).toBe('Analytical List Page');
+        expect(getFloorplanLabel('ovp')).toBe('Overview Page');
+        expect(getFloorplanLabel('feop')).toBe('Form Entry Object Page');
+        expect(getFloorplanLabel('basic')).toBe('Basic');
+    });
+
+    test('returns the templateType as fallback for unknown types', () => {
+        expect(getFloorplanLabel('unknown-type')).toBe('unknown-type');
     });
 });

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -39,6 +39,7 @@
         "@sap-ux/odata-service-inquirer": "workspace:*",
         "@sap-ux/fiori-elements-writer": "workspace:*",
         "@sap-ux/fiori-freestyle-writer": "workspace:*",
+        "@sap-ux/fiori-app-sub-generator": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/project-input-validator": "workspace:*",
         "@sap-ux/launch-config": "workspace:*",

--- a/packages/repo-app-import-sub-generator/src/app/index.ts
+++ b/packages/repo-app-import-sub-generator/src/app/index.ts
@@ -22,6 +22,7 @@ import {
     isCli,
     setYeomanEnvConflicterForce
 } from '@sap-ux/fiori-generator-shared';
+import { getFloorplanLabel } from '@sap-ux/fiori-app-sub-generator';
 import type {
     RepoAppDownloadOptions,
     RepoAppDownloadAnswers,
@@ -47,7 +48,7 @@ import { PromptState } from '../prompts/prompt-state.js';
 import { getAppConfig, getAdtDeployConfig } from './app-config-quick-deploy.js';
 import { getAbapRepoAppConfig, getAbapRepoDeployConfig, writeServiceMetadata } from './app-config-abap-repo.js';
 import type { AbapDeployConfig } from '@sap-ux/ui5-config';
-import { makeValidJson, processDebugArtifacts, addPackageJsonIfNotFound } from '../utils/file-helpers.js';
+import { makeValidJson, cleanupArtifacts, addPackageJsonIfNotFound } from '../utils/file-helpers.js';
 import { replaceWebappFiles, validateAndUpdateManifestUI5Version } from '../utils/updates.js';
 import { getYUIDetails } from '../prompts/prompt-helpers.js';
 import { isValidPromptState, validateQfaJsonFile } from '../utils/validators.js';
@@ -175,7 +176,7 @@ export default class extends Generator {
             await writeServiceMetadata(serviceProvider, webappPath, this.fs);
         }
 
-        processDebugArtifacts(webappPath, this.fs);
+        cleanupArtifacts(webappPath, this.fs);
         const appConfig = getAbapRepoAppConfig(webappPath, this.answers.selectedApp, this.fs);
 
         // If package.json does not exist in the extracted app, add a minimal one with the appId as the package name.
@@ -277,7 +278,7 @@ export default class extends Generator {
             generatorName: generatorName,
             generatorVersion: this.rootGeneratorVersion(),
             ui5Version: config.ui5?.version ?? '',
-            template: config.template.type,
+            template: getFloorplanLabel(config.template.type, config.service.version),
             serviceUrl: config.service.url,
             launchText: t('readMe.launchText')
         };

--- a/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
+++ b/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
@@ -47,31 +47,49 @@ export function readManifest(manifestFilePath: string, fs: Editor): Manifest {
 }
 
 /**
- * Removes debug, preload, and source map files from the extracted project path.
+ * Removes build artefacts from the extracted project that should not be present in a local development project.
+ * Handles debug files (-dbg.js), preload bundles, source maps, and transpiled JS files for TypeScript apps.
  * For -dbg.js files, copies the unminified content to the corresponding .js file first.
- * These files are build artefacts that cause issues with the UI5 CLI build if left in place.
  *
  * @param {string} extractedProjectPath - The path where the app files are extracted.
  * @param {Editor} fs - The file system editor.
  */
-export function processDebugArtifacts(extractedProjectPath: string, fs: Editor): void {
+export function cleanupArtifacts(extractedProjectPath: string, fs: Editor): void {
     const dbgSuffix = '-dbg.';
-    PromptState.admZip?.getEntries().forEach((entry) => {
+    const entries = PromptState.admZip?.getEntries() ?? [];
+    const tsEntryNames = new Set(entries.filter((e) => e.entryName.endsWith('.ts')).map((e) => e.entryName));
+
+    entries.forEach((entry) => {
         const name = entry.entryName;
+
+        // Replace debug variants (e.g. component-dbg.js) with their non-debug counterpart
         if (name.includes(dbgSuffix)) {
-            // copies contents of -dbg.js to .js file and removes the -dbg.js file
             const extractedDebugPath = join(extractedProjectPath, name.replace(dbgSuffix, '.'));
             const debugPath = join(extractedProjectPath, name);
             fs.write(extractedDebugPath, entry.getData().toString('utf8'));
             fs.delete(debugPath);
             RepoAppDownloadLogger.logger?.debug(
-                `processDebugArtifacts: Copied "${debugPath}" -> "${extractedDebugPath}" and removed debug file`
+                `cleanupArtifacts: Copied "${debugPath}" -> "${extractedDebugPath}" and removed debug file`
             );
-        } else if (name.endsWith('-preload.js') || name.endsWith('.js.map')) {
+            return;
+        }
+
+        // Remove preload bundles and source maps — not needed for local development
+        if (name.endsWith('-preload.js') || name.endsWith('.js.map')) {
             const filePath = join(extractedProjectPath, name);
             if (fs.exists(filePath)) {
                 fs.delete(filePath);
-                RepoAppDownloadLogger.logger?.debug(`processDebugArtifacts: Removed file: "${filePath}"`);
+                RepoAppDownloadLogger.logger?.debug(`cleanupArtifacts: Removed preload/map file: "${filePath}"`);
+            }
+            return;
+        }
+
+        // Remove transpiled .js files that have a .ts counterpart — TypeScript source takes precedence
+        if (tsEntryNames.size > 0 && name.endsWith('.js') && tsEntryNames.has(`${name.slice(0, -3)}.ts`)) {
+            const filePath = join(extractedProjectPath, name);
+            if (fs.exists(filePath)) {
+                fs.delete(filePath);
+                RepoAppDownloadLogger.logger?.debug(`cleanupArtifacts: Removed transpiled file: "${filePath}"`);
             }
         }
     });
@@ -79,7 +97,6 @@ export function processDebugArtifacts(extractedProjectPath: string, fs: Editor):
 
 /**
  * Writes a minimal package.json to the project path if one does not already exist.
- * Sets `sapux: true` for all apps except freestyle templates.
  *
  * @param {string} projectPath - The project root path.
  * @param {AbapRepoAppConfig} appConfig - The app configuration.
@@ -88,7 +105,7 @@ export function processDebugArtifacts(extractedProjectPath: string, fs: Editor):
 export function addPackageJsonIfNotFound(projectPath: string, appConfig: AbapRepoAppConfig, fs: Editor): void {
     const packageJsonPath = join(projectPath, FileName.Package);
     if (!fs.exists(packageJsonPath)) {
-        const packageJson: { name: string; sapux?: boolean } = { name: appConfig.app.id };
+        const packageJson: { name: string } = { name: appConfig.app.id };
         fs.writeJSON(packageJsonPath, packageJson);
     }
 }

--- a/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
+++ b/packages/repo-app-import-sub-generator/src/utils/file-helpers.ts
@@ -57,7 +57,9 @@ export function readManifest(manifestFilePath: string, fs: Editor): Manifest {
 export function cleanupArtifacts(extractedProjectPath: string, fs: Editor): void {
     const dbgSuffix = '-dbg.';
     const entries = PromptState.admZip?.getEntries() ?? [];
-    const tsEntryNames = new Set(entries.filter((e) => e.entryName.endsWith('.ts')).map((e) => e.entryName));
+    const tsEntryNames = new Set(
+        entries.filter((e) => e.entryName.endsWith('.ts') && !e.entryName.endsWith('.d.ts')).map((e) => e.entryName)
+    );
 
     entries.forEach((entry) => {
         const name = entry.entryName;

--- a/packages/repo-app-import-sub-generator/test/app.test.ts
+++ b/packages/repo-app-import-sub-generator/test/app.test.ts
@@ -117,7 +117,7 @@ jest.unstable_mockModule('../src/prompts/prompts', () => ({
 
 jest.unstable_mockModule('../src/utils/file-helpers', () => ({
     ...actualFileHelpers,
-    processDebugArtifacts: jest.fn(),
+    cleanupArtifacts: jest.fn(),
     addPackageJsonIfNotFound: jest.fn()
 }));
 
@@ -778,7 +778,7 @@ describe('Repo App Download', () => {
         ).resolves.not.toThrow();
 
         expect(downloadUtils.extractZip).toHaveBeenCalled();
-        expect(fileHelpers.processDebugArtifacts).toHaveBeenCalled();
+        expect(fileHelpers.cleanupArtifacts).toHaveBeenCalled();
         expect(getAbapRepoDeployConfig).toHaveBeenCalled();
     });
 
@@ -810,6 +810,8 @@ describe('Repo App Download', () => {
         expect(fs.existsSync(readMePath)).toBe(true);
         const readMeContent = fs.readFileSync(readMePath, 'utf-8');
         expect(readMeContent).toContain(appId);
+        expect(readMeContent).toContain('List Report Page');
+        expect(readMeContent).not.toContain('lrop');
     });
 
     it('should generate launch config for AbapRepository download type when vscode is provided', async () => {

--- a/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
+++ b/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
@@ -16,7 +16,7 @@ jest.unstable_mockModule('../../src/utils/logger', () => {
     return { default: mock, ...mock };
 });
 
-const { readManifest, makeValidJson, addPackageJsonIfNotFound, processDebugArtifacts, getTemplateTypeFromManifest } =
+const { readManifest, makeValidJson, addPackageJsonIfNotFound, cleanupArtifacts, getTemplateTypeFromManifest } =
     await import('../../src/utils/file-helpers.js');
 const RepoAppDownloadLogger = (await import('../../src/utils/logger.js')).default;
 
@@ -75,7 +75,7 @@ describe('makeValidJson', () => {
     });
 });
 
-describe('processDebugArtifacts', () => {
+describe('cleanupArtifacts', () => {
     const mockFs = {
         exists: jest.fn(),
         delete: jest.fn(),
@@ -92,7 +92,7 @@ describe('processDebugArtifacts', () => {
         const mockAdmZip = { getEntries: jest.fn(() => entries) };
         (PromptState as any)['_admZipInstance'] = mockAdmZip;
 
-        processDebugArtifacts('/webapp', mockFs as any);
+        cleanupArtifacts('/webapp', mockFs as any);
 
         expect(mockFs.write).toHaveBeenCalledWith(join('/webapp', 'Component.js'), dbgContent);
         expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'Component-dbg.js'));
@@ -109,7 +109,7 @@ describe('processDebugArtifacts', () => {
         const mockAdmZip = { getEntries: jest.fn(() => entries) };
         (PromptState as any)['_admZipInstance'] = mockAdmZip;
 
-        processDebugArtifacts('/webapp', mockFs as any);
+        cleanupArtifacts('/webapp', mockFs as any);
 
         expect(mockFs.write).toHaveBeenCalledWith(join('/webapp', 'ext/view/Main.controller.js'), dbgContent);
         expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'ext/view/Main-dbg.controller.js'));
@@ -126,7 +126,7 @@ describe('processDebugArtifacts', () => {
         (PromptState as any)['_admZipInstance'] = mockAdmZip;
         mockFs.exists.mockReturnValue(true);
 
-        processDebugArtifacts('/webapp', mockFs as any);
+        cleanupArtifacts('/webapp', mockFs as any);
 
         expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'Component-preload.js'));
         expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'Component.js.map'));
@@ -140,7 +140,43 @@ describe('processDebugArtifacts', () => {
         (PromptState as any)['_admZipInstance'] = mockAdmZip;
         mockFs.exists.mockReturnValue(false);
 
-        processDebugArtifacts('/webapp', mockFs as any);
+        cleanupArtifacts('/webapp', mockFs as any);
+
+        expect(mockFs.delete).not.toHaveBeenCalled();
+    });
+
+    it('should remove transpiled .js file when a corresponding .ts file exists', () => {
+        const entries = [
+            { entryName: 'Component.ts' },
+            { entryName: 'Component.js' },
+            { entryName: 'ext/view/Main.controller.ts' },
+            { entryName: 'ext/view/Main.controller.js' }
+        ];
+        (PromptState as any)['_admZipInstance'] = { getEntries: jest.fn(() => entries) };
+        mockFs.exists.mockReturnValue(true);
+
+        cleanupArtifacts('/webapp', mockFs as any);
+
+        expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'Component.js'));
+        expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'ext/view/Main.controller.js'));
+    });
+
+    it('should not remove .js file when no corresponding .ts file exists', () => {
+        const entries = [{ entryName: 'Component.js' }];
+        (PromptState as any)['_admZipInstance'] = { getEntries: jest.fn(() => entries) };
+        mockFs.exists.mockReturnValue(true);
+
+        cleanupArtifacts('/webapp', mockFs as any);
+
+        expect(mockFs.delete).not.toHaveBeenCalled();
+    });
+
+    it('should not delete transpiled .js file if it does not exist in mem-fs', () => {
+        const entries = [{ entryName: 'Component.ts' }, { entryName: 'Component.js' }];
+        (PromptState as any)['_admZipInstance'] = { getEntries: jest.fn(() => entries) };
+        mockFs.exists.mockReturnValue(false);
+
+        cleanupArtifacts('/webapp', mockFs as any);
 
         expect(mockFs.delete).not.toHaveBeenCalled();
     });
@@ -148,7 +184,7 @@ describe('processDebugArtifacts', () => {
     it('should do nothing when admZip is not set', () => {
         PromptState.reset();
 
-        processDebugArtifacts('/webapp', mockFs as any);
+        cleanupArtifacts('/webapp', mockFs as any);
 
         expect(mockFs.delete).not.toHaveBeenCalled();
         expect(mockFs.write).not.toHaveBeenCalled();

--- a/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
+++ b/packages/repo-app-import-sub-generator/test/utils/file-helpers.test.ts
@@ -161,6 +161,16 @@ describe('cleanupArtifacts', () => {
         expect(mockFs.delete).toHaveBeenCalledWith(join('/webapp', 'ext/view/Main.controller.js'));
     });
 
+    it('should not treat .d.ts declaration files as TypeScript source files', () => {
+        const entries = [{ entryName: 'ui5.d.ts' }, { entryName: 'Component.js' }];
+        (PromptState as any)['_admZipInstance'] = { getEntries: jest.fn(() => entries) };
+        mockFs.exists.mockReturnValue(true);
+
+        cleanupArtifacts('/webapp', mockFs as any);
+
+        expect(mockFs.delete).not.toHaveBeenCalled();
+    });
+
     it('should not remove .js file when no corresponding .ts file exists', () => {
         const entries = [{ entryName: 'Component.js' }];
         (PromptState as any)['_admZipInstance'] = { getEntries: jest.fn(() => entries) };

--- a/packages/repo-app-import-sub-generator/tsconfig.json
+++ b/packages/repo-app-import-sub-generator/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../feature-toggle"
     },
     {
+      "path": "../fiori-app-sub-generator"
+    },
+    {
       "path": "../fiori-elements-writer"
     },
     {

--- a/packages/ui5-application-writer/src/index.ts
+++ b/packages/ui5-application-writer/src/index.ts
@@ -197,6 +197,7 @@ async function enableTypescript(basePath: string, fs?: Editor): Promise<Editor> 
 
 export type { Package } from '@sap-ux/project-access';
 export { generate, enableTypescript, isTypescriptEnabled };
+export { ui5TSSupport } from './data/ui5Libs.js';
 export type { App, Ui5App, UI5, AppOptions } from './types.js';
 export { addEslintFeature } from './options.js';
 export {

--- a/packages/ui5-application-writer/src/options.ts
+++ b/packages/ui5-application-writer/src/options.ts
@@ -89,10 +89,13 @@ export async function enableTypescript(input: FeatureInput, keepOldComponent: bo
         ui5Config.addCustomTasks([ui5TSSupport.task]);
     });
     const compPath = join(input.basePath, 'webapp/Component.js');
-    if (keepOldComponent) {
-        input.fs.move(compPath, `${compPath}.old`);
-    } else {
-        input.fs.delete(compPath);
+    // Component.js may not exist if the project already uses TypeScript
+    if (input.fs.exists(compPath)) {
+        if (keepOldComponent) {
+            input.fs.move(compPath, `${compPath}.old`);
+        } else {
+            input.fs.delete(compPath);
+        }
     }
 }
 

--- a/packages/ui5-application-writer/test/index.test.ts
+++ b/packages/ui5-application-writer/test/index.test.ts
@@ -116,6 +116,15 @@ describe('UI5 templates', () => {
         await expect(enableTypescript(projectDir, fs)).rejects.toThrow();
     });
 
+    it('enableTypescript does not throw when Component.js does not exist (TypeScript project)', async () => {
+        const projectDir = join(outputDir, 'testapp-ts-no-component');
+        await generate(projectDir, { ...ui5AppConfig, ui5: { minUI5Version: '1.96.1' } }, fs);
+        fs.delete(join(projectDir, 'webapp/Component.js'));
+        await expect(enableTypescript(projectDir, fs)).resolves.not.toThrow();
+        expect(fs.exists(join(projectDir, 'webapp/Component.js'))).toBe(false);
+        expect(fs.exists(join(projectDir, 'webapp/Component.js.old'))).toBe(false);
+    });
+
     it('Check webapp/index.html templates are generated correctly for CAP application with ui5 version ', async () => {
         const projectDir = join(outputDir, 'testapp-cap');
         ui5AppConfig.app.projectType = 'CAPNodejs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34765,7 +34765,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1
+      axios: 1.16.1(debug@4.3.4)
     optional: true
 
   retry@0.12.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34765,7 +34765,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1(debug@4.3.4)
+      axios: 1.16.1
     optional: true
 
   retry@0.12.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3986,6 +3986,9 @@ importers:
       '@sap-ux/feature-toggle':
         specifier: workspace:*
         version: link:../feature-toggle
+      '@sap-ux/fiori-app-sub-generator':
+        specifier: workspace:*
+        version: link:../fiori-app-sub-generator
       '@sap-ux/fiori-elements-writer':
         specifier: workspace:*
         version: link:../fiori-elements-writer
@@ -34762,7 +34765,7 @@ snapshots:
 
   retry-axios@2.6.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.1(debug@4.3.4)
+      axios: 1.16.1
     optional: true
 
   retry@0.12.0: {}


### PR DESCRIPTION
 - After downloading a TypeScript app from ABAP repository, the generator automatically configures the project for local TypeScript development  `cleanupArtifacts` removes transpiled .js files with a .ts counterpart.                                                                                                 
  - `getFloorplanLabel` exported for template types to be written in read me.        
  - exported `ui5TSSupport` from writers to be inject ts custom middlewares to yaml files.                                               
                                                                                                                    