### PR TITLE
Move `getFloorplanLabel` to fiori generator shared   

### DIFF
--- a/.changeset/fix-move-read-me-util-ftn.md
+++ b/.changeset/fix-move-read-me-util-ftn.md
@@ -1,0 +1,7 @@
+---
+"@sap-ux/fiori-app-sub-generator": minor
+"@sap-ux/fiori-generator-shared": minor
+"@sap-ux/repo-app-import-sub-generator": patch
+---
+
+FIX: Move `getFloorplanLabel` to `@sap-ux/fiori-generator-shared` to avoid duplication across generators.

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/fioriAppGenerator.ts
@@ -19,7 +19,8 @@ import {
     type ILogWrapper,
     sendTelemetry,
     TelemetryHelper,
-    getFlpId
+    getFlpId,
+    getFloorplanLabel
 } from '@sap-ux/fiori-generator-shared';
 import type { Logger } from '@sap-ux/logger';
 import type { EntityRelatedAnswers } from '@sap-ux/odata-service-inquirer';
@@ -58,8 +59,7 @@ import {
     initI18nFioriAppSubGenerator,
     restoreServiceProviderLoggers,
     t,
-    updateDependentStep,
-    getFloorplanLabel
+    updateDependentStep
 } from '../utils/index.js';
 import { runPostGenerationTasks } from './end.js';
 import type { FioriAppGeneratorOptions } from './fioriAppGeneratorOptions.js';

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
@@ -1,4 +1,5 @@
 import { generateAppGenInfo, getHostEnvironment, getFloorplanLabel } from '@sap-ux/fiori-generator-shared';
+import type { AppGenInfo } from '@sap-ux/fiori-generator-shared';
 import type { Editor } from 'mem-fs-editor';
 import { basename, join } from 'node:path';
 import type { ApiHubConfig, State } from '../types/index.js';

--- a/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
+++ b/packages/fiori-app-sub-generator/src/fiori-app-generator/writing.ts
@@ -1,10 +1,9 @@
-import type { AppGenInfo } from '@sap-ux/fiori-generator-shared';
-import { generateAppGenInfo, getHostEnvironment } from '@sap-ux/fiori-generator-shared';
+import { generateAppGenInfo, getHostEnvironment, getFloorplanLabel } from '@sap-ux/fiori-generator-shared';
 import type { Editor } from 'mem-fs-editor';
 import { basename, join } from 'node:path';
 import type { ApiHubConfig, State } from '../types/index.js';
 import { DEFAULT_CAP_HOST } from '../types/index.js';
-import { getLaunchText, getReadMeDataSourceLabel, isAbapCloud, t, getFloorplanLabel } from '../utils/index.js';
+import { getLaunchText, getReadMeDataSourceLabel, isAbapCloud, t } from '../utils/index.js';
 
 /**
  * Writes app related information files - README.md & .appGenInfo.json.

--- a/packages/fiori-app-sub-generator/src/translations/fioriAppSubGenerator.i18n.json
+++ b/packages/fiori-app-sub-generator/src/translations/fioriAppSubGenerator.i18n.json
@@ -1,14 +1,5 @@
 {
     "floorplans": {
-        "label": {
-            "basic": "Basic{{odataVersion, odataVersionFormatter}}",
-            "fpm": "Custom Page{{odataVersion, odataVersionFormatter}}",
-            "lrop": "List Report Page{{odataVersion, odataVersionFormatter}}",
-            "worklist": "Worklist Page{{odataVersion, odataVersionFormatter}}",
-            "alp": "Analytical List Page{{odataVersion, odataVersionFormatter}}",
-            "ovp": "Overview Page{{odataVersion, odataVersionFormatter}}",
-            "feop": "Form Entry Object Page{{odataVersion, odataVersionFormatter}}"
-        },
         "description": {
             "basic": "Create a freestyle application, starting with an empty page.",
             "fpm": "Create an SAP Fiori elements application containing a custom page based on the flexible programming model.",

--- a/packages/fiori-app-sub-generator/src/utils/common.ts
+++ b/packages/fiori-app-sub-generator/src/utils/common.ts
@@ -318,14 +318,3 @@ export async function getAnnotations(
 
 /** @deprecated Import directly from `@sap-ux/fiori-generator-shared` instead. */
 export { restoreServiceProviderLoggers } from '@sap-ux/fiori-generator-shared';
