### PR TITLE
chore(deps): bump fast-xml-parser 5.10.1 → 5.11.0

### DIFF
--- a/.changeset/axios-extension-bump-fast-xml-parser.md
+++ b/.changeset/axios-extension-bump-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/axios-extension": patch
+---
+
+BUMP: Upgrade fast-xml-parser 5.10.1 → 5.11.0

--- a/.changeset/eslint-plugin-bump-fast-xml-parser.md
+++ b/.changeset/eslint-plugin-bump-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/project-access

--- a/.changeset/odata-service-inquirer-bump-fast-xml-parser.md
+++ b/.changeset/odata-service-inquirer-bump-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-inquirer": patch
+---
+
+BUMP: Upgrade fast-xml-parser 5.10.1 → 5.11.0

--- a/.changeset/odata-service-writer-bump-fast-xml-parser.md
+++ b/.changeset/odata-service-writer-bump-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-writer": patch
+---
+
+BUMP: Upgrade fast-xml-parser 5.10.1 → 5.11.0

--- a/.changeset/project-access-bump-fast-xml-parser.md
+++ b/.changeset/project-access-bump-fast-xml-parser.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/project-access": patch
+---
+
+BUMP: Upgrade fast-xml-parser 5.10.1 → 5.11.0

--- a/packages/axios-extension/package.json
+++ b/packages/axios-extension/package.json
@@ -32,7 +32,7 @@
         "@sap-ux/feature-toggle": "workspace:*",
         "axios": "1.18.1",
         "detect-content-type": "1.2.0",
-        "fast-xml-parser": "5.10.1",
+        "fast-xml-parser": "5.11.0",
         "lodash": "4.18.1",
         "open": "8.4.2",
         "qs": "6.15.3",

--- a/packages/fiori-docs-embeddings/package.json
+++ b/packages/fiori-docs-embeddings/package.json
@@ -37,7 +37,7 @@
         "@sap-ux/create": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@types/node": "22.20.1",
-        "fast-xml-parser": "5.10.1",
+        "fast-xml-parser": "5.11.0",
         "gray-matter": "^4.0.3",
         "jsdoc-api": "9.3.6",
         "marked": "^12.0.0",

--- a/packages/odata-service-inquirer/package.json
+++ b/packages/odata-service-inquirer/package.json
@@ -48,7 +48,7 @@
         "axios": "1.18.1",
         "axios-logger": "2.8.1",
         "circular-reference-remover": "2.1.0",
-        "fast-xml-parser": "5.10.1",
+        "fast-xml-parser": "5.11.0",
         "i18next": "26.3.6",
         "inquirer-autocomplete-prompt": "2.0.1",
         "os-name": "4.0.1",

--- a/packages/odata-service-writer/package.json
+++ b/packages/odata-service-writer/package.json
@@ -39,7 +39,7 @@
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
         "ejs": "3.1.10",
-        "fast-xml-parser": "5.10.1",
+        "fast-xml-parser": "5.11.0",
         "i18next": "26.3.6",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",

--- a/packages/project-access/package.json
+++ b/packages/project-access/package.json
@@ -36,7 +36,7 @@
         "@sap-ux/i18n": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
         "@ui5/manifest": "1.89.0",
-        "fast-xml-parser": "5.10.1",
+        "fast-xml-parser": "5.11.0",
         "findit2": "2.2.3",
         "json-parse-even-better-errors": "5.0.0",
         "mem-fs": "2.1.0",


### PR DESCRIPTION
Auto-generated dependency update for **fast-xml-parser** `5.10.1` → `5.11.0`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 10

**Changelog analysis:**
> Patch release — no breaking changes.

<details><summary>Agent report</summary>

All done. Here's the summary:

---

## SUCCESS

### Packages updated (5 package.json files)
| Package | Location | fast-xml-parser |
|---|---|---|
| `@sap-ux/axios-extension` | `dependencies` | 5.10.1 → 5.11.0 |
| `@sap-ux/odata-service-inquirer` | `dependencies` | 5.10.1 → 5.11.0 |
| `@sap-ux/odata-service-writer` | `dependencies` | 5.10.1 → 5.11.0 |
| `@sap-ux/project-access` | `dependencies` | 5.10.1 → 5.11.0 |
| `@sap-ux/fiori-docs-embeddings` | `devDependencies` only — no changeset needed | 5.10.1 → 5.11.0 |

### Changesets created (5 files)
1. `.changeset/axios-extension-bump-fast-xml-parser.md`
2. `.changeset/odata-service-inquirer-bump-fast-xml-parser.md`
3. `.changeset/odata-service-writer-bump-fast-xml-parser.md`
4. `.changeset/project-access-bump-fast-xml-parser.md`
5. `.changeset/eslint-plugin-bump-fast-xml-parser.md` ← cascade: `@sap-ux/eslint-plugin-fiori-tools` bundles `@sap-ux/project-access` via esbuild

### Validation
- `pnpm install --no-frozen-lockfile` ✅
- `pnpm validate:changesets` ✅
- `@sap-ux/axios-extension` tests: **210 passed** ✅
- `@sap-ux/project-access` tests: **432 passed** ✅

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.