### PR TITLE
chore: minor updates — vscode language server

### DIFF
--- a/.changeset/deploy-config-generator-shared-bump-vscode-logging-logger.md
+++ b/.changeset/deploy-config-generator-shared-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/deploy-config-generator-shared": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/.changeset/eslint-plugin-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/eslint-plugin-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/eslint-plugin-fiori-tools": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/fiori-annotation-api and @sap-ux/i18n

--- a/.changeset/fiori-annotation-api-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/fiori-annotation-api-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-annotation-api": patch
+---
+
+BUMP: Upgrade vscode-languageserver-textdocument 1.0.12 → 1.0.14

--- a/.changeset/fiori-generator-shared-bump-vscode-logging-logger.md
+++ b/.changeset/fiori-generator-shared-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-generator-shared": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/.changeset/fiori-mcp-server-bump-vscode-languageserver-types.md
+++ b/.changeset/fiori-mcp-server-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/fiori-mcp-server": patch
+---
+
+BUMP: Rebuild bundle with updated vscode-languageserver-types 3.18.0 → 3.18.3

--- a/.changeset/generator-odata-downloader-bump-vscode-logging-logger.md
+++ b/.changeset/generator-odata-downloader-bump-vscode-logging-logger.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/generator-odata-downloader": patch
+---
+
+BUMP: Upgrade @vscode-logging/logger 2.0.9 → 2.0.10

--- a/.changeset/i18n-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/i18n-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/i18n": patch
+---
+
+BUMP: Upgrade vscode-languageserver-textdocument 1.0.12 → 1.0.14

--- a/.changeset/sap-systems-ext-bump-vscode-languageserver-textdocument.md
+++ b/.changeset/sap-systems-ext-bump-vscode-languageserver-textdocument.md
@@ -1,0 +1,5 @@
+---
+"sap-ux-sap-systems-ext": patch
+---
+
+BUMP: Rebuild bundle with updated @sap-ux/i18n

--- a/.changeset/text-document-utils-bump-vscode-languageserver-types.md
+++ b/.changeset/text-document-utils-bump-vscode-languageserver-types.md
@@ -1,0 +1,5 @@
+---
+"@sap-ux/text-document-utils": patch
+---
+
+BUMP: Upgrade vscode-languageserver-types 3.18.0 → 3.18.3

--- a/packages/adp-flp-config-sub-generator/package.json
+++ b/packages/adp-flp-config-sub-generator/package.json
@@ -55,7 +55,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "yeoman-test": "6.3.0"

--- a/packages/deploy-config-generator-shared/package.json
+++ b/packages/deploy-config-generator-shared/package.json
@@ -32,7 +32,7 @@
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/fiori-generator-shared": "workspace:*",
         "@sap-ux/nodejs-utils": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "i18next": "26.3.6",
         "yeoman-generator": "5.10.0"
     },

--- a/packages/fiori-annotation-api/package.json
+++ b/packages/fiori-annotation-api/package.json
@@ -40,7 +40,7 @@
         "@xml-tools/parser": "1.0.11",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
-        "vscode-languageserver-textdocument": "1.0.12"
+        "vscode-languageserver-textdocument": "1.0.14"
     },
     "devDependencies": {
         "@jest/globals": "30.4.1",

--- a/packages/fiori-generator-shared/package.json
+++ b/packages/fiori-generator-shared/package.json
@@ -33,7 +33,7 @@
         "@sap-ux/btp-utils": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
         "@sap-ux/telemetry": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "i18next": "26.3.6",
         "logform": "2.7.0",
         "mem-fs": "2.1.0",

--- a/packages/flp-config-sub-generator/package.json
+++ b/packages/flp-config-sub-generator/package.json
@@ -54,7 +54,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-test": "4.0.6",
         "@sap-ux/nodejs-utils": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",

--- a/packages/generator-adp/package.json
+++ b/packages/generator-adp/package.json
@@ -68,7 +68,7 @@
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
         "@types/uuid": "11.0.0",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "yeoman-test": "6.3.0"

--- a/packages/generator-odata-downloader/package.json
+++ b/packages/generator-odata-downloader/package.json
@@ -62,7 +62,7 @@
         "@sap/ux-specification": "1.144.5",
         "@types/inquirer": "8.2.6",
         "@types/yeoman-generator": "5.2.14",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "deepmerge": "4.3.1",
         "i18next": "26.3.6",
         "inquirer": "8.2.7",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "jsonc-parser": "3.3.1",
-        "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-languageserver-textdocument": "1.0.14",
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -41,7 +41,7 @@
         "npm-run-all2": "9.0.2",
         "@jest/globals": "30.4.1",
         "ui5-tooling-transpile": "3.11.3",
-        "vscode-languageserver-textdocument": "1.0.12",
+        "vscode-languageserver-textdocument": "1.0.14",
         "@ui5/manifest": "1.89.0"
     },
     "browserslist": "defaults"

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -71,7 +71,7 @@
         "fs-extra": "11.3.6",
         "@sap-ux/store": "workspace:*",
         "@sap-ux/ui5-config": "workspace:*",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "@types/adm-zip": "0.5.8",
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",

