### PR TITLE
fix: use GitHub App token in lint auto-fix action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [22.x]
     runs-on: ${{ matrix.os }}
-    environment: release
+    environment: ci-secrets
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,21 +21,14 @@ jobs:
     environment: ci-secrets
     permissions:
       contents: write
-      id-token: write
 
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,17 +18,24 @@ jobs:
         os: [ubuntu-latest]
         node-version: [22.x]
     runs-on: ${{ matrix.os }}
-    environment: ci-secrets
+    environment: release
     permissions:
       contents: write
+      id-token: write
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,23 @@ jobs:
         node-version: [22.x]
     runs-on: ${{ matrix.os }}
     environment: ci-secrets
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout code repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.ACCESS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/renovate-pr-automation.yml
+++ b/.github/workflows/renovate-pr-automation.yml
@@ -18,10 +18,11 @@ jobs:
     create-changeset:
         name: Create Dependency Changeset
         runs-on: ubuntu-latest
-        environment: ci-secrets
+        environment: release
         permissions:
             contents: write
             pull-requests: read
+            id-token: write
         # All Renovate PRs EXCEPT @ui5/manifest (which has custom handling).
         # !head.repo.fork guards against pull_request_target pwn-request attacks.
         if: |
@@ -29,17 +30,23 @@ jobs:
             github.actor == 'renovate[bot]' &&
             !contains(github.event.pull_request.title, '@ui5/manifest')
         steps:
+            - name: Generate app token
+              id: app-token
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout PR branch
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Create changeset
               uses: mscharley/dependency-changesets-action@f96232368519695969bea8a8cfff7cca32b1e56a # v1.2.4
               with:
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   author-email: 'github-actions[bot]@users.noreply.github.com'
                   commit-message: 'chore: add changeset for dependency update'
 
@@ -47,22 +54,29 @@ jobs:
     update-manifest-fixtures:
         name: Update @ui5/manifest Fixtures & Changeset
         runs-on: ubuntu-latest
-        environment: ci-secrets
+        environment: release
         permissions:
             contents: write
             pull-requests: read
+            id-token: write
         # !head.repo.fork guards against pull_request_target pwn-request attacks.
         if: |
             !github.event.pull_request.head.repo.fork &&
             github.actor == 'renovate[bot]' &&
             contains(github.event.pull_request.title, '@ui5/manifest')
         steps:
+            - name: Generate app token
+              id: app-token
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout PR branch
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - name: Setup pnpm
               uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -103,6 +117,6 @@ jobs:
             - name: Create changeset
               uses: mscharley/dependency-changesets-action@f96232368519695969bea8a8cfff7cca32b1e56a # v1.2.4
               with:
-                  token: ${{ secrets.ACCESS_PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   author-email: 'github-actions[bot]@users.noreply.github.com'
                   commit-message: 'chore: add changeset for @ui5/manifest update'

--- a/.github/workflows/renovate-pr-automation.yml
+++ b/.github/workflows/renovate-pr-automation.yml
@@ -18,7 +18,7 @@ jobs:
     create-changeset:
         name: Create Dependency Changeset
         runs-on: ubuntu-latest
-        environment: release
+        environment: ci-secrets
         permissions:
             contents: write
             pull-requests: read
@@ -54,7 +54,7 @@ jobs:
     update-manifest-fixtures:
         name: Update @ui5/manifest Fixtures & Changeset
         runs-on: ubuntu-latest
-        environment: release
+        environment: ci-secrets
         permissions:
             contents: write
             pull-requests: read


### PR DESCRIPTION
## Summary

- Replaces `secrets.ACCESS_PAT` (a personal access token) with a GitHub App token in workflows that need to push commits back to branches
- Adds `permissions: contents: write` and `id-token: write` to affected jobs
- Uses the same `actions/create-github-app-token` + `environment: release` pattern already in use by the `version` job in `pipeline.yml`

## Problem

Two workflows were failing with `Permission to SAP/open-ux-tools.git denied` when trying to push commits back to branches, because `ACCESS_PAT` belongs to a contributor without push access to the repo.

## Changes

- **`.github/workflows/lint.yml`** — lint auto-fix job now uses GitHub App token to checkout and push lint fix commits
- **`.github/workflows/renovate-pr-automation.yml`** — both jobs (`create-changeset` and `update-manifest-fixtures`) now use GitHub App token for checkout, push, and the `dependency-changesets-action` token

## Test plan

- [ ] Trigger the lint action on a PR with a fixable lint issue and verify it successfully commits and pushes the fix
- [ ] Trigger a Renovate PR and verify changesets are created and committed successfully