### PR TITLE
feat: use new vscode variable vscode-button-secondaryBorder

### DIFF
--- a/.changeset/afraid-lies-stare.md
+++ b/.changeset/afraid-lies-stare.md
@@ -1,5 +1,6 @@
 ---
 '@sap-ux/ui-components': patch
+'sap-ux-sap-systems-ext': patch
 ---
 
 FEAT: use new vscode variable '--vscode-button-secondaryBorder' for secondary buttons

--- a/.changeset/afraid-lies-stare.md
+++ b/.changeset/afraid-lies-stare.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui-components': patch
+---
+
+FEAT: use new vscode variable '--vscode-button-secondaryBorder' for secondary buttons

--- a/packages/ui-components/.storybook/static/vscode-dark.css
+++ b/packages/ui-components/.storybook/static/vscode-dark.css
@@ -115,6 +115,7 @@
     --vscode-button-hoverBackground: #1177bb;
     --vscode-button-secondaryForeground: #ffffff;
     --vscode-button-secondaryBackground: #3a3d41;
+    --vscode-button-secondaryBorder: rgba(204, 204, 204, 0.15);
     --vscode-button-secondaryHoverBackground: #45494e;
     --vscode-checkbox-background: #3c3c3c;
     --vscode-checkbox-selectBackground: #252526;

--- a/packages/ui-components/.storybook/static/vscode-hcb.css
+++ b/packages/ui-components/.storybook/static/vscode-hcb.css
@@ -108,6 +108,7 @@
     --vscode-button-separator: rgba(255, 255, 255, 0.4);
     --vscode-button-border: #6fc3df;
     --vscode-button-secondaryForeground: #ffffff;
+    --vscode-button-secondaryBorder: #6fc3df;
     --vscode-checkbox-background: #000000;
     --vscode-checkbox-selectBackground: #0c141f;
     --vscode-checkbox-foreground: #ffffff;

--- a/packages/ui-components/.storybook/static/vscode-hcl.css
+++ b/packages/ui-components/.storybook/static/vscode-hcl.css
@@ -141,6 +141,7 @@
     --vscode-button-border: #0f4a85;
     --vscode-button-secondaryForeground: #292929;
     --vscode-button-secondaryBackground: #ffffff;
+    --vscode-button-secondaryBorder: #0f4a85;
     --vscode-radio-activeForeground: #292929;
     --vscode-radio-activeBackground: rgba(0, 0, 0, 0);
     --vscode-radio-activeBorder: #0f4a85;

--- a/packages/ui-components/.storybook/static/vscode-light.css
+++ b/packages/ui-components/.storybook/static/vscode-light.css
@@ -115,6 +115,7 @@
     --vscode-button-hoverBackground: #0062a3;
     --vscode-button-secondaryForeground: #ffffff;
     --vscode-button-secondaryBackground: #5f6a79;
+    --vscode-button-secondaryBorder: rgba(97, 97, 97, 0.15);
     --vscode-button-secondaryHoverBackground: #4c5561;
     --vscode-checkbox-background: #ffffff;
     --vscode-checkbox-selectBackground: #f3f3f3;

--- a/packages/ui-components/src/components/UIButton/UIDefaultButton.tsx
+++ b/packages/ui-components/src/components/UIButton/UIDefaultButton.tsx
@@ -7,6 +7,7 @@ import { COMMON_INPUT_STYLES } from '../UIInput/index.js';
 import { UiIcons } from '../Icons.js';
 
 const VSCODE_BORDER_COLOR = 'var(--vscode-button-border, transparent)';
