### PR TITLE
fix: When we select system we must not pass credentials from the answers to the abap provider.

### DIFF
--- a/.changeset/public-doodles-shake.md
+++ b/.changeset/public-doodles-shake.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/generator-adp': patch
+---
+
+fix: When we select system we must not pass credentials from the answers to the abap provider.

--- a/packages/generator-adp/src/app/questions/configuration.ts
+++ b/packages/generator-adp/src/app/questions/configuration.ts
@@ -315,7 +315,7 @@ export class ConfigPrompter {
                 hint: t('prompts.systemTooltip')
             },
             default: '',
-            validate: async (value: string, answers: ConfigAnswers) => await this.validateSystem(value, answers),
+            validate: (value: string) => this.validateSystem(value),
             additionalMessages: () => {
                 this.systemAdditionalMessage = getSystemAdditionalMessages(
                     this.flexUICapability,
@@ -334,12 +334,12 @@ export class ConfigPrompter {
     private getSystemValidationPromptForCli() {
         return {
             name: configPromptNames.systemValidationCli,
-            when: async (answers: ConfigAnswers): Promise<boolean> => {
-                if (!answers.system) {
+            when: async ({ system }: ConfigAnswers): Promise<boolean> => {
+                if (!system) {
                     return false;
                 }
 
-                const result = await this.validateSystem(answers.system, answers);
+                const result = await this.validateSystem(system);
                 if (typeof result === 'string') {
                     throw new Error(result);
                 }
@@ -785,10 +785,9 @@ export class ConfigPrompter {
      * loading the available applications.
      *
      * @param {string} system - The selected system.
-     * @param {ConfigAnswers} answers - The configuration answers provided by the user.
      * @returns An error message if validation fails, or true if the system selection is valid.
      */
-    private async validateSystem(system: string, answers: ConfigAnswers): Promise<string | boolean> {
+    private async validateSystem(system: string): Promise<string | boolean> {
         const validationResult = validateEmptyString(system);
         if (typeof validationResult === 'string') {
             return validationResult;

--- a/packages/generator-adp/src/app/questions/configuration.ts
+++ b/packages/generator-adp/src/app/questions/configuration.ts
@@ -794,19 +794,16 @@ export class ConfigPrompter {
             return validationResult;
         }
 
-        const options = {
-            system,
-            client: undefined,
-            username: answers.username,
-            password: answers.password
-        };
-
         try {
             this.targetApps = [];
             this.flexUICapability = undefined;
             this.selectedProjectType = undefined;
             this.selectedSystemType = undefined;
             this.supportedProject = undefined;
+            const options = {
+                system,
+                client: undefined
+            };
             this.abapProvider = await getConfiguredProvider(options, this.logger);
             this.isAuthRequired = (await this.getIsAuthRequired(system)) ?? false;
 

--- a/packages/generator-adp/test/unit/questions/configuration.test.ts
+++ b/packages/generator-adp/test/unit/questions/configuration.test.ts
@@ -207,6 +207,19 @@ describe('ConfigPrompter Integration Tests', () => {
             });
         });
 
+        it('system prompt validate should call getConfiguredProvider without username and password', async () => {
+            const prompts = configPrompter.getPrompts();
+            const systemPrompt = prompts.find((p) => p.name === configPromptNames.system);
+            expect(systemPrompt).toBeDefined();
+
+            await systemPrompt?.validate?.(dummyAnswers.system, dummyAnswers);
+
+            expect(mockGetConfiguredProvider).toHaveBeenCalledWith(
+                { system: dummyAnswers.system, client: undefined },
+                expect.anything()
+            );
+        });
+
         it('system prompt validate should set ui5 properties when system ui5 version is NOT detected', async () => {
             const prompts = configPrompter.getPrompts();
             const systemPrompt = prompts.find((p) => p.name === configPromptNames.system);


### PR DESCRIPTION
#5154

When we validate the system choice each time we create an abap provider which points to that system. If we include the credentials from the answers they will be passed to the next system of choice in case the first system requires authentication. We need to pass the credentials only when we validate the password prompt, where the actual login happens.

### Testing done
Manually verified on BAS/VSCode when we login to a system with dummy credentials which lead to error 401 and switch ti an authenticated system(the destination or the vscode system item have credentials injected) then the authenticated system loads the list of applications.

Before
<img width="957" height="657" alt="stale-password-before" src="https://github.com/user-attachments/assets/394bca9e-ab73-4454-b424-2c577436a788" />

After
<img width="957" height="657" alt="stale-password-after" src="https://github.com/user-attachments/assets/67bd944c-6ced-41cc-89ae-21d1e762519f" />


