### PR TITLE
chore(deps): bump vscode-languageserver-textdocument 1.0.12 → 1.0.14

### DIFF
--- a/.changeset/eslint-plugin-fiori-tools-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/eslint-plugin-fiori-tools-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/fiori-annotation-api and @sap-ux/i18n

--- a/.changeset/fiori-annotation-api-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/fiori-annotation-api-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-annotation-api": patch
+---
+
+BUMP: Upgrade vscode-languageserver-textdocument 1.0.12 → 1.0.14

--- a/.changeset/fiori-mcp-server-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/fiori-mcp-server-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/fiori-annotation-api and @sap-ux/i18n

--- a/.changeset/i18n-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/i18n-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/i18n": patch
+---
+
+BUMP: Upgrade vscode-languageserver-textdocument 1.0.12 → 1.0.14

--- a/.changeset/sap-systems-ext-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/sap-systems-ext-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"sap-ux-sap-systems-ext": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/i18n

--- a/packages/fiori-annotation-api/package.json
+++ b/packages/fiori-annotation-api/package.json
@@ -40,7 +40,7 @@
         "@xml-tools/parser": "1.0.11",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
-        "vscode-languageserver-textdocument": "1.0.12"
+        "vscode-languageserver-textdocument": "1.0.14"
     },
     "devDependencies": {
         "@jest/globals": "30.4.1",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "jsonc-parser": "3.3.1",
-        "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-languageserver-textdocument": "1.0.14",
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -41,7 +41,7 @@
         "npm-run-all2": "9.0.2",
         "@jest/globals": "30.4.1",
         "ui5-tooling-transpile": "3.11.3",
-        "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-languageserver-textdocument": "1.0.14",
         "@ui5/manifest": "1.89.0"
     },
     "browserslist": "defaults"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2257,8 +2257,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
     devDependencies:
       '@jest/globals':
         specifier: 30.4.1
@@ -3166,8 +3166,8 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
     devDependencies:
       '@jest/globals':
         specifier: 30.4.1
@@ -3878,8 +3878,8 @@ importers:
         specifier: 3.11.3
         version: 3.11.3(supports-color@8.1.1)
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
 
   packages/project-access:
     dependencies:
@@ -18856,6 +18856,9 @@ packages:
 
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-textdocument@1.0.14:
+    resolution: {integrity: sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==}
 
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
@@ -36402,6 +36405,8 @@ snapshots:
   void-elements@3.1.0: {}
 
   vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-textdocument@1.0.14: {}
 
   vscode-languageserver-types@3.17.5: {}
 


### PR DESCRIPTION
Auto-generated dependency update for **vscode-languageserver-textdocument** `1.0.12` → `1.0.14`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 9

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

All tests pass. Here's the summary:

---

## SUCCESS

**Package updated:** `vscode-languageserver-textdocument` `1.0.12` → `1.0.14`

### Packages updated (3)
| Package | Section |
|---|---|
| `@sap-ux/fiori-annotation-api` | `dependencies` |
| `@sap-ux/i18n` | `dependencies` |
| `@sap-ux-private/preview-middleware-client` | `devDependencies` |

### Changesets created (5)
| File | Package |
|---|---|
| `.changeset/fiori-annotation-api-bump-vscode-languageserver-textdocument.md` | `@sap-ux/fiori-annotation-api` |
| `.changeset/i18n-bump-vscode-languageserver-textdocument.md` | `@sap-ux/i18n` |
| `.changeset/fiori-mcp-server-bump-vscode-languageserver-textdocument.md` | `@sap-ux/fiori-mcp-server` (cascade) |
| `.changeset/eslint-plugin-fiori-tools-bump-vscode-languageserver-textdocument.md` | `@sap-ux/eslint-plugin-fiori-tools` (cascade) |
| `.changeset/sap-systems-ext-bump-vscode-languageserver-textdocument.md` | `sap-ux-sap-systems-ext` (cascade) |

> Note: `preview-middleware-client` only uses the package as a `devDependency` so no changeset was needed for it.

### Test results
- `@sap-ux/fiori-annotation-api`: **693 tests passed** ✅
- `@sap-ux/i18n`: **147 tests passed** ✅
- `pnpm validate:changesets`: **✅ All changesets validated successfully**

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.