--- a/packages/text-document-utils/package.json
+++ b/packages/text-document-utils/package.json
@@ -42,6 +42,6 @@
         "node": ">=22.x"
     },
     "dependencies": {
-        "vscode-languageserver-types": "3.18.0"
+        "vscode-languageserver-types": "3.18.3"
     }
 }

--- a/packages/ui-service-sub-generator/package.json
+++ b/packages/ui-service-sub-generator/package.json
@@ -55,7 +55,7 @@
         "@types/mem-fs-editor": "7.0.1",
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "jest-extended": "7.0.0",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",

--- a/packages/ui5-library-reference-sub-generator/package.json
+++ b/packages/ui5-library-reference-sub-generator/package.json
@@ -49,7 +49,7 @@
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
         "@types/vscode": "1.110.0",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "fs-extra": "11.3.6",
         "rimraf": "6.1.3",
         "vscode-uri": "3.1.0",

--- a/packages/ui5-library-sub-generator/package.json
+++ b/packages/ui5-library-sub-generator/package.json
@@ -49,7 +49,7 @@
         "@types/yeoman-environment": "2.10.11",
         "@types/yeoman-generator": "5.2.14",
         "@types/yeoman-test": "4.0.6",
-        "@vscode-logging/logger": "2.0.9",
+        "@vscode-logging/logger": "2.0.10",
         "jest-extended": "7.0.0",
         "mem-fs-editor": "9.4.0",
         "rimraf": "6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,8 +733,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -1767,8 +1767,8 @@ importers:
         specifier: workspace:*
         version: link:../nodejs-utils
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       i18next:
         specifier: 26.3.6
         version: 26.3.6(typescript@5.9.3)
@@ -2259,8 +2259,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
     devDependencies:
       '@jest/globals':
         specifier: 30.4.1
@@ -2638,8 +2638,8 @@ importers:
         specifier: workspace:*
         version: link:../telemetry
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       i18next:
         specifier: 26.3.6
         version: 26.3.6(typescript@5.9.3)
@@ -2945,8 +2945,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -3054,8 +3054,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -3126,8 +3126,8 @@ importers:
         specifier: 5.2.14
         version: 5.2.14
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       deepmerge:
         specifier: 4.3.1
         version: 4.3.1
@@ -3168,8 +3168,8 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
     devDependencies:
       '@jest/globals':
         specifier: 30.4.1
@@ -3880,8 +3880,8 @@ importers:
         specifier: 3.11.3
         version: 3.11.3(supports-color@8.1.1)
       vscode-languageserver-textdocument:
-        specifier: 1.0.12
-        version: 1.0.12
+        specifier: 1.0.14
+        version: 1.0.14
 
   packages/project-access:
     dependencies:
@@ -4128,8 +4128,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -4457,8 +4457,8 @@ importers:
   packages/text-document-utils:
     dependencies:
       vscode-languageserver-types:
-        specifier: 3.18.0
-        version: 3.18.0
+        specifier: 3.18.3
+        version: 3.18.3
 
   packages/ui-components:
     dependencies:
@@ -4845,8 +4845,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       jest-extended:
         specifier: 7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -5143,8 +5143,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       fs-extra:
         specifier: 11.3.6
         version: 11.3.6
@@ -5238,8 +5238,8 @@ importers:
         specifier: 4.0.6
         version: 4.0.6
       '@vscode-logging/logger':
