### PR TITLE
FEAT: add sap-no-deep-collection-facets eslint rule

### DIFF
--- a/.changeset/smooth-papayas-walk.md
+++ b/.changeset/smooth-papayas-walk.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/eslint-plugin-fiori-tools': minor
+---
+
+FEAT: Add rule sap-no-deep-collection-facets

--- a/packages/eslint-plugin-fiori-tools/README.md
+++ b/packages/eslint-plugin-fiori-tools/README.md
@@ -120,7 +120,9 @@ npx --yes @sap-ux/create@latest convert eslint-config --help
 
 |   Since   | Rule | Description | Recommended | Recommended for S/4HANA |
 |:---------:|------|-------------|:-----------:|:-----------------------:|
-|  new      | [sap-cloud-dev-adaptation-status](docs/rules/sap-cloud-dev-adaptation-status.md) | Ensures that `cloudDevAdaptationStatus` is defined in the `sap.fiori` section of the `manifest.json` file. | | ✅ |
+|  new      | [sap-no-deep-collection-facets](docs/rules/sap-no-deep-collection-facets.md) | Ensures `UI.CollectionFacet` elements are not nested at third level or deeper. | | ✅ |
+|  new      | [sap-no-single-facet-in-collection](docs/rules/sap-no-single-facet-in-collection.md) | Ensures `UI.CollectionFacet` is not used when it contains only a single `UI.ReferenceFacet`. | | ✅ |
+|  10.8.0   | [sap-cloud-dev-adaptation-status](docs/rules/sap-cloud-dev-adaptation-status.md) | Ensures that `cloudDevAdaptationStatus` is defined in the `sap.fiori` section of the `manifest.json` file. | | ✅ |
 |  10.7.6   | [sap-no-live-mode](docs/rules/sap-no-live-mode.md) | Ensures that live mode is not enabled. | | ✅ |
 |  10.2.0   | [sap-description-column-label](docs/rules/sap-description-column-label.md) | Ensures that the description text property referenced using the `Common.Text` annotation has a meaningful `Common.Label` annotation. It must not be a generic value such as "Name" or "Description", and not the same label as the `ID` property. | | ✅ |
 |  9.12.0   | [sap-text-arrangement-hidden](docs/rules/sap-text-arrangement-hidden.md) | Ensures that the text property referenced by a `UI.TextArrangement` annotation using the `Common.Text` annotation is not hidden by the `UI.Hidden` annotation | | ✅ |

