### PR TITLE
chore(deps): bump vscode-languageserver-types 3.18.0 → 3.18.3

### DIFF
--- a/.changeset/eslint-plugin-bump-vscode-languageserver-types.md
+++ b/.changeset/eslint-plugin-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/text-document-utils

--- a/.changeset/fiori-mcp-server-bump-vscode-languageserver-types.md
+++ b/.changeset/fiori-mcp-server-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/text-document-utils

--- a/.changeset/sap-systems-ext-bump-vscode-languageserver-types.md
+++ b/.changeset/sap-systems-ext-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"sap-ux-sap-systems-ext": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/text-document-utils

--- a/.changeset/text-document-utils-bump-vscode-languageserver-types.md
+++ b/.changeset/text-document-utils-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/text-document-utils": patch
+---
+
+BUMP: Upgrade vscode-languageserver-types 3.18.0 → 3.18.3

--- a/packages/text-document-utils/package.json
+++ b/packages/text-document-utils/package.json
@@ -42,6 +42,6 @@
         "node": ">=22.x"
     },
     "dependencies": {
-        "vscode-languageserver-types": "3.18.0"
+        "vscode-languageserver-types": "3.18.3"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4455,8 +4455,8 @@ importers:
   packages/text-document-utils:
     dependencies:
       vscode-languageserver-types:
-        specifier: 3.18.0
-        version: 3.18.0
+        specifier: 3.18.3
+        version: 3.18.3
 
   packages/ui-components:
     dependencies:
@@ -18860,8 +18860,8 @@ packages:
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
-  vscode-languageserver-types@3.18.0:
-    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+  vscode-languageserver-types@3.18.3:
+    resolution: {integrity: sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -36405,7 +36405,7 @@ snapshots:
 
   vscode-languageserver-types@3.17.5: {}
 
-  vscode-languageserver-types@3.18.0: {}
+  vscode-languageserver-types@3.18.3: {}
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
Auto-generated dependency update for **vscode-languageserver-types** `3.18.0` → `3.18.3`.

**Packages updated:** 0
**Changesets created:** 0
**Files changed:** 6

**Changelog analysis:**
> Patch release — no breaking changes expected.

<details><summary>Agent report</summary>

All tests pass. Here's the summary:

## SUCCESS

**Package updated:** 1
- `@sap-ux/text-document-utils`: `vscode-languageserver-types` 3.18.0 → 3.18.3

**Changesets created:** 4
| File | Package | Reason |
|------|---------|--------|
| `.changeset/text-document-utils-bump-vscode-languageserver-types.md` | `@sap-ux/text-document-utils` | Direct dependency bump |
| `.changeset/fiori-mcp-server-bump-vscode-languageserver-types.md` | `@sap-ux/fiori-mcp-server` | esbuild bundle cascade (direct devDep) |
| `.changeset/sap-systems-ext-bump-vscode-languageserver-types.md` | `sap-ux-sap-systems-ext` | esbuild bundle cascade (transitive) |
| `.changeset/eslint-plugin-bump-vscode-languageserver-types.md` | `@sap-ux/eslint-plugin-fiori-tools` | esbuild bundle cascade (transitive) |

**Validation:** `pnpm validate:changesets` ✅  
**Tests:** 62 passed, 94.54% coverage ✅  
**Source-level changes:** None required (patch release, no breaking changes)

</details>

> Draft PR — human review required. Run `pnpm build && pnpm test` before merging.