### PR TITLE
fix(fiori-mcp): OPA5 test dev skill sap.fe.test API access guide

### DIFF
--- a/.changeset/fiori-mcp-server-opa5-skill-improvements.md
+++ b/.changeset/fiori-mcp-server-opa5-skill-improvements.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+FIX: Improve sap-fiori-opa5-test-development skill with V4 pattern additions and API access guide

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/SKILL.md
@@ -9,7 +9,7 @@ description: Use this skill when writing, fixing, extending, or reviewing OPA5 i
   as the project context is SAP Fiori Elements. Not applicable to freestyle UI5 apps.
 metadata:
    author: sap-fiori-tools
-   version: "1.0.2"
+   version: "1.0.3"
 ---
 
 # SAP Fiori OPA5 Development Skill

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
@@ -32,7 +32,7 @@ APIJSON="${TEMP:-/tmp}/sap.fe.test.api.json"
 
 # Look up a specific method
 node -e "
-const data = JSON.parse(require('fs').readFileSync(process.env.TEMP || '/tmp' + '/sap.fe.test.api.json'));
+const data = JSON.parse(require('fs').readFileSync((process.env.TEMP || '/tmp') + '/sap.fe.test.api.json'));
 const cls = data.symbols.find(s => s.name === 'sap.fe.test.api.TableActions');
 const method = cls.methods.find(m => m.name === 'iChangeFilterField');
 console.log(JSON.stringify(method, null, 2));
@@ -40,7 +40,7 @@ console.log(JSON.stringify(method, null, 2));
 
 # List all methods of a class to discover what's available
 node -e "
-const data = JSON.parse(require('fs').readFileSync(process.env.TEMP || '/tmp' + '/sap.fe.test.api.json'));
+const data = JSON.parse(require('fs').readFileSync((process.env.TEMP || '/tmp') + '/sap.fe.test.api.json'));
 const cls = data.symbols.find(s => s.name === 'sap.fe.test.api.TableActions');
 console.log(cls.methods.map(m => m.name).join('\n'));
 "

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
@@ -65,7 +65,7 @@ Search for the method name directly in the installed `sap.fe` package under `nod
 ```bash
 grep -r "iChangeFilterField" node_modules/@sap/ux-ui5-tooling/node_modules --include="*.js" -l
 # or search the project's own node_modules for the sap.fe runtime
