### PR TITLE
chore(deps): bump @humanwhocodes/momoa 3.3.10 → 3.3.12

### DIFF
--- a/.changeset/eslint-plugin-fiori-tools-bump-humanwhocodes-momoa.md
+++ b/.changeset/eslint-plugin-fiori-tools-bump-humanwhocodes-momoa.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+BUMP: Upgrade @humanwhocodes/momoa 3.3.10 → 3.3.12

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -39,7 +39,7 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "0.14.0",
         "@eslint/plugin-kit": "0.6.1",
-        "@humanwhocodes/momoa": "^3.3.9",
+        "@humanwhocodes/momoa": "^3.3.12",
         "@jest/globals": "30.4.1",
         "@sap-ux/fiori-annotation-api": "workspace:*",
         "@sap-ux/odata-annotation-core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2055,8 +2055,8 @@ importers:
         specifier: 0.6.1
         version: 0.6.1
       '@humanwhocodes/momoa':
-        specifier: ^3.3.9
-        version: 3.3.10
+        specifier: ^3.3.12
+        version: 3.3.12
       '@jest/globals':
         specifier: 30.4.1
         version: 30.4.1(supports-color@8.1.1)
@@ -7293,8 +7293,8 @@ packages:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
-  '@humanwhocodes/momoa@3.3.10':
-    resolution: {integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==}
+  '@humanwhocodes/momoa@3.3.12':
+    resolution: {integrity: sha512-xS9xl4ieqTqhSZfKV3YXj/htwJCUxbgvkTVaK1fkESgrOzvoVSOTRQeQ8tTLOZUS0Csi2xqtJQXgVTRH5OEbHQ==}
     engines: {node: '>=18'}
 
   '@humanwhocodes/retry@0.4.3':
@@ -21785,7 +21785,7 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       '@eslint/plugin-kit': 0.4.1
-      '@humanwhocodes/momoa': 3.3.10
+      '@humanwhocodes/momoa': 3.3.12
       natural-compare: 1.4.0
 
   '@eslint/object-schema@2.1.7': {}
@@ -22019,7 +22019,7 @@ snapshots:
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
-  '@humanwhocodes/momoa@3.3.10': {}
+  '@humanwhocodes/momoa@3.3.12': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 


### PR DESCRIPTION
Auto-generated dependency update for **@humanwhocodes/momoa** `3.3.10` → `3.3.12`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 3

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

## SUCCESS

**Package updated:** `@sap-ux/eslint-plugin-fiori-tools`

**Changes made:**
| File | Change |
|------|--------|
| `packages/eslint-plugin-fiori-tools/package.json` | `@humanwhocodes/momoa` `^3.3.9` → `^3.3.12` |
| `pnpm-lock.yaml` | Regenerated via `pnpm install --no-frozen-lockfile` |
| `.changeset/eslint-plugin-fiori-tools-bump-humanwhocodes-momoa.md` | New changeset for `@sap-ux/eslint-plugin-fiori-tools` (patch) |

**Changeset validation:** ✅ `pnpm validate:changesets` passed

**Tests:** The 21 failing suites / 97 test failures are **pre-existing on the baseline branch** — identical counts before and after the bump. No regressions introduced.

**Notes:** `@humanwhocodes/momoa` is a `devDependency` of `@sap-ux/eslint-plugin-fiori-tools`, which is an esbuild-bundling package — so a changeset is required to trigger a rebuild and republish of the bundle (as per the cascade rules in `AGENTS.md`).

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.