-
-/**
- * Returns the human-readable display label for a given floorplan/template type.
- *
- * @param templateType - the template type string (e.g. 'lrop', 'fpm')
- * @param odataVersion - the OData version string (e.g. 'v2', 'v4')
- * @returns the display label (e.g. 'List Report Page V4', 'Custom Page V4')
- */
-export function getFloorplanLabel(templateType: string, odataVersion?: string): string {
-    return t(`floorplans.label.${templateType}`, { defaultValue: templateType, odataVersion });
-}

--- a/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/fiori-app-generator/fioriAppGenerator-lifecycle2.test.ts
@@ -228,9 +228,7 @@ describe('Test FioriAppGenerator', () => {
                 expect.objectContaining({ info: expect.any(Function), error: expect.any(Function) })
             );
             expect(TelemetryHelper.createTelemetryData).toHaveBeenCalledWith({
-                Template: t(`floorplans.label.${floorplan}`, {
-                    odataVersion: mockState.service.version
-                }),
+                Template: actualFioriGenShared.getFloorplanLabel(floorplan, mockState.service.version),
                 DataSource: mockState.service.source,
                 UI5Version: mockState.project.ui5Version,
                 Theme: mockState.project.ui5Theme,

--- a/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/common.test.ts
@@ -67,12 +67,12 @@ const {
     getAnnotations,
     getAppId,
     getCdsAnnotations,
-    getFloorplanLabel,
     getMinSupportedUI5Version,
     getODataVersion,
     getReadMeDataSourceLabel,
     getRequiredOdataVersion
 } = await import('../../../src/utils/common.js');
+const { getFloorplanLabel } = await import('@sap-ux/fiori-generator-shared');
 
 describe('Test utils', () => {
     beforeAll(async () => {

--- a/packages/fiori-app-sub-generator/test/unit/utils/i18n.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/utils/i18n.test.ts
@@ -6,7 +6,9 @@ describe('Test i18n', () => {
     });
     // Undefined interpolation properties should output as empty strings
     test('Undefined interpolation properties', () => {
-        expect(t('floorplans.label.basic')).toEqual(`Basic`);
-        expect(t('floorplans.label.basic', { odataVersion: '4' })).toEqual(`Basic V4`);
+        expect(t('steps.flpConfig.description')).toEqual(`Configure SAP Fiori launchpad settings .`);
+        expect(t('steps.flpConfig.description', { appFolderName: 'myApp' })).toEqual(
+            `Configure SAP Fiori launchpad settings myApp.`
+        );
     });
 });

--- a/packages/fiori-generator-shared/src/app-gen-info.ts
+++ b/packages/fiori-generator-shared/src/app-gen-info.ts
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Editor } from 'mem-fs-editor';
 import type { AbapCSN, AppGenInfo, ExternalParameters } from './types/index.js';
+import { t } from './i18n.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -81,4 +82,15 @@ export function generateAppGenInfo(destPath: string, appGenInfo: AppGenInfo, fs:
     fs.writeJSON(`${destPath}/.appGenInfo.json`, appGenInfoJson);
 
     return fs;
+}
+
+/**
+ * Returns the display label for a given floorplan template type.
+ *
+ * @param templateType - the template type key (e.g. 'lrop', 'fpm')
+ * @param odataVersion - optional OData version (e.g. '2', '4')
+ * @returns the display label (e.g. 'List Report Page V4')
+ */
+export function getFloorplanLabel(templateType: string, odataVersion?: string): string {
+    return t(`floorplans.label.${templateType}`, { defaultValue: templateType, odataVersion });
 }

--- a/packages/fiori-generator-shared/src/i18n.ts
+++ b/packages/fiori-generator-shared/src/i18n.ts
@@ -19,7 +19,13 @@ export async function initI18n(): Promise<void> {
         fallbackLng: 'en',
         defaultNS: NS,
         ns: [NS],
-        showSupportNotice: false
+        showSupportNotice: false,
+        interpolation: {
+            format: function odataVersionFormatter(odataVersion: string) {
+                return odataVersion ? ` V${odataVersion}` : '';
+            }
+        },
+        missingInterpolationHandler: () => ''
     });
 }
 

--- a/packages/fiori-generator-shared/src/i18n.ts
+++ b/packages/fiori-generator-shared/src/i18n.ts
@@ -21,8 +21,11 @@ export async function initI18n(): Promise<void> {
         ns: [NS],
         showSupportNotice: false,
         interpolation: {
-            format: function odataVersionFormatter(odataVersion: string) {
-                return odataVersion ? ` V${odataVersion}` : '';
+            format: function (value: string, format?: string) {
+                if (format === 'odataVersionFormatter') {
+                    return value ? ` V${value}` : '';
+                }
+                return value;
             }
         },
         missingInterpolationHandler: () => ''

--- a/packages/fiori-generator-shared/src/index.ts
+++ b/packages/fiori-generator-shared/src/index.ts
@@ -9,6 +9,6 @@ export * from './types/index.js';
 export { getPackageScripts } from './npm-package-scripts/getPackageScripts.js';
 export { getBootstrapResourceUrls } from './ui5/ui5.js';
 export { getDefaultTargetFolder, isExtensionInstalled, isCommandRegistered } from './vscode-helpers/vscode-helpers.js';
-export { generateAppGenInfo } from './app-gen-info.js';
+export { generateAppGenInfo, getFloorplanLabel } from './app-gen-info.js';
 export { getFlpId, getSemanticObject } from './app-helpers/app-helpers.js';
 export { setYeomanEnvConflicterForce } from './yeoman.js';

--- a/packages/fiori-generator-shared/src/translations/fiori-generator-shared.i18n.json
+++ b/packages/fiori-generator-shared/src/translations/fiori-generator-shared.i18n.json
@@ -17,5 +17,17 @@
         "systemTypeLabel": {
             "abapCloud": "ABAP Cloud"
         }
+    },
+    "floorplans": {
+        "label": {
+            "basic": "Basic{{odataVersion, odataVersionFormatter}}",
+            "fpm": "Custom Page{{odataVersion, odataVersionFormatter}}",
+            "lrop": "List Report Page{{odataVersion, odataVersionFormatter}}",
+            "worklist": "Worklist Page{{odataVersion, odataVersionFormatter}}",
+            "alp": "Analytical List Page{{odataVersion, odataVersionFormatter}}",
+            "ovp": "Overview Page{{odataVersion, odataVersionFormatter}}",
+            "feop": "Form Entry Object Page{{odataVersion, odataVersionFormatter}}",
+            "listdetail": "List Detail{{odataVersion, odataVersionFormatter}}"
+        }
     }
 }

--- a/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
+++ b/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
@@ -126,7 +126,8 @@ describe('getFloorplanLabel', () => {
         expect(getFloorplanLabel('alp', '4')).toBe('Analytical List Page V4');
     });
 
-    test('should return templateType as fallback for unknown template', () => {
+    test('should return templateType as fallback for unknown template without version suffix', () => {
+        // defaultValue has no interpolation token so version suffix is never appended for unknown templates
         expect(getFloorplanLabel('unknown-template')).toBe('unknown-template');
         expect(getFloorplanLabel('unknown-template', '4')).toBe('unknown-template');
     });

--- a/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
+++ b/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import memFs from 'mem-fs';
 import memFsEditor from 'mem-fs-editor';
 import { generateAppGenInfo, getFloorplanLabel } from '../../src/app-gen-info.js';
-import { initI18n } from '../../src/i18n.js';
+import { initI18n, t } from '../../src/i18n.js';
 import type { AppGenInfo } from '../../src/types/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -127,8 +127,14 @@ describe('getFloorplanLabel', () => {
     });
 
     test('should return templateType as fallback for unknown template without version suffix', () => {
-        // defaultValue has no interpolation token so version suffix is never appended for unknown templates
         expect(getFloorplanLabel('unknown-template')).toBe('unknown-template');
         expect(getFloorplanLabel('unknown-template', '4')).toBe('unknown-template');
+    });
+
+    test('should handle missing interpolation values and non-formatter interpolation', () => {
+        expect(t('logMessages.debug.loggingConfigured')).toBe('Logging has been configured at log level: .');
+        expect(t('logMessages.debug.loggingConfigured', { logLevel: 'info' })).toBe(
+            'Logging has been configured at log level: info.'
+        );
     });
 });