-grep -r "methodName" node_modules --include="TableActions*" -l
+grep -r "iChangeFilterField" node_modules --include="TableActions*" -l
 ```
 
 Once you find the file, read the JSDoc block above the method definition for the parameter list. The source files are minified in some distributions — in that case, look for a `.d.ts` type definition file alongside the `.js`, which is always readable.

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-sap-fe-test-api-guide.md
@@ -11,6 +11,67 @@ Check the UI5 version your app uses in `ui5.yaml` under `framework.version`, or 
 
 ---
 
+## Accessing the API Docs — Tool-Specific Notes
+
+The `SAPUI5 SDK - Demo Kit` (`ui5.sap.com`) uses client-side rendering (JavaScript SPA), so the hash-based URL (`#/api/...`) content is not available to a static fetcher.
+
+Use the first available option below:
+
+**Option 1 — Direct WebFetch or built-in URL access:**
+
+Agents with a browser-capable fetch (e.g. GitHub Copilot) can access `ui5.sap.com` directly — no workaround needed.
+
+**Option 2 — Download the API JSON (preferred fallback):**
+
+SAP publishes the full `sap.fe.test` API as a structured JSON file. Download it once per session (262 KB), then query only the symbol or method you need — never load the whole file into context.
+
+```bash
+# Download (check first to avoid re-downloading within the same session)
+APIJSON="${TEMP:-/tmp}/sap.fe.test.api.json"
+[ -f "$APIJSON" ] || curl -s "https://ui5.sap.com/test-resources/sap/fe/test/designtime/apiref/api.json" -o "$APIJSON"
+
+# Look up a specific method
+node -e "
+const data = JSON.parse(require('fs').readFileSync(process.env.TEMP || '/tmp' + '/sap.fe.test.api.json'));
+const cls = data.symbols.find(s => s.name === 'sap.fe.test.api.TableActions');
+const method = cls.methods.find(m => m.name === 'iChangeFilterField');
+console.log(JSON.stringify(method, null, 2));
+"
+
+# List all methods of a class to discover what's available
+node -e "
+const data = JSON.parse(require('fs').readFileSync(process.env.TEMP || '/tmp' + '/sap.fe.test.api.json'));
+const cls = data.symbols.find(s => s.name === 'sap.fe.test.api.TableActions');
+console.log(cls.methods.map(m => m.name).join('\n'));
+"
+```
+
+The top-level structure is `{ symbols: [ { name, methods, ... } ] }` — search `symbols` by `name` to find a class, then `methods` by `name` to find a method. On Windows use `process.env.TEMP`; on Linux/Mac use `/tmp`.
+
+**Option 3 — Chrome DevTools MCP (when available):**
+
+1. Navigate to the class page, e.g.:
+   `https://ui5.sap.com/#/api/sap.fe.test.api.TableActions`
+2. Then navigate to the specific method anchor to trigger lazy rendering of that section:
+   `https://ui5.sap.com/#/api/sap.fe.test.api.TableActions%23methods/iChangeFilterField`
+3. Use `wait_for` + `take_snapshot` to read the rendered parameter table.
+
+The `%23` is a URL-encoded `#` — required because the fragment already uses `#` for the SPA route.
+
+**Option 4 — `node_modules` source (last resort):**
+
+Search for the method name directly in the installed `sap.fe` package under `node_modules`. This is version-exact and always available offline:
+
+```bash
+grep -r "iChangeFilterField" node_modules/@sap/ux-ui5-tooling/node_modules --include="*.js" -l
+# or search the project's own node_modules for the sap.fe runtime
+grep -r "methodName" node_modules --include="TableActions*" -l
+```
+
+Once you find the file, read the JSDoc block above the method definition for the parameter list. The source files are minified in some distributions — in that case, look for a `.d.ts` type definition file alongside the `.js`, which is always readable.
+
+---
+
 ## Navigating the API Docs
 
 The namespace is organized into folders. Understanding the structure lets you find any function quickly:

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
@@ -93,6 +93,18 @@ When.onTheListReport.onTable().iChangeSortOrder("Product Name", "Ascending");   
 When.onTheListReport.onTable().iChangeSortOrder("Product Name", "Descending");  // descending
 When.onTheListReport.onTable().iChangeSortOrder("Product Name", "None");        // remove sorting
 
+// Add / remove a column via the table settings (Columns tab of the p13n dialog)
+// First arg is the visible column header label, or { name: "<ODataPropertyName>" } for stability.
+// The dialog is opened and confirmed automatically — no separate open/confirm call needed.
+When.onTheListReport.onTable().iAddAdaptationColumn("Booking Confirmed");
+When.onTheListReport.onTable().iRemoveAdaptationColumn("Booking Confirmed");
+
+// Filter via the table settings (Filter tab of the p13n dialog)
+// First arg is { name: "<ODataPropertyName>" } — use the exact OData property name from metadata.xml.
+// The dialog is opened and confirmed automatically — no separate open/confirm call needed.
+When.onTheListReport.onTable().iChangeFilterField({ name: "AgencyID" }, "70004");
+When.onTheListReport.onTable().iChangeFilterField({ name: "AgencyID" }, "70004", true);  // bClearFirst: true
+
 // Group by column — first arg is the visible column header label (same rule as iChangeSortOrder)
 When.onTheListReport.onTable().iGroupByColumn("Product Name");
 // Assert grouping is active for a column
@@ -231,6 +243,7 @@ When.onTheObjectPage.onDialog().iConfirm();
 When.onTheObjectPage.onDialog().iCancel();
 
 // Change a field inside a dialog
+// ONLY works when the dialog uses sap.fe.Field building blocks (e.g. action parameter dialogs)
 When.onTheObjectPage.onDialog()
     .iChangeDialogField({property: "Reason"}, "Test reason");
 
@@ -238,6 +251,29 @@ When.onTheObjectPage.onDialog()
 When.onTheObjectPage.onDialog()
     .iChangeDialogField({property: "RejectionReason"}, "Not applicable")
     .and.iConfirm();
