### PR TITLE
chore(deps): bump @types/lodash 4.17.24 → 4.17.25

### DIFF
--- a/packages/abap-deploy-config-writer/package.json
+++ b/packages/abap-deploy-config-writer/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/axios-extension/package.json
+++ b/packages/axios-extension/package.json
@@ -46,7 +46,7 @@
         "@jest/globals": "30.4.1",
         "@sap-ux/vocabularies-types": "0.16.0",
         "@sap-ux/project-access": "workspace:*",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "nock": "14.0.16",
         "supertest": "7.2.2",
         "@types/proxy-from-env": "1.0.4"

--- a/packages/fiori-app-sub-generator/package.json
+++ b/packages/fiori-app-sub-generator/package.json
@@ -69,7 +69,7 @@
         "@sap-ux/jest-file-matchers": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/vscode": "1.110.0",

--- a/packages/fiori-elements-writer/package.json
+++ b/packages/fiori-elements-writer/package.json
@@ -55,7 +55,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/fiori-freestyle-writer/package.json
+++ b/packages/fiori-freestyle-writer/package.json
@@ -53,7 +53,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/flp-config-inquirer/package.json
+++ b/packages/flp-config-inquirer/package.json
@@ -45,7 +45,7 @@
         "@jest/globals": "30.4.1",
         "@sap-devx/yeoman-ui-types": "1.25.1",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "inquirer": "8.2.7"
     },
     "engines": {

--- a/packages/flp-config-sub-generator/package.json
+++ b/packages/flp-config-sub-generator/package.json
@@ -58,7 +58,7 @@
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "rimraf": "6.1.3",
         "unionfs": "4.6.0",
         "yeoman-test": "6.3.0"

--- a/packages/inquirer-common/package.json
+++ b/packages/inquirer-common/package.json
@@ -58,7 +58,7 @@
         "@sap-devx/yeoman-ui-types": "1.25.1",
         "@types/inquirer": "8.2.6",
         "@types/semver": "7.7.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "jest-extended": "7.0.0"
     },
     "engines": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
         "@types/debug": "4.1.13",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/vscode": "1.110.0",
         "jest-extended": "7.0.0",
         "logform": "2.7.0"

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -76,7 +76,7 @@
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "rimraf": "6.1.3",
         "unionfs": "4.6.0",
         "yeoman-environment": "3.19.3",

--- a/packages/ui5-application-inquirer/package.json
+++ b/packages/ui5-application-inquirer/package.json
@@ -46,7 +46,7 @@
         "@sap-ux/cap-config-writer": "workspace:*",
         "@types/inquirer-autocomplete-prompt": "2.0.2",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/semver": "7.7.1",
         "inquirer": "8.2.7"
     },

--- a/packages/ui5-application-writer/package.json
+++ b/packages/ui5-application-writer/package.json
@@ -47,7 +47,7 @@
         "@sap-ux/project-access": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/semver": "7.7.1",

--- a/packages/ui5-config/package.json
+++ b/packages/ui5-config/package.json
@@ -41,7 +41,7 @@
     },
     "devDependencies": {
         "@sap-ux/store": "workspace:*",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/semver": "7.7.1",
         "@types/js-yaml": "4.0.9"
     },

--- a/packages/ui5-library-writer/package.json
+++ b/packages/ui5-library-writer/package.json
@@ -49,7 +49,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "fs-extra": "11.3.6",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -42,7 +42,7 @@
         "yaml": "2.9.0"
     },
     "devDependencies": {
-        "@types/lodash": "4.17.24"
+        "@types/lodash": "4.17.25"
     },
     "engines": {
         "node": ">=22.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,8 +649,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -1050,8 +1050,8 @@ importers:
         specifier: 0.16.0
         version: 0.16.0
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/proxy-from-env':
         specifier: 1.0.4
         version: 1.0.4
@@ -2388,8 +2388,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2533,8 +2533,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2606,8 +2606,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2867,8 +2867,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       inquirer:
         specifier: 8.2.7
         version: 8.2.7(@types/node@22.20.1)
@@ -2925,8 +2925,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -3267,8 +3267,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -3394,8 +3394,8 @@ importers:
         specifier: 4.1.13
         version: 4.1.13
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/vscode':
         specifier: 1.110.0
         version: 1.110.0
@@ -4108,8 +4108,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -4919,8 +4919,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -4968,8 +4968,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -5011,8 +5011,8 @@ importers:
         specifier: 4.0.9
         version: 4.0.9
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -5300,8 +5300,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -5472,8 +5472,8 @@ importers:
         version: 2.9.0
     devDependencies:
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
 
   tests/fixtures/projects/mock:
     devDependencies:
@@ -10366,8 +10366,8 @@ packages:
   '@types/livereload@0.9.5':
     resolution: {integrity: sha512-2RXcRKdivPmn67pwjytvHoRv46AeXaLYVUWA0zkel1XSAOH5i71G0KfUdE5u3g80T155gR3Fo3ilVaqparLsVA==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -25841,7 +25841,7 @@ snapshots:
     dependencies:
       '@types/ws': 8.18.1
 
-  '@types/lodash@4.17.24': {}
+  '@types/lodash@4.17.25': {}
 
   '@types/markdown-it@14.1.2':
     dependencies:


### PR DESCRIPTION
Auto-generated dependency update for **@types/lodash** `4.17.24` → `4.17.25`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 16

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

All done. Here's the summary:

## SUCCESS

**Package:** `@types/lodash` 4.17.24 → 4.17.25

**Packages updated (15):**
- `@sap-ux/abap-deploy-config-writer`
- `@sap-ux/axios-extension`
- `@sap-ux/fiori-app-sub-generator`
- `@sap-ux/fiori-elements-writer`
- `@sap-ux/fiori-freestyle-writer`
- `@sap-ux/flp-config-inquirer`
- `@sap-ux/flp-config-sub-generator`
- `@sap-ux/inquirer-common`
- `@sap-ux/logger`
- `@sap-ux/repo-app-import-sub-generator`
- `@sap-ux/ui5-application-inquirer`
- `@sap-ux/ui5-application-writer`
- `@sap-ux/ui5-config`
- `@sap-ux/ui5-library-writer`
- `@sap-ux/yaml`

**Changesets created:** None required — `@types/lodash` appears exclusively in `devDependencies` across all packages (it's a type definition package, not a runtime dependency).

**Validation:** `pnpm validate:changesets` → ✅ All changesets validated successfully

**`pnpm install`:** Completed cleanly, lockfile regenerated (`+1 -1` package change).

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.