### PR TITLE
chore: minor updates — workspace utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "husky": "8.0.3",
         "jest": "30.4.2",
         "jest-sonar": "0.2.16",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "nx": "22.7.8",
         "postcss": "8.5.26",
         "prebuild-install": "^7.1.3",

--- a/packages/annotation-generator/package.json
+++ b/packages/annotation-generator/package.json
@@ -36,7 +36,7 @@
         "mem-fs": "2.1.0",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/cds-annotation-parser/package.json
+++ b/packages/cds-annotation-parser/package.json
@@ -33,7 +33,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/cds-odata-annotation-converter/package.json
+++ b/packages/cds-odata-annotation-converter/package.json
@@ -41,7 +41,7 @@
     "devDependencies": {
         "@sap-ux/odata-annotation-core-types": "workspace:*",
         "@sap-ux/project-access": "workspace:*",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/control-property-editor-common/package.json
+++ b/packages/control-property-editor-common/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "@sap-ux/logger": "workspace:*",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "rimraf": "6.1.3",
         "ts-jest": "29.4.11"
     },

--- a/packages/control-property-editor/package.json
+++ b/packages/control-property-editor/package.json
@@ -45,7 +45,7 @@
         "i18next": "26.3.6",
         "jest-environment-jsdom": "30.4.1",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-i18next": "15.7.4",

--- a/packages/fiori-annotation-api/package.json
+++ b/packages/fiori-annotation-api/package.json
@@ -47,7 +47,7 @@
         "@sap/cds-compiler": "4.8.0",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/fiori-docs-embeddings/package.json
+++ b/packages/fiori-docs-embeddings/package.json
@@ -42,7 +42,7 @@
         "jsdoc-api": "9.3.6",
         "marked": "^12.0.0",
         "node-fetch": "^3.3.2",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "tsx": "4.23.1"
     },
     "keywords": [

--- a/packages/fiori-mcp-server/package.json
+++ b/packages/fiori-mcp-server/package.json
@@ -88,7 +88,7 @@
         "i18next": "26.3.6",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "os-name": "4.0.1",
         "promptfoo": "0.122.0",
         "xml-formatter": "3.7.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@jest/globals": "30.4.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "ts-node": "10.9.2",

--- a/packages/odata-annotation-core-types/package.json
+++ b/packages/odata-annotation-core-types/package.json
@@ -42,7 +42,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     },
     "engines": {
         "node": ">=22.x"

--- a/packages/odata-annotation-core/package.json
+++ b/packages/odata-annotation-core/package.json
@@ -43,7 +43,7 @@
         "@sap-ux/text-document-utils": "workspace:*"
     },
     "devDependencies": {
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@sap-ux/odata-entity-model": "workspace:*"
     },
     "engines": {

--- a/packages/odata-entity-model/package.json
+++ b/packages/odata-entity-model/package.json
@@ -33,6 +33,6 @@
     },
     "devDependencies": {
         "@sap-ux/odata-annotation-core-types": "workspace:*",
-        "npm-run-all2": "9.0.2"
+        "npm-run-all2": "9.0.3"
     }
 }

--- a/packages/odata-vocabularies/package.json
+++ b/packages/odata-vocabularies/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@jest/globals": "30.4.1",
         "axios": "1.18.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "prettier": "3.9.5",
         "tsx": "4.23.1"
     },

--- a/packages/preview-middleware-client/package.json
+++ b/packages/preview-middleware-client/package.json
@@ -38,7 +38,7 @@
         "@sap-ux/i18n": "workspace:*",
         "@ui5/cli": "4.0.62",
         "eslint-plugin-jsdoc": "62.8.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "@jest/globals": "30.4.1",
         "ui5-tooling-transpile": "3.11.3",
         "vscode-languageserver-textdocument": "1.0.12",

--- a/packages/preview-middleware/package.json
+++ b/packages/preview-middleware/package.json
@@ -75,7 +75,7 @@
         "dotenv": "17.4.2",
         "express": "4.22.1",
         "nock": "14.0.16",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "supertest": "7.2.2"
     },
     "peerDependencies": {

--- a/packages/sap-systems-ext/package.json
+++ b/packages/sap-systems-ext/package.json
@@ -65,7 +65,7 @@
         "i18next": "26.3.6",
         "jsonc-parser": "3.3.1",
         "normalize-path": "3.0.0",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "os-name": "4.0.1",
         "vscode-uri": "3.1.0",
         "@vscode/vsce": "3.9.2"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -70,7 +70,7 @@
         "eslint-plugin-storybook": "0.6.15",
         "jest-environment-jsdom": "^29.7.0",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "require-from-string": "2.0.2",

--- a/packages/ui-prompting/package.json
+++ b/packages/ui-prompting/package.json
@@ -66,7 +66,7 @@
         "eslint-plugin-storybook": "0.6.15",
         "jest-environment-jsdom": "30.4.1",
         "jest-scss-transform": "1.0.4",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "sass": "1.102.0",

--- a/packages/xml-odata-annotation-converter/package.json
+++ b/packages/xml-odata-annotation-converter/package.json
@@ -39,7 +39,7 @@
         "@xml-tools/ast": "5.0.5",
         "@xml-tools/parser": "1.0.11",
         "chevrotain": "7.1.1",
-        "npm-run-all2": "9.0.2",
+        "npm-run-all2": "9.0.3",
         "prettier": "3.9.5"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: 0.2.16
         version: 0.2.16
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       nx:
         specifier: 22.7.8
         version: 22.7.8(@swc/core@1.15.46(@swc/helpers@0.5.19))
@@ -912,8 +912,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/app-config-writer:
     dependencies:
@@ -1264,8 +1264,8 @@ importers:
         version: 7.1.1
     devDependencies:
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/cds-odata-annotation-converter:
     dependencies:
@@ -1295,8 +1295,8 @@ importers:
         specifier: workspace:*
         version: link:../project-access
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/cf-deploy-config-inquirer:
     dependencies:
@@ -1586,8 +1586,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       postcss-modules:
         specifier: 6.0.1
         version: 6.0.1(postcss@8.5.26)
@@ -1634,8 +1634,8 @@ importers:
         specifier: workspace:*
         version: link:../logger
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -2275,8 +2275,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/fiori-app-sub-generator:
     dependencies:
@@ -2462,8 +2462,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       tsx:
         specifier: 4.23.1
         version: 4.23.1
@@ -2795,8 +2795,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       os-name:
         specifier: 4.0.1
         version: 4.0.1
@@ -3187,8 +3187,8 @@ importers:
         specifier: 9.4.0
         version: 9.4.0(mem-fs@2.1.0)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.15.46(@swc/helpers@0.5.19))(@types/node@22.20.1)(typescript@5.9.3)
