### PR TITLE
fix(app-config-writer): no card generator for CAP node without cds-plugin-ui5

### DIFF
--- a/.changeset/long-ears-kiss.md
+++ b/.changeset/long-ears-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/app-config-writer': patch
+---
+
+fix: do not allow adding card generator for CAP node projects w/o cds-plugin-ui5

--- a/packages/app-config-writer/src/cards-config/index.ts
+++ b/packages/app-config-writer/src/cards-config/index.ts
@@ -135,12 +135,11 @@ export async function enableCardGeneratorConfig(
         throw new Error('The cards-editor command is not supported for CAP Java projects.');
     }
 
-    if (projectType === 'CAPNodejs' && !capRoot) {
-        throw new Error(`Could not find CAP project root for path '${basePath}'.`);
-    }
-
     if (projectType === 'CAPNodejs') {
-        await ensureCdsPluginUi5(capRoot as string, fs);
+        if (!capRoot) {
+            throw new Error(`Could not find CAP project root for path '${basePath}'.`);
+        }
+        await ensureCdsPluginUi5(capRoot, fs);
     }
 
     await updateMiddlewaresForPreview(fs, basePath, yamlPath, logger);

--- a/packages/app-config-writer/src/cards-config/index.ts
+++ b/packages/app-config-writer/src/cards-config/index.ts
@@ -7,7 +7,7 @@ import type { MiddlewareConfig as PreviewConfig } from '@sap-ux/preview-middlewa
 import type { ToolsLogger } from '@sap-ux/logger';
 import { FileName, type Package, readUi5Yaml, getProjectType, findCapProjectRoot } from '@sap-ux/project-access';
 import { updateMiddlewaresForPreview } from '../common/ui5-yaml.js';
-import { ensureMinUI5Version } from './prerequisites.js';
+import { ensureMinUI5Version, ensureCdsPluginUi5 } from './prerequisites.js';
 import { updateCapRootPackageJsonForCards } from './cap.js';
 
 const DEPENDENCY_NAME = '@sap-ux/cards-editor-middleware';
@@ -137,6 +137,10 @@ export async function enableCardGeneratorConfig(
 
     if (projectType === 'CAPNodejs' && !capRoot) {
         throw new Error(`Could not find CAP project root for path '${basePath}'.`);
+    }
+
+    if (projectType === 'CAPNodejs') {
+        await ensureCdsPluginUi5(capRoot as string, fs);
     }
 
     await updateMiddlewaresForPreview(fs, basePath, yamlPath, logger);

--- a/packages/app-config-writer/src/cards-config/prerequisites.ts
+++ b/packages/app-config-writer/src/cards-config/prerequisites.ts
@@ -1,5 +1,10 @@
 import type { Editor } from 'mem-fs-editor';
-import { getMinimumUI5Version, getProjectType, findProjectRoot } from '@sap-ux/project-access';
+import {
+    getMinimumUI5Version,
+    getProjectType,
+    findProjectRoot,
+    checkCdsUi5PluginEnabled
+} from '@sap-ux/project-access';
 import { gte } from 'semver';
 import { readManifest } from '../common/utils.js';
 
@@ -26,6 +31,22 @@ export async function ensureMinUI5Version(basePath: string, fs: Editor): Promise
     if (minUI5Version && !gte(minUI5Version, featureVersion)) {
         throw new Error(
             `The card generator is only supported for projects with a minimum SAPUI5 version of ${featureVersion} or higher. The detected minimum SAPUI5 version is ${minUI5Version}. Update the sap.ui5.minUI5Version property in the manifest.json file and ensure the SAPUI5 version used is ${featureVersion} or higher.`
+        );
+    }
+}
+
+/**
+ * Ensures that `cds-plugin-ui5` is installed and enabled in the CAP root for CAP Node.js projects.
+ * The card generator relies on the CDS development server to serve the UI5 app, which requires this plugin.
+ *
+ * @param capRoot - path to the CAP project root
+ * @param fs - file system reference
+ * @throws {Error} if `cds-plugin-ui5` is not enabled in the CAP root
+ */
+export async function ensureCdsPluginUi5(capRoot: string, fs: Editor): Promise<void> {
+    if (!(await checkCdsUi5PluginEnabled(capRoot, fs))) {
+        throw new Error(
+            `The cards-editor command requires 'cds-plugin-ui5' to be installed and enabled in the CAP root package.json.`
         );
     }
 }

