### PR TITLE
chore(deps): bump @vscode-logging/logger 2.0.9 → 2.0.10

### DIFF
--- a/.changeset/deploy-config-generator-shared-bump-vscode-logging-logger.md
+++ b/.changeset/deploy-config-generator-shared-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/deploy-config-generator-shared": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/.changeset/fiori-generator-shared-bump-vscode-logging-logger.md
+++ b/.changeset/fiori-generator-shared-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-generator-shared": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/.changeset/generator-odata-downloader-bump-vscode-logging-logger.md
+++ b/.changeset/generator-odata-downloader-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/generator-odata-downloader": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/packages/adp-flp-config-sub-generator/package.json
+++ b/packages/adp-flp-config-sub-generator/package.json
@@ -55,7 +55,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "yeoman-test": "6.3.0"

--- a/packages/deploy-config-generator-shared/package.json
+++ b/packages/deploy-config-generator-shared/package.json
@@ -32,7 +32,7 @@
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/nodejs-utils": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "i18next": "26.3.6",
         "yeoman-generator": "5.10.0"
     },

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -33,7 +33,7 @@
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/telemetry": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "i18next": "26.3.6",
         "logform": "2.7.0",
         "mem-fs": "2.1.0",

--- a/packages/flp-config-sub-generator/package.json
+++ b/packages/flp-config-sub-generator/package.json
@@ -54,7 +54,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-test": "4.0.6",
         "@sap-ux/nodejs-utils": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -68,7 +68,7 @@
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
         "@types/uuid": "11.0.0",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "yeoman-test": "6.3.0"

--- a/packages/generator-odata-downloader/package.json
+++ b/packages/generator-odata-downloader/package.json
@@ -62,7 +62,7 @@
         "@sap/ux-specification": "1.144.5",
         "@types/inquirer": "8.2.6",
         "@types/yeoman-generator": "5.2.14",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "deepmerge": "4.3.1",
         "i18next": "26.3.6",
         "inquirer": "8.2.7",

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -71,7 +71,7 @@
         "fs-extra": "11.3.6",
         "@sap-ux/store": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "@types/adm-zip": "0.5.8",
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",

--- a/packages/ui-service-sub-generator/package.json
+++ b/packages/ui-service-sub-generator/package.json
@@ -55,7 +55,7 @@
         "@types/mem-fs-editor": "7.0.1",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "jest-extended": "7.0.0",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",

--- a/packages/ui5-library-reference-sub-generator/package.json
+++ b/packages/ui5-library-reference-sub-generator/package.json
@@ -49,7 +49,7 @@
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
         "@types/vscode": "1.110.0",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "vscode-uri": "3.1.0",

--- a/packages/ui5-library-sub-generator/package.json
+++ b/packages/ui5-library-sub-generator/package.json
@@ -49,7 +49,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "jest-extended": "7.0.0",
         "mem-fs-editor": "9.4.0",
         "rimraf": "6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,8 +734,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -1765,8 +1765,8 @@ importers:
         specifier: workspace:*
         version: link:../nodejs-utils
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       i18next:
         specifier: 26.3.6
         version: 26.3.6(typescript@5.9.3)
@@ -2636,8 +2636,8 @@ importers:
         specifier: workspace:*
         version: link:../telemetry
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       i18next:
         specifier: 26.3.6
         version: 26.3.6(typescript@5.9.3)
@@ -2943,8 +2943,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -3052,8 +3052,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -3124,8 +3124,8 @@ importers:
         specifier: 5.2.14
         version: 5.2.14
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       deepmerge:
         specifier: 4.3.1
         version: 4.3.1
@@ -4126,8 +4126,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -4855,8 +4855,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       jest-extended:
         specifier: 7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -5153,8 +5153,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -5248,8 +5248,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       jest-extended:
         specifier: 7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -10922,11 +10922,11 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vscode-logging/logger@2.0.9':
-    resolution: {integrity: sha512-Kq7dmziSHej+6yADxoHCZU8Tspf7ucJeNjH+QPMAQlRfT0uaXlh1q5DpWnzSgznWIBrMc7lX82meThDKBxL+oA==}
+  '@vscode-logging/logger@2.0.10':
+    resolution: {integrity: sha512-Mg8aW5Bkim3p4vF2S+n5eEKzg/OBSdS9iom3GmmBUGtmZ07WlOROGYm+2i2sN0R05wnqoafuJbN9LeCwMuZIbw==}
 
-  '@vscode-logging/types@2.0.8':
-    resolution: {integrity: sha512-9mc5+Iob1BqJ00QExLwdz4+w0A1odSYjvzpKYfP0lVzr7Tdf4iWGspLADyTSC7DtJVQQ+tu411cBju+cYJxE/g==}
+  '@vscode-logging/types@2.0.10':
+    resolution: {integrity: sha512-Y8Qn0Xc7ej8BC+cbDAi5LUKJs3qMGni0zUGZgqhDrXq3sQS5SQ2KG4sk320Si2rdL/nqivJ/gaEAcxD61m1+3w==}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -26691,9 +26691,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vscode-logging/logger@2.0.9(supports-color@8.1.1)':
+  '@vscode-logging/logger@2.0.10(supports-color@8.1.1)':
     dependencies:
-      '@vscode-logging/types': 2.0.8
+      '@vscode-logging/types': 2.0.10
       fast-safe-stringify: 2.1.1
       fs-extra: 11.2.0
       lodash: 4.18.1
@@ -26705,7 +26705,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vscode-logging/types@2.0.8': {}
+  '@vscode-logging/types@2.0.10': {}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     optional: true


### PR DESCRIPTION
Auto-generated dependency update for **@vscode-logging/logger** `2.0.9` → `2.0.10`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 14

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

**SUCCESS**

## Summary

### Packages updated (10 total)

| Package | Section | Version |
|---|---|---|
| `@sap-ux/deploy-config-generator-shared` | `dependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/fiori-generator-shared` | `dependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/generator-odata-downloader` | `dependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/adp-flp-config-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/flp-config-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/generator-adp` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/repo-app-import-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/ui-service-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/ui5-library-reference-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |
| `@sap-ux/ui5-library-sub-generator` | `devDependencies` | 2.0.9 → 2.0.10 |

### Changesets created (3 — only runtime `dependencies`)
- `.changeset/deploy-config-generator-shared-bump-vscode-logging-logger.md`
- `.changeset/fiori-generator-shared-bump-vscode-logging-logger.md`
- `.changeset/generator-odata-downloader-bump-vscode-logging-logger.md`

### Validation
- `pnpm install --no-frozen-lockfile` ✅ — lockfile regenerated
- `pnpm validate:changesets` ✅ — "All changesets validated successfully" (no cascade changesets needed)
- Test failures observed are **pre-existing** (workspace packages like `@sap-ux/fiori-generator-shared` and `@sap-ux/telemetry` not built), not caused by this bump. No source-level breaking changes from `@vscode-logging/logger` 2.0.10 (patch release).

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.