--- a/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
+++ b/packages/fiori-generator-shared/test/app-gen-info/app-gen-info.test.ts
@@ -2,7 +2,8 @@ import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import memFs from 'mem-fs';
 import memFsEditor from 'mem-fs-editor';
-import { generateAppGenInfo } from '../../src/app-gen-info.js';
+import { generateAppGenInfo, getFloorplanLabel } from '../../src/app-gen-info.js';
+import { initI18n } from '../../src/i18n.js';
 import type { AppGenInfo } from '../../src/types/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -105,5 +106,28 @@ describe('Readme file generation tests', () => {
         };
         generateAppGenInfo(__dirname, readMe, editor);
         expect(editor.read(readMePath)).toMatchSnapshot();
+    });
+});
+
+describe('getFloorplanLabel', () => {
+    beforeAll(async () => {
+        await initI18n();
+    });
+
+    test('should return label without version suffix when no odataVersion provided', () => {
+        expect(getFloorplanLabel('lrop')).toBe('List Report Page');
+        expect(getFloorplanLabel('basic')).toBe('Basic');
+        expect(getFloorplanLabel('fpm')).toBe('Custom Page');
+    });
+
+    test('should return label with version suffix when odataVersion provided', () => {
+        expect(getFloorplanLabel('lrop', '4')).toBe('List Report Page V4');
+        expect(getFloorplanLabel('lrop', '2')).toBe('List Report Page V2');
+        expect(getFloorplanLabel('alp', '4')).toBe('Analytical List Page V4');
+    });
+
+    test('should return templateType as fallback for unknown template', () => {
+        expect(getFloorplanLabel('unknown-template')).toBe('unknown-template');
+        expect(getFloorplanLabel('unknown-template', '4')).toBe('unknown-template');
     });
 });

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -39,7 +39,6 @@
         "@sap-ux/odata-service-inquirer": "workspace:*",
         "@sap-ux/fiori-elements-writer": "workspace:*",
         "@sap-ux/fiori-freestyle-writer": "workspace:*",
