### PR TITLE
chore(deps): bump tsx 4.23.1 → 4.23.13

### DIFF
--- a/packages/fiori-docs-embeddings/package.json
+++ b/packages/fiori-docs-embeddings/package.json
@@ -43,7 +43,7 @@
         "marked": "^12.0.0",
         "node-fetch": "^3.3.2",
         "npm-run-all2": "9.0.2",
-        "tsx": "4.23.1"
+        "tsx": "4.23.13"
     },
     "keywords": [
         "mcp",

--- a/packages/odata-vocabularies/package.json
+++ b/packages/odata-vocabularies/package.json
@@ -37,7 +37,7 @@
         "axios": "1.18.1",
         "npm-run-all2": "9.0.2",
         "prettier": "3.9.5",
-        "tsx": "4.23.1"
+        "tsx": "4.23.13"
     },
     "engines": {
         "node": ">=22.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2463,8 +2463,8 @@ importers:
         specifier: 9.0.2
         version: 9.0.2
       tsx:
-        specifier: 4.23.1
-        version: 4.23.1
+        specifier: 4.23.13
+        version: 4.23.13
 
   packages/fiori-elements-writer:
     dependencies:
@@ -3698,8 +3698,8 @@ importers:
         specifier: 3.9.5
         version: 3.9.5
       tsx:
-        specifier: 4.23.1
-        version: 4.23.1
+        specifier: 4.23.13
+        version: 4.23.13
 
   packages/playwright:
     dependencies:
@@ -18443,8 +18443,8 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -33716,7 +33716,7 @@ snapshots:
       socket.io: 4.8.3(supports-color@8.1.1)
       socket.io-client: 4.8.3(supports-color@8.1.1)
       text-extensions: 3.1.0
-      tsx: 4.23.1
+      tsx: 4.23.13
       undici: 7.29.0
       winston: 3.19.0
       ws: 8.21.0
@@ -35912,7 +35912,7 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.9.3
 
-  tsx@4.23.1:
+  tsx@4.23.13:
     dependencies:
       esbuild: 0.28.2
     optionalDependencies:


### PR DESCRIPTION
Auto-generated dependency update for **tsx** `4.23.1` → `4.23.13`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 3

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

All tests pass. Here's the summary:

---

## ✅ SUCCESS

**Package bumped:** `tsx` `4.23.1` → `4.23.13`

**Packages updated (2):**
- `@sap-ux/fiori-docs-embeddings` — `devDependencies`
- `@sap-ux/odata-vocabularies` — `devDependencies`

**Changesets created:** None required  
Both packages use `tsx` only as a `devDependency`, and neither is an esbuild-bundling package — per project conventions, `devDependency`-only updates don't require changesets.

**`pnpm validate:changesets`:** ✅ All changesets validated successfully  
**Tests (`@sap-ux/odata-vocabularies`):** ✅ 78 passed, 1 skipped, 92.89% coverage

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.