### PR TITLE
fix(odata-service-writer): resolve TS strict null check on localUriParts guard

### DIFF
--- a/.changeset/fix-odata-service-writer-ts-undefined.md
+++ b/.changeset/fix-odata-service-writer-ts-undefined.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-writer": patch
+---
+
+FIX: Resolve TypeScript strict null check error in manifest.ts localUriParts guard

--- a/packages/odata-service-writer/src/data/manifest.ts
+++ b/packages/odata-service-writer/src/data/manifest.ts
@@ -371,7 +371,7 @@ function convertSingleService(
         const localUri = settings.localUri;
         // -> ["localService", "metadata.xml"]
         const localUriParts = localUri ? localUri.split('/') : undefined;
-        if (localUriParts?.[0] === DirName.LocalService && localUriParts.length === 2) {
+        if (localUriParts && localUriParts[0] === DirName.LocalService && localUriParts.length === 2) {
             const localFileName = localUriParts[localUriParts.length - 1];
             settings.localUri = `${DirName.LocalService}/${dataSourceKey}/${localFileName}`;
             // move related files to service folder


### PR DESCRIPTION
## Description

Fixes a latent TypeScript strict null check error in `packages/odata-service-writer/src/data/manifest.ts`.

The optional chaining `localUriParts?.[0]` does not narrow `localUriParts` itself to non-undefined for the remainder of the `&&` condition, causing TypeScript to flag `localUriParts.length` and `localUriParts.join()` as potentially undefined. Replacing with an explicit `localUriParts &&` guard correctly narrows the type for subsequent property accesses.

```diff
- if (localUriParts?.[0] === DirName.LocalService && localUriParts.length === 2) {
+ if (localUriParts && localUriParts[0] === DirName.LocalService && localUriParts.length === 2) {
```

> **Note:** This is a type-narrowing fix only — runtime behaviour is identical. The bug exists on `main` but was masked by the Nx remote cache; any PR that causes a cache miss (e.g. `pnpm-lock.yaml` changes) exposes the error, currently blocking [#4956](https://github.com/SAP/open-ux-tools/pull/4956).

## Type of change
- [x] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
- `pnpm --filter @sap-ux/odata-service-writer build` passes with no TypeScript errors.
- No behaviour change — the fix is purely a type narrowing correction.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- Correlation ID: `3be1da80-867c-11f1-882e-bfb1e940ee64`
- Event Trigger: `issue_comment.edited`
</details>