-        specifier: 2.0.9
-        version: 2.0.9(supports-color@8.1.1)
+        specifier: 2.0.10
+        version: 2.0.10(supports-color@8.1.1)
       jest-extended:
         specifier: 7.0.0
         version: 7.0.0(jest@30.4.2(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -10915,11 +10915,11 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vscode-logging/logger@2.0.9':
-    resolution: {integrity: sha512-Kq7dmziSHej+6yADxoHCZU8Tspf7ucJeNjH+QPMAQlRfT0uaXlh1q5DpWnzSgznWIBrMc7lX82meThDKBxL+oA==}
+  '@vscode-logging/logger@2.0.10':
+    resolution: {integrity: sha512-Mg8aW5Bkim3p4vF2S+n5eEKzg/OBSdS9iom3GmmBUGtmZ07WlOROGYm+2i2sN0R05wnqoafuJbN9LeCwMuZIbw==}
 
-  '@vscode-logging/types@2.0.8':
-    resolution: {integrity: sha512-9mc5+Iob1BqJ00QExLwdz4+w0A1odSYjvzpKYfP0lVzr7Tdf4iWGspLADyTSC7DtJVQQ+tu411cBju+cYJxE/g==}
+  '@vscode-logging/types@2.0.10':
+    resolution: {integrity: sha512-Y8Qn0Xc7ej8BC+cbDAi5LUKJs3qMGni0zUGZgqhDrXq3sQS5SQ2KG4sk320Si2rdL/nqivJ/gaEAcxD61m1+3w==}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -18774,11 +18774,14 @@ packages:
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
 
+  vscode-languageserver-textdocument@1.0.14:
+    resolution: {integrity: sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==}
+
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
-  vscode-languageserver-types@3.18.0:
-    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+  vscode-languageserver-types@3.18.3:
+    resolution: {integrity: sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -26620,9 +26623,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vscode-logging/logger@2.0.9(supports-color@8.1.1)':
+  '@vscode-logging/logger@2.0.10(supports-color@8.1.1)':
     dependencies:
-      '@vscode-logging/types': 2.0.8
+      '@vscode-logging/types': 2.0.10
       fast-safe-stringify: 2.1.1
       fs-extra: 11.2.0
       lodash: 4.18.1
@@ -26634,7 +26637,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vscode-logging/types@2.0.8': {}
+  '@vscode-logging/types@2.0.10': {}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     optional: true
@@ -36190,9 +36193,11 @@ snapshots:
 
   vscode-languageserver-textdocument@1.0.12: {}
 
+  vscode-languageserver-textdocument@1.0.14: {}
+
   vscode-languageserver-types@3.17.5: {}
 
-  vscode-languageserver-types@3.18.0: {}
+  vscode-languageserver-types@3.18.3: {}
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## Description
Minor dependency upgrades for the **vscode language server** package group across multiple packages in the monorepo.

**Packages updated:**
| Dependency | From | To |
|---|---|---|
| `@vscode-logging/logger` | `2.0.9` | `2.0.10` |
| `vscode-languageserver-textdocument` | `1.0.12` | `1.0.14` |
| `vscode-languageserver-types` | `3.18.0` | `3.18.3` |

**Affected packages:**
- `@sap-ux/deploy-config-generator-shared` — `@vscode-logging/logger` bump
- `@sap-ux/fiori-generator-shared` — `@vscode-logging/logger` bump
- `@sap-ux/generator-odata-downloader` — `@vscode-logging/logger` bump
- `@sap-ux/fiori-annotation-api` — `vscode-languageserver-textdocument` bump
- `@sap-ux/i18n` — `vscode-languageserver-textdocument` bump
- `@sap-ux/text-document-utils` — `vscode-languageserver-types` bump
- Several other packages rebuilt to pick up transitive updates (`@sap-ux/eslint-plugin-fiori-tools`, `@sap-ux/fiori-mcp-server`, `sap-ux-sap-systems-ext`)

Changeset files and `pnpm-lock.yaml` have been updated accordingly.

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Run `pnpm build && pnpm test` to verify no regressions are introduced by the dependency upgrades.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review
- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Correlation ID: `729ec8c0-adc4-11f1-8325-35d2e8c5b1b4`
- Event Trigger: `issue_comment.edited`
</details>