-        "@sap-ux/fiori-app-sub-generator": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@sap-ux/project-input-validator": "workspace:*",
         "@sap-ux/launch-config": "workspace:*",

--- a/packages/repo-app-import-sub-generator/src/app/index.ts
+++ b/packages/repo-app-import-sub-generator/src/app/index.ts
@@ -20,9 +20,9 @@ import {
     sendTelemetry,
     TelemetryHelper,
     isCli,
-    setYeomanEnvConflicterForce
+    setYeomanEnvConflicterForce,
+    getFloorplanLabel
 } from '@sap-ux/fiori-generator-shared';
-import { getFloorplanLabel } from '@sap-ux/fiori-app-sub-generator';
 import type {
     RepoAppDownloadOptions,
     RepoAppDownloadAnswers,

--- a/packages/repo-app-import-sub-generator/tsconfig.json
+++ b/packages/repo-app-import-sub-generator/tsconfig.json
@@ -22,9 +22,6 @@
       "path": "../feature-toggle"
     },
     {
-      "path": "../fiori-app-sub-generator"
-    },
-    {
       "path": "../fiori-elements-writer"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3986,9 +3986,6 @@ importers:
       '@sap-ux/feature-toggle':
         specifier: workspace:*
         version: link:../feature-toggle
-      '@sap-ux/fiori-app-sub-generator':
-        specifier: workspace:*
-        version: link:../fiori-app-sub-generator
       '@sap-ux/fiori-elements-writer':
         specifier: workspace:*
         version: link:../fiori-elements-writer


### PR DESCRIPTION
- Moved `getFloorplanLabel` from `fiori-app-sub-generator/src/utils/common.ts` to `@sap-ux/fiori-generator-shared/src/app-gen-info.ts`   as a shared utility                                       
- Added `floorplans.label ` translations and `odataVersionFormatter` interpolation to `fiori-generator-shared` i18n                      
- Removed duplicate `floorplans.label` translation block from `fiori-app-sub-generator`                                               
- Updated r`epo-app-import-sub-generator` to import `getFloorplanLabel` from shared instead of `fiori-app-sub-generator`, removing the   dependency entirely as flagged in   [PR comment](https://github.com/SAP/open-ux-tools/pull/4923#discussion_r3529380251) 