### PR TITLE
fix(eslint-pugin-fiori-tools): update babel/core version

### DIFF
--- a/.changeset/gentle-hoops-beam.md
+++ b/.changeset/gentle-hoops-beam.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/eslint-plugin-fiori-tools': patch
+---
+
+FIX: Downgrade the @babel/core dependency to 8.0.0-rc.6 to align with the other @babel/* packages. This ensures consistent versioning across all Babel dependencies and resolves a peer dependency mismatch between @babel/eslint-parser and @babel/core.

--- a/.changeset/gentle-hoops-beam.md
+++ b/.changeset/gentle-hoops-beam.md
@@ -2,4 +2,4 @@
 '@sap-ux/eslint-plugin-fiori-tools': patch
 ---
 
-FIX: Downgrade the @babel/core dependency to 8.0.0-rc.6 to align with the other @babel/* packages. This ensures consistent versioning across all Babel dependencies and resolves a peer dependency mismatch between @babel/eslint-parser and @babel/core.
+BUMP: Downgrade @babel/core to 8.0.0-rc.6 to align with @babel/eslint-parser and @babel/parser, resolving a peer dependency version mismatch.

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/parser": "8.61.1"
     },
     "devDependencies": {
-        "@babel/core": "8.0.1",
+        "@babel/core": "8.0.0-rc.6",
         "@babel/eslint-parser": "8.0.0-rc.6",
         "@babel/parser": "8.0.0-rc.6",
         "@eslint/js": "10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2007,11 +2007,11 @@ importers:
         version: 8.61.1(eslint@9.39.1)(typescript@5.9.3)
     devDependencies:
       '@babel/core':
-        specifier: 8.0.1
-        version: 8.0.1
+        specifier: 8.0.0-rc.6
+        version: 8.0.0-rc.6
       '@babel/eslint-parser':
         specifier: 8.0.0-rc.6
-        version: 8.0.0-rc.6(@babel/core@8.0.1)(eslint@9.39.1)
+        version: 8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)
       '@babel/parser':
         specifier: 8.0.0-rc.6
         version: 8.0.0-rc.6
@@ -5972,6 +5972,10 @@ packages:
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/core@8.0.0-rc.6':
+    resolution: {integrity: sha512-89SVbTu7p+M/W052SFC7R5QuQYgypfuO6HmBBbhA/Kzl6gME8Ly2QrVpIegvTxmcQKOzAPIxiEIfNk+Jxd26mw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
@@ -20426,6 +20430,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@8.0.0-rc.6':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.0-rc.6
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      find-up-simple: 1.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.1
+      semver: 7.8.5
+
   '@babel/core@8.0.1':
     dependencies:
       '@babel/code-frame': 8.0.0
@@ -20445,9 +20468,9 @@ snapshots:
       obug: 2.1.1
       semver: 7.8.5
 
-  '@babel/eslint-parser@8.0.0-rc.6(@babel/core@8.0.1)(eslint@9.39.1)':
+  '@babel/eslint-parser@8.0.0-rc.6(@babel/core@8.0.0-rc.6)(eslint@9.39.1)':
     dependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 8.0.0-rc.6
       eslint: 9.39.1
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1


### PR DESCRIPTION
## Description

Downgrades the `@babel/core` dependency in `eslint-plugin-fiori-tools` from version `8.0.1` back to `8.0.0-rc.6` to align with the other `@babel/*` packages (`@babel/eslint-parser` and `@babel/parser`) which are already pinned at `8.0.0-rc.6`. This ensures consistent versioning across all Babel dependencies and resolves a peer dependency mismatch between `@babel/eslint-parser` and `@babel/core`.

The `pnpm-lock.yaml` is updated accordingly to reflect the correct resolved version and dependency graph for `@babel/core@8.0.0-rc.6` and `@babel/eslint-parser@8.0.0-rc.6(@babel/core@8.0.0-rc.6)`.

## Type of change
- [x] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Verify that the lockfile resolves `@babel/eslint-parser` against `@babel/core@8.0.0-rc.6` without version conflicts, and that existing unit tests pass.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.9`

- Correlation ID: `8eaa8010-8cd4-11f1-8c20-3bd03f60f1f9`
- Output Template: Repository PR Template
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
