### PR TITLE
fix(ui5-config): adjust preview type

### DIFF
--- a/.changeset/ready-sides-argue.md
+++ b/.changeset/ready-sides-argue.md
@@ -2,6 +2,7 @@
 '@sap-ux/ui5-config': patch
 'sap-ux-sap-systems-ext': patch
 '@sap-ux/eslint-plugin-fiori-tools': patch
+'@sap-ux/fiori-mcp-server': patch
 ---
 
 fix: adjust preview middleware type

--- a/.changeset/ready-sides-argue.md
+++ b/.changeset/ready-sides-argue.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/ui5-config': patch
+---
+
+fix: adjust preview middelware type

--- a/.changeset/ready-sides-argue.md
+++ b/.changeset/ready-sides-argue.md
@@ -1,5 +1,7 @@
 ---
 '@sap-ux/ui5-config': patch
+'sap-ux-sap-systems-ext': patch
+'@sap-ux/eslint-plugin-fiori-tools': patch
 ---
 
 fix: adjust preview middleware type

--- a/.changeset/ready-sides-argue.md
+++ b/.changeset/ready-sides-argue.md
@@ -2,4 +2,4 @@
 '@sap-ux/ui5-config': patch
 ---
 
-fix: adjust preview middelware type
+fix: adjust preview middleware type

--- a/packages/ui5-config/src/types/index.ts
+++ b/packages/ui5-config/src/types/index.ts
@@ -78,6 +78,16 @@ export interface FioriPreviewConfig {
             action?: string; // Intent action
         };
     };
+    /**
+     * Configuration object for the local test setup
+     */
+    test?: Array<{
+        framework: 'OPA5' | 'QUnit' | 'Testsuite';
+        path?: string;
+        init?: string;
+        pattern?: string;
+        isolateJourneys?: boolean;
+    }>;
 }
 
 export interface ServeStaticPath {


### PR DESCRIPTION
## Description

Adjusts the `PreviewMiddlewareConfig` type in `@sap-ux/ui5-config` by adding an optional `test` property to support local test setup configuration. The new property accepts an array of test framework configurations, each specifying:

- `framework`: The test framework to use (`OPA5`, `QUnit`, or `Testsuite`)
- `path`: Optional mount path
- `init`: Optional initialization file
- `pattern`: Optional test pattern
- `isolateJourneys`: Optional flag to isolate journeys

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Type-level change only; existing unit tests should confirm no regressions are introduced.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.18`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: Repository PR Template
- Correlation ID: `04805020-90be-11f1-8706-964a1a24bb60`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
