### PR TITLE
feat(eslint-plugin-fiori-tools): add micro chart measure and dimension check rule

### DIFF
--- a/.changeset/micro-chart-requires-navigation-entity.md
+++ b/.changeset/micro-chart-requires-navigation-entity.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": minor
+---
+
+FEAT: add sap-micro-chart-requires-navigation-entity rule to validate that micro chart measures and dimensions use a 1:n navigation entity path

--- a/packages/eslint-plugin-fiori-tools/README.md
+++ b/packages/eslint-plugin-fiori-tools/README.md
@@ -120,7 +120,8 @@ npx --yes @sap-ux/create@latest convert eslint-config --help
 
 |   Since   | Rule | Description | Recommended | Recommended for S/4HANA |
 |:---------:|------|-------------|:-----------:|:-----------------------:|
-|  new      | [sap-cloud-dev-adaptation-status](docs/rules/sap-cloud-dev-adaptation-status.md) | Ensures that `cloudDevAdaptationStatus` is defined in the `sap.fiori` section of the `manifest.json` file. | | ✅ |
+|  new      | [sap-micro-chart-requires-navigation-entity](docs/rules/sap-micro-chart-requires-navigation-entity.md) | Ensures that micro chart (`UI.Chart` with types Line, Area, Column, StackedBar, or Comparison) measures and dimensions reference properties through a 1:n navigation entity path. | | ✅ |
+|  10.8.0   | [sap-cloud-dev-adaptation-status](docs/rules/sap-cloud-dev-adaptation-status.md) | Ensures that `cloudDevAdaptationStatus` is defined in the `sap.fiori` section of the `manifest.json` file. | | ✅ |
 |  10.7.6   | [sap-no-live-mode](docs/rules/sap-no-live-mode.md) | Ensures that live mode is not enabled. | | ✅ |
 |  10.2.0   | [sap-description-column-label](docs/rules/sap-description-column-label.md) | Ensures that the description text property referenced using the `Common.Text` annotation has a meaningful `Common.Label` annotation. It must not be a generic value such as "Name" or "Description", and not the same label as the `ID` property. | | ✅ |
 |  9.12.0   | [sap-text-arrangement-hidden](docs/rules/sap-text-arrangement-hidden.md) | Ensures that the text property referenced by a `UI.TextArrangement` annotation using the `Common.Text` annotation is not hidden by the `UI.Hidden` annotation | | ✅ |