+const VSCODE_SECONDARY_BORDER_COLOR = `var(--vscode-button-secondaryBorder, ${VSCODE_BORDER_COLOR})`;
 export const BASE_STYLES = {
     color: 'var(--vscode-button-foreground)',
     checkedBorderColor: 'var(--vscode-contrastActiveBorder, var(--vscode-button-border, transparent))',
@@ -19,10 +20,10 @@ export const BASE_STYLES = {
     },
     secondary: {
         backgroundColor: 'var(--vscode-button-secondaryBackground)',
-        disabledBorderColor: VSCODE_BORDER_COLOR,
-        borderColor: VSCODE_BORDER_COLOR,
+        disabledBorderColor: VSCODE_SECONDARY_BORDER_COLOR,
+        borderColor: VSCODE_SECONDARY_BORDER_COLOR,
         hoverBackgroundColor: 'var(--vscode-button-secondaryHoverBackground)',
-        hoverBorderColor: VSCODE_BORDER_COLOR,
+        hoverBorderColor: VSCODE_SECONDARY_BORDER_COLOR,
         color: 'var(--vscode-button-secondaryForeground)'
     },
     alert: {

--- a/packages/ui-components/src/components/UIToggle/UIToggle.tsx
+++ b/packages/ui-components/src/components/UIToggle/UIToggle.tsx
@@ -80,9 +80,9 @@ const COLORS = {
     thumb: {
         unchecked: {
             background: 'var(--vscode-button-secondaryBackground)',
-            borderColor: 'var(--vscode-button-border, transparent)',
+            borderColor: 'var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))',
             hover: {
-                borderColor: 'var(--vscode-button-border, transparent)',
+                borderColor: 'var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))',
                 background: 'var(--vscode-contrastBorder, var(--vscode-button-secondaryHoverBackground))'
             }
         },

--- a/packages/ui-components/test/unit/components/UIDefaultButton.test.tsx
+++ b/packages/ui-components/test/unit/components/UIDefaultButton.test.tsx
@@ -194,7 +194,7 @@ describe('<UIDefaultButton />', () => {
             `
             Object {
               "backgroundColor": "var(--vscode-button-secondaryBackground)",
-              "borderColor": "var(--vscode-button-border, transparent)",
+              "borderColor": "var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))",
               "borderRadius": "var(--vscode-cornerRadius-small, 4px)",
               "color": "var(--vscode-button-secondaryForeground)",
               "fontSize": "13px",
@@ -216,7 +216,7 @@ describe('<UIDefaultButton />', () => {
         expect(styles?.rootHovered).toMatchInlineSnapshot(`
             Object {
               "backgroundColor": "var(--vscode-button-secondaryHoverBackground)",
-              "borderColor": "var(--vscode-button-border, transparent)",
+              "borderColor": "var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))",
               "color": "var(--vscode-button-secondaryForeground)",
               "selectors": Object {
                 "svg > path, svg > rect": Object {
@@ -228,7 +228,7 @@ describe('<UIDefaultButton />', () => {
         expect(styles?.rootDisabled).toMatchInlineSnapshot(`
             Object {
               "backgroundColor": "var(--vscode-button-secondaryBackground)",
-              "borderColor": "var(--vscode-button-border, transparent)",
+              "borderColor": "var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))",
               "color": "var(--vscode-button-secondaryForeground)",
               "opacity": "0.5 !important",
             }

--- a/packages/ui-components/test/unit/components/UIToggle.test.tsx
+++ b/packages/ui-components/test/unit/components/UIToggle.test.tsx
@@ -121,7 +121,7 @@ describe('<UIToggle />', () => {
                   },
                   ":hover .ms-Toggle-thumb": Object {
                     "background": "var(--vscode-contrastBorder, var(--vscode-button-secondaryHoverBackground))",
-                    "borderColor": "var(--vscode-button-border, transparent)",
+                    "borderColor": "var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))",
                   },
                   "background": "var(--vscode-editorWidget-background)",
                   "borderColor": "var(--vscode-editorWidget-border)",
@@ -146,7 +146,7 @@ describe('<UIToggle />', () => {
                   },
                   "backgroundColor": "var(--vscode-button-secondaryBackground)",
                   "backgroundPosition": "center",
-                  "borderColor": "var(--vscode-button-border, transparent)",
+                  "borderColor": "var(--vscode-button-secondaryBorder, var(--vscode-button-border, transparent))",
                   "borderWidth": 1,
                   "height": 14,
                   "svg": Object {


### PR DESCRIPTION
vscode introduced new vscode variable `--vscode-button-secondaryBorder` for secondary buttons.
Previously we used `--vscode-button-border` for both primary and secondary button.
In this PR we apply `--vscode-button-secondaryBorder` to secondary button based on vscode design.
Before with new theme:
<img width="229" height="59" alt="image" src="https://github.com/user-attachments/assets/a84344d1-3545-4e11-bfe9-871270dde970" />

After:
<img width="268" height="54" alt="image" src="https://github.com/user-attachments/assets/1d236a2c-81e5-4212-8fa3-ac4475756df0" />

Additionally - applied variable to storybook themes and setting `--vscode-button-border` as fallback value if for some theme `--vscode-button-secondaryBorder` does not exist
