### PR TITLE
fix(axios-extension): Add waitForFirst option to fetchExternalServices with auth-failure early exit

### DIFF
--- a/.changeset/axios-extension-fetch-external-services-wait-for-first.md
+++ b/.changeset/axios-extension-fetch-external-services-wait-for-first.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/axios-extension": patch
+---
+
+FIX: add waitForFirst option to fetchExternalServices to abort on auth failure

--- a/.changeset/sap-systems-ext-cascade-axios-extension.md
+++ b/.changeset/sap-systems-ext-cascade-axios-extension.md
@@ -1,0 +1,5 @@
+---
+"sap-ux-sap-systems-ext": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/axios-extension

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -1,4 +1,5 @@
 import { join as joinPosix } from 'node:path/posix';
+import { isAxiosError } from 'axios';
 
 import { ODataVersion } from '../base/odata-service.js';
 import { ServiceProvider } from '../base/service-provider.js';
@@ -333,7 +334,7 @@ export class AbapServiceProvider extends ServiceProvider {
                     });
                 }
             } catch (error) {
-                const status = (error as { response?: { status?: number } })?.response?.status;
+                const status = isAxiosError(error) ? error.response?.status : undefined;
                 if (rejectOnAuthError && (status === 401 || status === 403)) {
                     throw error;
                 }
@@ -343,7 +344,7 @@ export class AbapServiceProvider extends ServiceProvider {
             }
         };
 