--- a/packages/app-config-writer/test/unit/cards-config/cap.test.ts
+++ b/packages/app-config-writer/test/unit/cards-config/cap.test.ts
@@ -25,7 +25,8 @@ jest.unstable_mockModule('../../../src/common/utils.js', () => ({
 }));
 
 jest.unstable_mockModule('../../../src/cards-config/prerequisites.js', () => ({
-    ensureMinUI5Version: jest.fn<typeof realPrerequisites.ensureMinUI5Version>().mockResolvedValue(undefined)
+    ensureMinUI5Version: jest.fn<typeof realPrerequisites.ensureMinUI5Version>().mockResolvedValue(undefined),
+    ensureCdsPluginUi5: jest.fn<typeof realPrerequisites.ensureCdsPluginUi5>().mockResolvedValue(undefined)
 }));
 
 jest.unstable_mockModule('../../../src/common/ui5-yaml.js', () => ({

--- a/packages/app-config-writer/test/unit/cards-config/prerequisites.test.ts
+++ b/packages/app-config-writer/test/unit/cards-config/prerequisites.test.ts
@@ -5,18 +5,20 @@ const mockGetMinimumUI5Version = jest.fn();
 const mockGetProjectType = jest.fn();
 const mockFindProjectRoot = jest.fn();
 const mockReadManifest = jest.fn();
+const mockCheckCdsUi5PluginEnabled = jest.fn();
 
 jest.unstable_mockModule('@sap-ux/project-access', () => ({
     getMinimumUI5Version: mockGetMinimumUI5Version,
     getProjectType: mockGetProjectType,
-    findProjectRoot: mockFindProjectRoot
+    findProjectRoot: mockFindProjectRoot,
+    checkCdsUi5PluginEnabled: mockCheckCdsUi5PluginEnabled
 }));
 
 jest.unstable_mockModule('../../../src/common/utils.js', () => ({
     readManifest: mockReadManifest
 }));
 
-const { ensureMinUI5Version } = await import('../../../src/cards-config/prerequisites.js');
+const { ensureMinUI5Version, ensureCdsPluginUi5 } = await import('../../../src/cards-config/prerequisites.js');
 
 describe('cards-config/prerequisites', () => {
     let mockFs: Editor;
@@ -96,5 +98,36 @@ describe('cards-config/prerequisites', () => {
         mockGetMinimumUI5Version.mockReturnValue(undefined);
 
         await expect(ensureMinUI5Version('/test/path', mockFs)).resolves.toBeUndefined();
+    });
+});
+
+describe('ensureCdsPluginUi5', () => {
+    let mockFs: Editor;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockFs = {} as Editor;
+    });
+
+    test('should not throw when cds-plugin-ui5 is enabled', async () => {
+        mockCheckCdsUi5PluginEnabled.mockResolvedValue(true);
+
+        await expect(ensureCdsPluginUi5('/cap/root', mockFs)).resolves.toBeUndefined();
+    });
+
+    test('should throw when cds-plugin-ui5 is not enabled', async () => {
+        mockCheckCdsUi5PluginEnabled.mockResolvedValue(false);
+
+        await expect(ensureCdsPluginUi5('/cap/root', mockFs)).rejects.toThrow(
+            "The cards-editor command requires 'cds-plugin-ui5' to be installed and enabled in the CAP root package.json."
+        );
+    });
+
+    test('should pass capRoot and fs to checkCdsUi5PluginEnabled', async () => {
+        mockCheckCdsUi5PluginEnabled.mockResolvedValue(true);
+
+        await ensureCdsPluginUi5('/cap/root', mockFs);
+
+        expect(mockCheckCdsUi5PluginEnabled).toHaveBeenCalledWith('/cap/root', mockFs);
     });
 });


### PR DESCRIPTION
## Description

This fix prevents the cards-editor/card generator from being configured in CAP Node.js projects that do not have `cds-plugin-ui5` installed and enabled. The card generator relies on the CDS development server to serve the UI5 app, which requires this plugin to be present.

## Type of change
- [x] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?

Unit tests were added to cover the new `ensureCdsPluginUi5` prerequisite function:
- Verifies no error is thrown when `cds-plugin-ui5` is enabled
- Verifies a descriptive error is thrown when `cds-plugin-ui5` is not enabled
- Verifies correct arguments are passed to `checkCdsUi5PluginEnabled`

The new check is invoked in `cards-config/index.ts` before proceeding with the card generator setup for `CAPNodejs` project types.

## Checklist:
- [x] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [x] Corresponding changes to the documentation has been done
- [x] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.2`

- Correlation ID: `dd98c4d0-7b76-11f1-8f8d-a85a703681bd`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
