### PR TITLE
chore(deps): bump css-loader 7.1.4 → 7.1.5

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -66,7 +66,7 @@
         "babel-jest": "30.4.1",
         "babel-loader": "10.1.1",
         "copyfiles": "2.4.1",
-        "css-loader": "7.1.4",
+        "css-loader": "7.1.5",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.8",
         "eslint": "9.39.1",

--- a/packages/ui-prompting/package.json
+++ b/packages/ui-prompting/package.json
@@ -60,7 +60,7 @@
         "babel-jest": "30.4.1",
         "babel-loader": "10.1.1",
         "copyfiles": "2.4.1",
-        "css-loader": "7.1.4",
+        "css-loader": "7.1.5",
         "eslint": "9.39.1",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-storybook": "0.6.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4540,8 +4540,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       css-loader:
-        specifier: 7.1.4
-        version: 7.1.4(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+        specifier: 7.1.5
+        version: 7.1.5(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       enzyme:
         specifier: 3.11.0
         version: 3.11.0
@@ -4658,8 +4658,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       css-loader:
-        specifier: 7.1.4
-        version: 7.1.4(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+        specifier: 7.1.5
+        version: 7.1.5(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       eslint:
         specifier: 9.39.1
         version: 9.39.1(supports-color@8.1.1)
@@ -12253,6 +12253,18 @@ packages:
 
   css-loader@7.1.4:
     resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      webpack: ^5.27.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
+  css-loader@7.1.5:
+    resolution: {integrity: sha512-Q7iAfQkU2twNBryKX/vGAlE+GAmkF7quhSzAGNK8fBimxk3+tqg245rH52UPb9dioBolBc8rP0ihmHBaDTJQBA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
@@ -25286,7 +25298,7 @@ snapshots:
       '@storybook/core-webpack': 10.5.1(storybook@10.5.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.11.2)(@types/react@16.14.69)(prettier@3.9.5)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
+      css-loader: 7.1.5(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       es-module-lexer: 1.7.0
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
       html-webpack-plugin: 5.6.6(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3))
@@ -28229,6 +28241,19 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.26)
       postcss-value-parser: 4.2.0
       semver: 7.7.4
+    optionalDependencies:
+      webpack: 5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
+
+  css-loader@7.1.5(webpack@5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
+      postcss-value-parser: 4.2.0
+      semver: 7.8.5
     optionalDependencies:
       webpack: 5.105.0(@swc/core@1.15.46(@swc/helpers@0.5.19))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(postcss@8.5.26)(uglify-js@3.19.3)
 


### PR DESCRIPTION
Auto-generated dependency update for **css-loader** `7.1.4` → `7.1.5`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 3

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

**SUCCESS**

## Summary

**Package:** `css-loader` 7.1.4 → 7.1.5

**Packages updated (devDependencies only):**
- `packages/ui-components/package.json`
- `packages/ui-prompting/package.json`

**Changesets created:** None — `css-loader` is a `devDependency` in both packages, so no changeset is required per the project conventions.

**Validation:** `pnpm validate:changesets` → ✅ All changesets validated successfully

**pnpm install:** Completed successfully, lockfile regenerated.

No source-level changes were needed (patch release, no breaking changes).

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.