--- a/packages/eslint-plugin-fiori-tools/docs/rules/sap-micro-chart-requires-navigation-entity.md
+++ b/packages/eslint-plugin-fiori-tools/docs/rules/sap-micro-chart-requires-navigation-entity.md
@@ -1,0 +1,194 @@
+ # Micro chart measures and dimensions must use a 1:n navigation entity path (`sap-micro-chart-requires-navigation-entity`)
+
+Validates that `UI.Chart` annotations referenced from page-visible locations only reference properties through a 1:n navigation property. SAP Fiori Elements micro charts cannot display data from properties of the same entity — they require a collection of related records accessed via navigation. Using direct entity properties causes the micro chart to fail to render or show no data.
+
+## Rule Details
+
+The rule only checks charts that are actually displayed on a page. A chart is considered page-visible when it is referenced via a `UI.DataFieldForAnnotation` record in one of:
+
+- A **List Report table** (`UI.LineItem` → `DataFieldForAnnotation.Target` → `@UI.Chart`)
+- An **Object Page table section** (`UI.LineItem` → `DataFieldForAnnotation.Target` → `@UI.Chart`)
+- An **Object Page header field group** (`UI.HeaderFacets` → `ReferenceFacet` → `UI.FieldGroup.Data` → `DataFieldForAnnotation.Target` → `@UI.Chart`)
+
+`UI.Chart` annotations that are not referenced from any of these locations are ignored.
+
+For every page-visible chart, every `PropertyPath` in the `Measures` and `Dimensions` collections must include a `/` navigation separator (e.g. `to_History/Revenue`). If any path references a property of the chart's own entity (no `/`), the entire `UI.Chart` annotation is flagged — one warning per chart regardless of how many invalid paths it contains.
+
+**Warning:** Micro chart measures and dimensions must reference properties from a 1:n navigation entity (e.g. "to_History/Revenue" instead of "Revenue").
+
+The following patterns are considered warnings:
+
+```xml
+<!-- ⚠ WRONG: Chart is referenced from a table column and Measures use a direct property -->
+<Annotations Target="MyService.SalesOrder">
+    <Annotation Term="UI.LineItem">
+        <Collection>
+            <Record Type="UI.DataFieldForAnnotation">
+                <PropertyValue Property="Target" AnnotationPath="@UI.Chart#MicroChart"/>
+            </Record>
+        </Collection>
+    </Annotation>
+    <Annotation Term="UI.Chart" Qualifier="MicroChart">
+        <Record>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+            <PropertyValue Property="Measures">
+                <Collection>
+                    <PropertyPath>TotalAmount</PropertyPath>
+                </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Dimensions">
+                <Collection>
+                    <PropertyPath>to_Items/Month</PropertyPath>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</Annotations>
+```
+
+```xml
+<!-- ⚠ WRONG: Chart is referenced from a table column and Dimensions use a direct property -->
+<Annotations Target="MyService.SalesOrder">
+    <Annotation Term="UI.LineItem">
+        <Collection>
+            <Record Type="UI.DataFieldForAnnotation">
+                <PropertyValue Property="Target" AnnotationPath="@UI.Chart#MicroChart"/>
+            </Record>
+        </Collection>
+    </Annotation>
+    <Annotation Term="UI.Chart" Qualifier="MicroChart">
+        <Record>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+            <PropertyValue Property="Measures">
+                <Collection>
+                    <PropertyPath>to_Items/MonthlyRevenue</PropertyPath>
+                </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Dimensions">
+                <Collection>
+                    <PropertyPath>Month</PropertyPath>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</Annotations>
+```
+
+```cds
+// ⚠ WRONG: Chart referenced from a table column; Measures use a direct property (no navigation)
+annotate service.SalesOrder with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#MicroChart'}],
+    UI.Chart #MicroChart: {
+        ChartType: #Line,
+        Measures: [TotalAmount],
+        Dimensions: [to_Items/Month]
+    }
+);
+```
+
+```cds
+// ⚠ WRONG: Chart referenced from a table column; Dimensions use a direct property (no navigation)
+annotate service.SalesOrder with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#MicroChart'}],
+    UI.Chart #MicroChart: {
+        ChartType: #Area,
+        Measures: [to_Items/MonthlyRevenue],
+        Dimensions: [Month]
+    }
+);
+```
+
+The following patterns are not considered warnings:
+
+```xml
+<!-- ✅ CORRECT: Chart referenced from a table column; both Measures and Dimensions navigate via a 1:n association -->
+<Annotations Target="MyService.SalesOrder">
+    <Annotation Term="UI.LineItem">
+        <Collection>
+            <Record Type="UI.DataFieldForAnnotation">
+                <PropertyValue Property="Target" AnnotationPath="@UI.Chart#RevenueTrend"/>
+            </Record>
+        </Collection>
+    </Annotation>
+    <Annotation Term="UI.Chart" Qualifier="RevenueTrend">
+        <Record>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+            <PropertyValue Property="Measures">
+                <Collection>
+                    <PropertyPath>to_Items/MonthlyRevenue</PropertyPath>
+                </Collection>
+            </PropertyValue>
+            <PropertyValue Property="Dimensions">
+                <Collection>
+                    <PropertyPath>to_Items/Month</PropertyPath>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</Annotations>
+```
+
+```xml
+<!-- ✅ CORRECT: Chart referenced from an Object Page header field group via UI.FieldGroup -->
+<Annotations Target="MyService.SalesOrder">
+    <Annotation Term="UI.HeaderFacets">
+        <Collection>
+            <Record Type="UI.ReferenceFacet">
+                <PropertyValue Property="ID" String="ChartHeader"/>
+                <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#ChartFG"/>
+            </Record>
+        </Collection>
+    </Annotation>
+    <Annotation Term="UI.FieldGroup" Qualifier="ChartFG">
+        <Record>
+            <PropertyValue Property="Data">
+                <Collection>
+                    <Record Type="UI.DataFieldForAnnotation">
+                        <PropertyValue Property="Target" AnnotationPath="@UI.Chart#MicroChart"/>
+                    </Record>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+    <Annotation Term="UI.Chart" Qualifier="MicroChart">
+        <Record>
+            <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column"/>
+            <PropertyValue Property="Measures">
+                <Collection>
+                    <PropertyPath>to_Items/GrossAmount</PropertyPath>
+                </Collection>
+            </PropertyValue>
+        </Record>
+    </Annotation>
+</Annotations>
+```
+
+```cds
+// ✅ CORRECT: Both paths go through the to_Items 1:n navigation
+annotate service.SalesOrder with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#ItemQuantities'}],
+    UI.Chart #ItemQuantities: {
+        ChartType: #Column,
+        Measures: [to_Items/quantity],
+        Dimensions: [to_Items/productID]
+    }
+);
+```
+
+### How to Fix
+
+1. Identify the entity that the `UI.Chart` annotation targets.
+2. Add a 1:n association (composition or association to many) from that entity to a related collection entity.
+3. Update the `Measures` and `Dimensions` `PropertyPath` values to reference properties through that navigation, e.g. `to_Items/Revenue` instead of `Revenue`.
+4. Make sure the chart is referenced from a `UI.DataFieldForAnnotation` inside a `UI.LineItem` table or a `UI.FieldGroup` header facet — charts that are not wired into a page are not checked by this rule.
+
+## Bug Report
+
+In case you detect an issue with the check please open a Github issue [here](https://github.com/SAP/open-ux-tools/issues).
+
+## Further Reading
+
+- [Configuring Charts](https://ui5.sap.com/#/topic/653ed0f4f0d743dbb33ace4f68886c4e)
+- [Adding a Micro Chart to a Table (OData V4)](https://ui5.sap.com/#/topic/b8312a4adde54f33a89480dbe12d8632)
+- [Micro Chart Facet in the Object Page Header (OData V4)](https://ui5.sap.com/#/topic/e219fd0c85b842c69ac3a514e712ece5)
+- [Adding a Micro Chart to a Table (OData V2)](https://ui5.sap.com/#/topic/6a52793ed9c248a8837b9d284711a402)

--- a/packages/eslint-plugin-fiori-tools/src/constants.ts
+++ b/packages/eslint-plugin-fiori-tools/src/constants.ts
@@ -1,4 +1,6 @@
 export const UI_LINE_ITEM = 'com.sap.vocabularies.UI.v1.LineItem';
+export const UI_CHART = 'com.sap.vocabularies.UI.v1.Chart';
+export const UI_DATA_FIELD_FOR_ANNOTATION = 'com.sap.vocabularies.UI.v1.DataFieldForAnnotation';
 export const COMMON_TEXT = 'com.sap.vocabularies.Common.v1.Text';
 export const COMMON_TEXT_ARRANGEMENT = 'com.sap.vocabularies.Common.v1.TextArrangement';
 export const COMMON_LABEL = 'com.sap.vocabularies.Common.v1.Label';

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -500,7 +500,8 @@ const fioriLanguageConfig: Linter.Config[] = [
             '@sap-ux/fiori-tools/sap-no-data-field-intent-based-navigation': 'warn',
             '@sap-ux/fiori-tools/sap-text-arrangement-hidden': 'warn',
             '@sap-ux/fiori-tools/sap-no-live-mode': 'warn',
-            '@sap-ux/fiori-tools/sap-cloud-dev-adaptation-status': 'warn'
+            '@sap-ux/fiori-tools/sap-cloud-dev-adaptation-status': 'warn',
+            '@sap-ux/fiori-tools/sap-micro-chart-requires-navigation-entity': 'warn'
         }
     }
 ];

--- a/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
+++ b/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
@@ -19,6 +19,7 @@ export const STRICT_UOM_FILTERING = 'sap-strict-uom-filtering';
 export const DESCRIPTION_COLUMN_LABEL = 'sap-description-column-label';
 export const NO_LIVE_MODE = 'sap-no-live-mode';
 export const CLOUD_DEV_ADAPTATION_STATUS = 'sap-cloud-dev-adaptation-status';
+export const MICRO_CHART_REQUIRES_NAVIGATION_ENTITY = 'sap-micro-chart-requires-navigation-entity';
 
 export interface WidthIncludingColumnHeaderDiagnostic {
     type: typeof WIDTH_INCLUDING_COLUMN_HEADER_RULE_TYPE;
@@ -192,6 +193,15 @@ export interface CloudDevAdaptationStatus {
     manifest: ManifestPropertyDiagnosticData;
 }
 
+export interface MicroChartRequiresNavigationEntity {
+    type: typeof MICRO_CHART_REQUIRES_NAVIGATION_ENTITY;
+    pageNames: string[];
+    annotation: {
+        reference: AnnotationReference;
+        reportedParent: Element;
+    };
+}
+
 export type Diagnostic =
     | WidthIncludingColumnHeaderDiagnostic
     | AnchorBarVisible
@@ -209,4 +219,5 @@ export type Diagnostic =
     | TextArrangementHidden
     | StrictUomFiltering
     | NoLiveMode
-    | CloudDevAdaptationStatus;
+    | CloudDevAdaptationStatus
+    | MicroChartRequiresNavigationEntity;

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
@@ -12,7 +12,7 @@ import {
 } from '@sap-ux/odata-annotation-core';
 import type { IndexedAnnotation, ParsedService } from '../parser/index.js';
 import { buildAnnotationIndexKey } from '../parser/index.js';
-import { UI_FIELD_GROUP, UI_LINE_ITEM } from '../../constants.js';
+import { UI_FIELD_GROUP, UI_LINE_ITEM, UI_CHART, UI_DATA_FIELD_FOR_ANNOTATION } from '../../constants.js';
 
 /**
  * index - Index of annotation
@@ -58,7 +58,10 @@ export type HeaderSectionNode = AnnotationBasedNode<'header-section', FieldGroup
 export type TableNode = AnnotationBasedNode<'table'>;
 export type FieldGroupNode = AnnotationBasedNode<'field-group'>;
 
-export type AnnotationNode = TableSectionNode | TableNode | HeaderSectionNode | FieldGroupNode;
+// NOSONAR - ChartNode provides semantic meaning for code readability
+export type ChartNode = AnnotationBasedNode<'chart'>;
+
+export type AnnotationNode = TableSectionNode | TableNode | HeaderSectionNode | FieldGroupNode | ChartNode;
 export type NodeLookup = {
     [K in AnnotationNode['type']]?: Extract<AnnotationNode, { type: K }>[];
 };
@@ -174,6 +177,140 @@ export function collectSections(
         ...getOPHeaderSections(entityType, service)
     ];
     return sections;
+}
+
+/**
+ * Resolves an annotation path string to a `ChartNode` if it points to a `UI.Chart` annotation.
+ *
+ * @param entityType - The entity type from which the path is relative.
+ * @param annotationPath - The raw annotation path (e.g. `to_History/@UI.Chart#MicroChart`).
+ * @param aliasInfo - Alias information for resolving namespace prefixes.
+ * @param service - The parsed OData service.
+ * @returns A `ChartNode` if the path resolves to a `UI.Chart`, or `undefined` otherwise.
+ */
+function resolveChartAnnotation(
+    entityType: string,
+    annotationPath: string,
+    aliasInfo: AliasInformation,
+    service: ParsedService
+): ChartNode | undefined {
+    const fullyQualifiedPath = toFullyQualifiedPath(
+        aliasInfo.aliasMap,
+        '',
+        parsePath(`/${entityType}/${annotationPath}`)
+    );
+    const atIdx = fullyQualifiedPath.indexOf('@');
+    if (atIdx === -1) {
+        return undefined;
+    }
+    const [term, qualifier] = fullyQualifiedPath.substring(atIdx + 1).split('#');
+    if (term !== UI_CHART) {
+        return undefined;
+    }
+    const referencedEntityType = getReferencedEntityType(aliasInfo, entityType, annotationPath, service);
+    if (!referencedEntityType) {
+        return undefined;
+    }
+    const indexKey = buildAnnotationIndexKey(referencedEntityType, UI_CHART);
+    const indexedAnnotation = service.index.annotations[indexKey]?.[qualifier ?? 'undefined'];
+    if (!indexedAnnotation) {
+        return undefined;
+    }
+    return {
+        type: 'chart',
+        annotation: indexedAnnotation,
+        annotationPath: toFullyQualifiedPath(
+            aliasInfo.aliasMap,
+            aliasInfo.currentFileNamespace,
+            parsePath(annotationPath)
+        ),
+        children: []
+    };
+}
+
+/**
+ * Inspects a single record from a `UI.LineItem` collection and, if it is a
+ * `DataFieldForAnnotation` whose `Target` resolves to `UI.Chart`, pushes a
+ * `ChartNode` onto `charts` (deduped by annotation identity).
+ *
+ * @param record - The `Edm.Record` element to inspect.
+ * @param entityType - The entity type from which the annotation path is relative.
+ * @param aliasInfo - Alias information for namespace resolution.
+ * @param service - The parsed OData service.
+ * @param charts - Accumulator for collected chart nodes.
+ */
+function collectChartFromLineItemRecord(
+    record: Element,
+    entityType: string,
+    aliasInfo: AliasInformation,
+    service: ParsedService,
+    charts: ChartNode[]
+): void {
+    if (getRecordType(aliasInfo, record) !== UI_DATA_FIELD_FOR_ANNOTATION) {
+        return;
+    }
+    const path = getTargetAnnotationPath(record);
+    if (!path) {
+        return;
+    }
+    const chartNode = resolveChartAnnotation(entityType, path, aliasInfo, service);
+    if (chartNode && !charts.some((c) => c.annotation === chartNode.annotation)) {
+        charts.push(chartNode);
+    }
+}
+
+/**
+ * Collects chart nodes referenced from a `UI.LineItem` table annotation via
+ * `DataFieldForAnnotation.Target` → `UI.Chart`.
+ *
+ * @param tableNode - The table annotation node (from `page.lookup['table']`).
+ * @param service - The parsed OData service.
+ * @returns Array of chart nodes referenced from the table.
+ */
+export function collectChartsFromTableNode(tableNode: TableNode, service: ParsedService): ChartNode[] {
+    const charts: ChartNode[] = [];
+    const entityType = tableNode.annotation.target;
+    const [collection] = elementsWithName(Edm.Collection, tableNode.annotation.top.value);
+    if (!collection) {
+        return charts;
+    }
+    const aliasInfo = service.artifacts.aliasInfo[tableNode.annotation.top.uri];
+    for (const record of elementsWithName(Edm.Record, collection)) {
+        collectChartFromLineItemRecord(record, entityType, aliasInfo, service, charts);
+    }
+    return charts;
+}
+
+/**
+ * Collects chart nodes referenced from a `UI.FieldGroup` annotation via the `Data` collection's
+ * `DataFieldForAnnotation.Target` → `UI.Chart`.
+ *
+ * @param fieldGroupNode - The field group annotation node (from `page.lookup['field-group']`).
+ * @param service - The parsed OData service.
+ * @returns Array of chart nodes referenced from the field group.
+ */
+export function collectChartsFromFieldGroupNode(fieldGroupNode: FieldGroupNode, service: ParsedService): ChartNode[] {
+    const charts: ChartNode[] = [];
+    const entityType = fieldGroupNode.annotation.target;
+    const [record] = elementsWithName(Edm.Record, fieldGroupNode.annotation.top.value);
+    if (!record) {
+        return charts;
+    }
+    const dataPropertyValue = elementsWithName(Edm.PropertyValue, record).find(
+        (pv) => getElementAttributeValue(pv, Edm.Property) === 'Data'
+    );
+    if (!dataPropertyValue) {
+        return charts;
+    }
+    const [collection] = elementsWithName(Edm.Collection, dataPropertyValue);
+    if (!collection) {
+        return charts;
+    }
+    const aliasInfo = service.artifacts.aliasInfo[fieldGroupNode.annotation.top.uri];
+    for (const dataRecord of elementsWithName(Edm.Record, collection)) {
+        collectChartFromLineItemRecord(dataRecord, entityType, aliasInfo, service, charts);
+    }
+    return charts;
 }
 
 const findContentByName = (content: ElementChild[], name: string): ElementChild | undefined =>
@@ -522,12 +659,36 @@ export interface ObjectPageLike {
 }
 
 /**
- * Links an object page header section with its field group annotation.
- * Used by both FE v2 and v4 linkers.
+ * Collects chart nodes from a page's linked table and field-group lookup entries and adds them
+ * to `page.lookup['chart']`. Must be called after the table and field-group linker steps so
+ * that only charts actually displayed on the page are collected.
  *
- * @param section - Header section node to link
- * @param page - The object page being linked
+ * @param page - Object with a `lookup` map; satisfied by both LR and OP page types.
+ * @param page.lookup - Object holding page elements.
+ * @param service - The parsed OData service.
  */
+export function collectPageCharts(
+    page: { lookup: { [key: string]: any[] | undefined } },
+    service: ParsedService
+): void {
+    for (const tableEntry of (page.lookup['table'] ?? []) as Array<{ annotation?: TableNode }>) {
+        if (tableEntry.annotation) {
+            for (const chartNode of collectChartsFromTableNode(tableEntry.annotation, service)) {
+                page.lookup['chart'] ??= [];
+                page.lookup['chart']!.push({ type: 'chart', annotation: chartNode, configuration: {}, children: [] });
+            }
+        }
+    }
+    for (const fieldGroupEntry of (page.lookup['field-group'] ?? []) as Array<{ annotation?: FieldGroupNode }>) {
+        if (fieldGroupEntry.annotation) {
+            for (const chartNode of collectChartsFromFieldGroupNode(fieldGroupEntry.annotation, service)) {
+                page.lookup['chart'] ??= [];
+                page.lookup['chart']!.push({ type: 'chart', annotation: chartNode, configuration: {}, children: [] });
+            }
+        }
+    }
+}
+
 export function collectHeaderSections(section: HeaderSectionNode, page: ObjectPageLike): void {
     if (section.type !== 'header-section') {
         return;

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
@@ -622,8 +622,18 @@ export function getEntityForContextPath(contextPath: string, service: ParsedServ
     if (!entity) {
         return undefined;
     }
-
-    return resolveNavigationProperties(entity, segments);
+    const resolved = resolveNavigationProperties(entity, segments);
+    if (resolved) {
+        return resolved;
+    }
+    // Fallback: when entity set content doesn't carry nav properties directly (e.g. V4 metadata
+    // where nav props live on the entity type), resolve through the structured type instead.
+    const structuredType = entity.structuredType;
+    if (!structuredType) {
+        return;
+    }
+    const entityType = service.artifacts.metadataService.getMetadataElement(structuredType);
+    return entityType ? resolveNavigationProperties(entityType, segments) : undefined;
 }
 
 export function getEntityTypeForContextPath(contextPath: string, service: ParsedService): MetadataElement | undefined {
@@ -648,7 +658,7 @@ export function getEntityTypeForContextPath(contextPath: string, service: Parsed
  * @param root - The starting metadata element
  * @param segments - Array of navigation property names to traverse
  */
-function resolveNavigationProperties(root: MetadataElement, segments: string[]): MetadataElement | undefined {
+export function resolveNavigationProperties(root: MetadataElement, segments: string[]): MetadataElement | undefined {
     if (segments.length === 0) {
         return root;
     }

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/annotations.ts
@@ -626,6 +626,22 @@ export function getEntityForContextPath(contextPath: string, service: ParsedServ
     return resolveNavigationProperties(entity, segments);
 }
 
+export function getEntityTypeForContextPath(contextPath: string, service: ParsedService): MetadataElement | undefined {
+    if (!contextPath.startsWith('/')) {
+        return;
+    }
+    const path = contextPath.substring(1);
+    const [entityTypeName, ...segments] = path.split('/');
+    if (!entityTypeName) {
+        return;
+    }
+    const entityType = service.index.entityTypes[entityTypeName];
+    if (!entityType) {
+        return undefined;
+    }
+    return resolveNavigationProperties(entityType, segments);
+}
+
 /**
  * Resolves navigation properties along a path to find the target entity.
  *

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v2.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v2.ts
@@ -2,8 +2,21 @@ import type { MetadataElement } from '@sap-ux/odata-annotation-core';
 import type { LinkerContext, ConfigurationBase } from './types.js';
 import { getParsedServiceByName } from '../utils.js';
 import type { ParsedService } from '../parser/index.js';
-import type { AnnotationNode, FieldGroupNode, HeaderSectionNode, TableNode, TableSectionNode } from './annotations.js';
-import { collectHeaderSections, collectSections, collectTables, getConfigurationKey } from './annotations.js';
+import type {
+    AnnotationNode,
+    ChartNode,
+    FieldGroupNode,
+    HeaderSectionNode,
+    TableNode,
+    TableSectionNode
+} from './annotations.js';
+import {
+    collectPageCharts,
+    collectHeaderSections,
+    collectSections,
+    collectTables,
+    getConfigurationKey
+} from './annotations.js';
 import type { FlexChange, MinUI5Version, ParsedApp, PropertyChangeConfig } from '../parser/types.js';
 import { isLowerThanMinimalUi5Version } from '../../utils/version.js';
 
@@ -44,8 +57,9 @@ export type FlexChangeProperty = 'enableExport' | 'showPasteButton' | 'useExport
 export type OrphanTable = ConfigurationBase<'orphan-table', TableSettings>;
 export type Table = AnnotationBasedNode<TableNode, TableSettings>;
 export type FieldGroup = AnnotationBasedNode<FieldGroupNode, {}>;
+export type Chart = AnnotationBasedNode<ChartNode, {}>;
 
-export type Node = Section | Table | OrphanTable | FieldGroup;
+export type Node = Section | Table | OrphanTable | FieldGroup | Chart;
 export type NodeLookup<T extends Node> = {
     [K in T['type']]?: Extract<T, { type: K }>[];
 };
@@ -60,7 +74,7 @@ export interface FeV2ListReport extends ConfigurationBase<'list-report-page', Pa
     entitySetName: string;
     entity: MetadataElement;
     tables: (Table | OrphanTable)[];
-    lookup: NodeLookup<Table | OrphanTable | FieldGroup>;
+    lookup: NodeLookup<Table | OrphanTable | FieldGroup | Chart>;
 }
 
 export interface FeV2ObjectPage extends ConfigurationBase<'object-page', PageSetting> {
@@ -69,7 +83,7 @@ export interface FeV2ObjectPage extends ConfigurationBase<'object-page', PageSet
     entitySetName: string;
     entity: MetadataElement;
     sections: Section[];
-    lookup: NodeLookup<Table | Section | FieldGroup>;
+    lookup: NodeLookup<Table | Section | FieldGroup | Chart>;
 }
 
 export type FeV2PageType = FeV2ListReport | FeV2ObjectPage;
@@ -472,6 +486,7 @@ function linkListReportPage(
     };
 
     linkListReportTable(page, [...path, name], tables, target, context.app);
+    collectPageCharts(page, mainService);
     linkedApp.pages.push(page);
 }
 
@@ -533,6 +548,7 @@ function linkObjectPagePage(
     for (const section of sections.filter((section) => section.type === 'header-section')) {
         collectHeaderSections(section, page);
     }
+    collectPageCharts(page, mainService);
     linkedApp.pages.push(page);
 }
 

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
@@ -2,8 +2,15 @@ import type { MetadataElement } from '@sap-ux/odata-annotation-core';
 import type { ParsedService } from '../parser/index.js';
 import type { LinkerContext, ConfigurationBase, ConfigurationProperty } from './types.js';
 import { getParsedServiceByName } from '../utils.js';
-import type { AnnotationNode, FieldGroupNode, HeaderSectionNode, TableNode, TableSectionNode } from './annotations.js';
-import { collectTables, collectSections, collectHeaderSections } from './annotations.js';
+import type {
+    AnnotationNode,
+    ChartNode,
+    FieldGroupNode,
+    HeaderSectionNode,
+    TableNode,
+    TableSectionNode
+} from './annotations.js';
+import { collectPageCharts, collectTables, collectSections, collectHeaderSections } from './annotations.js';
 
 export interface ApplicationSetting {
     createMode: string;
@@ -26,7 +33,7 @@ export interface FeV4ListReport extends ConfigurationBase<'list-report-page', Pa
     contextPath: string;
     entity: MetadataElement;
     tables: (Table | OrphanTable)[];
-    lookup: NodeLookup<Table | OrphanTable | FieldGroup>;
+    lookup: NodeLookup<Table | OrphanTable | FieldGroup | Chart>;
 }
 
 export interface FeV4ObjectPage extends ConfigurationBase<'object-page'> {
@@ -35,7 +42,7 @@ export interface FeV4ObjectPage extends ConfigurationBase<'object-page'> {
     contextPath: string;
     entity: MetadataElement;
     sections: Section[];
-    lookup: NodeLookup<Table | Section | FieldGroup>;
+    lookup: NodeLookup<Table | Section | FieldGroup | Chart>;
     header: {
         anchorBarVisible: ConfigurationProperty<boolean>;
         visible: ConfigurationProperty<boolean>;
@@ -73,6 +80,7 @@ export interface TableSettings {
 export type OrphanTable = ConfigurationBase<'orphan-table', TableSettings>;
 export type Table = AnnotationBasedNode<TableNode, TableSettings>;
 export type FieldGroup = AnnotationBasedNode<FieldGroupNode, {}>;
+export type Chart = AnnotationBasedNode<ChartNode, {}>;
 
 interface ManifestApplicationSettings {
     macros?: {
@@ -224,7 +232,7 @@ function getCreationModeValues(tableType?: string): string[] {
     return ['InlineCreationRows', 'NewPage'];
 }
 
-export type Node = Section | Table | OrphanTable | FieldGroup;
+export type Node = Section | Table | OrphanTable | FieldGroup | Chart;
 export type NodeLookup<T extends Node> = {
     [K in T['type']]?: Extract<T, { type: K }>[];
 };
@@ -291,35 +299,61 @@ export function runFeV4Linker(context: LinkerContext): LinkedFeV4App {
         const path = ['sap.ui5', 'routing', 'targets'];
         if (target.name === 'sap.fe.templates.ListReport') {
             linkListReport(context, linkedApp, path, name, contextPath, entity, target);
-        } else if (target.name === 'sap.fe.templates.ObjectPage' && entity.structuredType) {
-            const sections = collectSections('v4', entity.structuredType, mainService);
-
-            const page: FeV4ObjectPage = {
-                type: 'object-page',
-                targetName: name,
-                componentName: target.name,
-                contextPath,
-                entity: entity,
-                configuration: {},
-                sections: [],
-                lookup: {},
-                header: {
-                    anchorBarVisible: {
-                        values: [true, false],
-                        configurationPath: []
-                    },
-                    visible: {
-                        values: [true, false],
-                        configurationPath: []
-                    }
-                }
-            };
-            linkV4ObjectPageSections(page, path, name, sections, target);
-            linkObjectPageHeader(page, target);
-            linkedApp.pages.push(page);
+        } else if (target.name === 'sap.fe.templates.ObjectPage') {
+            linkObjectPage(linkedApp, path, name, contextPath, entity, target, mainService);
         }
     }
     return linkedApp;
+}
+
+/**
+ * Links a Fiori Elements V4 object page, collecting sections and charts.
+ *
+ * @param linkedApp - The linked app structure to push the page into
+ * @param path - Configuration path segments to the page
+ * @param name - The routing target name
+ * @param contextPath - The entity context path
+ * @param entity - The entity metadata element
+ * @param target - The routing target configuration
+ * @param mainService - The parsed OData service
+ */
+function linkObjectPage(
+    linkedApp: LinkedFeV4App,
+    path: string[],
+    name: string,
+    contextPath: string,
+    entity: MetadataElement,
+    target: Target,
+    mainService: ParsedService
+): void {
+    if (!entity.structuredType) {
+        return;
+    }
+    const sections = collectSections('v4', entity.structuredType, mainService);
+    const page: FeV4ObjectPage = {
+        type: 'object-page',
+        targetName: name,
+        componentName: 'sap.fe.templates.ObjectPage',
+        contextPath,
+        entity: entity,
+        configuration: {},
+        sections: [],
+        lookup: {},
+        header: {
+            anchorBarVisible: {
+                values: [true, false],
+                configurationPath: []
+            },
+            visible: {
+                values: [true, false],
+                configurationPath: []
+            }
+        }
+    };
+    linkV4ObjectPageSections(page, path, name, sections, target);
+    linkObjectPageHeader(page, target);
+    collectPageCharts(page, mainService);
+    linkedApp.pages.push(page);
 }
 
 interface Target {
@@ -414,6 +448,7 @@ function linkListReport(
         lookup: {}
     };
     linkListReportTable(page, [...path, name], tables, target);
+    collectPageCharts(page, mainService);
     linkedApp.pages.push(page);
 }
 

--- a/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/linker/fe-v4.ts
@@ -10,7 +10,13 @@ import type {
     TableNode,
     TableSectionNode
 } from './annotations.js';
-import { collectPageCharts, collectTables, collectSections, collectHeaderSections } from './annotations.js';
+import {
+    collectPageCharts,
+    collectTables,
+    collectSections,
+    collectHeaderSections,
+    getEntityForContextPath
+} from './annotations.js';
 
 export interface ApplicationSetting {
     createMode: string;
@@ -653,69 +659,6 @@ function getEntity(settings: PageSettings, service: ParsedService): MetadataElem
         return service.index.entitySets[settings.entitySet];
     }
     return undefined;
-}
-
-/**
- * Resolves a metadata element from a context path string.
- *
- * @param contextPath - The context path (e.g., '/EntitySet/NavigationProperty')
- * @param service - The parsed OData service
- */
-function getEntityForContextPath(contextPath: string, service: ParsedService): MetadataElement | undefined {
-    if (!contextPath.startsWith('/')) {
-        return;
-    }
-    const path = contextPath.substring(1);
-    const [entityName, ...segments] = path.split('/');
-    if (!entityName) {
-        return;
-    }
-    const entity = service.index.entitySets[entityName];
-    if (!entity) {
-        return undefined;
-    }
-    const entityType = resolveNavigationProperties(entity, segments);
-
-    if (!entityType) {
-        const entityStructureType = service.index.entitySets[entityName]?.structuredType;
-        if (!entityStructureType) {
-            return;
-        }
-        const pageEntityType = service.artifacts.metadataService.getMetadataElement(entityStructureType);
-        if (!pageEntityType) {
-            return;
-        }
-        return resolveNavigationProperties(pageEntityType, segments);
-    }
-
-    return entityType;
-}
-
-/**
- * Resolves navigation properties along a path to find the target entity.
- *
- * @param root - The starting metadata element
- * @param segments - Array of navigation property names to traverse
- */
-function resolveNavigationProperties(root: MetadataElement, segments: string[]): MetadataElement | undefined {
-    if (segments.length === 0) {
-        return root;
-    }
-    let current = root;
-    for (const segment of segments) {
-        let found = false;
-        for (const child of current.content) {
-            if (child.name === segment) {
-                current = child;
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            return undefined;
-        }
-    }
-    return current;
 }
 
 /**

--- a/packages/eslint-plugin-fiori-tools/src/project-context/parser/service.ts
+++ b/packages/eslint-plugin-fiori-tools/src/project-context/parser/service.ts
@@ -21,7 +21,7 @@ export interface ServiceIndex {
      * Key is simple identifier as it would be used in context path by SAP Fiori elements.
      */
     entitySets: Record<string, MetadataElement>;
-
+    entityTypes: Record<string, MetadataElement>;
     annotations: AnnotationIndex;
 }
 
@@ -230,6 +230,7 @@ export function buildServiceIndex(
     v2Annotations: V2Annotation[] = []
 ): ServiceIndex {
     const entitySets: Record<string, MetadataElement> = {};
+    const entityTypes: Record<string, MetadataElement> = {};
     for (const document of Object.values(artifacts.annotationFiles)) {
         documents[document.uri] = document;
     }
@@ -241,6 +242,8 @@ export function buildServiceIndex(
             entityContainer = element;
         } else if (element.kind === 'EntitySet' || element.kind === 'entitySet') {
             entitySets[element.name] = element;
+        } else if (element.kind === 'EntityType' || element.kind === 'entityType') {
+            entityTypes[element.name] = element;
         }
     });
 
@@ -249,6 +252,7 @@ export function buildServiceIndex(
     return {
         entitySets: entitySets,
         entityContainer,
+        entityTypes: entityTypes,
         annotations: annotationIndex
     };
 }

--- a/packages/eslint-plugin-fiori-tools/src/rules/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/index.ts
@@ -17,7 +17,8 @@ import {
     TEXT_ARRANGEMENT_HIDDEN,
     STRICT_UOM_FILTERING,
     NO_LIVE_MODE,
-    CLOUD_DEV_ADAPTATION_STATUS
+    CLOUD_DEV_ADAPTATION_STATUS,
+    MICRO_CHART_REQUIRES_NAVIGATION_ENTITY
 } from '../language/diagnostics.js';
 
 // Import all rules
@@ -86,6 +87,7 @@ import condensedTableLayout from './sap-condensed-table-layout.js';
 import textArrangementHidden from './sap-text-arrangement-hidden.js';
 import noLiveMode from './sap-no-live-mode.js';
 import cloudDevAdaptationStatus from './sap-cloud-dev-adaptation-status.js';
+import microChartRequiresNavigationEntity from './sap-micro-chart-requires-navigation-entity.js';
 
 import type { Rule } from 'eslint';
 
@@ -154,5 +156,6 @@ export const rules: Record<string, Rule.RuleModule | FioriRuleDefinition | Fiori
     [TABLE_PERSONALIZATION]: tablePersonalization,
     [TEXT_ARRANGEMENT_HIDDEN]: textArrangementHidden,
     [NO_LIVE_MODE]: noLiveMode,
-    [CLOUD_DEV_ADAPTATION_STATUS]: cloudDevAdaptationStatus
+    [CLOUD_DEV_ADAPTATION_STATUS]: cloudDevAdaptationStatus,
+    [MICRO_CHART_REQUIRES_NAVIGATION_ENTITY]: microChartRequiresNavigationEntity
 };

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
@@ -1,0 +1,172 @@
+import type { Element } from '@sap-ux/odata-annotation-core';
+import { Edm, elementsWithName, elements } from '@sap-ux/odata-annotation-core';
+import { createFioriRule } from '../language/rule-factory.js';
+import type { FioriRuleDefinition } from '../types.js';
+import type { MicroChartRequiresNavigationEntity } from '../language/diagnostics.js';
+import { MICRO_CHART_REQUIRES_NAVIGATION_ENTITY } from '../language/diagnostics.js';
+import { FioriAnnotationSourceCode } from '../language/annotations/source-code.js';
+import type { IndexedAnnotation } from '../project-context/parser/index.js';
+
+/** Annotation record properties whose `PropertyPath` values must use a navigation path. */
+const MICRO_CHART_CHECKED_PROPS = ['Measures', 'Dimensions'] as const;
+
+/**
+ * Returns the text content of a `PropertyPath` element.
+ * In both XML and CDS representations the path value is stored as a text node.
+ *
+ * @param element - The `PropertyPath` element to read.
+ * @returns The path string, or an empty string if the element has no text content.
+ */
+function getPropertyPathText(element: Element): string {
+    const textNode = element.content?.find((c) => c.type === 'text');
+    return textNode?.type === 'text' && textNode.text ? textNode.text : '';
+}
+
+/**
+ * Inspects a single `UI.Chart` annotation and appends one diagnostic (reported on the
+ * annotation node itself) when any `Measures` or `Dimensions` `PropertyPath` lacks a
+ * navigation separator (`/`).
+ *
+ * @param annotation - The indexed annotation entry containing the top-level element and its URI.
+ * @param annotation.top - The top-level annotation node.
+ * @param annotation.top.uri - Source URI of the annotation document.
+ * @param annotation.top.value - The parsed annotation `Element`.
+ * @param pageNames - Names of pages that reference this chart annotation.
+ * @param problems - Accumulator array to which new diagnostics are pushed.
+ */
+function checkChartAnnotation(
+    annotation: { top: { uri: string; value: Element } },
+    pageNames: string[],
+    problems: MicroChartRequiresNavigationEntity[]
+): void {
+    const annotationElement = annotation.top.value;
+    const [record] = elementsWithName(Edm.Record, annotationElement);
+    if (!record) {
+        return;
+    }
+
+    for (const propName of MICRO_CHART_CHECKED_PROPS) {
+        const propValueEl = elements(
+            (el) => el.name === Edm.PropertyValue && el.attributes[Edm.Property]?.value === propName,
+            record
+        )[0];
+        if (!propValueEl) {
+            continue;
+        }
+
+        const [collection] = elementsWithName(Edm.Collection, propValueEl);
+        if (!collection) {
+            continue;
+        }
+
+        for (const propPath of elementsWithName(Edm.PropertyPath, collection)) {
+            const pathValue = getPropertyPathText(propPath);
+            if (pathValue && !pathValue.includes('/')) {
+                problems.push({
+                    type: MICRO_CHART_REQUIRES_NAVIGATION_ENTITY,
+                    pageNames,
+                    annotation: {
+                        reference: { uri: annotation.top.uri, value: annotationElement },
+                        reportedParent: annotationElement
+                    }
+                });
+                return;
+            }
+        }
+    }
+}
+
+type ChartLookupItem = { annotation?: { annotation?: IndexedAnnotation } };
+
+/**
+ * Registers a single chart lookup item into the page map, keyed by its `IndexedAnnotation`.
+ *
+ * @param map - The map being built.
+ * @param chart - A single chart lookup entry from `page.lookup['chart']`.
+ * @param targetName - The page target name that references this chart.
+ */
+function addChartToPageMap(map: Map<IndexedAnnotation, string[]>, chart: ChartLookupItem, targetName: string): void {
+    const indexedAnnotation = chart.annotation?.annotation;
+    if (!indexedAnnotation) {
+        return;
+    }
+    const names = map.get(indexedAnnotation) ?? [];
+    if (!names.includes(targetName)) {
+        names.push(targetName);
+    }
+    map.set(indexedAnnotation, names);
+}
+
+/**
+ * Builds a map from each `IndexedAnnotation` to the list of page target-names that
+ * reference it via `lookup['chart']` entries across all apps in the project.
+ *
+ * @param sourceCode - The Fiori annotation source code providing the project context.
+ * @returns A `Map` keyed by `IndexedAnnotation`, valued by an array of page target-names.
+ */
+function buildChartPageMap(sourceCode: FioriAnnotationSourceCode): Map<IndexedAnnotation, string[]> {
+    const chartPageMap = new Map<IndexedAnnotation, string[]>();
+    for (const appKey of Object.keys(sourceCode.projectContext.linkedModel.apps)) {
+        const linkedApp = sourceCode.projectContext.linkedModel.apps[appKey];
+        for (const page of linkedApp.pages) {
+            const charts = (page as { lookup?: Record<string, ChartLookupItem[]> }).lookup?.['chart'] ?? [];
+            for (const chart of charts) {
+                addChartToPageMap(chartPageMap, chart, page.targetName);
+            }
+        }
+    }
+    return chartPageMap;
+}
+
+const rule: FioriRuleDefinition = createFioriRule({
+    ruleId: MICRO_CHART_REQUIRES_NAVIGATION_ENTITY,
+    meta: {
+        type: 'suggestion',
+        docs: {
+            recommended: true,
+            description: 'Micro chart measures and dimensions must use a 1:n navigation entity path.',
+            url: 'https://github.com/SAP/open-ux-tools/blob/main/packages/eslint-plugin-fiori-tools/docs/rules/sap-micro-chart-requires-navigation-entity.md'
+        },
+        messages: {
+            [MICRO_CHART_REQUIRES_NAVIGATION_ENTITY]:
+                'Micro chart measures and dimensions must reference properties from a 1:n navigation entity.'
+        }
+    },
+    check(context) {
+        if (!(context.sourceCode instanceof FioriAnnotationSourceCode)) {
+            return [];
+        }
+        const problems: MicroChartRequiresNavigationEntity[] = [];
+        const chartPageMap = buildChartPageMap(context.sourceCode);
+        for (const [annotation, pageNames] of chartPageMap) {
+            checkChartAnnotation(annotation, pageNames, problems);
+        }
+        return problems;
+    },
+    createAnnotations(context, validationResult) {
+        if (validationResult.length === 0) {
+            return {};
+        }
+        const lookup = new Set<Element>();
+        for (const diagnostic of validationResult) {
+            lookup.add(diagnostic.annotation.reportedParent);
+        }
+        return {
+            ['target>element[name="Annotation"]'](node: Element): void {
+                if (!lookup.has(node)) {
+                    return;
+                }
+                validationResult
+                    .filter((r) => r.annotation.reportedParent === node)
+                    .forEach((r) => {
+                        context.report({
+                            node: r.annotation.reference.value,
+                            messageId: MICRO_CHART_REQUIRES_NAVIGATION_ENTITY
+                        });
+                    });
+            }
+        };
+    }
+});
+
+export default rule;

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
@@ -1,13 +1,14 @@
-import type { Element } from '@sap-ux/odata-annotation-core';
+import type { Element, MetadataElement } from '@sap-ux/odata-annotation-core';
 import { Edm, elementsWithName, elements } from '@sap-ux/odata-annotation-core';
 import { createFioriRule } from '../language/rule-factory.js';
 import type { FioriRuleDefinition } from '../types.js';
 import type { MicroChartRequiresNavigationEntity } from '../language/diagnostics.js';
 import { MICRO_CHART_REQUIRES_NAVIGATION_ENTITY } from '../language/diagnostics.js';
 import { FioriAnnotationSourceCode } from '../language/annotations/source-code.js';
-import type { IndexedAnnotation } from '../project-context/parser/index.js';
+import type { IndexedAnnotation, ParsedService } from '../project-context/parser/index.js';
+import { getEntityTypeForContextPath } from '../project-context/linker/annotations.js';
 
-/** Annotation record properties whose `PropertyPath` values must use a navigation path. */
+/** Annotation record properties whose `PropertyPath` values must use a 1:n navigation path. */
 const MICRO_CHART_CHECKED_PROPS = ['Measures', 'Dimensions'] as const;
 
 /**
@@ -23,20 +24,68 @@ function getPropertyPathText(element: Element): string {
 }
 
 /**
- * Inspects a single `UI.Chart` annotation and appends one diagnostic (reported on the
- * annotation node itself) when any `Measures` or `Dimensions` `PropertyPath` lacks a
- * navigation separator (`/`).
+ * Returns `true` when `pathValue` violates the 1:n navigation requirement.
  *
- * @param annotation - The indexed annotation entry containing the top-level element and its URI.
- * @param annotation.top - The top-level annotation node.
- * @param annotation.top.uri - Source URI of the annotation document.
- * @param annotation.top.value - The parsed annotation `Element`.
+ * Uses the linker pattern from `getEntityForContextPath`: navigates
+ * `/${pageEntityName}/${firstSegment}` to obtain the navigation property element from
+ * the metadata service (handling entity-set → entity-type fallback for V2 and CDS).
+ * The element's `isCollectionValued` flag is the authoritative answer.
+ *
+ * When the metadata service cannot resolve the segment (incomplete fixtures, unknown
+ * entity, CDS kinds not exposed as NavigationProperty), the function falls back to
+ * requiring a `/` separator as a best-effort heuristic.
+ *
+ * @param pathValue - The property path string to validate.
+ * @param chartEntityType - The entity type name of the chart's context.
+ * @param service - The parsed OData service.
+ * @returns `true` when the path violates the 1:n navigation requirement, `false` when valid or undetermined.
+ */
+function violatesNavigationRule(
+    pathValue: string,
+    chartEntityType: string,
+    service: ParsedService | undefined
+): boolean {
+    if (!pathValue) {
+        return false;
+    }
+    if (service) {
+        let navSegments = pathValue.split('/');
+        // Navigate /<entitySetName>/<segment> — mirrors the linker's getEntityForContextPath pattern.
+        // getEntityForContextPath handles entity-set lookup (V4), structuredType fallback (V2),
+        // and returns the metadata element for the first path segment.
+        let navElement = getEntityTypeForContextPath(`/${chartEntityType}/${navSegments[0]}`, service);
+        while (navElement?.isEntityType) {
+            // If the navElement is an entity type, we need to check if it has a structured type and get that instead.
+            navSegments = navSegments.slice(1);
+            navElement = getEntityTypeForContextPath(`/${navElement.structuredType}/${navSegments[0]}`, service);
+        }
+        if (navElement) {
+            // Metadata resolved the segment — isCollectionValued is the authoritative answer.
+            return !navElement.isCollectionValued;
+        }
+    }
+    return false; // Undetermined: service not available or segment not resolved.  Do not report.
+}
+
+/**
+ * Inspects a single `UI.Chart` annotation and appends one diagnostic when any `Measures`
+ * or `Dimensions` `PropertyPath` does not traverse a 1:n navigation property.
+ *
+ * The check only runs when **both** `Measures` and `Dimensions` are present.  Charts that
+ * use a `DataPoint` pattern (e.g. Bullet, Harvey Ball, Radial) omit `Dimensions` by design;
+ * skipping those avoids false positives for the DataPoint-based measure reference in `Measures`.
+ *
+ * @param annotation - The full indexed annotation, used for both the element and its target entity type.
  * @param pageNames - Names of pages that reference this chart annotation.
+ * @param chartEntityType - The entity type name of the chart's context.
+ * @param service - The parsed OData service providing the metadata for multiplicity checks.
  * @param problems - Accumulator array to which new diagnostics are pushed.
  */
 function checkChartAnnotation(
-    annotation: { top: { uri: string; value: Element } },
+    annotation: IndexedAnnotation,
     pageNames: string[],
+    chartEntityType: string,
+    service: ParsedService | undefined,
     problems: MicroChartRequiresNavigationEntity[]
 ): void {
     const annotationElement = annotation.top.value;
@@ -45,15 +94,20 @@ function checkChartAnnotation(
         return;
     }
 
-    for (const propName of MICRO_CHART_CHECKED_PROPS) {
-        const propValueEl = elements(
-            (el) => el.name === Edm.PropertyValue && el.attributes[Edm.Property]?.value === propName,
-            record
-        )[0];
-        if (!propValueEl) {
-            continue;
-        }
+    const propValueEls = MICRO_CHART_CHECKED_PROPS.map(
+        (propName) =>
+            elements(
+                (el) => el.name === Edm.PropertyValue && el.attributes[Edm.Property]?.value === propName,
+                record
+            )[0]
+    );
 
+    // Skip charts that do not declare both Measures and Dimensions (e.g. DataPoint-based charts).
+    if (propValueEls.some((el) => !el)) {
+        return;
+    }
+
+    for (const propValueEl of propValueEls) {
         const [collection] = elementsWithName(Edm.Collection, propValueEl);
         if (!collection) {
             continue;
@@ -61,7 +115,7 @@ function checkChartAnnotation(
 
         for (const propPath of elementsWithName(Edm.PropertyPath, collection)) {
             const pathValue = getPropertyPathText(propPath);
-            if (pathValue && !pathValue.includes('/')) {
+            if (violatesNavigationRule(pathValue, chartEntityType, service)) {
                 problems.push({
                     type: MICRO_CHART_REQUIRES_NAVIGATION_ENTITY,
                     pageNames,
@@ -77,6 +131,11 @@ function checkChartAnnotation(
 }
 
 type ChartLookupItem = { annotation?: { annotation?: IndexedAnnotation } };
+type ChartPageEntry = {
+    pageNames: string[];
+    chartEntityType: MetadataElement;
+    service: ParsedService;
+};
 
 /**
  * Registers a single chart lookup item into the page map, keyed by its `IndexedAnnotation`.
@@ -84,34 +143,53 @@ type ChartLookupItem = { annotation?: { annotation?: IndexedAnnotation } };
  * @param map - The map being built.
  * @param chart - A single chart lookup entry from `page.lookup['chart']`.
  * @param targetName - The page target name that references this chart.
+ * @param pageTargetName - The target name of the page that references this chart.
+ * @param service - The OData service associated with the app that owns this chart.
  */
-function addChartToPageMap(map: Map<IndexedAnnotation, string[]>, chart: ChartLookupItem, targetName: string): void {
+function addChartToPageMap(
+    map: Map<IndexedAnnotation, ChartPageEntry>,
+    chart: ChartLookupItem,
+    targetName: string,
+    pageTargetName: string,
+    service: ParsedService
+): void {
     const indexedAnnotation = chart.annotation?.annotation;
     if (!indexedAnnotation) {
         return;
     }
-    const names = map.get(indexedAnnotation) ?? [];
-    if (!names.includes(targetName)) {
-        names.push(targetName);
+    const chartEntityType = service.artifacts.metadataService.getMetadataElement(targetName);
+    if (!chartEntityType) {
+        return;
     }
-    map.set(indexedAnnotation, names);
+    const entry = map.get(indexedAnnotation) ?? { pageNames: [] as string[], chartEntityType, service };
+    if (!entry.pageNames.includes(pageTargetName)) {
+        entry.pageNames.push(pageTargetName);
+    }
+    map.set(indexedAnnotation, entry);
 }
 
 /**
- * Builds a map from each `IndexedAnnotation` to the list of page target-names that
- * reference it via `lookup['chart']` entries across all apps in the project.
+ * Builds a map from each `IndexedAnnotation` to its page target-names, the page entity, and
+ * the owning OData service, collected from `lookup['chart']` entries across all apps in the project.
  *
  * @param sourceCode - The Fiori annotation source code providing the project context.
- * @returns A `Map` keyed by `IndexedAnnotation`, valued by an array of page target-names.
+ * @returns A `Map` keyed by `IndexedAnnotation`, valued by page names, the page entity, and the OData service.
  */
-function buildChartPageMap(sourceCode: FioriAnnotationSourceCode): Map<IndexedAnnotation, string[]> {
-    const chartPageMap = new Map<IndexedAnnotation, string[]>();
+function buildChartPageMap(sourceCode: FioriAnnotationSourceCode): Map<IndexedAnnotation, ChartPageEntry> {
+    const chartPageMap = new Map<IndexedAnnotation, ChartPageEntry>();
     for (const appKey of Object.keys(sourceCode.projectContext.linkedModel.apps)) {
         const linkedApp = sourceCode.projectContext.linkedModel.apps[appKey];
+        const appIndex = sourceCode.projectContext.index.apps[appKey];
+        const service = appIndex ? sourceCode.projectContext.getIndexedServiceForMainService(appIndex) : undefined;
+        if (!service) {
+            continue;
+        }
         for (const page of linkedApp.pages) {
-            const charts = (page as { lookup?: Record<string, ChartLookupItem[]> }).lookup?.['chart'] ?? [];
+            const pageTyped = page as { lookup?: Record<string, ChartLookupItem[]>; entity?: MetadataElement };
+            const charts = pageTyped.lookup?.['chart'] ?? [];
             for (const chart of charts) {
-                addChartToPageMap(chartPageMap, chart, page.targetName);
+                const chartEntityType = chart.annotation?.annotation?.target ?? '';
+                addChartToPageMap(chartPageMap, chart, chartEntityType, page.targetName, service);
             }
         }
     }
@@ -138,8 +216,8 @@ const rule: FioriRuleDefinition = createFioriRule({
         }
         const problems: MicroChartRequiresNavigationEntity[] = [];
         const chartPageMap = buildChartPageMap(context.sourceCode);
-        for (const [annotation, pageNames] of chartPageMap) {
-            checkChartAnnotation(annotation, pageNames, problems);
+        for (const [annotation, { pageNames, service }] of chartPageMap) {
+            checkChartAnnotation(annotation, pageNames, annotation.target, service, problems);
         }
         return problems;
     },

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
@@ -26,19 +26,19 @@ function getPropertyPathText(element: Element): string {
 /**
  * Returns `true` when `pathValue` violates the 1:n navigation requirement.
  *
- * Uses the linker pattern from `getEntityForContextPath`: navigates
- * `/${pageEntityName}/${firstSegment}` to obtain the navigation property element from
- * the metadata service (handling entity-set → entity-type fallback for V2 and CDS).
- * The element's `isCollectionValued` flag is the authoritative answer.
+ * Traverses each segment of the path against the entity type index (keyed by fully-qualified
+ * name matching `annotation.target`).  At each step:
+ * - If the segment is a collection-valued (1:n) navigation → valid, return `false`.
+ * - If the segment is a 1:1 navigation entity type → follow `structuredType` to next entity.
+ * - If the segment is a scalar property with no prior 1:n hop → violation, return `true`.
  *
- * When the metadata service cannot resolve the segment (incomplete fixtures, unknown
- * entity, CDS kinds not exposed as NavigationProperty), the function falls back to
+ * When a segment cannot be resolved (incomplete fixtures, unknown entity), falls back to
  * requiring a `/` separator as a best-effort heuristic.
  *
  * @param pathValue - The property path string to validate.
- * @param chartEntityType - The entity type name of the chart's context.
+ * @param chartEntityType - The fully-qualified entity type name of the chart's annotation target.
  * @param service - The parsed OData service.
- * @returns `true` when the path violates the 1:n navigation requirement, `false` when valid or undetermined.
+ * @returns `true` when the path violates the 1:n navigation requirement, `false` when valid.
  */
 function violatesNavigationRule(
     pathValue: string,
@@ -49,22 +49,27 @@ function violatesNavigationRule(
         return false;
     }
     if (service) {
-        let navSegments = pathValue.split('/');
-        // Navigate /<entitySetName>/<segment> — mirrors the linker's getEntityForContextPath pattern.
-        // getEntityForContextPath handles entity-set lookup (V4), structuredType fallback (V2),
-        // and returns the metadata element for the first path segment.
-        let navElement = getEntityTypeForContextPath(`/${chartEntityType}/${navSegments[0]}`, service);
-        while (navElement?.isEntityType) {
-            // If the navElement is an entity type, we need to check if it has a structured type and get that instead.
-            navSegments = navSegments.slice(1);
-            navElement = getEntityTypeForContextPath(`/${navElement.structuredType}/${navSegments[0]}`, service);
-        }
-        if (navElement) {
-            // Metadata resolved the segment — isCollectionValued is the authoritative answer.
-            return !navElement.isCollectionValued;
+        let currentEntityType = chartEntityType;
+        for (const segment of pathValue.split('/')) {
+            const navElement = getEntityTypeForContextPath(`/${currentEntityType}/${segment}`, service);
+            if (!navElement) {
+                break; // Segment unresolvable — fall through to heuristic.
+            }
+            if (navElement.isCollectionValued) {
+                return false; // Confirmed 1:n navigation — valid.
+            }
+            if (navElement.isEntityType && navElement.structuredType) {
+                // Confirmed 1:1 navigation hop — traverse into its entity type.
+                currentEntityType = navElement.structuredType;
+                continue;
+            }
+            // Element found but not classified as navigation (e.g. CDS association without flags set,
+            // or scalar property). Fall through to heuristic to avoid false positives.
+            break;
         }
     }
-    return false; // Undetermined: service not available or segment not resolved.  Do not report.
+    // Metadata unavailable or segment not resolved — require a navigation separator as best-effort.
+    return !pathValue.includes('/');
 }
 
 /**

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-micro-chart-requires-navigation-entity.ts
@@ -192,8 +192,16 @@ function buildChartPageMap(sourceCode: FioriAnnotationSourceCode): Map<IndexedAn
         for (const page of linkedApp.pages) {
             const pageTyped = page as { lookup?: Record<string, ChartLookupItem[]>; entity?: MetadataElement };
             const charts = pageTyped.lookup?.['chart'] ?? [];
+            const pageEntityTypePath = pageTyped.entity?.structuredType;
             for (const chart of charts) {
                 const chartEntityType = chart.annotation?.annotation?.target ?? '';
+                // Charts whose annotation target is a different entity type than the page entity are
+                // referenced via a navigation path (e.g. `_Booking/@UI.Chart`). The sub-entity is
+                // already a 1:n navigation target, so its direct properties are valid without an
+                // additional navigation prefix — skip the check for these charts.
+                if (pageEntityTypePath && chartEntityType !== pageEntityTypePath) {
+                    continue;
+                }
                 addChartToPageMap(chartPageMap, chart, chartEntityType, page.targetName, service);
             }
         }

--- a/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-cds.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-cds.test.ts
@@ -1,0 +1,114 @@
+import { RuleTester } from 'eslint';
+import microChartRule from '../../src/rules/sap-micro-chart-requires-navigation-entity.js';
+import { meta, languages } from '../../src/index.js';
+import { setup, CAP_ANNOTATIONS, CAP_ANNOTATIONS_PATH, CAP_APP_PATH } from '../test-helper.js';
+
+const ruleTester = new RuleTester({
+    plugins: { ['@sap-ux/eslint-plugin-fiori-tools']: { ...meta, languages } },
+    language: '@sap-ux/eslint-plugin-fiori-tools/fiori'
+});
+
+const TEST_NAME = 'sap-micro-chart-requires-navigation-entity - CDS';
+const EXPECTED_MESSAGE = 'Micro chart measures and dimensions must reference properties from a 1:n navigation entity.';
+const { createValidTest, createInvalidTest } = setup(TEST_NAME, CAP_APP_PATH);
+
+// CDS: service.Incidents entity; incidentFlow is a 1:n navigation to IncidentFlow
+// UI.LineItem with DataFieldForAnnotation makes the chart page-visible (overwrites base UI.LineItem via CDS last-wins).
+
+const CDS_MICRO_CHART_VALID = `
+annotate service.Incidents with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#CdsTrend'}],
+    UI.Chart #CdsTrend: {
+        ChartType: #Line,
+        Measures: [incidentFlow/criticality],
+        Dimensions: [incidentFlow/id]
+    }
+);`;
+
+const CDS_NON_MICRO_CHART = `
+annotate service.Incidents with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#CdsBar'}],
+    UI.Chart #CdsBar: {
+        ChartType: #Bar,
+        Measures: [status],
+        Dimensions: [category_code]
+    }
+);`;
+
+const CDS_MICRO_CHART_INVALID = `
+annotate service.Incidents with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#CdsBad'}],
+    UI.Chart #CdsBad: {
+        ChartType: #Column,
+        Measures: [status],
+        Dimensions: [incidentFlow/id]
+    }
+);`;
+
+const CDS_MICRO_CHART_DIMENSIONS_INVALID = `
+annotate service.Incidents with @(
+    UI.LineItem: [{$Type: 'UI.DataFieldForAnnotation', Target: '@UI.Chart#CdsDimBad'}],
+    UI.Chart #CdsDimBad: {
+        ChartType: #Area,
+        Measures: [incidentFlow/criticality],
+        Dimensions: [category_code]
+    }
+);`;
+
+ruleTester.run(TEST_NAME, microChartRule, {
+    valid: [
+        createValidTest(
+            {
+                name: 'non CDS file - json',
+                filename: 'some-other-file.json',
+                code: '{}'
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'CDS: no chart annotations',
+                filename: CAP_ANNOTATIONS_PATH,
+                code: CAP_ANNOTATIONS
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'CDS: micro chart with navigation paths',
+                filename: CAP_ANNOTATIONS_PATH,
+                code: CAP_ANNOTATIONS + CDS_MICRO_CHART_VALID
+            },
+            []
+        )
+    ],
+    invalid: [
+        createInvalidTest(
+            {
+                name: 'CDS: Bar chart with direct Measures - reported',
+                filename: CAP_ANNOTATIONS_PATH,
+                code: CAP_ANNOTATIONS + CDS_NON_MICRO_CHART,
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'CDS: micro chart Measures without navigation',
+                filename: CAP_ANNOTATIONS_PATH,
+                code: CAP_ANNOTATIONS + CDS_MICRO_CHART_INVALID,
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'CDS: micro chart Dimensions without navigation',
+                filename: CAP_ANNOTATIONS_PATH,
+                code: CAP_ANNOTATIONS + CDS_MICRO_CHART_DIMENSIONS_INVALID,
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        )
+    ]
+});

--- a/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-xml.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-xml.test.ts
@@ -1,0 +1,378 @@
+import { RuleTester } from 'eslint';
+import microChartRule from '../../src/rules/sap-micro-chart-requires-navigation-entity.js';
+import { meta, languages } from '../../src/index.js';
+import {
+    getAnnotationsAsXmlCode,
+    setup,
+    V2_ANNOTATIONS,
+    V2_ANNOTATIONS_PATH,
+    V4_ANNOTATIONS,
+    V4_ANNOTATIONS_PATH
+} from '../test-helper.js';
+
+const ruleTester = new RuleTester({
+    plugins: { ['@sap-ux/eslint-plugin-fiori-tools']: { ...meta, languages } },
+    language: '@sap-ux/eslint-plugin-fiori-tools/fiori'
+});
+
+const TEST_NAME = 'sap-micro-chart-requires-navigation-entity';
+const EXPECTED_MESSAGE = 'Micro chart measures and dimensions must reference properties from a 1:n navigation entity.';
+const { createValidTest, createInvalidTest } = setup(TEST_NAME);
+
+// V4 entity: IncidentService.Incidents (incidentFlow is a 1:n navigation to IncidentFlow)
+// V2 entity: TECHED_ALP_SOA_SRV.Z_SEPMRA_SO_SALESORDERANALYSISType
+// V4: UI.LineItem with DataFieldForAnnotation makes charts page-visible (LR table column)
+// V2: UI.HeaderFacets + UI.FieldGroup + DataFieldForAnnotation makes charts page-visible (OP header field group)
+
+const V4_NON_MICRO_CHART = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Bar"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>status</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>category_code</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_VALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart#RevenueTrend"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="RevenueTrend">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>incidentFlow/criticality</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>incidentFlow/id</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_QUALIFIED_VALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart#ColumnTrend"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="ColumnTrend">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>incidentFlow/criticality</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_MEASURES_INVALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Line"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>status</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>incidentFlow/id</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_DIMENSIONS_INVALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Area"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>incidentFlow/criticality</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>category_code</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_BOTH_INVALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/StackedBar"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>status</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>category_code</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V4_MICRO_CHART_QUALIFIED_INVALID = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart#BadChart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="BadChart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Comparison"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>title</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+// V2: chart referenced via UI.HeaderFacets → UI.FieldGroup (OP header field group)
+// The ReferenceFacet must include ID so processReferenceFacetRecord can link it.
+const V2_MICRO_CHART_VALID = `
+    <Annotations Target="TECHED_ALP_SOA_SRV.Z_SEPMRA_SO_SALESORDERANALYSISType">
+        <Annotation Term="UI.HeaderFacets">
+            <Collection>
+                <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="ID" String="ChartHeader"/>
+                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#ChartFG"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="ChartFG">
+            <Record>
+                <PropertyValue Property="Data">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAnnotation">
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Column"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>to_Items/GrossAmount</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>to_Items/Currency</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+const V2_MICRO_CHART_INVALID = `
+    <Annotations Target="TECHED_ALP_SOA_SRV.Z_SEPMRA_SO_SALESORDERANALYSISType">
+        <Annotation Term="UI.HeaderFacets">
+            <Collection>
+                <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="ID" String="ChartHeader"/>
+                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#ChartFG"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.FieldGroup" Qualifier="ChartFG">
+            <Record>
+                <PropertyValue Property="Data">
+                    <Collection>
+                        <Record Type="UI.DataFieldForAnnotation">
+                            <PropertyValue Property="Target" AnnotationPath="@UI.Chart"/>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+        <Annotation Term="UI.Chart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Area"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>GrossAmount</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+                <PropertyValue Property="Dimensions">
+                    <Collection>
+                        <PropertyPath>DeliveryCalendarYear</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
+ruleTester.run(TEST_NAME, microChartRule, {
+    valid: [
+        createValidTest(
+            {
+                name: 'non XML file - json',
+                filename: 'some-other-file.json',
+                code: '{}'
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: no chart annotations',
+                filename: V4_ANNOTATIONS_PATH,
+                code: V4_ANNOTATIONS
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: micro chart with all navigation paths',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_VALID)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: qualified micro chart with navigation paths',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_QUALIFIED_VALID)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V2: micro chart with all navigation paths',
+                filename: V2_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V2_ANNOTATIONS, V2_MICRO_CHART_VALID)
+            },
+            []
+        )
+    ],
+    invalid: [
+        createInvalidTest(
+            {
+                name: 'V4: micro chart with Dimensions without navigation - reported',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_DIMENSIONS_INVALID),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: Bar chart with direct Measures - reported',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_NON_MICRO_CHART),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: micro chart with Measures without navigation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_MEASURES_INVALID),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: micro chart with both Measures and Dimensions without navigation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_BOTH_INVALID),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: qualified micro chart with Measures without navigation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_QUALIFIED_INVALID),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                // Chart is referenced from OP header field group via UI.HeaderFacets → UI.FieldGroup.
+                // Only the injected chart (GrossAmount, no navigation) is checked.
+                name: 'V2: micro chart with direct properties',
+                filename: V2_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V2_ANNOTATIONS, V2_MICRO_CHART_INVALID),
+                errors: [{ message: EXPECTED_MESSAGE }]
+            },
+            []
+        )
+    ]
+});

--- a/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-xml.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/rules/sap-micro-chart-requires-navigation-entity-xml.test.ts
@@ -97,6 +97,29 @@ const V4_MICRO_CHART_QUALIFIED_VALID = `
         </Annotation>
     </Annotations>`;
 
+// DataPoint-based chart (e.g. Bullet): Dimensions absent by design, Measures acts as a logical
+// reference key — navigation paths are not required when Dimensions is omitted.
+const V4_MICRO_CHART_DATAPOINT_ONLY_MEASURES = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.LineItem">
+            <Collection>
+                <Record Type="UI.DataFieldForAnnotation">
+                    <PropertyValue Property="Target" AnnotationPath="@UI.Chart#BulletChart"/>
+                </Record>
+            </Collection>
+        </Annotation>
+        <Annotation Term="UI.Chart" Qualifier="BulletChart">
+            <Record>
+                <PropertyValue Property="ChartType" EnumMember="UI.ChartType/Bullet"/>
+                <PropertyValue Property="Measures">
+                    <Collection>
+                        <PropertyPath>status</PropertyPath>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Annotation>
+    </Annotations>`;
+
 const V4_MICRO_CHART_MEASURES_INVALID = `
     <Annotations Target="IncidentService.Incidents">
         <Annotation Term="UI.LineItem">
@@ -310,6 +333,24 @@ ruleTester.run(TEST_NAME, microChartRule, {
         ),
         createValidTest(
             {
+                // Comparison chart with only Measures (no Dimensions, no nav paths): DataPoint pattern.
+                // The rule only fires when BOTH Measures and Dimensions are present.
+                name: 'V4: chart with only Measures and no Dimensions is not checked even without navigation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_QUALIFIED_INVALID)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: DataPoint-based chart with only Measures and no Dimensions is not checked',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_DATAPOINT_ONLY_MEASURES)
+            },
+            []
+        ),
+        createValidTest(
+            {
                 name: 'V2: micro chart with all navigation paths',
                 filename: V2_ANNOTATIONS_PATH,
                 code: getAnnotationsAsXmlCode(V2_ANNOTATIONS, V2_MICRO_CHART_VALID)
@@ -350,15 +391,6 @@ ruleTester.run(TEST_NAME, microChartRule, {
                 name: 'V4: micro chart with both Measures and Dimensions without navigation',
                 filename: V4_ANNOTATIONS_PATH,
                 code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_BOTH_INVALID),
-                errors: [{ message: EXPECTED_MESSAGE }]
-            },
-            []
-        ),
-        createInvalidTest(
-            {
-                name: 'V4: qualified micro chart with Measures without navigation',
-                filename: V4_ANNOTATIONS_PATH,
-                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MICRO_CHART_QUALIFIED_INVALID),
                 errors: [{ message: EXPECTED_MESSAGE }]
             },
             []

--- a/packages/fiori-docs-embeddings/data_local/ux-ui5-tooling-README.md
+++ b/packages/fiori-docs-embeddings/data_local/ux-ui5-tooling-README.md
@@ -139,7 +139,7 @@ You can also connect to multiple back-end systems like this.
       url: https://my.backend.com:1234
 ```
 #### [Connecting to the SAP Business Technology Platform](#connecting-to-the-sap-business-technology-platform)
-If you want to connect to an ABAP Environment on SAP Business Technology Platform then you will need to set the optional property `scp` to `true`. For any other target, remove this property or set it to `false`.
+If you want to connect to an ABAP Environment on SAP Business Technology Platform, you **must** set the `authenticationType` property to `reentranceTicket`. The default authentication type is `basic`, which is not supported on ABAP Environment on SAP Business Technology Platform.
 
 ```
 - name: fiori-tools-proxy
@@ -148,7 +148,7 @@ If you want to connect to an ABAP Environment on SAP Business Technology Platfor
     backend:
     - path: /sap
       url: https://my.steampunk.com:1234
-      scp: true
+      authenticationType: reentranceTicket
 ```
 
 #### [Connecting to the SAP Business Accelerator Hub](#connecting-to-the-sap-business-accelerator-hub)
@@ -676,11 +676,6 @@ The target object contains properties identifying your target SAP system.
 - `<number> range [0..999]` (optional)
 - The client property is used to identify the SAP client that is to be used in the backend system. It translates to the url parameter `sap-client=<client>` If the client parameter is not provide, the default client will be used.
 
-##### scp
-
-- `<boolean>` (default: `false`)
-- By default, the deployment task will use basic authentication when connecting to the backend. If the target system is ABAP Environment on SAP Business Technology Platform, this parameter needs to be set to `true`.
-
 ##### service
 
 - `<string>` (default: `/sap/opu/odata/UI5/ABAP_REPOSITORY_SRV`)
@@ -704,7 +699,7 @@ For local usage, we recommend to not use the credentials object at all. As resul
 
 ##### authenticationType 
 - `<string>` (optional)
-- Authentication type for the app (e.g. 'basic', 'reentranceTicket'). IMPORTANT: It is required for authentication with reentrance tickets.
+- Authentication type for the app (e.g. `'basic'`, `'reentranceTicket'`). When connecting to an ABAP Environment on SAP Business Technology Platform, set this to `reentranceTicket`. This replaces the deprecated `scp` property.
 
 #### app
 


### PR DESCRIPTION
This rule is developed by leveraging skill fiori-eslint-dev in this PR: https://github.com/SAP/open-ux-tools/pull/4985

## Description
Adds the new ESLint rule `sap-micro-chart-requires-navigation-entity` for `@sap-ux/eslint-plugin-fiori-tools`.

This rule validates page-visible `UI.Chart` annotations and reports `Measures` or `Dimensions` `PropertyPath` entries that do not reference data through a 1:n navigation entity path. It covers charts referenced from List Report/Object Page tables and Object Page header field groups.

Key changes:
- Registers the new rule in the plugin and recommended configuration.
- Adds chart linking support for FE V2 and V4 pages so only displayed charts are checked.
- Extends service indexing/navigation resolution to support entity type lookup and context path traversal.
- Adds rule documentation, README entry, and changeset.
- Adds XML and CDS RuleTester coverage for valid and invalid chart scenarios.

Related context: https://github.com/SAP/open-ux-tools/pull/4985

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [ ] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Added automated ESLint `RuleTester` coverage for:
- XML annotations for FE V2 and FE V4 scenarios
- CDS annotations
- Valid navigation-based measure/dimension paths
- Invalid direct property paths for measures and dimensions
- Charts that should be skipped, such as DataPoint-style charts without dimensions

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [x] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.48`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `5e2967c0-b665-11f1-83a1-adfddf0072cb`
</details>
