### PR TITLE
fix: prevent YUI webview crash on service selection step

### DIFF
--- a/.changeset/fix-icli-vscode-pid.md
+++ b/.changeset/fix-icli-vscode-pid.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-generator-shared": patch
+---
+
+FIX: Prevent isCli() returning true inside VS Code extension host on Windows/Node 24.x by checking VSCODE_PID environment variable

--- a/.changeset/fix-service-selection-null-crash.md
+++ b/.changeset/fix-service-selection-null-crash.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/odata-service-inquirer": patch
+---
+
+FIX: Guard against null service in validate when useAutoComplete is true; prevents crash when YUI calls validate before any service is selected

--- a/packages/fiori-generator-shared/src/environment.ts
+++ b/packages/fiori-generator-shared/src/environment.ts
@@ -7,6 +7,11 @@ import { hostEnvironment, type HostEnvironmentId } from './types/index.js';
  * @returns true if it is a cli environment, false otherwise
  */
 export function isCli(): boolean {
+    // VSCODE_PID is set by VS Code in its extension host; process.stdin.isTTY can be true
+    // on Windows with Node 24.x even inside VS Code, so exclude this case from CLI detection
+    if (process.env.VSCODE_PID) {
+        return false;
+    }
     if (process.argv[1]?.includes('yo') || process.stdin.isTTY) {
         return true;
     } else {

--- a/packages/fiori-generator-shared/test/environment.test.ts
+++ b/packages/fiori-generator-shared/test/environment.test.ts
@@ -35,6 +35,14 @@ describe('environment utils', () => {
         process.stdin.destroy();
     });
 
+    it('should return false when VSCODE_PID is set even if process.stdin.isTTY is true', () => {
+        process.env.VSCODE_PID = '12345';
+        process.stdin.isTTY = true;
+        process.argv[1] = 'path/to/mock';
+        expect(isCli()).toBe(false);
+        delete process.env.VSCODE_PID;
+    });
+
     it('should return true for cli', () => {
         mockCli(true);
         expect(isCli()).toBe(true);

--- a/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
+++ b/packages/odata-service-inquirer/src/prompts/datasources/sap-system/service-selection/questions.ts
@@ -163,7 +163,7 @@ export function getSystemServiceQuestion(
         ): Promise<string | boolean | ValidationLink> => {
             let serviceAnswer = service as ServiceAnswer;
             // Autocomplete passes the entire choice object as the answer, so we need to extract the value
-            if (promptOptions?.useAutoComplete && (service as ListChoiceOptions).value) {
+            if (promptOptions?.useAutoComplete && service != null && (service as ListChoiceOptions).value) {
                 serviceAnswer = (service as ListChoiceOptions).value;
             }
 

--- a/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/questions.test.ts
+++ b/packages/odata-service-inquirer/test/unit/prompts/sap-system/service-selection/questions.test.ts
@@ -734,6 +734,19 @@ describe('Test new system prompt', () => {
         expect(mockValidateService).toHaveBeenCalledWith(flightChoice?.value, connectionValidatorMock, undefined);
     });
 
+    test('Should not throw when validate is called with null (YUI calls validate before selection is made)', async () => {
+        const connectValidator = new ConnectionValidatorClass();
+        connectionValidatorMock.validatedUrl = 'http://some.abap.system:1234';
+        const systemServiceQuestions = getSystemServiceQuestion(connectValidator, promptNamespace, {
+            useAutoComplete: true
+        });
+        const serviceSelectionPrompt = systemServiceQuestions.find(
+            (question) => question.name === `${promptNamespace}:${promptNames.serviceSelection}`
+        );
+        // YUI calls validate with null before any service is selected — must not throw
+        await expect((serviceSelectionPrompt?.validate as Function)(null)).resolves.not.toThrow();
+    });
+
     test('Should apply `additionalMessages` prompt option', async () => {
         const connectValidator = new ConnectionValidatorClass();
         connectionValidatorMock.catalogs = {


### PR DESCRIPTION
## Summary

Fixes #5152 — VS Code Yeoman-UI webview crashes immediately on service selection step (on-prem and BTP), while CLI works fine.

**Root cause:**
- `isCli()` in `fiori-generator-shared` checks `process.stdin.isTTY` to detect CLI context. On Windows with Node 24.x, VS Code's extension host has `process.stdin.isTTY === true`, so `isCli()` incorrectly returns `true` inside VS Code.
- This causes `useAutoComplete: true` for the `serviceSelection` prompt (should be `false` in YUI).
- With `useAutoComplete: true`, prompt type becomes `autocomplete`. YUI calls `validate(null)` on first render before any selection, hitting `(null as ListChoiceOptions).value` → `TypeError: Cannot read properties of null (reading 'value')`.

**Two fixes:**
1. **Defensive fix** (`odata-service-inquirer`): guard `service != null` before accessing `.value` in `validate` — prevents crash regardless of environment detection.
2. **Root cause fix** (`fiori-generator-shared`): `isCli()` now checks `VSCODE_PID` env var and returns `false` early, preventing the `process.stdin.isTTY` false positive.

**Reference:** `VSCODE_PID` is set by VS Code's electron main process and inherited by all child processes including the extension host:
https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/main.ts#L477

## Test plan

- [ ] New test: `validate(null)` with `useAutoComplete: true` resolves without throwing
- [ ] New test: `isCli()` returns `false` when `VSCODE_PID` is set, even with `process.stdin.isTTY === true`
- [ ] Both package test suites pass
- [ ] Manual verification: open App Generator in VS Code on Windows, select ABAP On Premise, log in — service selection step should no longer crash