@@ -3486,8 +3486,8 @@ importers:
         specifier: workspace:*
         version: link:../odata-entity-model
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-annotation-core-types:
     dependencies:
@@ -3496,8 +3496,8 @@ importers:
         version: link:../text-document-utils
     devDependencies:
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-entity-model:
     devDependencies:
@@ -3505,8 +3505,8 @@ importers:
         specifier: workspace:*
         version: link:../odata-annotation-core-types
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
 
   packages/odata-service-inquirer:
     dependencies:
@@ -3694,8 +3694,8 @@ importers:
         specifier: '>=1.18.0'
         version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       prettier:
         specifier: 3.9.5
         version: 3.9.5
@@ -3837,8 +3837,8 @@ importers:
         specifier: 14.0.16
         version: 14.0.16
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       supertest:
         specifier: 7.2.2
         version: 7.2.2(supports-color@8.1.1)
@@ -3871,8 +3871,8 @@ importers:
         specifier: 62.8.1
         version: 62.8.1(eslint@10.7.0(supports-color@8.1.1))(supports-color@8.1.1)
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       ui5-tooling-modules:
         specifier: 3.35.0
         version: 3.35.0(@ui5/project@4.0.17(@ui5/builder@4.3.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
@@ -4215,8 +4215,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       os-name:
         specifier: 4.0.1
         version: 4.0.1
@@ -4554,8 +4554,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -4666,8 +4666,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(babel-jest@30.4.1(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -5446,8 +5446,8 @@ importers:
         specifier: 7.1.1
         version: 7.1.1
       npm-run-all2:
-        specifier: 9.0.2
-        version: 9.0.2
+        specifier: 9.0.3
+        version: 9.0.3
       prettier:
         specifier: 3.9.5
         version: 3.9.5
@@ -11227,6 +11227,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansi-styles@7.0.0:
+    resolution: {integrity: sha512-kKvt3m4uwzqL0wlkPd09CmljPJGOZZ4D0fP65sqFSvPkMRKhNi+74MgIJ5QxE6SxqB4t4KyUFGg8+n5zjo6hew==}
+    engines: {node: '>=22'}
+
   antlr4@4.9.3:
     resolution: {integrity: sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g==}
     engines: {node: '>=14'}
@@ -15837,6 +15841,11 @@ packages:
 
   npm-run-all2@9.0.2:
     resolution: {integrity: sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
+    hasBin: true
+
+  npm-run-all2@9.0.3:
+    resolution: {integrity: sha512-BQAEdU1PtYc48qYRdghW2BVTQT3VqWCoFQmO87NlM1h1PYwMCKQpUWaNyB20V26caNzFsXQDfyOdznLlHCih6g==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
     hasBin: true
 
@@ -26978,6 +26987,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansi-styles@7.0.0: {}
+
   antlr4@4.9.3: {}
 
   anymatch@3.1.3:
@@ -32411,6 +32422,17 @@ snapshots:
   npm-run-all2@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.4
+      pidtree: 1.0.0
+      read-package-json-fast: 6.0.0
+      shell-quote: 1.10.0
+      which: 7.0.0
+
+  npm-run-all2@9.0.3:
+    dependencies:
+      ansi-styles: 7.0.0
       cross-spawn: 7.0.6
       memorystream: 0.3.1
       picomatch: 4.0.4


### PR DESCRIPTION
## Description

Bumps the `npm-run-all2` dependency from `9.0.2` to `9.0.3` across all workspace packages and the root `package.json`. The lockfile (`pnpm-lock.yaml`) is updated accordingly, including the addition of the new `ansi-styles@7.0.0` transitive dependency introduced by `npm-run-all2@9.0.3`.

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Run `pnpm build && pnpm test` to verify no regressions were introduced by the version bump.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review
- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `48163a40-adb8-11f1-88bf-90b85c939b9b`
</details>
