### PR TITLE
chore: bump @types/vscode 1.109.0 → 1.110.0 (Aug 2026)

### DIFF
--- a/packages/adp-flp-config-sub-generator/package.json
+++ b/packages/adp-flp-config-sub-generator/package.json
@@ -51,7 +51,7 @@
         "@jest/types": "30.4.1",
         "@types/fs-extra": "11.0.4",
         "@types/inquirer": "8.2.6",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",

--- a/packages/environment-check/package.json
+++ b/packages/environment-check/package.json
@@ -48,7 +48,7 @@
         "@types/archiver": "7.0.0",
         "@types/minimist": "1.2.5",
         "@types/prompts": "2.4.9",
-        "@types/vscode": "1.109.0"
+        "@types/vscode": "1.110.0"
     },
     "files": [
         "dist",

--- a/packages/feature-toggle/package.json
+++ b/packages/feature-toggle/package.json
@@ -38,7 +38,7 @@
         "@jest/globals": "30.4.1",
         "jest-when": "4.0.3",
         "rimraf": "6.1.3",
-        "@types/vscode": "1.109.0"
+        "@types/vscode": "1.110.0"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/fiori-app-sub-generator/package.json
+++ b/packages/fiori-app-sub-generator/package.json
@@ -72,7 +72,7 @@
         "@types/lodash": "4.17.24",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -46,7 +46,7 @@
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@sap-ux/logger": "workspace:*",

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -62,7 +62,7 @@
         "@jest/types": "30.4.1",
         "@types/fs-extra": "11.0.4",
         "@types/inquirer": "8.2.6",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@sap-ux/deploy-config-sub-generator": "workspace:*",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -41,7 +41,7 @@
     "devDependencies": {
         "@types/debug": "4.1.13",
         "@types/lodash": "4.17.24",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "jest-extended": "7.0.0",
         "logform": "2.7.0"
     },

--- a/packages/nodejs-utils/package.json
+++ b/packages/nodejs-utils/package.json
@@ -37,7 +37,7 @@
         "@jest/globals": "30.4.1",
         "@sap-ux/logger": "workspace:*",
         "@types/semver": "7.7.1",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "mock-spawn": "0.2.6"
     },
     "files": [

--- a/packages/sap-systems-ext/package.json
+++ b/packages/sap-systems-ext/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/sap-systems-ext"
     },
     "engines": {
-        "vscode": "^1.109.0",
+        "vscode": "^1.110.0",
         "node": ">=22.x"
     },
     "files": [
@@ -58,7 +58,7 @@
         "@sap-ux/sap-systems-ext-webapp": "workspace:*",
         "@sap-ux/telemetry": "workspace:*",
         "@types/normalize-path": "3.0.2",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@zowe/secrets-for-zowe-sdk": "8.32.0",
         "cross-env": "10.1.0",
         "fast-glob": "3.3.3",

--- a/packages/ui5-library-reference-sub-generator/package.json
+++ b/packages/ui5-library-reference-sub-generator/package.json
@@ -48,7 +48,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
-        "@types/vscode": "1.109.0",
+        "@types/vscode": "1.110.0",
         "@vscode-logging/logger": "2.0.9",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,8 +701,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@types/yeoman-environment':
         specifier: 2.10.11
         version: 2.10.11
@@ -1994,8 +1994,8 @@ importers:
         specifier: 2.4.9
         version: 2.4.9
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
 
   packages/eslint-plugin-fiori-tools:
     dependencies:
@@ -2176,8 +2176,8 @@ importers:
         specifier: 30.4.1
         version: 30.4.1(supports-color@8.1.1)
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       jest-when:
         specifier: 4.0.3
         version: 4.0.3(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))
@@ -2376,8 +2376,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@types/yeoman-environment':
         specifier: 2.10.11
         version: 2.10.11
@@ -2655,8 +2655,8 @@ importers:
         specifier: 7.7.1
         version: 7.7.1
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@types/yeoman-environment':
         specifier: 2.10.11
         version: 2.10.11
@@ -3019,8 +3019,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@types/yeoman-environment':
         specifier: 2.10.11
         version: 2.10.11
@@ -3376,8 +3376,8 @@ importers:
         specifier: 4.17.24
         version: 4.17.24
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       jest-extended:
         specifier: 7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -3444,8 +3444,8 @@ importers:
         specifier: 7.7.1
         version: 7.7.1
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       mock-spawn:
         specifier: 0.2.6
         version: 0.2.6
@@ -4168,8 +4168,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@vscode/vsce':
         specifier: 3.7.1
         version: 3.7.1(supports-color@8.1.1)
@@ -5117,8 +5117,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/vscode':
-        specifier: 1.109.0
-        version: 1.109.0
+        specifier: 1.110.0
+        version: 1.110.0
       '@types/yeoman-environment':
         specifier: 2.10.11
         version: 2.10.11
@@ -10630,8 +10630,8 @@ packages:
   '@types/vinyl@2.0.12':
     resolution: {integrity: sha512-Sr2fYMBUVGYq8kj3UthXFAu5UN6ZW+rYr4NACjZQJvHvj+c8lYv0CahmZ2P/r7iUkN44gGUBwqxZkrKXYPb7cw==}
 
-  '@types/vscode@1.109.0':
-    resolution: {integrity: sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==}
+  '@types/vscode@1.110.0':
+    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -26894,7 +26894,7 @@ snapshots:
       '@types/expect': 1.20.4
       '@types/node': 22.13.14
 
-  '@types/vscode@1.109.0': {}
+  '@types/vscode@1.110.0': {}
 
   '@types/webidl-conversions@7.0.3':
     optional: true


### PR DESCRIPTION
## Description

Bumps `@types/vscode` from `1.109.0` to `1.110.0` across all packages that reference it, and updates the `engines.vscode` field in `sap-systems-ext` to `^1.110.0`. All changes are to `devDependencies` only, so no changesets are required.

**Packages updated (10):**
- `adp-flp-config-sub-generator`
- `environment-check`
- `feature-toggle`
- `fiori-app-sub-generator`
- `fiori-generator-shared`
- `generator-adp`
- `logger`
- `nodejs-utils`
- `sap-systems-ext`
- `ui5-library-reference-sub-generator`

The `pnpm-lock.yaml` file is also updated to reflect the new resolved integrity hash for `@types/vscode@1.110.0`.

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
- All changes are `devDependencies` only — no runtime behavior is affected.
- The `sap-ux-sap-systems-ext` build (tsc + esbuild) passes with the updated engine constraint.
- No changeset needed.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.33`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `0c764ab0-9ca2-11f1-9c0e-ea12dabd4568`
</details>
