### PR TITLE
chore: generate skills config json

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,6 +60,8 @@ jobs:
               run: pnpm run build
               env:
                   NX_CLOUD_ACCESS_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.NX_CLOUD_ACCESS_TOKEN || '' }}
+            - name: Validate skills config
+              run: pnpm run validate:skills-config
             - name: Run lint on forks
               if: github.event.pull_request.head.repo.full_name != github.repository
               run: pnpm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,12 @@
 #!/bin/sh
 pnpm run:pretty-quick
 pnpm audit
+
+# Validate skills.sh.json when skill directories are touched
+if git diff --cached --name-only | grep -qE '^(packages/fiori-mcp-server/skills/|\.agents/skills/)'; then
+  pnpm validate:skills-config || {
+    echo ""
+    echo "Run 'pnpm generate:skills-config', stage skills.sh.json, then commit again."
+    exit 1
+  }
+fi

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
         "clean:nx:all": "nx run-many --target=clean --all",
         "clean:nx:reset": "nx reset",
         "validate:changesets": "node scripts/validate-changesets.mjs",
+        "generate:skills-config": "node scripts/generate-skills-config.mjs",
+        "validate:skills-config": "node scripts/generate-skills-config.mjs --check",
         "build": "pnpm validate:changesets && nx run-many --target=build --all",
         "build:force": "nx run-many --target=build --all --skip-nx-cache",
         "format": "pnpm recursive run format",

--- a/scripts/generate-skills-config.mjs
+++ b/scripts/generate-skills-config.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'yaml';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const OUTPUT_FILE = path.join(ROOT, 'skills.sh.json');
+
+const GROUPS = [
+    {
+        title: 'SAP Fiori Application Development',
+        description: 'Skills for creating, modifying, and testing SAP Fiori elements applications',
+        dir: path.join(ROOT, 'packages', 'fiori-mcp-server', 'skills')
+    },
+    {
+        title: 'open-ux-tools Development',
+        description: 'Skills for working on the open-ux-tools monorepo itself',
+        dir: path.join(ROOT, '.agents', 'skills')
+    }
+];
+
+/**
+ * Reads the `name` field from a SKILL.md YAML frontmatter block.
+ * Returns null if no valid frontmatter is found.
+ */
+function readSkillName(skillMdPath) {
+    const content = fs.readFileSync(skillMdPath, 'utf8');
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!match) return null;
+    const parsed = yaml.parse(match[1]);
+    return typeof parsed?.name === 'string' ? parsed.name.trim() : null;
+}
+
+/**
+ * Scans a directory for subdirectories containing SKILL.md and returns
+ * the skill names sorted alphabetically.
+ */
+function collectSkills(dir) {
+    if (!fs.existsSync(dir)) return [];
+    return fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => path.join(dir, entry.name, 'SKILL.md'))
+        .filter((skillMd) => fs.existsSync(skillMd))
+        .map(readSkillName)
+        .filter(Boolean)
+        .sort();
+}
+
+const config = {
+    $schema: 'https://www.skills.sh/schemas/skills.sh.schema.json',
+    notGrouped: 'bottom',
+    groupings: GROUPS.map(({ title, description, dir }) => ({
+        title,
+        description,
+        skills: collectSkills(dir)
+    }))
+};
+
+const output = JSON.stringify(config, null, 2) + '\n';
+
+const checkMode = process.argv.includes('--check');
+
+if (checkMode) {
+    const existing = fs.existsSync(OUTPUT_FILE) ? fs.readFileSync(OUTPUT_FILE, 'utf8') : '';
+    if (existing !== output) {
+        console.error('skills.sh.json is out of date. Run `pnpm generate:skills-config` and commit the result.');
+        process.exit(1);
+    }
+    console.log('skills.sh.json is up to date.');
+} else {
+    fs.writeFileSync(OUTPUT_FILE, output);
+    console.log(`Written: ${path.relative(ROOT, OUTPUT_FILE)}`);
+}

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://www.skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "SAP Fiori Application Development",
+      "description": "Skills for creating, modifying, and testing SAP Fiori elements applications",
+      "skills": [
+        "sap-fiori-add-visual-filter",
+        "sap-fiori-analytical-chart",
+        "sap-fiori-app-development",
+        "sap-fiori-create-cli",
+        "sap-fiori-eslint-plugin",
+        "sap-fiori-opa5-test-development"
+      ]
+    },
+    {
+      "title": "open-ux-tools Development",
+      "description": "Skills for working on the open-ux-tools monorepo itself",
+      "skills": [
+        "odata-vocabularies-sync"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds automated generation and validation of the `skills.sh.json` configuration file, which groups and lists available skills for SAP Fiori application development and open-ux-tools monorepo development.

A new script (`scripts/generate-skills-config.mjs`) scans skill directories for `SKILL.md` files, extracts skill names from their YAML frontmatter, and generates a structured `skills.sh.json` output. The script also supports a `--check` mode to verify the file is up to date without modifying it.

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
- The script generates `skills.sh.json` correctly via `pnpm generate:skills-config`
- Validation mode (`pnpm validate:skills-config`) passes when the file is up to date and fails when it is stale
- A pre-commit hook enforces that `skills.sh.json` is regenerated whenever skill directories (`packages/fiori-mcp-server/skills/` or `.agents/skills/`) are modified
- CI pipeline includes a `Validate skills config` step that runs `pnpm validate:skills-config` after the build

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- Correlation ID: `0a756100-9654-11f1-8105-8af58ff7227b`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
</details>
