### PR TITLE
chore: minor updates — @types

### DIFF
--- a/packages/abap-deploy-config-writer/package.json
+++ b/packages/abap-deploy-config-writer/package.json
@@ -43,7 +43,7 @@
     },
     "devDependencies": {
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/axios-extension/package.json
+++ b/packages/axios-extension/package.json
@@ -46,7 +46,7 @@
         "@jest/globals": "30.4.1",
         "@sap-ux/vocabularies-types": "0.16.0",
         "@sap-ux/project-access": "workspace:*",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "nock": "14.0.16",
         "supertest": "7.2.2",
         "@types/proxy-from-env": "1.0.4"

--- a/packages/fiori-app-sub-generator/package.json
+++ b/packages/fiori-app-sub-generator/package.json
@@ -69,7 +69,7 @@
         "@sap-ux/jest-file-matchers": "workspace:*",
         "@sap-ux/logger": "workspace:*",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/vscode": "1.110.0",

--- a/packages/fiori-elements-writer/package.json
+++ b/packages/fiori-elements-writer/package.json
@@ -55,7 +55,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/fiori-freestyle-writer/package.json
+++ b/packages/fiori-freestyle-writer/package.json
@@ -53,7 +53,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "@types/semver": "7.7.1",

--- a/packages/flp-config-inquirer/package.json
+++ b/packages/flp-config-inquirer/package.json
@@ -45,7 +45,7 @@
         "@jest/globals": "30.4.1",
         "@sap-devx/yeoman-ui-types": "1.25.1",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "inquirer": "8.2.7"
     },
     "engines": {

--- a/packages/flp-config-sub-generator/package.json
+++ b/packages/flp-config-sub-generator/package.json
@@ -58,7 +58,7 @@
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "rimraf": "6.1.3",
         "unionfs": "4.6.0",
         "yeoman-test": "6.3.0"

--- a/packages/inquirer-common/package.json
+++ b/packages/inquirer-common/package.json
@@ -58,7 +58,7 @@
         "@sap-devx/yeoman-ui-types": "1.25.1",
         "@types/inquirer": "8.2.6",
         "@types/semver": "7.7.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "jest-extended": "7.0.0"
     },
     "engines": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
         "@types/debug": "4.1.13",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/vscode": "1.110.0",
         "jest-extended": "7.0.0",
         "logform": "2.7.0"

--- a/packages/repo-app-import-sub-generator/package.json
+++ b/packages/repo-app-import-sub-generator/package.json
@@ -76,7 +76,7 @@
         "memfs": "3.4.13",
         "mem-fs-editor": "9.4.0",
         "lodash": "4.18.1",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "rimraf": "6.1.3",
         "unionfs": "4.6.0",
         "yeoman-environment": "3.19.3",

--- a/packages/ui5-application-inquirer/package.json
+++ b/packages/ui5-application-inquirer/package.json
@@ -46,7 +46,7 @@
         "@sap-ux/cap-config-writer": "workspace:*",
         "@types/inquirer-autocomplete-prompt": "2.0.2",
         "@types/inquirer": "8.2.6",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/semver": "7.7.1",
         "inquirer": "8.2.7"
     },

--- a/packages/ui5-application-writer/package.json
+++ b/packages/ui5-application-writer/package.json
@@ -47,7 +47,7 @@
         "@sap-ux/project-access": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs": "1.1.2",
         "@types/mem-fs-editor": "7.0.1",
         "@types/semver": "7.7.1",

--- a/packages/ui5-config/package.json
+++ b/packages/ui5-config/package.json
@@ -41,7 +41,7 @@
     },
     "devDependencies": {
         "@sap-ux/store": "workspace:*",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/semver": "7.7.1",
         "@types/js-yaml": "4.0.9"
     },

--- a/packages/ui5-library-writer/package.json
+++ b/packages/ui5-library-writer/package.json
@@ -49,7 +49,7 @@
         "@sap-ux/eslint-plugin-fiori-tools": "workspace:*",
         "@types/ejs": "3.1.5",
         "@types/fs-extra": "11.0.4",
-        "@types/lodash": "4.17.24",
+        "@types/lodash": "4.17.25",
         "@types/mem-fs-editor": "7.0.1",
         "@types/mem-fs": "1.1.2",
         "fs-extra": "11.3.6",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -42,7 +42,7 @@
         "yaml": "2.9.0"
     },
     "devDependencies": {
-        "@types/lodash": "4.17.24"
+        "@types/lodash": "4.17.25"
     },
     "engines": {
         "node": ">=22.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,8 +648,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -1049,8 +1049,8 @@ importers:
         specifier: 0.16.0
         version: 0.16.0
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/proxy-from-env':
         specifier: 1.0.4
         version: 1.0.4
@@ -2390,8 +2390,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2535,8 +2535,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2608,8 +2608,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -2869,8 +2869,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       inquirer:
         specifier: 8.2.7
         version: 8.2.7(@types/node@22.20.1)
@@ -2927,8 +2927,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -3269,8 +3269,8 @@ importers:
         specifier: 8.2.6
         version: 8.2.6
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -3396,8 +3396,8 @@ importers:
         specifier: 4.1.13
         version: 4.1.13
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/vscode':
         specifier: 1.110.0
         version: 1.110.0
@@ -4110,8 +4110,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -4909,8 +4909,8 @@ importers:
         specifier: 2.0.2
         version: 2.0.2
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -4958,8 +4958,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -5001,8 +5001,8 @@ importers:
         specifier: 4.0.9
         version: 4.0.9
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -5290,8 +5290,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
       '@types/mem-fs':
         specifier: 1.1.2
         version: 1.1.2
@@ -5462,8 +5462,8 @@ importers:
         version: 2.9.0
     devDependencies:
       '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
+        specifier: 4.17.25
+        version: 4.17.25
 
   tests/fixtures/projects/mock:
     devDependencies:
@@ -10359,8 +10359,8 @@ packages:
   '@types/livereload@0.9.5':
     resolution: {integrity: sha512-2RXcRKdivPmn67pwjytvHoRv46AeXaLYVUWA0zkel1XSAOH5i71G0KfUdE5u3g80T155gR3Fo3ilVaqparLsVA==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -25770,7 +25770,7 @@ snapshots:
     dependencies:
       '@types/ws': 8.18.1
 
-  '@types/lodash@4.17.24': {}
+  '@types/lodash@4.17.25': {}
 
   '@types/markdown-it@14.1.2':
     dependencies:


### PR DESCRIPTION
## Description

Bumps the `@types/lodash` dev dependency from `4.17.24` to `4.17.25` across all affected packages in the monorepo. This is a minor/patch type update to the TypeScript type definitions for Lodash.

**Packages updated:**
- `abap-deploy-config-writer`
- `axios-extension`
- `fiori-app-sub-generator`
- `fiori-elements-writer`
- `fiori-freestyle-writer`
- `flp-config-inquirer`
- `flp-config-sub-generator`
- `inquirer-common`
- `logger`
- `repo-app-import-sub-generator`
- `ui5-application-inquirer`
- `ui5-application-writer`
- `ui5-config`
- `ui5-library-writer`
- `yaml`

The `pnpm-lock.yaml` lockfile has been updated accordingly to reflect the new resolved version and integrity hash.

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Run `pnpm build && pnpm test` to validate the dependency update does not introduce any regressions.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review
- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Correlation ID: `3faf0b20-adb8-11f1-8332-2c5978225e9f`
- Event Trigger: `issue_comment.edited`
</details>
