### PR TITLE
Feat/fiori mcp/adjust opa5 test dev skill

### DIFF
--- a/.changeset/lazy-beds-grin.md
+++ b/.changeset/lazy-beds-grin.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+fix: adjust opa5 test development skill initial workflow

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
@@ -30,7 +30,16 @@ The `/test` folder must be present (e.g. at `webapp/test`). If it is missing, as
 
 ---
 
-## Step 1: Detect OData Version
+## Step 1: Locate the Project Root
+
+When the user provides a project name or ID (e.g. `fin.test.rap.lr3`) instead of a file path:
+1. Search for `manifest.json` files under common project roots (e.g. `webapp/manifest.json`).
+2. Match the `"id"` field in `sap.app` to the given name, or look for a folder whose name contains the given ID.
+3. Once found, treat the folder containing `webapp/manifest.json` as the project root for all subsequent steps.
+
+---
+
+## Step 2: Detect OData Version
 
 Before writing any test code, determine whether the app is OData V4 or V2. The two test libraries are completely different and must never be mixed.
 
@@ -56,14 +65,28 @@ If neither signal is present, ask the user to confirm the OData version before p
 
 ---
 
-## Step 2: Follow the Matching Guide
+## Step 3: Follow the Matching Guide
 
 Once the version is confirmed:
 
-1. Read the shared sections below ("Test Endpoint and Running Tests", "Mock Server") - they apply to both V4 and V2.
+1. Read the shared sections further below ("Test Endpoint and Running Tests", "Mock Server") - they apply to both V4 and V2.
 2. Then read the version-specific guide for all test library decisions:
    - **OData V4** - read `references/v4-instructions.md`
    - **OData V2** - read `references/v2-instructions.md`
+
+---
+
+## Adding a New Journey
+
+When the user asks to add an additional journey (not just a new `opaTest` inside an existing journey):
+
+1. **Find the test root** - search for files matching `*Journey.js`, `*Journey.ts`, `*Journey.gen.js`, or `*Journey.gen.ts` in the project. The folder containing those files is the integration test root. These files typically live in a folder named `integration` within the test directory, e.g. `webapp/test/integration`.
+2. **Understand the wiring** - read the existing journey files and any entry point files to understand how journeys are registered. Three setups are possible:
+   - **Virtual endpoint** (V4) - no registration needed; the middleware picks up any file matching the configured pattern (default: ends in `Journey.js` or `Journey.ts`)
+   - **Physical entry point** (V4) - add the new journey's module path to the `sap.ui.require` array in `OpaTests.qunit.js`
+   - **Custom wiring** (e.g. S/4 apps with `AllJourneys.js` or `AllJourneys.json`) - follow the existing pattern
+3. **Create the journey file** following the same naming pattern as existing journeys.
+4. **Confirm** to the user which file was created and how it is registered (or that registration is automatic).
 
 ---
 

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
@@ -9,7 +9,7 @@ description: Use this skill when writing, fixing, extending, or reviewing OPA5 i
   as the project context is SAP Fiori Elements. Not applicable to freestyle UI5 apps.
 metadata:
    author: sap-fiori-tools
-   version: "1.0.0"
+   version: "1.0.1"
 ---
 
 # SAP Fiori OPA5 Development Skill


### PR DESCRIPTION
## Description

This PR adjusts the initial workflow of the OPA5 test development skill in the `fiori-mcp-server` package. The changes improve the skill's step-by-step guide by adding a new first step for project root location and expanding guidance on adding new journeys.

Key changes to `SKILL.md`:

- **New "Step 1: Locate the Project Root"** — Added a dedicated step to help identify the project root when a user provides a project name or ID instead of a file path, by searching for `manifest.json` and matching the `sap.app` `"id"` field.
- **Renumbered steps** — The former "Step 1: Detect OData Version" and "Step 2: Follow the Matching Guide" are now "Step 2" and "Step 3" respectively.
- **New "Adding a New Journey" section** — Provides structured guidance for adding an additional journey file, including how to find the test root, understand the wiring setup (virtual endpoint, physical entry point, or custom wiring), and confirm the outcome to the user.
- Minor wording tweak in Step 3 instructions ("shared sections below" → "shared sections further below").
- Version bumped from `1.0.0` to `1.0.1`.

## Type of change
- [x] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Verify the updated `SKILL.md` guidance flows correctly by simulating OPA5 test development scenarios where the user provides a project ID instead of a path, and scenarios where a new journey needs to be added to an existing project.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- Correlation ID: `c1f7c1f0-8688-11f1-91de-a95dec0a26c0`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: Repository PR Template
- Event Trigger: `pull_request.ready_for_review`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
