### PR TITLE
chore(deps): bump npm-run-all2 9.0.2 → 9.0.3

### DIFF
--- a/packages/annotation-generator/package.json
+++ b/packages/annotation-generator/package.json
@@ -36,7 +36,7 @@
         "mem-fs": "2.1.0",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/cds-annotation-parser/package.json
+++ b/packages/cds-annotation-parser/package.json
@@ -33,7 +33,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/cds-odata-annotation-converter/package.json
+++ b/packages/cds-odata-annotation-converter/package.json
@@ -41,7 +41,7 @@
     "devDependencies": {
         "@sap-ux/odata-annotation-core-types": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/control-property-editor-common/package.json
+++ b/packages/control-property-editor-common/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "@sap-ux/logger": "workspace:*",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "rimraf": "6.1.3",
         "ts-jest": "29.4.11"
     },

--- a/packages/control-property-editor/package.json
+++ b/packages/control-property-editor/package.json
@@ -45,7 +45,7 @@
         "i18next": "26.3.6",
         "jest-environment-jsdom": "30.4.1",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-i18next": "15.7.4",

--- a/packages/fiori-annotation-api/package.json
+++ b/packages/fiori-annotation-api/package.json
@@ -47,7 +47,7 @@
         "@sap/cds-compiler": "4.8.0",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/fiori-docs-embeddings/package.json
+++ b/packages/fiori-docs-embeddings/package.json
@@ -42,7 +42,7 @@
         "jsdoc-api": "9.3.6",
         "marked": "^12.0.0",
         "node-fetch": "^3.3.2",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "tsx": "4.23.1"
     },
     "keywords": [

--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -88,7 +88,7 @@
         "i18next": "26.3.6",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "os-name": "4.0.1",
         "promptfoo": "0.122.0",
         "xml-formatter": "3.7.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@jest/globals": "30.4.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "ts-node": "10.9.2",

--- a/packages/odata-annotation-core-types/package.json
+++ b/packages/odata-annotation-core-types/package.json
@@ -42,7 +42,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/odata-annotation-core/package.json
+++ b/packages/odata-annotation-core/package.json
@@ -43,7 +43,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@sap-ux/odata-entity-model": "workspace:*"
     },
     "engines": {

--- a/packages/odata-entity-model/package.json
+++ b/packages/odata-entity-model/package.json
@@ -33,6 +33,6 @@
     },
     "devDependencies": {
         "@sap-ux/odata-annotation-core-types": "workspace:*",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     }
 }

--- a/packages/odata-vocabularies/package.json
+++ b/packages/odata-vocabularies/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@jest/globals": "30.4.1",
         "axios": "1.18.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "prettier": "3.9.5",
         "tsx": "4.23.1"
     },

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -38,7 +38,7 @@
         "@sap-ux/i18n": "workspace:*",
         "@ui5/cli": "4.0.62",
         "eslint-plugin-jsdoc": "62.8.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@jest/globals": "30.4.1",
         "ui5-tooling-transpile": "3.11.3",
         "vscode-languageserver-textdocument": "1.0.12",

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -75,7 +75,7 @@
         "dotenv": "17.4.2",
         "express": "4.22.1",
         "nock": "14.0.16",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "supertest": "7.2.2"
     },
     "peerDependencies": {

--- a/packages/sap-systems-ext/package.json
+++ b/packages/sap-systems-ext/package.json
@@ -65,7 +65,7 @@
         "i18next": "26.3.6",
         "jsonc-parser": "3.3.1",
         "normalize-path": "3.0.0",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "os-name": "4.0.1",
         "vscode-uri": "3.1.0",
         "@vscode/vsce": "3.9.2"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -74,7 +74,7 @@
         "eslint-plugin-storybook": "0.6.15",
         "jest-environment-jsdom": "^29.7.0",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "require-from-string": "2.0.2",

--- a/packages/ui-prompting/package.json
+++ b/packages/ui-prompting/package.json
@@ -66,7 +66,7 @@
         "eslint-plugin-storybook": "0.6.15",
         "jest-environment-jsdom": "30.4.1",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "sass": "1.102.0",

--- a/packages/xml-odata-annotation-converter/package.json
+++ b/packages/xml-odata-annotation-converter/package.json
@@ -39,7 +39,7 @@
         "@xml-tools/ast": "5.0.5",
         "@xml-tools/parser": "1.0.11",
         "chevrotain": "7.1.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "prettier": "3.9.5"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,8 +913,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/app-config-writer:
     dependencies:
@@ -1265,8 +1265,8 @@ importers:
         version: 7.1.1
     devDependencies:
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/cds-odata-annotation-converter:
     dependencies:
@@ -1296,8 +1296,8 @@ importers:
         specifier: workspace:*
         version: link:../project-access
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/cf-deploy-config-inquirer:
     dependencies:
@@ -1587,8 +1587,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       postcss-modules:
         specifier: 6.0.1
         version: 6.0.1(postcss@8.5.26)
@@ -1635,8 +1635,8 @@ importers:
         specifier: workspace:*
         version: link:../logger
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -2273,8 +2273,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/fiori-app-sub-generator:
     dependencies:
@@ -2460,8 +2460,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       tsx:
         specifier: 4.23.1
         version: 4.23.1
@@ -2793,8 +2793,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       os-name:
         specifier: 4.0.1
         version: 4.0.1
@@ -3185,8 +3185,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)
@@ -3484,8 +3484,8 @@ importers:
         specifier: workspace:*
         version: link:../odata-entity-model
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-annotation-core-types:
     dependencies:
