### PR TITLE
fix: findCapProjectRoot starts with parent

### DIFF
--- a/.changeset/project-access-fix-cap-root-search-bump.md
+++ b/.changeset/project-access-fix-cap-root-search-bump.md
@@ -1,0 +1,7 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+"sap-ux-sap-systems-ext": patch
+"@sap-ux/fiori-mcp-server": patch
+---
+
+BUMP: Rebuild with updated @sap-ux/project-access

--- a/.changeset/project-access-fix-cap-root-search.md
+++ b/.changeset/project-access-fix-cap-root-search.md
@@ -1,5 +1,6 @@
 ---
 "@sap-ux/project-access": patch
+"@sap-ux/eslint-plugin-fiori-tools": patch
 ---
 
 FIX: findCapProjectRoot now correctly starts search at the given path instead of its parent, so passing a CAP root directly returns it as expected

--- a/.changeset/project-access-fix-cap-root-search.md
+++ b/.changeset/project-access-fix-cap-root-search.md
@@ -1,8 +1,5 @@
 ---
 "@sap-ux/project-access": patch
-"@sap-ux/eslint-plugin-fiori-tools": patch
-"sap-ux-sap-systems-ext": patch
-"@sap-ux/fiori-mcp-server": patch
 ---
 
 FIX: findCapProjectRoot now correctly starts search at the given path instead of its parent, so passing a CAP root directly returns it as expected

--- a/.changeset/project-access-fix-cap-root-search.md
+++ b/.changeset/project-access-fix-cap-root-search.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/project-access": patch
+---
+
+FIX: findCapProjectRoot now correctly starts search at the given path instead of its parent, so passing a CAP root directly returns it as expected

--- a/.changeset/project-access-fix-cap-root-search.md
+++ b/.changeset/project-access-fix-cap-root-search.md
@@ -1,6 +1,7 @@
 ---
 "@sap-ux/project-access": patch
 "@sap-ux/eslint-plugin-fiori-tools": patch
+"sap-ux-sap-systems-ext": patch
 ---
 
 FIX: findCapProjectRoot now correctly starts search at the given path instead of its parent, so passing a CAP root directly returns it as expected

--- a/.changeset/project-access-fix-cap-root-search.md
+++ b/.changeset/project-access-fix-cap-root-search.md
@@ -2,6 +2,7 @@
 "@sap-ux/project-access": patch
 "@sap-ux/eslint-plugin-fiori-tools": patch
 "sap-ux-sap-systems-ext": patch
+"@sap-ux/fiori-mcp-server": patch
 ---
 
 FIX: findCapProjectRoot now correctly starts search at the given path instead of its parent, so passing a CAP root directly returns it as expected

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -241,6 +241,10 @@ export async function findRootsForPath(
         // Check if app is included in CAP project
         const projectRoot = await findCapProjectRoot(appRoot, undefined, { memFs, cache });
         if (projectRoot) {
+            if (projectRoot === appRoot) {
+                // appRoot is the CAP root itself - e.g. app has no own package.json inside the CAP project, not supported
+                return null;
+            }
             // App included in CAP
             return {
                 appRoot,
@@ -281,7 +285,7 @@ export async function findCapProjectRoot(
         }
         const { memFs, cache } = getFindOptions(options);
         const { root } = parse(path);
-        let projectRoot = dirname(path);
+        let projectRoot = path;
         while (projectRoot !== root) {
             if (!cache.capProjectType.has(projectRoot)) {
                 cache.capProjectType.set(projectRoot, await getCapProjectType(projectRoot, memFs));

--- a/packages/project-access/src/project/search.ts
+++ b/packages/project-access/src/project/search.ts
@@ -242,7 +242,7 @@ export async function findRootsForPath(
         const projectRoot = await findCapProjectRoot(appRoot, undefined, { memFs, cache });
         if (projectRoot) {
             if (projectRoot === appRoot) {
-                // appRoot is the CAP root itself - e.g. app has no own package.json inside the CAP project, not supported
+                // appRoot is the CAP root itself, meaning there is no enclosing CAP project - not a supported app layout
                 return null;
             }
             // App included in CAP

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -366,6 +366,8 @@ describe('Test findRootsForPath() with cache', () => {
 
     test('Test caching', async () => {
         const capProjectType = new Map<string, CapProjectType | undefined>([
+            // findCapProjectRoot now starts at appRoot itself (fiori_elements), so that entry must be pre-seeded
+            // or the spy would observe a set() call for it
             [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix/app/fiori_elements'), undefined],
             [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix/app'), undefined],
             [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix'), 'CAPNodejs']
@@ -399,5 +401,9 @@ describe('Test findCapProjectRoot()', () => {
 
     test('Return CAP root when called with the CAP root itself', async () => {
         expect(await findCapProjectRoot(projectRoot, false)).toBe(projectRoot);
+    });
+
+    test('Return CAP root when called with the CAP root itself and checkForAppRouter=true', async () => {
+        expect(await findCapProjectRoot(projectRoot)).toBe(projectRoot);
     });
 });

--- a/packages/project-access/test/project/find-apps.test.ts
+++ b/packages/project-access/test/project/find-apps.test.ts
@@ -366,6 +366,7 @@ describe('Test findRootsForPath() with cache', () => {
 
     test('Test caching', async () => {
         const capProjectType = new Map<string, CapProjectType | undefined>([
+            [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix/app/fiori_elements'), undefined],
             [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix/app'), undefined],
             [join(__dirname, '../test-data/project/find-all-apps/CAP/CAPnode_mix'), 'CAPNodejs']
         ]);
@@ -394,5 +395,9 @@ describe('Test findCapProjectRoot()', () => {
 
     test('Do not ignore apps in root/app', async () => {
         expect(await findCapProjectRoot(appRoot, false)).toBe(projectRoot);
+    });
+
+    test('Return CAP root when called with the CAP root itself', async () => {
+        expect(await findCapProjectRoot(projectRoot, false)).toBe(projectRoot);
     });
 });


### PR DESCRIPTION
## Description

Fixes a bug in `findCapProjectRoot` where the search was starting at the **parent** of the given path instead of the path itself. This meant that passing a CAP project root directly would not return it as expected, since the search began one level above.

**Changes:**
- **`search.ts`**: Changed `let projectRoot = dirname(path)` to `let projectRoot = path` so the search starts at the provided path rather than its parent directory.
- **`search.ts`**: Added a guard in `findRootsForPath` to return `null` when `appRoot === projectRoot` (i.e., the app has no own `package.json` inside the CAP project and the CAP root is resolved as the app root itself — an unsupported scenario).
- **`find-apps.test.ts`**: Added test cases to verify:
  - `findCapProjectRoot` correctly returns the CAP root when called with the CAP root path directly.
  - Updated caching test to include the `fiori_elements` app path in the pre-populated cache.

## Type of change
- [x] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
- Unit tests added for `findCapProjectRoot` to verify the fix, including calling it directly with a CAP root path.
- Existing tests updated to reflect the corrected search start behavior.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.28.2`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: Repository PR Template
- Correlation ID: `3ac40720-85bb-11f1-89d6-b8e45764e830`
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
