### PR TITLE
feat(fiori-mcp-server): Skill productization

### DIFF
--- a/.changeset/honest-zoos-kneel.md
+++ b/.changeset/honest-zoos-kneel.md
@@ -1,0 +1,5 @@
+---
+'@sap-ux/fiori-mcp-server': patch
+---
+
+FEAT: Split sap-fiori-adp-controller-extension skill into workflow core and reference files (hitl-gating, actions-reference, example-session) add enhancement to knowledge base

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/SKILL.md
@@ -1,9 +1,12 @@
 ---
-name: adp-controller-extension-flow
-description: Use when making RTA changes to a SAP Fiori adaptation project via the adaptation editor — adding/removing UI elements, changing properties, renaming labels, hiding controls, or extending controllers and fragments.
+name: sap-fiori-adp-controller-extension
+description: Use when the user wants to make UI changes to a SAP Fiori adaptation project via the adaptation editor — adding buttons, fields, columns, or sections, changing labels or properties, hiding controls, or extending controllers with custom logic. Trigger on phrases like 'add a button', 'hide a field', 'add a column', 'customize the toolbar', or 'extend the controller' when working in an adaptation project context.
+metadata:
+  author: sap-fiori-tools
+  version: "0.0.1"
 ---
 
-# ADP Controller Extension Flow
+# SAP Fiori ADP Controller Extension
 
 Drive Runtime Authoring (RTA) in the SAP Fiori adaptation editor through the **`run_rta_workflow_step`** MCP tool exposed by `fiori-mcp-server`. The tool handles browser automation server-side; this skill orchestrates the step sequence and the AI decisions between steps.
 
@@ -11,7 +14,7 @@ Drive Runtime Authoring (RTA) in the SAP Fiori adaptation editor through the **`
 
 ## Prerequisites
 
-- `fiori-mcp` server running (provides `run_rta_workflow_step`)
+- **`@sap-ux/fiori-mcp-server` running as an MCP server.** It provides `run_rta_workflow_step` and the other `fiori-mcp` tools this skill drives without it none of the tool calls below resolve. See the package's install/setup instructions: https://www.npmjs.com/package/@sap-ux/fiori-mcp-server
 - Adaptation editor URL (user-provided)
 - A Chromium-based browser the server can launch. Resolution order:
   1. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` env var (absolute path to a Chromium binary)
@@ -21,18 +24,13 @@ Drive Runtime Authoring (RTA) in the SAP Fiori adaptation editor through the **`
 
 ### Chromium fallback (no system Chrome)
 
-If no system Chrome is found and no env override is set, the server falls back to Playwright's bundled Chromium. The bundle is **not** included with `playwright-core`, so it has to be installed once on the host machine:
+If no system Chrome is found and no env override is set, the server falls back to Playwright's bundled Chromium. Install it once if needed:
 
 ```bash
 npx playwright install chromium
 ```
 
-When `start` fails with `Executable doesn't exist at .../chromium-XXXX/...`, run that command and retry. Mention to the user that the first install downloads ~120 MB and can take a minute. Subsequent runs reuse the cached browser.
-
-Detection sequence the skill should follow on a `start` failure that mentions a missing browser:
-1. Inspect the error message — if it references a missing Chromium binary, prompt the user to run `npx playwright install chromium` (or run it on their behalf if they consent).
-2. After install completes, retry `start` with the same payload.
-3. If detection still fails, ask the user to set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to a known Chrome/Chromium binary.
+The first install downloads ~120 MB. Subsequent runs reuse the cache. See the Error Handling table for the detection sequence on a `start` failure.
 
 ## Tool Contract
 
@@ -65,119 +63,11 @@ For the standard adaptation editor preview iframe, pass `frameId: "preview"` in 
 
 ## Actions Reference
 