+```
+
+> **`iChangeDialogField` cannot be used for the mass Edit action dialog.** It only works for dialogs that use `sap.fe.Field` building blocks (e.g. standard action parameter dialogs). The mass Edit dialog is NOT such a dialog.
+
+### Mass Edit dialog
+
+Use `onMassEditDialog()` instead of `onDialog()`, and `iChangeField` instead of `iChangeDialogField`.
+
+To set a new value for a field, two steps are required:
+1. Select `< Enter New Value >` from the dropdown for that field.
+2. Set the actual value (as `rawText` for a plain input, or open value help for a VH-backed field).
+
+```javascript
+// Step 1: select "Enter New Value" from the field's dropdown
+When.onTheTravelObjectPage.onMassEditDialog()
+    .iChangeField({ property: "CustomerID" }, { dropDownText: "< Enter New Value >" });
+
+// Step 2: type the value directly (for plain input fields)
+When.onTheTravelObjectPage.onMassEditDialog()
+    .iChangeField({ property: "CustomerID" }, { rawText: "45" });
+
+// Confirm the mass edit dialog
+When.onTheTravelObjectPage.onMassEditDialog().iConfirm();
 ```
 
 ---

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
@@ -471,4 +471,3 @@ When.onTheShell.iNavigateBack();
 ```javascript
 Then.iSeeMessageToast("Object saved.");
 ```
-```

--- a/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-opa5-test-development/references/v4-standard-patterns.md
@@ -419,6 +419,31 @@ Then.onTheObjectPage.onTable({property: "items"}).iCheckRows(3);
 
 ---
 
+## Sub-Object Page (two-level navigation)
+
+When an app has a sub-object page, a separate page object is needed for each level. The setup is the same as for a top-level Object Page (see `references/v4-instructions.md` and `references/v4-journeyrunner.md`) with one difference: the `contextPath` or `entitySet` in the page object constructor comes from the sub-object page's manifest target — always read it from `manifest.json`, never guess.
+
+- `contextPath`: `/<ParentEntitySet>/<NavigationProperty>` — used when the manifest target has `contextPath` in its settings
+- `entitySet`: `<SubEntitySet>` (no leading slash) — used when the manifest target has `entitySet` instead
+
+**Journey** - navigate through all levels explicitly, asserting each page is reached:
+
+```javascript
+Given.iStartMyApp();
+Then.onThe<Entity>List.iSeeThisPage();
+
+When.onThe<Entity>List.onTable().iPressRow(0);
+Then.onThe<Entity>ObjectPage.iSeeThisPage();
+
+// <SectionId>   = section ID from @UI.Facets annotation
+// <NavProperty> = OData navigation property name from metadata.xml
+When.onThe<Entity>ObjectPage.iGoToSection({ section: "<SectionId>" });
+When.onThe<Entity>ObjectPage.onTable({ property: "<NavProperty>" }).iPressRow(0);
+Then.onThe<SubEntity>ObjectPage.iSeeThisPage();
+```
+
+---
+
 ## Chart / Analytical List Page (ALP)
 
 ```javascript


### PR DESCRIPTION
## Description

Improves the `sap-fiori-opa5-test-development` skill in the Fiori MCP server by adding missing OData V4 patterns and a comprehensive guide for accessing the `sap.fe.test` API documentation when direct browser-based access is unavailable.

### Key changes:

**`v4-sap-fe-test-api-guide.md`** — Added a new "Accessing the API Docs — Tool-Specific Notes" section with four fallback options for fetching `sap.fe.test` API documentation in AI agent contexts where the SAPUI5 Demo Kit SPA cannot be rendered:
- Direct WebFetch (e.g. GitHub Copilot)
- Download the API JSON (`api.json`) and query it via Node.js scripts
- Chrome DevTools MCP with URL-encoded anchors
- Searching `node_modules` source/type definitions as a last resort

**`v4-standard-patterns.md`** — Added several missing V4 test patterns:
- `iAddAdaptationColumn` / `iRemoveAdaptationColumn` for table column management via p13n dialog
- `iChangeFilterField` for table filter via p13n dialog
- Clarification that `iChangeDialogField` only works for `sap.fe.Field`-based dialogs (not mass Edit)
- New **Mass Edit dialog** section using `onMassEditDialog()` with `iChangeField`
- **Sub-Object Page (two-level navigation)** section explaining `contextPath` vs `entitySet` setup and journey navigation pattern

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Changes are limited to skill documentation (`.md` files) used by the MCP server. Verify by running the OPA5 skill in an agent context and confirming it correctly suggests the new patterns and API access methods.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.9`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `99c28a80-8c28-11f1-968e-4ebe1a6b3aec`
- Output Template: Repository PR Template
</details>
