### PR TITLE
fix(pipeline): make vsix release resilient to npm publish/release split runs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -253,11 +253,35 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Detect extension publication
-              if: steps.changesetPublish.outputs.published == 'true'
               run: |
-                  PUBLISHED=$(echo '${{ steps.changesetPublish.outputs.publishedPackages }}' | jq -r '.[].name')
-                  # Extract the first package name matching sap-ux-*-ext
-                  EXT_PKG=$(echo "$PUBLISHED" | grep -E '^sap-ux-.*-ext$' | head -n 1 || true)
+                  EXT_PKG=""
+
+                  # Primary path: extension was published in this run
+                  if [ "${{ steps.changesetPublish.outputs.published }}" == "true" ]; then
+                    PUBLISHED=$(echo '${{ steps.changesetPublish.outputs.publishedPackages }}' | jq -r '.[].name')
+                    EXT_PKG=$(echo "$PUBLISHED" | grep -E '^sap-ux-.*-ext$' | head -n 1 || true)
+                  fi
+
+                  # Fallback: extension is on npm but GitHub Release is missing the vsix asset.
+                  # This covers the case where a previous run published to npm but crashed before
+                  # creating the GitHub Release (e.g. due to a concurrent versioning commit).
+                  if [ -z "$EXT_PKG" ]; then
+                    # Enumerate all extension packages in the workspace
+                    EXT_PKGS=$(find packages -maxdepth 2 -name "package.json" -exec sh -c 'jq -r "select(.name | test(\"^sap-ux-.*-ext$\")) | .name" "$1" 2>/dev/null' _ {} \;)
+                    for PKG in $EXT_PKGS; do
+                      NPM_VERSION=$(npm view "$PKG" version 2>/dev/null || true)
+                      if [ -z "$NPM_VERSION" ]; then
+                        continue
+                      fi
+                      TAG="${PKG}@${NPM_VERSION}"
+                      # Check whether a GitHub Release for this tag already has a vsix asset
+                      ASSET_COUNT=$(gh release view "$TAG" --repo ${{ github.repository }} --json assets --jq '[.assets[].name | select(endswith(".vsix"))] | length' 2>/dev/null || echo "0")
+                      if [ "$ASSET_COUNT" == "0" ]; then
+                        EXT_PKG="$PKG"
+                        break
+                      fi
+                    done
+                  fi
 
                   if [ -n "$EXT_PKG" ]; then
                     echo "EXTENSION_UPDATED=true" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

- The `Detect extension publication` step was gated on `steps.changesetPublish.outputs.published == 'true'`, so if a previous run already published the extension to npm but crashed before creating the GitHub Release with the vsix, the next run would skip the vsix build entirely
- Adds a fallback path: if no extension was published in the current run, enumerate workspace extension packages, check npm for the latest version, and verify whether the corresponding GitHub Release already has a vsix asset — if not, proceed to build and attach it
- This mirrors how `changesets/action` is already resilient for npm (only publishes what's missing from the registry)

Fixes the missing vsix on https://github.com/SAP/open-ux-tools/releases/tag/sap-ux-sap-systems-ext%401.0.17 — the next merge to main will attach the vsix to that release automatically.

## Test plan

- [ ] Verify the next push to main attaches the vsix to the existing `sap-ux-sap-systems-ext@1.0.17` release
- [ ] Verify a normal release run (extension published fresh) still works via the primary path