-These are the canonical RTA actions surfaced through each overlay's `actionIds` (and detailed in the `actionsCatalog` returned alongside `get_overlays`). **Always pick by `id` from this table — never invent or guess action IDs.** If `actionsCatalog` contains an `id` not listed here, treat it as unknown and ask the user before proceeding.
-
-### `CTX_ADDXML` — Add: Fragment
-
-Insert an XML fragment as a child of the selected control. This is the action for "add a button / field / column / section" via a fragment file.
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `fragmentPath` | string | yes | Path to the fragment XML, formatted `fragments/<Name>.fragment.xml`. |
-| `targetAggregation` | string | yes | Aggregation of the parent control where the fragment is inserted (e.g. `content`, `items`, `headerContent`). Read from `get_context`. |
-| `index` | int | yes | Position within the aggregation. Use `0` for first, the current child count for "append at end". |
-
-### `CTX_EXTEND_CONTROLLER` — Extend Controller
-
-Attach a controller extension JS file to a view. Use this when fragment event handlers reference methods that need a JS implementation, or whenever the user asks for behavior changes (handlers, lifecycle hooks, formatters).
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `codeRef` | string | yes | Path to the controller extension, formatted `coding/<Name>.js`. |
-| `viewId` | string | yes | Any control id inside the view, or the view id itself. The `controlId` of the current selection works. |
-| `instanceSpecific` | boolean | no | `true` extends only this view instance; `false`/omitted extends every view that uses this controller. |
-
-### Disambiguation by intent
-
-| User intent | Action |
-|---|---|
-| "add a button / field / column / section / dialog opener" | `CTX_ADDXML` (fragment carries the new control) |
-| "make this button do X" / "open a dialog when …" / "change behavior" | `CTX_EXTEND_CONTROLLER` (handler lives in the controller extension) |
-| "add a button that opens a dialog" | **Both**, in this order: `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. Run as two separate iterations of Steps 4–9. |
-
-If the `actionsCatalog` exposes more actions than these for a control, surface them to the user rather than picking — this skill is only authoritative for `CTX_ADDXML` and `CTX_EXTEND_CONTROLLER`.
+`CTX_ADDXML` (fragment insert) and `CTX_EXTEND_CONTROLLER` (controller attach). Field schemas and disambiguation table: **[references/actions-reference.md](references/actions-reference.md)**.
 
 ## Confidence & HITL Gating
 
-Three steps in this workflow are AI judgment calls, not deterministic lookups: control selection (Step 4), action selection (Step 5), and payload preparation (Step 8). Wrong choices at these points either edit the wrong UI or silently corrupt the change. To make HITL reliable, **rate every such decision with a self-assessed confidence in `[0, 1]`** and gate behavior on per-decision thresholds.
-
-### Confidence rubric
-
-Anchor your self-rating to evidence, not vibes:
-
-| Confidence | When to assign it |
-|---|---|
-| **0.95–1.00** | Exact, unambiguous match. Single candidate. Wording in the user's instruction maps 1:1 to one option. |
-| **0.85–0.94** | Strong match. Top candidate is clearly best; runner-up is materially worse. All required fields derived from explicit context or instructions. |
-| **0.65–0.84** | Likely match. Top candidate is plausible but the runner-up is also reasonable, or one non-critical field had to be inferred. |
-| **0.40–0.64** | Weak match. Several plausible candidates, or a required field was inferred from weak signals. |
-| **< 0.40** | No real match. Don't pick — list options and ask. |
-
-### Three bands → three behaviors
-
-| Band | Range | Behavior |
-|---|---|---|
-| **High** | ≥ high threshold | Proceed silently. Record the choice + confidence in the final summary. |
-| **Medium** | ask threshold ≤ x < high threshold | Proceed but **announce** the choice on one line: `Using <choice> (confidence 0.78). Continuing — interrupt to change.` Do not stop. |
-| **Low** | < ask threshold | **Stop and ask.** Present the top 2–3 ranked candidates with their confidences. Never guess. |
-
-### Medium-band lock-in (critical)
-
-A Medium-band announcement is a **soft commitment, not a draft**. The next tool call must use the announced choice exactly. If downstream evidence later invalidates the choice — for example, the overlay's `actionIds` doesn't contain the action you expected, `get_context` returns a structure that doesn't match, or the action call errors — you MUST:
-
-1. **Stop.** Do not silently switch to a different control, action, or payload. The user already saw "Using X" and is reasonably expecting X.
-2. **Report the contradiction explicitly:** what you announced, what came back, and what that means.
-3. **Ask the user how to proceed.** Offer concrete alternatives where possible (e.g. "(a) try a different control, (b) use a different action on the same control, (c) stop").
-
-Silently revising a Medium-band choice is the single worst HITL failure mode this skill protects against. The user's "interrupt to change" affordance is real-time only; once you've moved past it, ask explicitly before changing course.
-
-### Expected-action absence is a hard stop
-
-When you derived an expected action id in Step 5 from the user's intent (e.g. "add a button" → `CTX_ADDXML`) and the chosen control doesn't expose that action, **this is an ask point, not a search heuristic**. Do not silently iterate to a different control hoping the action appears. Instead:
-
-1. **Stop.** Tell the user, in plain terms, that the control they're working with doesn't support the action needed for this intent. Name the control and the missing action explicitly.
-2. **Propose a similar control if one exists.** Look at the overlay list for candidates of the same or compatible `controlType` (e.g. another `OverflowToolbar`, another `Toolbar`, the parent container) and name **one specific alternative** with the reason it's similar. Do not list five — pick the closest one.
-3. **Wait for explicit confirmation.** Do not switch controls until the user replies. If they confirm, restart from Step 5 (action selection) on the new control and verify the expected action is present *before* announcing.
-4. **If no similar control is obvious**, ask the user to point at one or to clarify what they meant — don't guess.
-
-This rule has special weight when the **user explicitly named the control** (e.g. "add a button to the TableToolbar"). In that case the model must not silently substitute a different control under any circumstance — the user said which one, and a missing action means the request itself is impossible as stated, which the user must be told.
-
-This rule applies even when the chosen control was selected in the High band. A High-band control plus an unexpected action set is a higher-priority signal than the original control-selection confidence.
-
-Phrasing template:
-
-> The `<chosenControl>` (`<controlType>`) doesn't expose `<expectedAction>` — only `<actual ids>`.
->
-> The closest similar control on this page is `<proposedControl>` (`<controlType>`), because `<reason>`. Should I switch to `<proposedControl>` and continue, or did you mean a different control?
-
-### Per-decision thresholds
-
-| Decision | High ≥ | Ask < | Reasoning |
-|---|---|---|---|
-| Step 4 — Control selection | 0.95 | 0.60 | Cheap to undo if wrong (the action will fail or look obviously wrong). |
-| Step 5 — Action selection | 0.85 | 0.65 | Few options, usually obvious; bump slightly higher because the wrong action causes a wrong *kind* of change. |
-| Step 8 — Payload preparation | 0.90 | 0.70 | **Highest risk.** Action can succeed yet produce a broken/misplaced change. Bias toward asking. |
-
-### Ambiguity overrides confidence (must ask)
-
-The Medium band is for "I know which one and the runner-up is materially worse, but not by a wide margin." It is **not** for "two candidates look interchangeable." When two or more candidates are roughly equally plausible — same `controlType`, similar labels, both reasonable matches for the user's words — that is a **disambiguation problem, not a confidence problem**. Treat it as a hard ask regardless of the score:
-
-- Two or more candidates within **0.10** confidence of each other → **stop and ask**, even if the top score is in the High band on paper.
-- "I'll pick the more conventional one" or "this is where row actions live" reasoning is not a tiebreaker — it's a guess. List the candidates and ask.
-
-Concrete example: a ListReport page has both a `TableToolbar` and a `FooterToolbar`. The user said "the toolbar." Both are `sap.m.OverflowToolbar`. Don't pick — ask.
-
-### Required-field rule (Step 8)
-
-A required field whose value cannot be derived from (a) the action's payload schema, (b) the element context, or (c) explicit user instructions **caps the whole-payload confidence at 0.55** regardless of how strong the other fields are. That puts payload prep into the "ask" band by default whenever guessing is required.
-
-### Multi-change runs
-
-When executing many changes in one session, the cumulative chance of a wrong silent decision grows. **Lower the high threshold of every decision by 0.05 once the run has > 3 changes** so that the 4th and later changes are announced more aggressively. Always re-run `get_overlays` between iterations — confidence drops if the snapshot is stale.
-
-### Reporting
-
-The final summary (Step 14) must include, per change: chosen control, action, and the confidence the model assigned to each AI decision. This makes silent high-confidence decisions auditable after the fact.
+Three steps require AI judgment: control selection (Step 4), action selection (Step 5), and payload preparation (Step 8). Full rubric, per-decision thresholds, and gating rules: **[references/hitl-gating.md](references/hitl-gating.md)**.
 
 ## Workflow
 
@@ -188,6 +78,8 @@ The final summary (Step 14) must include, per change: chosen control, action, an
 Call `run_rta_workflow_step` with `step: "start"`, `site` (the editor URL from `open_adaptation_editor`), and payload `{ site, frameId: "preview" }`. Verify `rtaStarted: true`. Pass `site` and `frameId` to every subsequent step. On `false`, wait 3 s and retry once.
 
 ### Step 2 — Navigate the app to the editing target
+
+**When to skip Step 2.** If `get_overlays` already returns the control the user named (the page is on the right view from the start), skip to Step 3. The page-action loop is for navigation, not for editing.
 
 The RTA flow assumes the control to edit is already on screen. For Fiori Elements apps this often isn't true on first load — a List Report shows no rows until the Filter Bar search is triggered; an Object Page is only reachable after picking a row. Drive that navigation through the page-action steps before reaching for `get_overlays`.
 
@@ -202,8 +94,6 @@ Call `step: "get_page_actions"`. The result has two arrays:
 2. **Handle `needs_user_action`.** If `result.status === "needs_user_action"`, surface `result.reason` to the user — typically a precondition the framework can't satisfy itself (mandatory filter not set, value help required). Wait for them to resolve it, then call `get_page_actions` again.
 3. **Fall through to `interactive` only when no registered action fits.** Pick the entry whose `label` and `kind` match the user's words and call `step: "press_interactive"` with `payload: { controlId }`. The press uses a real user-gesture click and waits best-effort for the page to change.
 4. **Loop.** After each `call_page_action` / `press_interactive`, call `get_page_actions` again. The `registered` set is the live signal that you've moved to a new context — e.g. `navigateToSection` appearing means you're now on an Object Page. Repeat until the editing target is reachable.
-
-**When to skip Step 2.** If `get_overlays` already returns the control the user named (the page is on the right view from the start), skip to Step 3. The page-action loop is for navigation, not for editing.
 
 **`interactive` is a fallback, not the primary path.** A registered action wraps the framework's own knowledge of "what does it mean to load data here"; an interactive press is a generic click. Reach for `press_interactive` only when (a) `registered` is empty for what you need, *or* (b) `call_page_action` returned `needs_user_action` for a reason the user is unlikely to resolve themselves (e.g. a confirmation dialog only the LLM can read).
 
@@ -248,14 +138,11 @@ Store the chosen `controlId` and its confidence for the final summary.
 
 The chosen overlay carries its available action ids in `actionIds`; the rich per-action metadata (label, description, parameters) for each id lives in the top-level `actionsCatalog` returned alongside `get_overlays`. There is no separate `get_actions` step — read both from the Step 3 response.
 
-Pick an action by `id` from the **Actions Reference** above. **Never invent an action id**; if `actionsCatalog` contains an id that isn't in the reference, ask the user.
+Pick an action by `id` from the **[Actions Reference](references/actions-reference.md)**. **Never invent an action id**; if `actionsCatalog` contains an id that isn't in the reference, ask the user.
 
-Map user intent (see *Disambiguation by intent* in the reference):
-- "add a button/field/column/section" → `CTX_ADDXML`
-- "make X happen on click", "open a dialog", "change behavior" → `CTX_EXTEND_CONTROLLER`
-- "add a button that does X" → both (run as two iterations).
+Map user intent using the *Disambiguation by intent* table in the [Actions Reference](references/actions-reference.md). If the verb doesn't map cleanly (e.g. "tweak the toolbar"), confidence is low — list the actions from `actionIds` (with their labels from `actionsCatalog`) and ask.
 
-**Confidence gating** (thresholds: high ≥ 0.85, ask < 0.65):
+**Confidence gating** (thresholds from [references/hitl-gating.md](references/hitl-gating.md#per-decision-thresholds)):
 - **Schema-inspection prerequisite for High band:** Before assigning ≥ 0.85, you must have read the candidate's `parameters` schema (from `actionsCatalog[actionId]`) and confirmed it matches the kind of operation the user described. If you have not inspected the schema, cap confidence at **0.65** (medium → announce, do not run silently).
 - **Same-verb penalty:** If two or more candidates share a verb token in their id or label (e.g. multiple `ADD_*` actions in `actionIds`), subtract **0.20** from the top candidate's confidence unless the schemas clearly distinguish them.
 - **High-band requirement:** When proceeding silently, record an `Alternatives considered:` line stating which other actions were rejected and the schema/semantic reason. If you can't articulate the discriminator, the choice isn't High.
@@ -283,14 +170,14 @@ Call `step: "get_context"`, payload `{ controlId, actionId }`. The response is r
 
 #### Mandatory aggregation/member verification (hard rule — no exceptions)
 
-`get_context` tells you which aggregations exist (`aggregationsByClass[]`, `parentAggregationName`, `defaultChildAggregation`) and which control defines each one (`definedIn` + `libraryName`), but **not what they're for**. Before writing any fragment XML you MUST call `mcp__fiori-mcp__lookup_ui5_documentation` to verify the aggregation's accepted type and cardinality against the actual deployed UI5 version.
+`get_context` tells you which aggregations exist (`aggregationsByClass[]`, `parentAggregationName`, `defaultChildAggregation`) and which control defines each one (`definedIn` + `libraryName`), but **not what they're for**. Before writing any fragment XML you MUST call `lookup_ui5_documentation` to verify the aggregation's accepted type and cardinality against the actual deployed UI5 version.
 
 **Never skip this call.** Type contracts change between UI5 releases — the only safe source is the tool output.
 
-Call `mcp__fiori-mcp__lookup_ui5_documentation` for every aggregation you plan to use:
+Call `lookup_ui5_documentation` for every aggregation you plan to use:
 
 ```