--- a/packages/eslint-plugin-fiori-tools/docs/rules/sap-no-deep-collection-facets.md
+++ b/packages/eslint-plugin-fiori-tools/docs/rules/sap-no-deep-collection-facets.md
@@ -205,5 +205,4 @@ In case you detect an issue with this rule, please open a GitHub issue [here](ht
 
 ## Further Reading
 
-- [SAP Fiori Design Guidelines - Object Page Sections](https://experience.sap.com/fiori-design-web/object-page/)
-- [UI.Facets Vocabulary Reference](https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md#Facets)
+- [Defining and Configuring Sections](https://ui5.sap.com/#/topic/facfea09018d4376acaceddb7e3f03b6)

--- a/packages/eslint-plugin-fiori-tools/docs/rules/sap-no-deep-collection-facets.md
+++ b/packages/eslint-plugin-fiori-tools/docs/rules/sap-no-deep-collection-facets.md
@@ -1,0 +1,209 @@
+# UI.CollectionFacet should not be nested at third level or deeper (sap-no-deep-collection-facets)
+
+SAP Fiori elements does not consider `UI.CollectionFacet` elements that are nested at the third level or deeper within the `UI.Facets` annotation. This rule detects deeply nested collection facets and recommends reorganizing the facet structure to use a maximum of two nesting levels for proper rendering and functionality.
+
+## Rule Details
+
+This rule checks `UI.Facets` annotations on object pages and identifies any `UI.CollectionFacet` records that appear at the third level of nesting or deeper. SAP Fiori elements supports up to two levels of `UI.CollectionFacet` nesting:
+
+- **Level 1** (direct children of `UI.Facets`): ✅ Supported
+- **Level 2** (children of level 1 `UI.CollectionFacet`): ✅ Supported  
+- **Level 3 and deeper**: ❌ Not considered by Fiori elements
+
+### Warning Message
+
+```
+UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.
+```
+
+### The following patterns are considered warnings:
+
+**Three-level nesting:**
+
+```xml
+<Annotations Target="IncidentService.Incidents">
+    <Annotation Term="UI.Facets">
+        <Collection>
+            <Record Type="UI.CollectionFacet">
+                <PropertyValue Property="ID" String="Level1"/>
+                <PropertyValue Property="Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="ID" String="Level2"/>
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <!-- ❌ Level 3 CollectionFacet - WARNING -->
+                                    <Record Type="UI.CollectionFacet">
+                                        <PropertyValue Property="ID" String="Level3"/>
+                                        <PropertyValue Property="Facets">
+                                            <Collection>
+                                                <Record Type="UI.ReferenceFacet">
+                                                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                                </Record>
+                                            </Collection>
+                                        </PropertyValue>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Collection>
+    </Annotation>
+</Annotations>
+```
+
+**CDS equivalent:**
+
+```cds
+annotate service.Incidents with @(
+    UI.Facets : [
+        {
+            $Type : 'UI.CollectionFacet',
+            ID    : 'Level1',
+            Facets: [
+                {
+                    $Type : 'UI.CollectionFacet',
+                    ID    : 'Level2',
+                    Facets: [
+                        // ❌ Level 3 CollectionFacet - WARNING
+                        {
+                            $Type : 'UI.CollectionFacet',
+                            ID    : 'Level3',
+                            Facets: [
+                                {
+                                    $Type : 'UI.ReferenceFacet',
+                                    Target: '@UI.FieldGroup#Details'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+);
+```
+
+### The following patterns are not considered warnings:
+
+**Two-level nesting (maximum supported depth):**
+
+```xml
+<Annotations Target="IncidentService.Incidents">
+    <Annotation Term="UI.Facets">
+        <Collection>
+            <Record Type="UI.CollectionFacet">
+                <PropertyValue Property="ID" String="Level1"/>
+                <PropertyValue Property="Facets">
+                    <Collection>
+                        <!-- ✅ Level 2 CollectionFacet - OK -->
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="ID" String="Level2"/>
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Collection>
+    </Annotation>
+</Annotations>
+```
+
+**Single-level facets:**
+
+```xml
+<Annotations Target="IncidentService.Incidents">
+    <Annotation Term="UI.Facets">
+        <Collection>
+            <!-- ✅ Direct ReferenceFacets - OK -->
+            <Record Type="UI.ReferenceFacet">
+                <PropertyValue Property="ID" String="Details"/>
+                <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+            </Record>
+            <Record Type="UI.ReferenceFacet">
+                <PropertyValue Property="ID" String="Address"/>
+                <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Address"/>
+            </Record>
+        </Collection>
+    </Annotation>
+</Annotations>
+```
+
+## How to Fix
+
+Reorganize your facet structure to flatten deeply nested `UI.CollectionFacet` elements. Consider one of these approaches:
+
+1. **Remove unnecessary nesting:** If a `UI.CollectionFacet` contains only one child, replace it with a direct `UI.ReferenceFacet`.
+
+2. **Flatten the hierarchy:** Move nested content up to a higher level by combining or reorganizing sections.
+
+3. **Use side-by-side facets:** Place facets at the same level rather than nesting them deeply.
+
+**Before (3 levels - violation):**
+
+```xml
+<Record Type="UI.CollectionFacet">
+    <PropertyValue Property="ID" String="Outer"/>
+    <PropertyValue Property="Facets">
+        <Collection>
+            <Record Type="UI.CollectionFacet">
+                <PropertyValue Property="ID" String="Middle"/>
+                <PropertyValue Property="Facets">
+                    <Collection>
+                        <Record Type="UI.CollectionFacet">
+                            <PropertyValue Property="ID" String="Inner"/>
+                            <PropertyValue Property="Facets">
+                                <Collection>
+                                    <Record Type="UI.ReferenceFacet">
+                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                    </Record>
+                                </Collection>
+                            </PropertyValue>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Collection>
+    </PropertyValue>
+</Record>
+```
+
+**After (2 levels - correct):**
+
+```xml
+<Record Type="UI.CollectionFacet">
+    <PropertyValue Property="ID" String="Outer"/>
+    <PropertyValue Property="Facets">
+        <Collection>
+            <Record Type="UI.CollectionFacet">
+                <PropertyValue Property="ID" String="Middle"/>
+                <PropertyValue Property="Facets">
+                    <Collection>
+                        <!-- Flattened: use ReferenceFacet directly -->
+                        <Record Type="UI.ReferenceFacet">
+                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                        </Record>
+                    </Collection>
+                </PropertyValue>
+            </Record>
+        </Collection>
+    </PropertyValue>
+</Record>
+```
+
+## Bug Report
+
+In case you detect an issue with this rule, please open a GitHub issue [here](https://github.com/SAP/open-ux-tools/issues).
+
+## Further Reading
+
+- [SAP Fiori Design Guidelines - Object Page Sections](https://experience.sap.com/fiori-design-web/object-page/)
+- [UI.Facets Vocabulary Reference](https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md#Facets)

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/eslint-plugin-fiori-tools",
-    "version": "10.9.4",
+    "version": "10.9.3",
     "description": "Custom linting plugin for Fiori tools apps",
     "type": "module",
     "repository": {

--- a/packages/eslint-plugin-fiori-tools/package.json
+++ b/packages/eslint-plugin-fiori-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sap-ux/eslint-plugin-fiori-tools",
-    "version": "10.9.3",
+    "version": "10.9.4",
     "description": "Custom linting plugin for Fiori tools apps",
     "type": "module",
     "repository": {

--- a/packages/eslint-plugin-fiori-tools/src/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/index.ts
@@ -500,7 +500,9 @@ const fioriLanguageConfig: Linter.Config[] = [
             '@sap-ux/fiori-tools/sap-no-data-field-intent-based-navigation': 'warn',
             '@sap-ux/fiori-tools/sap-text-arrangement-hidden': 'warn',
             '@sap-ux/fiori-tools/sap-no-live-mode': 'warn',
-            '@sap-ux/fiori-tools/sap-cloud-dev-adaptation-status': 'warn'
+            '@sap-ux/fiori-tools/sap-cloud-dev-adaptation-status': 'warn',
+            '@sap-ux/fiori-tools/sap-no-single-facet-in-collection': 'warn',
+            '@sap-ux/fiori-tools/sap-no-deep-collection-facets': 'warn'
         }
     }
 ];

--- a/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
+++ b/packages/eslint-plugin-fiori-tools/src/language/diagnostics.ts
@@ -19,6 +19,8 @@ export const STRICT_UOM_FILTERING = 'sap-strict-uom-filtering';
 export const DESCRIPTION_COLUMN_LABEL = 'sap-description-column-label';
 export const NO_LIVE_MODE = 'sap-no-live-mode';
 export const CLOUD_DEV_ADAPTATION_STATUS = 'sap-cloud-dev-adaptation-status';
+export const NO_SINGLE_FACET_IN_COLLECTION = 'sap-no-single-facet-in-collection';
+export const NO_DEEP_COLLECTION_FACETS = 'sap-no-deep-collection-facets';
 
 export interface WidthIncludingColumnHeaderDiagnostic {
     type: typeof WIDTH_INCLUDING_COLUMN_HEADER_RULE_TYPE;
@@ -188,6 +190,22 @@ export interface NoLiveMode {
 export interface CloudDevAdaptationStatus {
     type: typeof CLOUD_DEV_ADAPTATION_STATUS;
     manifest: ManifestPropertyDiagnosticData;
+}
+export interface NoSingleFacetInCollection {
+    type: typeof NO_SINGLE_FACET_IN_COLLECTION;
+    pageNames: string[];
+    annotation: {
+        reference: AnnotationReference;
+        reportedParent: Element;
+    };
+}
+export interface NoDeepCollectionFacets {
+    type: typeof NO_DEEP_COLLECTION_FACETS;
+    pageNames: string[];
+    annotation: {
+        reference: AnnotationReference;
+        reportedParent: Element;
+    };
 }
 
 export type Diagnostic =

--- a/packages/eslint-plugin-fiori-tools/src/rules/index.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/index.ts
@@ -17,7 +17,9 @@ import {
     TEXT_ARRANGEMENT_HIDDEN,
     STRICT_UOM_FILTERING,
     NO_LIVE_MODE,
-    CLOUD_DEV_ADAPTATION_STATUS
+    CLOUD_DEV_ADAPTATION_STATUS,
+    NO_SINGLE_FACET_IN_COLLECTION,
+    NO_DEEP_COLLECTION_FACETS
 } from '../language/diagnostics.js';
 
 // Import all rules
@@ -86,6 +88,8 @@ import condensedTableLayout from './sap-condensed-table-layout.js';
 import textArrangementHidden from './sap-text-arrangement-hidden.js';
 import noLiveMode from './sap-no-live-mode.js';
 import cloudDevAdaptationStatus from './sap-cloud-dev-adaptation-status.js';
+import noSingleFacetInCollection from './sap-no-single-facet-in-collection.js';
+import noDeepCollectionFacets from './sap-no-deep-collection-facets.js';
 
 import type { Rule } from 'eslint';
 
@@ -154,5 +158,7 @@ export const rules: Record<string, Rule.RuleModule | FioriRuleDefinition | Fiori
     [TABLE_PERSONALIZATION]: tablePersonalization,
     [TEXT_ARRANGEMENT_HIDDEN]: textArrangementHidden,
     [NO_LIVE_MODE]: noLiveMode,
-    [CLOUD_DEV_ADAPTATION_STATUS]: cloudDevAdaptationStatus
+    [CLOUD_DEV_ADAPTATION_STATUS]: cloudDevAdaptationStatus,
+    [NO_SINGLE_FACET_IN_COLLECTION]: noSingleFacetInCollection,
+    [NO_DEEP_COLLECTION_FACETS]: noDeepCollectionFacets
 };

--- a/packages/eslint-plugin-fiori-tools/src/rules/sap-no-deep-collection-facets.ts
+++ b/packages/eslint-plugin-fiori-tools/src/rules/sap-no-deep-collection-facets.ts
@@ -1,0 +1,193 @@
+import type { AliasInformation, Element } from '@sap-ux/odata-annotation-core';
+import { Edm, elementsWithName } from '@sap-ux/odata-annotation-core';
+import { createFioriRule } from '../language/rule-factory.js';
+import type { FioriRuleDefinition } from '../types.js';
+import type { NoDeepCollectionFacets } from '../language/diagnostics.js';
+import { NO_DEEP_COLLECTION_FACETS } from '../language/diagnostics.js';
+import { getRecordType, getPropertyValueElement } from '../project-context/linker/annotations.js';
+import { buildAnnotationIndexKey, type ParsedService } from '../project-context/parser/index.js';
+import type { FeV4ObjectPage } from '../project-context/linker/fe-v4.js';
+import type { FeV2ObjectPage } from '../project-context/linker/fe-v2.js';
+import { FioriAnnotationSourceCode } from '../language/annotations/source-code.js';
+
+const UI_FACETS = 'com.sap.vocabularies.UI.v1.Facets';
+const UI_COLLECTION_FACET = 'com.sap.vocabularies.UI.v1.CollectionFacet';
+
+/**
+ * Returns the child Collection element of the Facets property inside a CollectionFacet record, if present.
+ *
+ * @param record - A CollectionFacet Record element
+ * @returns The child Collection element, or undefined
+ */
+function getFacetsChildCollection(record: Element): Element | undefined {
+    const facetsPropertyValue = getPropertyValueElement(record, 'Facets');
+    if (!facetsPropertyValue) {
+        return undefined;
+    }
+    const [childCollection] = elementsWithName(Edm.Collection, facetsPropertyValue);
+    return childCollection;
+}
+
+/**
+ * Recursively finds CollectionFacet records that appear at third level or deeper.
+ * Collects all violating CollectionFacets discovered during the traversal.
+ *
+ * @param collection - The Collection element to traverse
+ * @param aliasInfo - Alias information for resolving qualified names
+ * @param currentLevel - The current nesting level (1 = direct children of UI.Facets)
+ * @param violations - Accumulator for found violations (mutated in place)
+ */
+function findDeepCollectionFacets(
+    collection: Element,
+    aliasInfo: AliasInformation,
+    currentLevel: number,
+    violations: Element[]
+): void {
+    const records = elementsWithName(Edm.Record, collection);
+
+    for (const record of records) {
+        const recordType = getRecordType(aliasInfo, record);
+
+        if (recordType === UI_COLLECTION_FACET) {
+            // If this CollectionFacet is at level 3 or deeper, it's a violation
+            if (currentLevel >= 3) {
+                violations.push(record);
+            }
+
+            // Recursively check nested Facets
+            const childCollection = getFacetsChildCollection(record);
+            if (childCollection) {
+                findDeepCollectionFacets(childCollection, aliasInfo, currentLevel + 1, violations);
+            }
+        }
+    }
+}
+
+/**
+ * Checks an object page's UI.Facets annotations for CollectionFacets at third level or deeper.
+ * Deduplicates: if the same CollectionFacet is shared across pages, merges pageNames.
+ *
+ * @param page - Object page (V4 or V2)
+ * @param parsedService - Parsed annotation service
+ * @param problems - Array of found rule violations (mutated in place)
+ */
+function checkPageFacetAnnotations(
+    page: FeV4ObjectPage | FeV2ObjectPage,
+    parsedService: ParsedService,
+    problems: NoDeepCollectionFacets[]
+): void {
+    const entityType = page.entity?.structuredType;
+    if (!entityType) {
+        return;
+    }
+
+    const annotationKey = buildAnnotationIndexKey(entityType, UI_FACETS);
+    const annotationMap = parsedService.index.annotations[annotationKey];
+    if (!annotationMap) {
+        return;
+    }
+
+    for (const annotation of Object.values(annotationMap)) {
+        const aliasInfo = parsedService.artifacts.aliasInfo[annotation.top.uri];
+        const [facetsCollection] = elementsWithName(Edm.Collection, annotation.top.value);
+        if (!facetsCollection) {
+            continue;
+        }
+
+        const violations: Element[] = [];
+        findDeepCollectionFacets(facetsCollection, aliasInfo, 1, violations);
+
+        for (const collectionFacet of violations) {
+            const existingIndex = problems.findIndex((p) => p.annotation.reference.value === collectionFacet);
+            if (existingIndex > -1) {
+                problems[existingIndex] = {
+                    ...problems[existingIndex],
+                    pageNames: [...problems[existingIndex].pageNames, page.targetName]
+                };
+            } else {
+                problems.push({
+                    type: NO_DEEP_COLLECTION_FACETS,
+                    pageNames: [page.targetName],
+                    annotation: {
+                        reference: {
+                            uri: annotation.top.uri,
+                            value: collectionFacet
+                        },
+                        reportedParent: annotation.top.value
+                    }
+                });
+            }
+        }
+    }
+}
+
+const rule: FioriRuleDefinition = createFioriRule({
+    ruleId: NO_DEEP_COLLECTION_FACETS,
+    meta: {
+        type: 'problem',
+        docs: {
+            recommended: true,
+            description: 'UI.CollectionFacet should not be nested at third level or deeper.',
+            url: 'https://github.com/SAP/open-ux-tools/blob/main/packages/eslint-plugin-fiori-tools/docs/rules/sap-no-deep-collection-facets.md'
+        },
+        messages: {
+            [NO_DEEP_COLLECTION_FACETS]:
+                'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+        },
+        schema: []
+    },
+
+    check(context) {
+        if (!(context.sourceCode instanceof FioriAnnotationSourceCode)) {
+            return [];
+        }
+        const problems: NoDeepCollectionFacets[] = [];
+
+        for (const [appKey, app] of Object.entries(context.sourceCode.projectContext.linkedModel.apps)) {
+            const parsedApp = context.sourceCode.projectContext.index.apps[appKey];
+            const parsedService = context.sourceCode.projectContext.getIndexedServiceForMainService(parsedApp);
+            if (!parsedService) {
+                continue;
+            }
+            for (const page of app.pages) {
+                if (page.type !== 'object-page') {
+                    continue;
+                }
+                checkPageFacetAnnotations(page, parsedService, problems);
+            }
+        }
+
+        return problems;
+    },
+
+    createAnnotations(context, validationResult) {
+        if (validationResult.length === 0) {
+            return {};
+        }
+        const lookup = new Map<Element, NoDeepCollectionFacets[]>();
+        for (const diagnostic of validationResult) {
+            const existing = lookup.get(diagnostic.annotation.reportedParent);
+            if (existing) {
+                existing.push(diagnostic);
+            } else {
+                lookup.set(diagnostic.annotation.reportedParent, [diagnostic]);
+            }
+        }
+        return {
+            ['target>element[name="Annotation"]'](node: Element): void {
+                const diagnostics = lookup.get(node);
+                if (!diagnostics) {
+                    return;
+                }
+                for (const r of diagnostics) {
+                    context.report({
+                        node: r.annotation.reference.value,
+                        messageId: NO_DEEP_COLLECTION_FACETS
+                    });
+                }
+            }
+        };
+    }
+});
+
+export default rule;

--- a/packages/eslint-plugin-fiori-tools/test/rules/sap-no-deep-collection-facets.test.ts
+++ b/packages/eslint-plugin-fiori-tools/test/rules/sap-no-deep-collection-facets.test.ts
@@ -1,0 +1,404 @@
+import { RuleTester } from 'eslint';
+import noDeepCollectionFacetsRule from '../../src/rules/sap-no-deep-collection-facets.js';
+import { meta, languages } from '../../src/index.js';
+import {
+    getAnnotationsAsXmlCode,
+    getManifestAsCode,
+    setup,
+    V2_ANNOTATIONS,
+    V2_ANNOTATIONS_PATH,
+    V4_ANNOTATIONS,
+    V4_ANNOTATIONS_PATH,
+    V4_MANIFEST,
+    V4_MANIFEST_PATH
+} from '../test-helper.js';
+
+const ruleTester = new RuleTester({
+    plugins: { ['@sap-ux/eslint-plugin-fiori-tools']: { ...meta, languages } },
+    language: '@sap-ux/eslint-plugin-fiori-tools/fiori'
+});
+
+const TEST_NAME = 'sap-no-deep-collection-facets';
+const { createValidTest, createInvalidTest } = setup(TEST_NAME);
+
+// V4: two-level nesting (valid - second level is allowed)
+const V4_TWO_LEVEL_NESTING = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Label" String="Level 1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Label" String="Level 2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.ReferenceFacet">
+                                            <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V4: three-level nesting (violation - third level CollectionFacet)
+const V4_THREE_LEVEL_NESTING = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Label" String="Level 1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Label" String="Level 2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.CollectionFacet">
+                                            <PropertyValue Property="ID" String="Level3"/>
+                                            <PropertyValue Property="Label" String="Level 3 - VIOLATION"/>
+                                            <PropertyValue Property="Facets">
+                                                <Collection>
+                                                    <Record Type="UI.ReferenceFacet">
+                                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                                    </Record>
+                                                </Collection>
+                                            </PropertyValue>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V4: four-level nesting (multiple violations)
+const V4_FOUR_LEVEL_NESTING = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.CollectionFacet">
+                                            <PropertyValue Property="ID" String="Level3"/>
+                                            <PropertyValue Property="Facets">
+                                                <Collection>
+                                                    <Record Type="UI.CollectionFacet">
+                                                        <PropertyValue Property="ID" String="Level4"/>
+                                                        <PropertyValue Property="Facets">
+                                                            <Collection>
+                                                                <Record Type="UI.ReferenceFacet">
+                                                                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                                                </Record>
+                                                            </Collection>
+                                                        </PropertyValue>
+                                                    </Record>
+                                                </Collection>
+                                            </PropertyValue>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V4: single-level facets (valid)
+const V4_SINGLE_LEVEL_FACETS = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="ID" String="Details"/>
+                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                </Record>
+                <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="ID" String="Address"/>
+                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Address"/>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V4: mixed structure with third-level violation
+const V4_MIXED_STRUCTURE = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.ReferenceFacet">
+                    <PropertyValue Property="ID" String="SimpleReference"/>
+                    <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Simple"/>
+                </Record>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.ReferenceFacet">
+                                <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1WithNesting"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.CollectionFacet">
+                                            <PropertyValue Property="ID" String="Level3Violation"/>
+                                            <PropertyValue Property="Facets">
+                                                <Collection>
+                                                    <Record Type="UI.ReferenceFacet">
+                                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Address"/>
+                                                    </Record>
+                                                </Collection>
+                                            </PropertyValue>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V2: three-level nesting (violation)
+const V2_THREE_LEVEL_NESTING = `
+    <Annotations Target="TECHED_ALP_SOA_SRV.Z_SEPMRA_SO_SALESORDERANALYSISType">
+        <Annotation Term="UI.Facets">
+            <Collection>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.CollectionFacet">
+                                            <PropertyValue Property="ID" String="Level3"/>
+                                            <PropertyValue Property="Facets">
+                                                <Collection>
+                                                    <Record Type="UI.ReferenceFacet">
+                                                        <PropertyValue Property="Target" AnnotationPath="@UI.LineItem"/>
+                                                    </Record>
+                                                </Collection>
+                                            </PropertyValue>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+// V4: qualified annotation with three-level nesting (violation)
+const V4_QUALIFIED_THREE_LEVEL = `
+    <Annotations Target="IncidentService.Incidents">
+        <Annotation Term="UI.Facets" Qualifier="MyQualifier">
+            <Collection>
+                <Record Type="UI.CollectionFacet">
+                    <PropertyValue Property="ID" String="Level1"/>
+                    <PropertyValue Property="Facets">
+                        <Collection>
+                            <Record Type="UI.CollectionFacet">
+                                <PropertyValue Property="ID" String="Level2"/>
+                                <PropertyValue Property="Facets">
+                                    <Collection>
+                                        <Record Type="UI.CollectionFacet">
+                                            <PropertyValue Property="ID" String="Level3"/>
+                                            <PropertyValue Property="Facets">
+                                                <Collection>
+                                                    <Record Type="UI.ReferenceFacet">
+                                                        <PropertyValue Property="Target" AnnotationPath="@UI.FieldGroup#Details"/>
+                                                    </Record>
+                                                </Collection>
+                                            </PropertyValue>
+                                        </Record>
+                                    </Collection>
+                                </PropertyValue>
+                            </Record>
+                        </Collection>
+                    </PropertyValue>
+                </Record>
+            </Collection>
+        </Annotation>
+    </Annotations>`;
+
+ruleTester.run(TEST_NAME, noDeepCollectionFacetsRule, {
+    valid: [
+        createValidTest(
+            {
+                name: 'V4: no UI.Facets annotation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: V4_ANNOTATIONS
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: single-level ReferenceFacets only',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_SINGLE_LEVEL_FACETS)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: two-level nesting (second level allowed)',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_TWO_LEVEL_NESTING)
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V2: no UI.Facets annotation',
+                filename: V2_ANNOTATIONS_PATH,
+                code: V2_ANNOTATIONS
+            },
+            []
+        ),
+        createValidTest(
+            {
+                name: 'V4: violation pattern on entity with only a list report page is not flagged',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_THREE_LEVEL_NESTING)
+            },
+            [
+                {
+                    filename: V4_MANIFEST_PATH,
+                    code: getManifestAsCode(V4_MANIFEST, [
+                        { path: ['sap.ui5', 'routing', 'targets', 'IncidentsObjectPage'], value: undefined }
+                    ])
+                }
+            ]
+        )
+    ],
+    invalid: [
+        createInvalidTest(
+            {
+                name: 'V4: three-level CollectionFacet nesting',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_THREE_LEVEL_NESTING),
+                errors: [
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    }
+                ]
+            },
+            [
+                {
+                    filename: V4_MANIFEST_PATH,
+                    code: getManifestAsCode(V4_MANIFEST, [])
+                }
+            ]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: four-level nesting (reports level 3 and level 4)',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_FOUR_LEVEL_NESTING),
+                errors: [
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    },
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    }
+                ]
+            },
+            [
+                {
+                    filename: V4_MANIFEST_PATH,
+                    code: getManifestAsCode(V4_MANIFEST, [])
+                }
+            ]
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: mixed structure with one third-level violation',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_MIXED_STRUCTURE),
+                errors: [
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    }
+                ]
+            },
+            [
+                {
+                    filename: V4_MANIFEST_PATH,
+                    code: getManifestAsCode(V4_MANIFEST, [])
+                }
+            ]
+        ),
+        createInvalidTest(
+            {
+                name: 'V2: three-level CollectionFacet nesting',
+                filename: V2_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V2_ANNOTATIONS, V2_THREE_LEVEL_NESTING),
+                errors: [
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    }
+                ]
+            },
+            []
+        ),
+        createInvalidTest(
+            {
+                name: 'V4: qualified annotation with three-level nesting',
+                filename: V4_ANNOTATIONS_PATH,
+                code: getAnnotationsAsXmlCode(V4_ANNOTATIONS, V4_QUALIFIED_THREE_LEVEL),
+                errors: [
+                    {
+                        message:
+                            'UI.CollectionFacet at third level or deeper is not considered by SAP Fiori elements. Reorganize your facet structure to use a maximum of two levels.'
+                    }
+                ]
+            },
+            [
+                {
+                    filename: V4_MANIFEST_PATH,
+                    code: getManifestAsCode(V4_MANIFEST, [])
+                }
+            ]
+        )
+    ]
+});

--- a/packages/jest-file-matchers/src/matchers/toMatchFilesIn/index.ts
+++ b/packages/jest-file-matchers/src/matchers/toMatchFilesIn/index.ts
@@ -1,7 +1,7 @@
 import { toMatchFile } from '../toMatchFileSnapshot/index.js';
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { minimatch } from 'minimatch';
+import minimatch from 'minimatch';
 import type { Filter, MatcherOptions } from '../types.js';
 import { extractMessage } from '../utils.js';
 

--- a/packages/jest-file-matchers/src/matchers/toMatchFilesIn/index.ts
+++ b/packages/jest-file-matchers/src/matchers/toMatchFilesIn/index.ts
@@ -1,7 +1,7 @@
 import { toMatchFile } from '../toMatchFileSnapshot/index.js';
 import fs from 'node:fs';
 import { join } from 'node:path';
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import type { Filter, MatcherOptions } from '../types.js';
 import { extractMessage } from '../utils.js';
 


### PR DESCRIPTION
Internal issue: 39356

## Description
Adds a new `sap-no-deep-collection-facets` ESLint rule for Fiori annotation sources. The rule reports `UI.CollectionFacet` records nested at the third level or deeper within `UI.Facets`, since SAP Fiori elements only supports up to two collection facet nesting levels.

This change includes:
- New rule implementation for V2/V4 object page annotation validation
- Diagnostic type and rule registration in the plugin rule index
- Recommended configuration entry for the new rule
- Rule documentation with warning examples, valid examples, and remediation guidance
- README rule table update
- Changeset for a minor release of `@sap-ux/eslint-plugin-fiori-tools`

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Added `RuleTester` coverage for the new rule, including:
- Valid single-level and two-level facet structures
- Invalid three-level and four-level nested `UI.CollectionFacet` structures
- V2 and V4 annotation scenarios
- Qualified `UI.Facets` annotations
- Mixed facet structures with multiple violations
- Validation limited to object pages only

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [x] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.37`

- Event Trigger: `pull_request.edited`
- File Content Strategy: Full file content
- LLM: `gpt-5.5`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: Repository PR Template
- Correlation ID: `23cd50f0-b1d3-11f1-8497-6d3d266eafe1`
</details>
