### PR TITLE
fix(fiori-mcp): Propagate authenticationType from BackendSystem to Fiori generator config

### DIFF
--- a/.changeset/fiori-app-sub-generator-authentication-type.md
+++ b/.changeset/fiori-app-sub-generator-authentication-type.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-app-sub-generator": patch
+---
+
+FIX: thread authenticationType into connectedSystem backendSystem in service defaults

--- a/.changeset/fiori-generator-shared-authentication-type.md
+++ b/.changeset/fiori-generator-shared-authentication-type.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-generator-shared": patch
+---
+
+FIX: add authenticationType field to AppConfig service type

--- a/.changeset/fiori-mcp-authentication-type.md
+++ b/.changeset/fiori-mcp-authentication-type.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+FIX: propagate authenticationType from BackendSystem into the generator config written to disk

--- a/packages/fiori-app-sub-generator/src/app-headless/transforms.ts
+++ b/packages/fiori-app-sub-generator/src/app-headless/transforms.ts
@@ -147,7 +147,12 @@ function _setServiceDefaults(floorplan: AppConfig['floorplan'], service?: AppCon
         client: service?.client,
         edmx: service?.edmx,
         version,
-        valueListMetadata: service?.externalServices
+        valueListMetadata: service?.externalServices,
+        connectedSystem: {
+            backendSystem: {
+                authenticationType: service?.authenticationType
+            }
+        }
     } as Service;
 
     if (service?.destination) {

--- a/packages/fiori-app-sub-generator/test/unit/app-headless/transforms.test.ts
+++ b/packages/fiori-app-sub-generator/test/unit/app-headless/transforms.test.ts
@@ -1,6 +1,7 @@
 import { t } from '../../../src/utils/i18n.js';
 import { transformExtState } from '../../../src/app-headless/transforms.js';
 import type { FFAppConfig } from '../../../src/types/index.js';
+import { AuthenticationType } from '@sap-ux/store';
 import {
     appConfigInvalidCapServiceName,
     appConfigInvalidEdmx,
@@ -49,6 +50,7 @@ describe('Test headless', () => {
             },
             service: {
                 client: undefined,
+                connectedSystem: { backendSystem: { authenticationType: undefined } },
                 destinationName: 'SomeDestinationName',
                 edmx: expect.stringContaining(
                     '<?xml version="1.0" encoding="utf-8" ?><edmx:DataServices m:DataServiceVersion="2.0"></edmx:DataServices><edmx:Edmx Version="1.0"'
@@ -66,6 +68,7 @@ describe('Test headless', () => {
         const state = transformExtState(appConfigWithValueListMetadata as unknown as FFAppConfig);
         expect(state.service).toEqual({
             client: undefined,
+            connectedSystem: { backendSystem: { authenticationType: undefined } },
             destinationName: 'SomeDestinationName',
             edmx: expect.stringContaining('<?xml version="1.0" encoding="utf-8" ?>'),
             host: undefined,
@@ -110,5 +113,14 @@ describe('Test headless', () => {
         };
         const state = transformExtState(appConfigWithVirtualEndpointsEnabled as unknown as FFAppConfig);
         expect(state.project.enableVirtualEndpoints).toBe(true);
+    });
+
+    test('authenticationType is threaded into connectedSystem when provided', () => {
+        const appConfigWithAuth = {
+            ...appConfigDest,
+            service: { ...appConfigDest.service, authenticationType: AuthenticationType.Basic }
+        };
+        const state = transformExtState(appConfigWithAuth as unknown as FFAppConfig);
+        expect(state.service?.connectedSystem?.backendSystem?.authenticationType).toBe(AuthenticationType.Basic);
     });
 });

--- a/packages/fiori-generator-shared/src/types/headless.ts
+++ b/packages/fiori-generator-shared/src/types/headless.ts
@@ -2,7 +2,7 @@ import { Authentication } from '@sap-ux/btp-utils';
 import type { Annotations, EntitySetData, ExternalService } from '@sap-ux/axios-extension';
 import type { FloorplanKey } from './app-gen.js';
 import type { CapRuntime } from './cap.js';
-import { AuthenticationType } from '@sap-ux/store';
+import type { AuthenticationType } from '@sap-ux/store';
 
 /**
  * Shared types used by headless generation from multiple modules

--- a/packages/fiori-generator-shared/src/types/headless.ts
+++ b/packages/fiori-generator-shared/src/types/headless.ts
@@ -2,6 +2,7 @@ import { Authentication } from '@sap-ux/btp-utils';
 import type { Annotations, EntitySetData, ExternalService } from '@sap-ux/axios-extension';
 import type { FloorplanKey } from './app-gen.js';
 import type { CapRuntime } from './cap.js';
+import { AuthenticationType } from '@sap-ux/store';
 
 /**
  * Shared types used by headless generation from multiple modules
@@ -125,6 +126,7 @@ export interface AppConfig {
         readonly scp?: boolean; // If available key store entry must be available or provided at app runtime
         readonly destination?: string;
         readonly destinationInstance?: string;
+        readonly authenticationType?: AuthenticationType; // Required to write correct ui5.yaml authenticationType
         readonly edmx?: string;
         readonly annotations?: Annotations | Annotations[];
         readonly capService?: {

--- a/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
@@ -10,6 +10,7 @@ import type { Annotations, ExternalService, ServiceProvider } from '@sap-ux/axio
 import { createForDestination, AbapServiceProvider, ODataVersion } from '@sap-ux/axios-extension';
 import { createAbapServiceProvider, findSystem } from './services/sap-system.js';
 import { WebIDEUsage } from '@sap-ux/btp-utils';
+import { BackendSystem } from '@sap-ux/store';
 
 async function executeOData(validated: GeneratorConfigOData, appPath: string): Promise<GenerateAppOutput> {
     const generatorConfigValidated: GeneratorConfigOData = validateWithSchema(generatorConfigOData, validated);
@@ -47,7 +48,7 @@ async function executeOData(validated: GeneratorConfigOData, appPath: string): P
     try {
         if (generatorConfig.service) {
             const { servicePath, host, client, destination } = generatorConfig.service;
-            const { edmx, externalServices, annotations } = await resolveServiceMetadata(
+            const { edmx, externalServices, annotations, authenticationType } = await resolveServiceMetadata(
                 metadataPath,
                 servicePath,
                 host,
@@ -57,6 +58,7 @@ async function executeOData(validated: GeneratorConfigOData, appPath: string): P
             generatorConfig.service.edmx = edmx;
             generatorConfig.service.externalServices = externalServices;
             generatorConfig.service.annotations = annotations;
+            generatorConfig.service.authenticationType = authenticationType;
         }
 
         const content = JSON.stringify(generatorConfig, null, 4);
@@ -133,7 +135,7 @@ async function resolveServiceMetadata(
     host: string,
     client?: string,
     destination?: string
-): Promise<Pick<NonNullable<GeneratorConfigODataWithAPI['service']>, 'edmx' | 'externalServices' | 'annotations'>> {
+): Promise<Pick<NonNullable<GeneratorConfigODataWithAPI['service']>, 'edmx' | 'externalServices' | 'annotations' | 'authenticationType'>> {
     const metadata = await FSpromises.readFile(metadataPath, { encoding: 'utf8' });
 
     if (!host && !destination) {
@@ -141,8 +143,9 @@ async function resolveServiceMetadata(
     }
 
     let serviceProvider: AbapServiceProvider | undefined;
+    let backendSystem: BackendSystem | undefined;
     try {
-        serviceProvider = await getAbapServiceProvider(host, client, destination);
+        ({ serviceProvider, backendSystem } = await getAbapServiceProvider(host, client, destination) ?? {});
     } catch (error) {
         logger.error(
             `Error creating the ABAP service provider: ${error instanceof Error ? error.message : String(error)}`
@@ -160,7 +163,8 @@ async function resolveServiceMetadata(
     return {
         edmx: metadata,
         externalServices: await getExternalServiceMetadata(serviceProvider, servicePath, metadata),
-        annotations: await getServiceAnnotations(serviceProvider, servicePath, metadata)
+        annotations: await getServiceAnnotations(serviceProvider, servicePath, metadata),
+        authenticationType: backendSystem?.authenticationType ?? undefined
     };
 }
 
@@ -267,8 +271,9 @@ async function getAbapServiceProvider(
     host: string,
     client?: string,
     destinationName?: string
-): Promise<AbapServiceProvider | undefined> {
+): Promise<{ serviceProvider?: AbapServiceProvider; backendSystem?: BackendSystem; } | undefined> {
     let serviceProvider: ServiceProvider | undefined;
+    let backendSystem: BackendSystem | undefined;
     if (destinationName) {
         // To avoid an additional call to listDestinations, we create a destination provider directly with the given name.
         const destination = { Name: destinationName, WebIDEUsage: WebIDEUsage.ODATA_ABAP };
@@ -285,6 +290,7 @@ async function getAbapServiceProvider(
         const { system } = await findSystem(findSystemQuery);
         if (system) {
             serviceProvider = createAbapServiceProvider(system);
+            backendSystem = system;
         } else {
             const clientInfo = client ? ` and client: ${client}` : '';
             logger.error(`Failed to find system for host: ${host}${clientInfo}`);
@@ -297,5 +303,5 @@ async function getAbapServiceProvider(
         return undefined;
     }
 
-    return serviceProvider;
+    return { serviceProvider, backendSystem };
 }

--- a/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
@@ -135,7 +135,12 @@ async function resolveServiceMetadata(
     host: string,
     client?: string,
     destination?: string
-): Promise<Pick<NonNullable<GeneratorConfigODataWithAPI['service']>, 'edmx' | 'externalServices' | 'annotations' | 'authenticationType'>> {
+): Promise<
+    Pick<
+        NonNullable<GeneratorConfigODataWithAPI['service']>,
+        'edmx' | 'externalServices' | 'annotations' | 'authenticationType'
+    >
+> {
     const metadata = await FSpromises.readFile(metadataPath, { encoding: 'utf8' });
 
     if (!host && !destination) {
@@ -145,7 +150,7 @@ async function resolveServiceMetadata(
     let serviceProvider: AbapServiceProvider | undefined;
     let backendSystem: BackendSystem | undefined;
     try {
-        ({ serviceProvider, backendSystem } = await getAbapServiceProvider(host, client, destination) ?? {});
+        ({ serviceProvider, backendSystem } = (await getAbapServiceProvider(host, client, destination)) ?? {});
     } catch (error) {
         logger.error(
             `Error creating the ABAP service provider: ${error instanceof Error ? error.message : String(error)}`
@@ -271,7 +276,7 @@ async function getAbapServiceProvider(
     host: string,
     client?: string,
     destinationName?: string
-): Promise<{ serviceProvider?: AbapServiceProvider; backendSystem?: BackendSystem; } | undefined> {
+): Promise<{ serviceProvider?: AbapServiceProvider; backendSystem?: BackendSystem } | undefined> {
     let serviceProvider: ServiceProvider | undefined;
     let backendSystem: BackendSystem | undefined;
     if (destinationName) {

--- a/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
@@ -10,7 +10,7 @@ import type { Annotations, ExternalService, ServiceProvider } from '@sap-ux/axio
 import { createForDestination, AbapServiceProvider, ODataVersion } from '@sap-ux/axios-extension';
 import { createAbapServiceProvider, findSystem } from './services/sap-system.js';
 import { WebIDEUsage } from '@sap-ux/btp-utils';
-import { BackendSystem } from '@sap-ux/store';
+import type { BackendSystem } from '@sap-ux/store';
 
 async function executeOData(validated: GeneratorConfigOData, appPath: string): Promise<GenerateAppOutput> {
     const generatorConfigValidated: GeneratorConfigOData = validateWithSchema(generatorConfigOData, validated);
@@ -164,7 +164,7 @@ async function resolveServiceMetadata(
         edmx: metadata,
         externalServices: await getExternalServiceMetadata(serviceProvider, servicePath, metadata),
         annotations: await getServiceAnnotations(serviceProvider, servicePath, metadata),
-        authenticationType: backendSystem?.authenticationType ?? undefined
+        authenticationType: backendSystem?.authenticationType
     };
 }
 

--- a/packages/fiori-mcp-server/src/tools/schemas/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/schemas/generate-fiori-app-odata.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { convertToSchema } from '../../utils/index.js';
 import { entityConfig, floorplan, project, serviceOdata as service } from './appgen-config-schema-props.js';
 import type { Annotations, ExternalService } from '@sap-ux/axios-extension';
-import { AuthenticationType } from '@sap-ux/store';
+import type { AuthenticationType } from '@sap-ux/store';
 
 export const generatorConfigOData = z.object({
     entityConfig: entityConfig.optional(),

--- a/packages/fiori-mcp-server/src/tools/schemas/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/schemas/generate-fiori-app-odata.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { convertToSchema } from '../../utils/index.js';
 import { entityConfig, floorplan, project, serviceOdata as service } from './appgen-config-schema-props.js';
 import type { Annotations, ExternalService } from '@sap-ux/axios-extension';
+import { AuthenticationType } from '@sap-ux/store';
 
 export const generatorConfigOData = z.object({
     entityConfig: entityConfig.optional(),
@@ -35,6 +36,7 @@ export type GeneratorConfigODataWithAPI = GeneratorConfigOData &
             edmx?: string;
             externalServices?: (ExternalService & { metadata: string })[];
             annotations?: Annotations;
+            authenticationType?: AuthenticationType;
         };
     };
 

--- a/packages/fiori-mcp-server/test/unit/tools/generate-fiori-app-odata-external-services.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/generate-fiori-app-odata-external-services.test.ts
@@ -467,6 +467,20 @@ describe('generateFioriAppOData - External Services', () => {
             expect(result.status).toBe('Success');
         });
 
+        test('should write authenticationType from backendSystem into the generator config', async () => {
+            // Given: A system with an authenticationType
+            const mockSystem = { url: 'https://example.com', authenticationType: 'basic' };
+            mockFindSystem.mockResolvedValue({ system: mockSystem });
+            mockCreateAbapServiceProvider.mockReturnValue(new MockAbapServiceProvider());
+
+            // When: Generating the app
+            await generateFioriAppOData(validArgs);
+
+            // Then: authenticationType from the found system is written into the config
+            const configContent = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
+            expect(configContent.service.authenticationType).toBe('basic');
+        });
+
         test('should create the ABAP service provider only once and reuse it for external services and annotations', async () => {
             // Given: A V2 service with BOTH external service references and backend annotations
             mockGetExternalServiceReferences.mockReturnValue([{ type: 'value-list' }]);


### PR DESCRIPTION
## Summary

Internal issue: 39322

- Add `authenticationType` field to `AppConfig.service` in `fiori-generator-shared`
- Pass `authenticationType` from resolved `BackendSystem` through `resolveServiceMetadata` and assign it to `generatorConfig.service` before writing config to disk
- Thread `authenticationType` into `connectedSystem.backendSystem` in `_setServiceDefaults`

Fixes #39322

## Test plan

- [ ] `transforms.test.ts`: updated two existing `toEqual` expectations to include `connectedSystem`; added test confirming `authenticationType` threads through
- [ ] `generate-fiori-app-odata-external-services.test.ts`: added test confirming `authenticationType` from `BackendSystem` lands in written config JSON
- [ ] `pnpm lint` passes on all three changed packages
- [ ] `pnpm test` passes on all three changed packages