@@ -3494,8 +3494,8 @@ importers:
         version: link:../text-document-utils
     devDependencies:
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-entity-model:
     devDependencies:
@@ -3503,8 +3503,8 @@ importers:
         specifier: workspace:*
         version: link:../odata-annotation-core-types
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-service-inquirer:
     dependencies:
@@ -3692,8 +3692,8 @@ importers:
         specifier: '>=1.18.0'
         version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       prettier:
         specifier: 3.9.5
         version: 3.9.5
@@ -3835,8 +3835,8 @@ importers:
         specifier: 14.0.16
         version: 14.0.16
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       supertest:
         specifier: 7.2.2
         version: 7.2.2(supports-color@8.1.1)
@@ -3869,8 +3869,8 @@ importers:
         specifier: 62.8.1
         version: 62.8.1(eslint@10.7.0(supports-color@8.1.1))(supports-color@8.1.1)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       ui5-tooling-modules:
         specifier: 3.35.0
         version: 3.35.0(@ui5/project@4.0.17(@ui5/builder@4.3.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
@@ -4213,8 +4213,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       os-name:
         specifier: 4.0.1
         version: 4.0.1
@@ -4564,8 +4564,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -4676,8 +4676,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -5456,8 +5456,8 @@ importers:
         specifier: 7.1.1
         version: 7.1.1
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       prettier:
         specifier: 3.9.5
         version: 3.9.5
@@ -11240,6 +11240,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansi-styles@7.0.0:
+    resolution: {integrity: sha512-kKvt3m4uwzqL0wlkPd09CmljPJGOZZ4D0fP65sqFSvPkMRKhNi+74MgIJ5QxE6SxqB4t4KyUFGg8+n5zjo6hew==}
+    engines: {node: '>=22'}
+
   antlr4@4.9.3:
     resolution: {integrity: sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g==}
     engines: {node: '>=14'}
@@ -15905,6 +15909,11 @@ packages:
 
   npm-run-all2@9.0.2:
     resolution: {integrity: sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
+    hasBin: true
+
+  npm-run-all2@9.0.3:
+    resolution: {integrity: sha512-BQAEdU1PtYc48qYRdghW2BVTQT3VqWCoFQmO87NlM1h1PYwMCKQpUWaNyB20V26caNzFsXQDfyOdznLlHCih6g==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
     hasBin: true
 
@@ -27062,6 +27071,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansi-styles@7.0.0: {}
+
   antlr4@4.9.3: {}
 
   anymatch@3.1.3:
@@ -32597,6 +32608,17 @@ snapshots:
   npm-run-all2@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.4
+      pidtree: 1.0.0
+      read-package-json-fast: 6.0.0
+      shell-quote: 1.10.0
+      which: 7.0.0
+
+  npm-run-all2@9.0.3:
+    dependencies:
+      ansi-styles: 7.0.0
       cross-spawn: 7.0.6
       memorystream: 0.3.1
       picomatch: 4.0.4


### PR DESCRIPTION
Auto-generated dependency update for **npm-run-all2** `9.0.2` → `9.0.3`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 20

**Changelog analysis:**
> Patch release — no breaking changes expected.


<details><summary>Agent report</summary>

All tests pass. Here's the summary:

---

## Result: SUCCESS

**Package updated:** `npm-run-all2` `9.0.2` → `9.0.3`

**Packages updated (19):**
- annotation-generator, cds-annotation-parser, cds-odata-annotation-converter, control-property-editor-common, control-property-editor, fiori-annotation-api, fiori-docs-embeddings, fiori-mcp-server, i18n, odata-annotation-core-types, odata-annotation-core, odata-entity-model, odata-vocabularies, preview-middleware-client, preview-middleware, sap-systems-ext, ui-components, ui-prompting, xml-odata-annotation-converter

**Changesets created:** None required — `npm-run-all2` appears only in `devDependencies` across all packages (not a runtime dependency, not a bundled workspace package), so no changesets are needed per the AGENTS.md rules.

**Validation:** `pnpm validate:changesets` ✅

**Tests:** `@sap-ux/i18n` — 147 tests passed ✅

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.