-mcp__fiori-mcp__lookup_ui5_documentation({
+lookup_ui5_documentation({
   lookupType: "aggregation",   // or "property" or "event"
   library: "<libraryName from aggregationsByClass>",
   control: "<control FQ name — leaf control is fine; the tool walks the chain>",
@@ -317,7 +204,7 @@ The `library` field in the tool response is the **exact string to use as the XML
 
 Run this step only if the user's intention involves binding the element to a data source **and** `availableModels` from Step 6 didn't already answer the question. For the simple "which entity is this control bound to" case, `availableModels[<name>].contextEntityType` is usually enough; reach for the EDMX only when you need richer information (property details, navigation paths, annotations, or entities outside the current binding context).
 
-**IMPORTANT** Call `mcp__fiori-mcp__read_odata_metadata_adp` with the adaptation project path to retrieve the metadata (EDMX) of the OData services available to the application. Always use this tool — do not curl, fetch, or grep EDMX from disk. Use the returned entities, properties, navigation paths, key fields, and annotations as context to decide:
+**IMPORTANT** Call `read_odata_metadata_adp` with the adaptation project path to retrieve the metadata (EDMX) of the OData services available to the application. Always use this tool — do not curl, fetch, or grep EDMX from disk. Use the returned entities, properties, navigation paths, key fields, and annotations as context to decide:
 
 - Which entity set / entity type to bind against
 - The exact property name and path (including any navigation traversal)
@@ -338,7 +225,7 @@ Feed these decisions into Step 8 (payload preparation) and into the fragment XML
 
 ### Step 8 — Prepare action payload (AI decision)
 
-Build `actionPayload` from the action's `parameters` schema (Step 5), the element context (Step 6), and the user's instructions. **Use the exact field names from the Actions Reference** — `fragmentPath` (not `fragmentName`), `codeRef`, `viewId`, etc.
+Build `actionPayload` from the action's `parameters` schema (Step 5), the element context (Step 6), and the user's instructions. **Use the exact field names from the [Actions Reference](references/actions-reference.md)** — `fragmentPath` (not `fragmentName`), `codeRef`, `viewId`, etc.
 
 **For `CTX_ADDXML`:**
 - `fragmentPath`: `fragments/<Name>.fragment.xml` — pick `<Name>` from the user's intent (e.g. `OrderDetailsButton`). The fragment file itself is created in Step 12.
@@ -359,9 +246,9 @@ General rules:
 - **Existing change awareness:** before finalising any payload or generated code, review the existing changes in the project (imported key user changes and any developer changes already in `webapp/changes/`) for related intent. When an existing change addresses something similar to the current requirement, align the new output with it — reuse the same property names, URL patterns, entity paths, and logic rather than re-deriving them independently. Silently diverging from an established pattern in the same project is a defect.
 - Validate types match the schema (string vs int vs boolean — `index` is int, not string).
 
-**Confidence gating** (thresholds: high ≥ 0.90, ask < 0.70 — strictest of the three because a successful `call_action` with a wrong payload is the worst silent failure):
+**Confidence gating** (thresholds from [references/hitl-gating.md](references/hitl-gating.md#per-decision-thresholds) — strictest of the three because a successful `call_action` with a wrong payload is the worst silent failure):
 - Per-field confidence: use the rubric. Whole-payload confidence is the **minimum** of the per-field values.
-- **Required-field rule:** a required field whose value cannot be derived from schema, context, or explicit instruction caps whole-payload confidence at **0.55** — push to the ask band even if every other field is perfect.
+- **Required-field rule:** see *Confidence & HITL Gating* — a required field with no derivable value caps whole-payload confidence at 0.55 (ask band).
 - **High** → submit the payload silently.
 - **Medium** → announce the payload: `Action <actionId> with payload <JSON> (confidence 0.7x). Continuing — interrupt to change.` Continue.
 - **Low** → present the payload as a draft and ask for confirmation or corrections before calling.
@@ -386,7 +273,7 @@ Call `step: "save"`. Returns `{ saved: true }` on success.
 
 ### Step 12 — Generate fragment and controller extension content
 
-After saving, use `mcp__fiori-mcp__adp_controller_extension` to fill in the content for any fragments and controller extensions that were created.
+After saving, use `adp_controller_extension` to fill in the content for any fragments and controller extensions that were created.
 
 **Phase 1 — knowledge base.** Call with:
 - `appPath`: adaptation project path
@@ -449,12 +336,18 @@ If an expected control is missing from the overlay list for other reasons (wrong
 
 Call `step: "stop"`. The server closes the session; if it was the last one, the browser shuts down too.
 
-Then kill the editor server:
+Then kill the editor server. `open_adaptation_editor` already returns ready-made kill instructions for the host platform — relay those. The manual forms, by platform:
 
+**Mac/Linux:**
 ```
-kill <processId>
-# or by port:
-lsof -ti:<port> | xargs kill
+kill -9 $(lsof -ti:<port>)   # by port (recommended)
+kill <processId>             # by PID
+```
+
+**Windows:**
+```
+for /f "tokens=5" %a in ('netstat -ano ^| findstr :<port>') do taskkill /PID %a /F   :: by port
+taskkill /PID <processId> /F                                                          :: by PID
 ```
 
 Report to the user: summary of all changes made, files created, any issues encountered, **plus the confidence the model assigned to each AI decision (control selection, action selection, payload prep) for every change** — this makes silent high-confidence decisions auditable after the fact.
@@ -469,10 +362,10 @@ Report to the user: summary of all changes made, files created, any issues encou
 | Expected action id is not in the chosen overlay's `actionIds` | **Stop.** This is the hard-stop case from *Confidence & HITL Gating*. Do not silently switch controls or actions. Tell the user what you expected, what came back, and ask how to proceed. |
 | Action execution fails | Report error, offer retry with different params. |
 | Save fails | Report error. Inform user changes may be lost. |
+| `adp_controller_extension` Phase 1 (knowledge base) fails | Surface the error and stop. Ask the user to verify `appPath` points to an adaptation project root (a folder containing `webapp/manifest.appdescr_variant`). |
 | `Unknown site` or missing `site` field | Pass the `site` URL from `open_adaptation_editor` to every step. |
 | `Frontend action ... not registered` | The editor hasn't finished loading, or wrong frame. Verify `frameId: "preview"` and retry. |
-| `Executable doesn't exist at .../chromium-...` or `browserType.launch: ...` referencing a missing browser | No system Chrome and no Playwright Chromium installed. Run `npx playwright install chromium` (one-time, ~120 MB) and retry `start`. |
-| `Chromium executable not found` (custom message from the server) | Same as above — Playwright Chromium isn't installed and no system Chrome was found. Install via `npx playwright install chromium`. |
+| `Executable doesn't exist at .../chromium-...` or `browserType.launch: ...` referencing a missing browser | No system Chrome and no Playwright Chromium installed. (1) Prompt the user to run `npx playwright install chromium` (or run it on their behalf if they consent). (2) Retry `start` with the same payload. (3) If still failing, ask the user to set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to a known Chrome/Chromium binary. |
 
 ## Multi-Change Strategy
 
@@ -486,28 +379,4 @@ When the user requests multiple changes:
 
 ## Example Session
 
-User: "Add a custom button to the object page toolbar that shows a dialog with order details."
-
-This intent maps to **two actions** (see *Disambiguation by intent*): `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. The app starts on a List Report, so the Object Page toolbar isn't on screen yet — the page-action loop drives the navigation first.
-
-1. `start` with `{ site, frameId: "preview" }` → `{ site, frameId, rtaStarted: true }`
-2. `get_page_actions` → `registered: [{ id: "loadData", … }]`. The user's target is on the Object Page, so the table needs rows first.
-3. `call_page_action({ id: "loadData" })` → `result: { status: "ok" }`. Filter Bar search ran and rows arrived.
-4. `get_page_actions` → `registered` now includes `navigateToRow`.
-5. `call_page_action({ id: "navigateToRow" })` → `result: { status: "ok" }`. The Object Page is mounted.
-6. `get_overlays` → find the toolbar control (confidence 0.88 → High → silent). The overlay's `actionIds` includes `CTX_ADDXML` and `CTX_EXTEND_CONTROLLER`; `actionsCatalog` has the parameter schemas.
-7. **Iteration 1 — add the button:**
-   - `get_context` for `(<toolbar>, CTX_ADDXML)` → returns `parentAggregationName`, `aggregationsByClass` (with `content.contentLength`), `availableModels`
-   - Action confidence 0.92 (High; alternatives considered: only fragment-add was in `actionIds`)
-   - Payload `{ fragmentPath: "fragments/OrderDetailsButton.fragment.xml", targetAggregation: "content", index: <contentLength> }` confidence 0.91 → High
-   - `call_action` → `success: true`
-8. **Iteration 2 — add the controller extension:**
-   - The same overlay's `actionIds` still includes `CTX_EXTEND_CONTROLLER`
-   - `get_context` for `(<toolbar>, CTX_EXTEND_CONTROLLER)` → returns `viewId`
-   - Payload `{ codeRef: "coding/OrderDetailsExt.js", viewId: "<viewId>" }` confidence 0.93 → High
-   - `call_action` → `success: true`
-9. `save` → `saved: true`
-10. `adp_controller_extension` Phase 1 → knowledge base
-11. Generate fragment XML (`OrderDetailsButton.fragment.xml`) + controller extension (`OrderDetailsExt.js` with the press handler that opens the dialog), Phase 2 writes files
-12. `restart` → `{ site, frameId, rtaStarted: true }`. Navigate to the Object Page toolbar again via `get_page_actions` / `call_page_action`, then `get_overlays` — confirm the inserted fragment overlay (`OrderDetailsButton`) appears.
-13. `stop`, then kill the editor server. Report done — including the confidence the model assigned to each AI decision.
+Worked example (button + dialog on an Object Page): **[references/example-session.md](references/example-session.md)**.

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/SKILL.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/SKILL.md
@@ -61,9 +61,9 @@ For the standard adaptation editor preview iframe, pass `frameId: "preview"` in 
 
 > **When to reach for the page-action steps.** The six RTA steps (`get_overlays` → … → `save`) assume the page is already showing the control to edit. In Fiori Elements apps that often isn't true on first load — a List Report shows no rows until "Go" is pressed; an Object Page is only reachable after picking a row. Use `get_page_actions` / `call_page_action` / `press_interactive` to drive these pre-RTA navigations from the skill instead of asking the user to click manually. See **Step 2 — Navigate the app** below.
 
-## Actions Reference
+## RTA Actions
 
-`CTX_ADDXML` (fragment insert) and `CTX_EXTEND_CONTROLLER` (controller attach). Field schemas and disambiguation table: **[references/actions-reference.md](references/actions-reference.md)**.
+`CTX_ADDXML` (fragment insert) and `CTX_EXTEND_CONTROLLER` (controller attach). Field schemas and disambiguation table: **[references/rta-actions.md](references/rta-actions.md)**.
 
 ## Confidence & HITL Gating
 
@@ -138,9 +138,9 @@ Store the chosen `controlId` and its confidence for the final summary.
 
 The chosen overlay carries its available action ids in `actionIds`; the rich per-action metadata (label, description, parameters) for each id lives in the top-level `actionsCatalog` returned alongside `get_overlays`. There is no separate `get_actions` step — read both from the Step 3 response.
 
-Pick an action by `id` from the **[Actions Reference](references/actions-reference.md)**. **Never invent an action id**; if `actionsCatalog` contains an id that isn't in the reference, ask the user.
+Pick an action by `id` from the **[RTA Actions](references/rta-actions.md)** — and only if that `id` is also present in the chosen overlay's `actionIds`. **Never invent an action id.** If the user's intent needs an action that isn't in the reference, surface the overlay's available actions and ask the user rather than picking.
 
-Map user intent using the *Disambiguation by intent* table in the [Actions Reference](references/actions-reference.md). If the verb doesn't map cleanly (e.g. "tweak the toolbar"), confidence is low — list the actions from `actionIds` (with their labels from `actionsCatalog`) and ask.
+Map user intent using the *Disambiguation by intent* table in the [RTA Actions](references/rta-actions.md). If the verb doesn't map cleanly (e.g. "tweak the toolbar"), confidence is low — list the actions from `actionIds` (with their labels from `actionsCatalog`) and ask.
 
 **Confidence gating** (thresholds from [references/hitl-gating.md](references/hitl-gating.md#per-decision-thresholds)):
 - **Schema-inspection prerequisite for High band:** Before assigning ≥ 0.85, you must have read the candidate's `parameters` schema (from `actionsCatalog[actionId]`) and confirmed it matches the kind of operation the user described. If you have not inspected the schema, cap confidence at **0.65** (medium → announce, do not run silently).
@@ -225,7 +225,7 @@ Feed these decisions into Step 8 (payload preparation) and into the fragment XML
 
 ### Step 8 — Prepare action payload (AI decision)
 
-Build `actionPayload` from the action's `parameters` schema (Step 5), the element context (Step 6), and the user's instructions. **Use the exact field names from the [Actions Reference](references/actions-reference.md)** — `fragmentPath` (not `fragmentName`), `codeRef`, `viewId`, etc.
+Build `actionPayload` from the action's `parameters` schema (Step 5), the element context (Step 6), and the user's instructions. **Use the exact field names from the [RTA Actions](references/rta-actions.md)** — `fragmentPath` (not `fragmentName`), `codeRef`, `viewId`, etc.
 
 **For `CTX_ADDXML`:**
 - `fragmentPath`: `fragments/<Name>.fragment.xml` — pick `<Name>` from the user's intent (e.g. `OrderDetailsButton`). The fragment file itself is created in Step 12.
@@ -379,4 +379,4 @@ When the user requests multiple changes:
 
 ## Example Session
 
-Worked example (button + dialog on an Object Page): **[references/example-session.md](references/example-session.md)**.
+Workflow example (button + dialog on an Object Page): **[references/example-session.md](references/example-session.md)**.

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/actions-reference.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/actions-reference.md
@@ -1,0 +1,31 @@
+# Actions Reference
+
+> Referenced from [SKILL.md](../SKILL.md). Use the `id` values from this table — **never invent or guess an action id.** If `actionsCatalog` exposes ids not listed here, surface them to the user rather than picking.
+
+## `CTX_ADDXML` — Add: Fragment
+
+Insert an XML fragment as a child of the selected control. This is the action for "add a button / field / column / section" via a fragment file.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fragmentPath` | string | yes | Path to the fragment XML, formatted `fragments/<Name>.fragment.xml`. |
+| `targetAggregation` | string | yes | Aggregation of the parent control where the fragment is inserted (e.g. `content`, `items`, `headerContent`). Read from `get_context`. |
+| `index` | int | yes | Position within the aggregation. Use `0` for first, the current child count for "append at end". |
+
+## `CTX_EXTEND_CONTROLLER` — Extend Controller
+
+Attach a controller extension JS file to a view. Use this when fragment event handlers reference methods that need a JS implementation, or whenever the user asks for behavior changes (handlers, lifecycle hooks, formatters).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `codeRef` | string | yes | Path to the controller extension, formatted `coding/<Name>.js`. |
+| `viewId` | string | yes | Any control id inside the view, or the view id itself. The `controlId` of the current selection works. |
+| `instanceSpecific` | boolean | no | `true` extends only this view instance; `false`/omitted extends every view that uses this controller. |
+
+## Disambiguation by intent
+
+| User intent | Action |
+|---|---|
+| "add a button / field / column / section / dialog opener" | `CTX_ADDXML` (fragment carries the new control) |
+| "make this button do X" / "open a dialog when …" / "change behavior" | `CTX_EXTEND_CONTROLLER` (handler lives in the controller extension) |
+| "add a button that opens a dialog" | **Both**, in this order: `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. Run as two separate iterations of Steps 4–9. |

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/example-session.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/example-session.md
@@ -1,0 +1,29 @@
+# Example Session
+
+> Referenced from [SKILL.md](../SKILL.md). Worked walkthrough of the full skill flow for a button + dialog on an Object Page.
+
+**User request:** "Add a custom button to the object page toolbar that shows a dialog with order details."
+
+This intent maps to **two actions** (see *Disambiguation by intent* in [actions-reference.md](actions-reference.md)): `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. The app starts on a List Report, so the Object Page toolbar isn't on screen yet — the page-action loop drives the navigation first.
+
+1. `start` with `{ site, frameId: "preview" }` → `{ site, frameId, rtaStarted: true }`
+2. `get_page_actions` → `registered: [{ id: "loadData", … }]`. The user's target is on the Object Page, so the table needs rows first.
+3. `call_page_action({ id: "loadData" })` → `result: { status: "ok" }`. Filter Bar search ran and rows arrived.
+4. `get_page_actions` → `registered` now includes `navigateToRow`.
+5. `call_page_action({ id: "navigateToRow" })` → `result: { status: "ok" }`. The Object Page is mounted.
+6. `get_overlays` → find the toolbar control (confidence 0.88 → High → silent). The overlay's `actionIds` includes `CTX_ADDXML` and `CTX_EXTEND_CONTROLLER`; `actionsCatalog` has the parameter schemas.
+7. **Iteration 1 — add the button:**
+   - `get_context` for `(<toolbar>, CTX_ADDXML)` → returns `parentAggregationName`, `aggregationsByClass` (with `content.contentLength`), `availableModels`
+   - Action confidence 0.92 (High; alternatives considered: only fragment-add was in `actionIds`)
+   - Payload `{ fragmentPath: "fragments/OrderDetailsButton.fragment.xml", targetAggregation: "content", index: <contentLength> }` confidence 0.91 → High
+   - `call_action` → `success: true`
+8. **Iteration 2 — add the controller extension:**
+   - The same overlay's `actionIds` still includes `CTX_EXTEND_CONTROLLER`
+   - `get_context` for `(<toolbar>, CTX_EXTEND_CONTROLLER)` → returns `viewId`
+   - Payload `{ codeRef: "coding/OrderDetailsExt.js", viewId: "<viewId>" }` confidence 0.93 → High
+   - `call_action` → `success: true`
+9. `save` → `saved: true`
+10. `adp_controller_extension` Phase 1 → knowledge base
+11. Generate fragment XML (`OrderDetailsButton.fragment.xml`) + controller extension (`OrderDetailsExt.js` with the press handler that opens the dialog), Phase 2 writes files
+12. `restart` → `{ site, frameId, rtaStarted: true }`. Navigate to the Object Page toolbar again via `get_page_actions` / `call_page_action`, then `get_overlays` — confirm the inserted fragment overlay (`OrderDetailsButton`) appears.
+13. `stop`, then kill the editor server. Report done — including the confidence the model assigned to each AI decision.

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/example-session.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/example-session.md
@@ -4,7 +4,7 @@
 
 **User request:** "Add a custom button to the object page toolbar that shows a dialog with order details."
 
-This intent maps to **two actions** (see *Disambiguation by intent* in [actions-reference.md](actions-reference.md)): `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. The app starts on a List Report, so the Object Page toolbar isn't on screen yet — the page-action loop drives the navigation first.
+This intent maps to **two actions** (see *Disambiguation by intent* in [rta-actions.md](rta-actions.md)): `CTX_ADDXML` for the button, then `CTX_EXTEND_CONTROLLER` for the press handler. The app starts on a List Report, so the Object Page toolbar isn't on screen yet — the page-action loop drives the navigation first.
 
 1. `start` with `{ site, frameId: "preview" }` → `{ site, frameId, rtaStarted: true }`
 2. `get_page_actions` → `registered: [{ id: "loadData", … }]`. The user's target is on the Object Page, so the table needs rows first.

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/hitl-gating.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/hitl-gating.md
@@ -1,0 +1,83 @@
+# Confidence & HITL Gating
+
+> Referenced from [SKILL.md](../SKILL.md). The workflow steps refer back here for thresholds and rules.
+
+Three steps in this workflow are AI judgment calls, not deterministic lookups: control selection (Step 4), action selection (Step 5), and payload preparation (Step 8). Wrong choices at these points either edit the wrong UI or silently corrupt the change. To make HITL reliable, **rate every such decision with a self-assessed confidence in `[0, 1]`** and gate behavior on per-decision thresholds.
+
+## Confidence rubric
+
+Anchor your self-rating to evidence, not vibes:
+
+| Confidence | When to assign it |
+|---|---|
+| **0.95–1.00** | Exact, unambiguous match. Single candidate. Wording in the user's instruction maps 1:1 to one option. |
+| **0.85–0.94** | Strong match. Top candidate is clearly best; runner-up is materially worse. All required fields derived from explicit context or instructions. |
+| **0.65–0.84** | Likely match. Top candidate is plausible but the runner-up is also reasonable, or one non-critical field had to be inferred. |
+| **0.40–0.64** | Weak match. Several plausible candidates, or a required field was inferred from weak signals. |
+| **< 0.40** | No real match. Don't pick — list options and ask. |
+
+## Three bands → three behaviors
+
+| Band | Range | Behavior |
+|---|---|---|
+| **High** | ≥ high threshold | Proceed silently. Record the choice + confidence in the final summary. |
+| **Medium** | ask threshold ≤ x < high threshold | Proceed but **announce** the choice on one line: `Using <choice> (confidence 0.78). Continuing — interrupt to change.` Do not stop. |
+| **Low** | < ask threshold | **Stop and ask.** Present the top 2–3 ranked candidates with their confidences. Never guess. |
+
+## Medium-band lock-in (critical)
+
+A Medium-band announcement is a **soft commitment, not a draft**. The next tool call must use the announced choice exactly. If downstream evidence later invalidates the choice — for example, the overlay's `actionIds` doesn't contain the action you expected, `get_context` returns a structure that doesn't match, or the action call errors — you MUST:
+
+1. **Stop.** Do not silently switch to a different control, action, or payload. The user already saw "Using X" and is reasonably expecting X.
+2. **Report the contradiction explicitly:** what you announced, what came back, and what that means.
+3. **Ask the user how to proceed.** Offer concrete alternatives where possible (e.g. "(a) try a different control, (b) use a different action on the same control, (c) stop").
+
+Silently revising a Medium-band choice is the single worst HITL failure mode this skill protects against. The user's "interrupt to change" affordance is real-time only; once you've moved past it, ask explicitly before changing course.
+
+## Expected-action absence is a hard stop
+
+When you derived an expected action id in Step 5 from the user's intent (e.g. "add a button" → `CTX_ADDXML`) and the chosen control doesn't expose that action, **this is an ask point, not a search heuristic**. Do not silently iterate to a different control hoping the action appears. Instead:
+
+1. **Stop.** Tell the user, in plain terms, that the control they're working with doesn't support the action needed for this intent. Name the control and the missing action explicitly.
+2. **Propose a similar control if one exists.** Look at the overlay list for candidates of the same or compatible `controlType` (e.g. another `OverflowToolbar`, another `Toolbar`, the parent container) and name **one specific alternative** with the reason it's similar. Do not list five — pick the closest one.
+3. **Wait for explicit confirmation.** Do not switch controls until the user replies. If they confirm, restart from Step 5 (action selection) on the new control and verify the expected action is present *before* announcing.
+4. **If no similar control is obvious**, ask the user to point at one or to clarify what they meant — don't guess.
+
+This rule has special weight when the **user explicitly named the control** (e.g. "add a button to the TableToolbar"). In that case the model must not silently substitute a different control under any circumstance — the user said which one, and a missing action means the request itself is impossible as stated, which the user must be told.
+
+This rule applies even when the chosen control was selected in the High band. A High-band control plus an unexpected action set is a higher-priority signal than the original control-selection confidence.
+
+Phrasing template:
+
+> The `<chosenControl>` (`<controlType>`) doesn't expose `<expectedAction>` — only `<actual ids>`.
+>
+> The closest similar control on this page is `<proposedControl>` (`<controlType>`), because `<reason>`. Should I switch to `<proposedControl>` and continue, or did you mean a different control?
+
+## Per-decision thresholds
+
+| Decision | High ≥ | Ask < | Reasoning |
+|---|---|---|---|
+| Step 4 — Control selection | 0.95 | 0.60 | Cheap to undo if wrong (the action will fail or look obviously wrong). |
+| Step 5 — Action selection | 0.85 | 0.65 | Few options, usually obvious; bump slightly higher because the wrong action causes a wrong *kind* of change. |
+| Step 8 — Payload preparation | 0.90 | 0.70 | **Highest risk.** Action can succeed yet produce a broken/misplaced change. Bias toward asking. |
+
+## Ambiguity overrides confidence (must ask)
+
+The Medium band is for "I know which one and the runner-up is materially worse, but not by a wide margin." It is **not** for "two candidates look interchangeable." When two or more candidates are roughly equally plausible — same `controlType`, similar labels, both reasonable matches for the user's words — that is a **disambiguation problem, not a confidence problem**. Treat it as a hard ask regardless of the score:
+
+- Two or more candidates within **0.10** confidence of each other → **stop and ask**, even if the top score is in the High band on paper.
+- "I'll pick the more conventional one" or "this is where row actions live" reasoning is not a tiebreaker — it's a guess. List the candidates and ask.
+
+Concrete example: a ListReport page has both a `TableToolbar` and a `FooterToolbar`. The user said "the toolbar." Both are `sap.m.OverflowToolbar`. Don't pick — ask.
+
+## Required-field rule (Step 8)
+
+A required field whose value cannot be derived from (a) the action's payload schema, (b) the element context, or (c) explicit user instructions **caps the whole-payload confidence at 0.55** regardless of how strong the other fields are. That puts payload prep into the "ask" band by default whenever guessing is required.
+
+## Multi-change runs
+
+When executing many changes in one session, the cumulative chance of a wrong silent decision grows. **For runs with more than 3 changes, be more conservative: prefer announcing choices rather than proceeding silently, and always re-run `get_overlays` between iterations — confidence drops if the snapshot is stale.**
+
+## Reporting
+
+The final summary (Step 14) must include, per change: chosen control, action, and the confidence the model assigned to each AI decision. This makes silent high-confidence decisions auditable after the fact.

--- a/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/rta-actions.md
+++ b/packages/fiori-mcp-server/skills/sap-fiori-adp-controller-extension/references/rta-actions.md
@@ -1,4 +1,4 @@
-# Actions Reference
+# RTA Actions
 
 > Referenced from [SKILL.md](../SKILL.md). Use the `id` values from this table — **never invent or guess an action id.** If `actionsCatalog` exposes ids not listed here, surface them to the user rather than picking.
 

--- a/packages/fiori-mcp-server/src/tools/adp-controller-extension/knowledge-base.ts
+++ b/packages/fiori-mcp-server/src/tools/adp-controller-extension/knowledge-base.ts
@@ -6,7 +6,7 @@ const KNOWLEDGE_BASE = `You are a SAPUI5 Adaptation Project expert specializing 
 
 IMPORTANT RULES:
 1. For controller extensions, always use "sap/ui/core/mvc/ControllerExtension" (NOT "sap/ui/core/mvc/Controller"). Use ControllerExtension.extend() pattern for proper adaptation project architecture.
-2. Assign stable, unique IDs to all controls, elements, subcontrols, items, and sub-items even when they have a key or other identifying attribute. This is crucial for adaptation project functionality.
+2. Assign stable, unique IDs to all controls, elements, subcontrols, items, and sub-items even when they have a key or other identifying attribute. This is crucial for adaptation project functionality. Exception: do NOT add an id attribute to Dialog controls — see ID & CONTROL HANDLING.
 3. When providing code, always provide the entire file! Do not omit parts or replace them with an ellipsis. Keep the rest of the file as-is in your reply, only touch the part that needs to be changed.
 4. Immediately before each code block belonging to a file, with no other text in between, write the full path+name of the file in the following format: **Path:** fullFilePath. It is of extreme importance to always provide this format with the word 'Path' before the file path and no other content between this line and the code block.
 
@@ -65,6 +65,8 @@ FRAGMENT LOAD PATH DECIDES THE HANDLER FORM (CRITICAL):
 
 CONTROLLER EXTENSION FILES (JS/TS) - File Paths and Namespaces:
 - File path: webapp/changes/coding/{controller-extension-name}.js
+- Do NOT add .controller to the file name
+- Do not create a new controller extension file if one already exists for the selected view — add methods to the existing file instead
 - Namespace in ControllerExtension.extend(): use the variant id as the base:
   * ControllerExtension.extend("{variant-id}.{ControllerExtName}", {...})
 - Example (CUSTOMER_BASE, id "customer.app.variant2"): ControllerExtension.extend("customer.app.variant2.ControllerExt", {...})
@@ -95,33 +97,22 @@ IMPORTANT: The controlType comment refers to the PARENT control that will contai
 
 CONTROLLER EXTENSION WORKFLOW:
 1. Read manifest.appdescr_variant:
-   - Extract 'id' property (app variant id) - this is the BASE for the change file namespace,
-     the ControllerExtension.extend() namespace, the fragment handler paths, and Fragment.load names
-   - Extract 'layer' property - informational; the "customer." segment (when present) is already part
-     of the id for CUSTOMER_BASE projects, so you never add it separately
+   - Extract 'id' property (app variant id) — the BASE for all namespaces (see CONTROLLER EXTENSION NAMESPACE PATTERN)
+   - Extract 'layer' property — informational only
 
-2. Use the variant id verbatim as the namespace base:
-   - The project folder name is informational only — do NOT build namespaces from it
-   - The same variant id feeds fragment handlers, the extend() namespace, and Fragment.load names
+2. Use the variant id verbatim as the namespace base — do NOT build namespaces from the project folder name.
 
-3. Create controller extension file:
-   - File path: webapp/changes/coding/{ControllerExtName}.js
+3. Create controller extension file (see CONTROLLER EXTENSION FILES for path and namespace rules):
    - Do NOT add .controller to the file name
    - Use sap.ui.define with "sap/ui/core/mvc/ControllerExtension" (NOT sap/ui/core/mvc/Controller)
-   - Namespace pattern: return ControllerExtension.extend("{variant-id}.{ControllerExtName}", {...});
-   - Example (CUSTOMER_BASE, id "customer.app.variant2"): ControllerExtension.extend("customer.app.variant2.ControllerExt", {...})
-   - Example (standard, id "app.variant2"): ControllerExtension.extend("app.variant2.ControllerExt", {...})
 
 4. Create XML fragment file (if needed):
    - Add stable, unique IDs to ALL controls and sub-elements
    - Wire event handlers with the variant-id-based pattern:
      * press=".extension.{variant-id}.{ControllerExt}.{methodName}"
    - The ".extension" prefix is ONLY used in fragment XML event handlers
-   - The "customer." segment appears only because it is part of the variant id — never add it separately
-   - EXCEPTION — dialog / programmatically-loaded fragments: if this fragment is opened via
-     Fragment.load({ controller: this }) (not adopted into a view), use BARE method names
-     (press="onClose"), NOT the ".extension.*" path. See "FRAGMENT LOAD PATH DECIDES THE
-     HANDLER FORM" above. Emit "controller: this" in every generated Fragment.load call.
+   - EXCEPTION — dialog / programmatically-loaded fragments: use BARE method names (press="onClose").
+     See "FRAGMENT LOAD PATH DECIDES THE HANDLER FORM" above.
 
 5. Do not create duplicate files:
    - Do not create a new controller extension file if one already exists for the selected view
@@ -156,6 +147,8 @@ ON-DEMAND PROPERTY FETCHING (CRITICAL):
   Work with the data inside the success/then callback — never outside it.
 - This applies even when the property "should" be there logically. A handler that constructs a URL,
   a label, or any computed output from model properties must fetch those properties explicitly.
+- For numeric "lower than" thresholds use \`Math.floor\`, not \`Math.round\` — \`Math.round\` can round
+  above the threshold (e.g. \`Math.round(40.95) = 41 > 40.95\`).
 
 PROGRAMMATIC FRAGMENT CONTROLS (CRITICAL):
 - Fragment.load() resolves with the root control instance, not a fragment holder.
@@ -168,11 +161,8 @@ PROGRAMMATIC FRAGMENT CONTROLS (CRITICAL):
 
 OUTPUT REQUIREMENTS:
 - Each response must be self-contained and production-ready.
-- Each file must be complete, not partial.
-- Maintain consistent namespaces and controller references.
-- Follow adaptation project structure and conventions.
 - Include comments in code only where useful to explain complex logic.
-- CRITICAL: Assign stable, unique IDs to all controls, elements, subcontrols, items, and sub-items—even when they have a key or an identifying attribute. Verify all elements have IDs before responding.`;
+- CRITICAL: Verify all controls and sub-elements have stable, unique IDs before responding.`;
 
 /**
  * Builds the progressive-disclosure response sent back when the tool is


### PR DESCRIPTION
Title: Productize SAP Fiori ADP Controller Extension Skill

## Description
Productizes the SAP Fiori ADP controller extension skill by renaming and enriching the skill metadata, modularizing long guidance into reference documents, and tightening workflow instructions for safer adaptation project changes.

Key updates:
- Renamed the skill to `sap-fiori-adp-controller-extension` with clearer trigger guidance and metadata.
- Split large sections from `SKILL.md` into dedicated references:
  - `actions-reference.md`
  - `hitl-gating.md`
  - `example-session.md`
- Updated workflow guidance for navigation, action selection, payload preparation, cleanup, and error handling.
- Standardized MCP tool references to public tool names.
- Improved Chromium fallback and editor-server shutdown instructions across platforms.
- Enhanced ADP controller extension knowledge base rules around:
  - stable IDs, with a Dialog exception
  - controller extension naming and reuse
  - variant-id-based namespaces
  - fragment handler resolution
  - on-demand OData property fetching
  - numeric threshold handling

## Type of change
- [ ] Bug (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a new feature)
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected)
- [x] Non-Breaking chores (Changes to tools, libraries, build process, documentation, etc)
- [ ] None of the above (Reviewers might ask for more clarification)

## How have you tested?
Documentation and prompt-only changes. Reviewed the updated skill flow, reference links, and knowledge base guidance for consistency and completeness.

## Checklist:
- [ ] The code conforms to the [general development principles](https://github.com/SAP/open-ux-tools/blob/main/docs/Guidelines.md)
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [x] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests pass locally
- [ ] I have reviewed and addressed all Hyperspace bot findings (or explicitly explained dismissals)
- [ ] I have done an Agentic review

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.30`

- Correlation ID: `5ef40d40-adbe-11f1-9a1e-0f37fa369d08`
- Event Trigger: `pull_request.opened`
- Output Template: Repository PR Template
- LLM: `gpt-5.5`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