-        if (waitForFirst && references.length > 1) {
+        if (waitForFirst) {
             const [first, ...rest] = references;
             try {
                 await fetchOne(first, true);
@@ -351,7 +352,9 @@ export class AbapServiceProvider extends ServiceProvider {
                 this.log.warn('Authentication failure fetching external service metadata, aborting remaining requests');
                 return valueListReferences;
             }
-            await Promise.allSettled(rest.map((ref) => fetchOne(ref)));
+            if (rest.length > 0) {
+                await Promise.allSettled(rest.map((ref) => fetchOne(ref)));
+            }
         } else {
             await Promise.allSettled(references.map((ref) => fetchOne(ref)));
         }

--- a/packages/axios-extension/src/abap/abap-service-provider.ts
+++ b/packages/axios-extension/src/abap/abap-service-provider.ts
@@ -301,11 +301,18 @@ export class AbapServiceProvider extends ServiceProvider {
      * Collects ValueListReferences annotation values from the service metadata and annotation files.
      *
      * @param references - Service references for which metadata should be fetched.
+     * @param waitForFirst - When true and more than one reference is provided, the first request is awaited before
+     *   the remaining requests are fired in parallel. An authentication failure (401/403) on the first request
+     *   aborts the entire fetch — useful to prevent cascading redirects in SSO/ReentranceTicket auth flows.
      * @returns A list of ValueListReferences found in the metadata and annotations.
      */
-    public async fetchExternalServices(references: ExternalServiceReference[]): Promise<ExternalService[]> {
+    public async fetchExternalServices(
+        references: ExternalServiceReference[],
+        waitForFirst = false
+    ): Promise<ExternalService[]> {
         const valueListReferences: ExternalService[] = [];
-        const allPromises = references.map(async (reference) => {
+
+        const fetchOne = async (reference: ExternalServiceReference, rejectOnAuthError = false): Promise<void> => {
             const { serviceRootPath, value } = reference;
             const externalServicePath = joinPosix(serviceRootPath, value).replace('/$metadata', '');
             const externalService = this.service(externalServicePath);
@@ -326,13 +333,28 @@ export class AbapServiceProvider extends ServiceProvider {
                     });
                 }
             } catch (error) {
+                const status = (error as { response?: { status?: number } })?.response?.status;
+                if (rejectOnAuthError && (status === 401 || status === 403)) {
+                    throw error;
+                }
                 this.log.warn(
-                    `Could not fetch value list reference metadata from ${externalServicePath}, ${error.message}`
+                    `Could not fetch value list reference metadata from ${externalServicePath}, ${(error as Error).message}`
                 );
             }
-        });
+        };
 
-        await Promise.allSettled(allPromises);
+        if (waitForFirst && references.length > 1) {
+            const [first, ...rest] = references;
+            try {
+                await fetchOne(first, true);
+            } catch {
+                this.log.warn('Authentication failure fetching external service metadata, aborting remaining requests');
+                return valueListReferences;
+            }
+            await Promise.allSettled(rest.map((ref) => fetchOne(ref)));
+        } else {
+            await Promise.allSettled(references.map((ref) => fetchOne(ref)));
+        }
 
         return valueListReferences;
     }

--- a/packages/axios-extension/test/abap/abap-service-provider.test.ts
+++ b/packages/axios-extension/test/abap/abap-service-provider.test.ts
@@ -421,7 +421,10 @@ describe('AbapServiceProvider', () => {
             });
 
             test('should abort remaining requests and log warning on 401 from first', async () => {
-                const authError = Object.assign(new Error('Unauthorized'), { isAxiosError: true, response: { status: 401 } });
+                const authError = Object.assign(new Error('Unauthorized'), {
+                    isAxiosError: true,
+                    response: { status: 401 }
+                });
                 const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
                 const logSpy = jest.spyOn(provider.log, 'warn');
                 jest.spyOn(provider, 'service').mockImplementation((path) => {
@@ -441,7 +444,10 @@ describe('AbapServiceProvider', () => {
             });
 
             test('should abort remaining requests on 403 from first', async () => {
-                const authError = Object.assign(new Error('Forbidden'), { isAxiosError: true, response: { status: 403 } });
+                const authError = Object.assign(new Error('Forbidden'), {
+                    isAxiosError: true,
+                    response: { status: 403 }
+                });
                 const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
                 jest.spyOn(provider, 'service').mockImplementation((path) => {
                     if (path === '/sap/opu/odata/srv_f4/one') {
@@ -485,7 +491,10 @@ describe('AbapServiceProvider', () => {
             });
 
             test('should abort on 401 when only one reference is provided', async () => {
-                const authError = Object.assign(new Error('Unauthorized'), { isAxiosError: true, response: { status: 401 } });
+                const authError = Object.assign(new Error('Unauthorized'), {
+                    isAxiosError: true,
+                    response: { status: 401 }
+                });
                 const logSpy = jest.spyOn(provider.log, 'warn');
                 jest.spyOn(provider, 'service').mockReturnValue({
                     metadata: jest.fn().mockRejectedValue(authError)

--- a/packages/axios-extension/test/abap/abap-service-provider.test.ts
+++ b/packages/axios-extension/test/abap/abap-service-provider.test.ts
@@ -421,7 +421,7 @@ describe('AbapServiceProvider', () => {
             });
 
             test('should abort remaining requests and log warning on 401 from first', async () => {
-                const authError = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+                const authError = Object.assign(new Error('Unauthorized'), { isAxiosError: true, response: { status: 401 } });
                 const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
                 const logSpy = jest.spyOn(provider.log, 'warn');
                 jest.spyOn(provider, 'service').mockImplementation((path) => {
@@ -441,7 +441,7 @@ describe('AbapServiceProvider', () => {
             });
 
             test('should abort remaining requests on 403 from first', async () => {
-                const authError = Object.assign(new Error('Forbidden'), { response: { status: 403 } });
+                const authError = Object.assign(new Error('Forbidden'), { isAxiosError: true, response: { status: 403 } });
                 const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
                 jest.spyOn(provider, 'service').mockImplementation((path) => {
                     if (path === '/sap/opu/odata/srv_f4/one') {
@@ -482,6 +482,21 @@ describe('AbapServiceProvider', () => {
 
                 expect(result).toHaveLength(1);
                 expect(metadataSpy).toHaveBeenCalledTimes(1);
+            });
+
+            test('should abort on 401 when only one reference is provided', async () => {
+                const authError = Object.assign(new Error('Unauthorized'), { isAxiosError: true, response: { status: 401 } });
+                const logSpy = jest.spyOn(provider.log, 'warn');
+                jest.spyOn(provider, 'service').mockReturnValue({
+                    metadata: jest.fn().mockRejectedValue(authError)
+                } as any);
+
+                const result = await provider.fetchExternalServices([references[0]], true);
+
+                expect(result).toHaveLength(0);
+                expect(logSpy).toHaveBeenCalledWith(
+                    'Authentication failure fetching external service metadata, aborting remaining requests'
+                );
             });
         });
     });

--- a/packages/axios-extension/test/abap/abap-service-provider.test.ts
+++ b/packages/axios-extension/test/abap/abap-service-provider.test.ts
@@ -393,5 +393,96 @@ describe('AbapServiceProvider', () => {
             );
             expect(serviceSpy).toHaveBeenCalledWith('/sap/opu/odata/srv_f4/one');
         });
+
+        describe('waitForFirst', () => {
+            const references = [
+                {
+                    type: 'value-list' as const,
+                    target: 'target1',
+                    serviceRootPath: '/sap/opu/odata/sap/ZMY_SERVICE_SRV/',
+                    value: '../../srv_f4/one/$metadata'
+                },
+                {
+                    type: 'value-list' as const,
+                    target: 'target2',
+                    serviceRootPath: '/sap/opu/odata/sap/ZMY_SERVICE_SRV/',
+                    value: '../../srv_f4/two/$metadata'
+                }
+            ];
+
+            test('should fetch all when first request succeeds', async () => {
+                const metadataSpy = jest.fn().mockResolvedValue('metadata');
+                jest.spyOn(provider, 'service').mockReturnValue({ metadata: metadataSpy } as any);
+
+                const result = await provider.fetchExternalServices(references, true);
+
+                expect(result).toHaveLength(2);
+                expect(metadataSpy).toHaveBeenCalledTimes(2);
+            });
+
+            test('should abort remaining requests and log warning on 401 from first', async () => {
+                const authError = Object.assign(new Error('Unauthorized'), { response: { status: 401 } });
+                const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
+                const logSpy = jest.spyOn(provider.log, 'warn');
+                jest.spyOn(provider, 'service').mockImplementation((path) => {
+                    if (path === '/sap/opu/odata/srv_f4/one') {
+                        return { metadata: jest.fn().mockRejectedValue(authError) } as any;
+                    }
+                    return { metadata: secondMetadataSpy } as any;
+                });
+
+                const result = await provider.fetchExternalServices(references, true);
+
+                expect(result).toHaveLength(0);
+                expect(secondMetadataSpy).not.toHaveBeenCalled();
+                expect(logSpy).toHaveBeenCalledWith(
+                    'Authentication failure fetching external service metadata, aborting remaining requests'
+                );
+            });
+
+            test('should abort remaining requests on 403 from first', async () => {
+                const authError = Object.assign(new Error('Forbidden'), { response: { status: 403 } });
+                const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
+                jest.spyOn(provider, 'service').mockImplementation((path) => {
+                    if (path === '/sap/opu/odata/srv_f4/one') {
+                        return { metadata: jest.fn().mockRejectedValue(authError) } as any;
+                    }
+                    return { metadata: secondMetadataSpy } as any;
+                });
+
+                const result = await provider.fetchExternalServices(references, true);
+
+                expect(result).toHaveLength(0);
+                expect(secondMetadataSpy).not.toHaveBeenCalled();
+            });
+
+            test('should continue with remaining requests when first fails with non-auth error', async () => {
+                const nonAuthError = Object.assign(new Error('Not found'), { response: { status: 404 } });
+                const secondMetadataSpy = jest.fn().mockResolvedValue('metadata');
+                const logSpy = jest.spyOn(provider.log, 'warn');
+                jest.spyOn(provider, 'service').mockImplementation((path) => {
+                    if (path === '/sap/opu/odata/srv_f4/one') {
+                        return { metadata: jest.fn().mockRejectedValue(nonAuthError) } as any;
+                    }
+                    return { metadata: secondMetadataSpy } as any;
+                });
+
+                const result = await provider.fetchExternalServices(references, true);
+
+                expect(result).toHaveLength(1);
+                expect(secondMetadataSpy).toHaveBeenCalled();
+                expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Not found'));
+            });
+
+            test('should behave like normal fetch when only one reference is provided', async () => {
+                const metadataSpy = jest.fn().mockResolvedValue('metadata');
+                jest.spyOn(provider, 'service').mockReturnValue({ metadata: metadataSpy } as any);
+
+                const result = await provider.fetchExternalServices([references[0]], true);
+
+                expect(result).toHaveLength(1);
+                expect(metadataSpy).toHaveBeenCalledTimes(1);
+            });
+        });
     });
 });

--- a/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
+++ b/packages/fiori-mcp-server/src/tools/generate-fiori-app-odata.ts
@@ -201,7 +201,7 @@ async function getExternalServiceMetadata(
 
         logger.info(`Found ${externalServiceRefs.length} external service reference(s), fetching metadata...`);
 
-        const extServiceData = await serviceProvider.fetchExternalServices(externalServiceRefs);
+        const extServiceData = await serviceProvider.fetchExternalServices(externalServiceRefs, true);
         const duration = (performance.now() - startTime).toFixed(0);
         logger.info(`Successfully fetched ${extServiceData.length} external service(s) in ${duration}ms`);
         return extServiceData;

--- a/packages/fiori-mcp-server/test/unit/tools/generate-fiori-app-odata-external-services.test.ts
+++ b/packages/fiori-mcp-server/test/unit/tools/generate-fiori-app-odata-external-services.test.ts
@@ -110,7 +110,7 @@ describe('generateFioriAppOData - External Services', () => {
             // Then: External services should be fetched
             expect(mockGetExternalServiceReferences).toHaveBeenCalledWith(validArgs.service.servicePath, '<edmx/>', []);
             expect(mockFindSystem).toHaveBeenCalled();
-            expect(mockProvider.fetchExternalServices).toHaveBeenCalledWith(mockRefs);
+            expect(mockProvider.fetchExternalServices).toHaveBeenCalledWith(mockRefs, true);
             expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Found 1 external service reference'));
             expect(mockLogger.info).toHaveBeenCalledWith(
                 expect.stringContaining('Successfully fetched 1 external service')
@@ -499,7 +499,7 @@ describe('generateFioriAppOData - External Services', () => {
             expect(mockFindSystem).toHaveBeenCalledTimes(1);
             expect(mockCreateAbapServiceProvider).toHaveBeenCalledTimes(1);
             // And both consumers used that same provider instance
-            expect(mockProvider.fetchExternalServices).toHaveBeenCalledWith([{ type: 'value-list' }]);
+            expect(mockProvider.fetchExternalServices).toHaveBeenCalledWith([{ type: 'value-list' }], true);
             expect(mockGetAnnotations).toHaveBeenCalledWith({ path: validArgs.service.servicePath });
             const configContent = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
             expect(configContent.service.externalServices).toEqual([{ name: 'Help1', metadata: '<edmx/>' }]);


### PR DESCRIPTION
## Summary

Internal issue: 39343

- Adds optional `waitForFirst` parameter to `fetchExternalServices` (default `false`, backward-compatible) to prevent multiple parallel browser redirects for Cloud auth
- When `waitForFirst=true`, the first request acts as a canary — a 401/403 auth failure aborts the remaining requests immediately, preventing cascading redirects in SSO/ReentranceTicket flows
- Non-auth failures (404, network errors) on the first request are swallowed and the rest proceed normally
- `fiori-mcp-server` already passes `waitForFirst=true` when fetching external service metadata; test assertions updated to reflect this

## Test Plan

- [ ] `axios-extension`: 5 new `waitForFirst` tests covering success, 401 abort, 403 abort, non-auth continue, single-reference passthrough — all pass (28 total)
- [ ] `fiori-mcp-server`: existing external-services tests updated for new call signature — all pass (21 total)