### PR TITLE
fix: add input validation to mcp tools

### DIFF
--- a/.changeset/fiori-mcp-server-input-validation.md
+++ b/.changeset/fiori-mcp-server-input-validation.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+fix: add input validation and consistent error throwing to list_functionality and execute_functionality tools

--- a/packages/fiori-mcp-server/src/tools/execute-functionality.ts
+++ b/packages/fiori-mcp-server/src/tools/execute-functionality.ts
@@ -23,7 +23,7 @@ export async function executeFunctionality(params: ExecuteFunctionalityInput): P
     if (!functionalityId) {
         throw new Error('functionalityId parameter is required');
     }
-    if (!appPath) {
+    if (!appPath?.trim()) {
         throw new Error('appPath parameter is required');
     }
     if (!parameters) {

--- a/packages/fiori-mcp-server/src/tools/execute-functionality.ts
+++ b/packages/fiori-mcp-server/src/tools/execute-functionality.ts
@@ -26,6 +26,9 @@ export async function executeFunctionality(params: ExecuteFunctionalityInput): P
     if (!appPath) {
         throw new Error('appPath parameter is required');
     }
+    if (!parameters) {
+        throw new Error('parameters is required');
+    }
     // Custom/external functionalities
     const externalFunctionality =
         typeof functionalityId === 'string' ? FUNCTIONALITIES_HANDLERS.get(functionalityId) : undefined;

--- a/packages/fiori-mcp-server/src/tools/list-functionalities.ts
+++ b/packages/fiori-mcp-server/src/tools/list-functionalities.ts
@@ -10,39 +10,37 @@ import type { Parser } from '@sap/ux-specification';
  *
  * @param params - The input parameters for listing functionalities.
  * @param params.appPath - The path to the application.
- * @returns A promise that resolves to either a ListFunctionalitiesOutput object or an error message string.
+ * @returns A promise that resolves to a ListFunctionalitiesOutput object.
  */
-export async function listFunctionalities(
-    params: ListFunctionalitiesInput
-): Promise<ListFunctionalitiesOutput | string> {
+export async function listFunctionalities(params: ListFunctionalitiesInput): Promise<ListFunctionalitiesOutput> {
     const { appPath } = params;
+    if (!appPath?.trim()) {
+        throw new Error('appPath parameter is required');
+    }
+
     let functionalities: Functionality[] = [];
-    try {
-        // If we need dynamic handlers then we can add additional method in interface of FUNCTIONALITIES_HANDLERS
-        for (const functionality of FUNCTIONALITIES_DETAILS) {
-            functionalities.push({
-                functionalityId: functionality.functionalityId,
-                description: functionality.description
-            });
-        }
-        const project = await resolveApplication(appPath);
-        const apps = project?.applicationAccess?.project.apps ?? {};
-        if (project?.applicationAccess && Object.keys(apps).length) {
-            const { applicationAccess } = project;
-            const ftfsFileIo = new SapuxFtfsFileIO(applicationAccess);
-            const application = await ftfsFileIo.getApplicationModel();
-            if (application) {
-                functionalities = functionalities.concat(await getAppFunctionalities(applicationAccess, application));
-                const pages = Object.keys(application?.pages ?? {});
-                for (const pageId of pages) {
-                    functionalities = functionalities.concat(
-                        await getPageFunctionalities(applicationAccess, application, pageId)
-                    );
-                }
+    // If we need dynamic handlers then we can add additional method in interface of FUNCTIONALITIES_HANDLERS
+    for (const functionality of FUNCTIONALITIES_DETAILS) {
+        functionalities.push({
+            functionalityId: functionality.functionalityId,
+            description: functionality.description
+        });
+    }
+    const project = await resolveApplication(appPath);
+    const apps = project?.applicationAccess?.project.apps ?? {};
+    if (project?.applicationAccess && Object.keys(apps).length) {
+        const { applicationAccess } = project;
+        const ftfsFileIo = new SapuxFtfsFileIO(applicationAccess);
+        const application = await ftfsFileIo.getApplicationModel();
+        if (application) {
+            functionalities = functionalities.concat(await getAppFunctionalities(applicationAccess, application));
+            const pages = Object.keys(application?.pages ?? {});
+            for (const pageId of pages) {
+                functionalities = functionalities.concat(
+                    await getPageFunctionalities(applicationAccess, application, pageId)
+                );
             }
         }
-    } catch (error) {
-        return `Error while trying to list functionalities: ${error.message}`;
     }
     return {
         applicationPath: appPath,

--- a/packages/fiori-mcp-server/src/types/input.ts
+++ b/packages/fiori-mcp-server/src/types/input.ts
@@ -20,6 +20,7 @@ export const ListFunctionalitiesInputSchema = zod.object({
     /** Path to the Fiori application */
     appPath: zod
         .string()
+        .min(1)
         .describe(
             'Path to the root folder of the Fiori application (where package.json and ui5.yaml reside) if one exists or to the current directory. Path should be an absolute path.'
         )

--- a/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
+++ b/packages/fiori-mcp-server/test/unit/tools/__snapshots__/index.test.ts.snap
@@ -382,6 +382,7 @@ Object {
   "properties": Object {
     "appPath": Object {
       "description": "Path to the root folder of the Fiori application (where package.json and ui5.yaml reside) if one exists or to the current directory. Path should be an absolute path.",
+      "minLength": 1,
       "type": "string",
     },
   },

--- a/packages/fiori-mcp-server/test/unit/tools/execute-functionality.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/execute-functionality.test.ts
@@ -284,14 +284,26 @@ describe('executeFunctionality', () => {
         expect(updateManifestJSONMock).toHaveBeenCalledWith(updatedManifest);
     });
 
-    test('Without appPath', async () => {
-        await expect(
-            executeFunctionality({
-                appPath: '',
-                functionalityId: 'add-page',
-                parameters: {}
-            })
-        ).rejects.toThrow('appPath parameter is required');
+    describe('appPath validation', () => {
+        test('throws when appPath is empty string', async () => {
+            await expect(
+                executeFunctionality({
+                    appPath: '',
+                    functionalityId: 'add-page',
+                    parameters: {}
+                })
+            ).rejects.toThrow('appPath parameter is required');
+        });
+
+        test('throws when appPath is whitespace only', async () => {
+            await expect(
+                executeFunctionality({
+                    appPath: '   ',
+                    functionalityId: 'add-page',
+                    parameters: {}
+                })
+            ).rejects.toThrow('appPath parameter is required');
+        });
     });
 
     test('Without functionalityId', async () => {

--- a/packages/fiori-mcp-server/test/unit/tools/execute-functionality.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/execute-functionality.test.ts
@@ -304,6 +304,16 @@ describe('executeFunctionality', () => {
         ).rejects.toThrow('functionalityId parameter is required');
     });
 
+    test('Without parameters', async () => {
+        await expect(
+            executeFunctionality({
+                appPath,
+                functionalityId: 'add-page',
+                parameters: undefined as unknown as Record<string, unknown>
+            })
+        ).rejects.toThrow('parameters is required');
+    });
+
     test('Change page property - flex change', async () => {
         const flexChangeFileName = 'id_1761320220775_2_propertyChange.change';
         const commitSpy = jest.spyOn(fsEditor, 'commit');

--- a/packages/fiori-mcp-server/test/unit/tools/list-functionalities.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/list-functionalities.test.ts
@@ -143,9 +143,16 @@ describe('listFunctionalities', () => {
         readAppMock.mockImplementation(() => {
             throw new Error('Dummy');
         });
-        const result = (await listFunctionalities({
-            appPath
-        })) as ListFunctionalitiesOutput;
-        expect(result).toEqual('Error while trying to list functionalities: Dummy');
+        await expect(listFunctionalities({ appPath })).rejects.toThrow('Dummy');
+    });
+
+    describe('input validation', () => {
+        test('throws when appPath is empty string', async () => {
+            await expect(listFunctionalities({ appPath: '' })).rejects.toThrow('appPath parameter is required');
+        });
+
+        test('throws when appPath is whitespace only', async () => {
+            await expect(listFunctionalities({ appPath: '   ' })).rejects.toThrow('appPath parameter is required');
+        });
     });
 });


### PR DESCRIPTION
## Summary

This PR improves input validation and error handling consistency in the `fiori-mcp-server` MCP tool handlers.

Previously, `list_functionality` silently accepted empty `appPath` values and swallowed internal errors as plain strings by bypassing the server's standard error response path. `execute_functionality` had a similar gap where omitting `parameters` caused a `TypeError` instead of a clear message.

## Changes

- `src/tools/list-functionalities.ts` - Added a guard that throws 'appPath parameter is required' and removed the `try-catch` so errors propagate to `server.ts`'s top-level error handler, which makes the error response consistent with all other tools.
- `src/types/input.ts` - Added at least one char constraint to `appPath` in `ListFunctionalitiesInputSchema` so the MCP JSON Schema rejects empty strings before the handler is called.
- `src/tools/execute-functionality.ts` — Added a guard that throws 'parameters is required', preventing a `TypeError` when parameters is `undefined`.
- `test/unit/tools/list-functionalities.test.ts` - Updated the existing error-path tests and added a new input validation describe block covering empty-string and whitespace-only `appPath` cases.
- `test/unit/tools/execute-functionality.test.ts` - Added a without-parameters test case asserting the new guard.
- `test/unit/tools/__snapshots__/index.test.ts.snap` - Updated the `list_functionality` input schema snapshot to include `"minLength": 1` reflecting the Zod schema change.